### PR TITLE
build: mainnet canisters

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,6 +4,6 @@ Juno is released under the GNU Affero General Public License Version 3 (AGPLv3) 
 
 All artwork and icons - provided by [Didier Renaud](https://www.customfuture.com/) - are licensed under the Creative Commons License [CC BY-NC-SA](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 
-The infrastructure of Juno - i.e. the canisters `xxt4w-7iaaa-aaaak-ad7rq-cai` and other services must not be used unless special agreements have been concluded with Juno.
+The infrastructure of Juno - i.e. the canisters listed in [canister_ids.json](canister_ids.json) and other services must not be used unless special agreements have been concluded with Juno.
 
 Juno is developed by [David Dal Busco](mailto:david.dalbusco@outlook.com).

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,5 +1,11 @@
 {
 	"frontend": {
 		"ic": "xxt4w-7iaaa-aaaak-ad7rq-cai"
+	},
+	"console": {
+		"ic": "cokmz-oiaaa-aaaal-aby6q-cai"
+	},
+	"observatory": {
+		"ic": "klbfr-lqaaa-aaaak-qbwsa-cai"
 	}
 }

--- a/src/console/Cargo.toml
+++ b/src/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/mission_control/Cargo.toml
+++ b/src/mission_control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mission_control"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/observatory/Cargo.toml
+++ b/src/observatory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "observatory"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/satellite/Cargo.toml
+++ b/src/satellite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satellite"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/shared/src/env.rs
+++ b/src/shared/src/env.rs
@@ -1,9 +1,15 @@
-pub static CONSOLE: &str = "rno2w-sqaaa-aaaaa-aaacq-cai";
+// Mainnet: cokmz-oiaaa-aaaal-aby6q-cai
+// Local: rno2w-sqaaa-aaaaa-aaacq-cai
+pub static CONSOLE: &str = "cokmz-oiaaa-aaaal-aby6q-cai";
 
-// On mainnet, use ic_ledger_types::MAINNET_LEDGER_CANISTER_ID;
-pub static LEDGER: &str = "r7inp-6aaaa-aaaaa-aaabq-cai";
+// Mainnet: ryjl3-tyaaa-aaaaa-aaaba-cai
+// Local: r7inp-6aaaa-aaaaa-aaabq-cai
+pub static LEDGER: &str = "ryjl3-tyaaa-aaaaa-aaaba-cai";
 
-// On mainnet, use ic_ledger_types::MAINNET_CYCLES_MINTING_CANISTER_ID
+// Mainnet: rkp4c-7iaaa-aaaaa-aaaca-cai
+// Local: rkp4c-7iaaa-aaaaa-aaaca-cai
 pub static CMC: &str = "rkp4c-7iaaa-aaaaa-aaaca-cai";
 
-pub static OBSERVATORY: &str = "renrk-eyaaa-aaaaa-aaada-cai";
+// Mainnet: klbfr-lqaaa-aaaak-qbwsa-cai
+// Local: renrk-eyaaa-aaaaa-aaada-cai
+pub static OBSERVATORY: &str = "klbfr-lqaaa-aaaak-qbwsa-cai";


### PR DESCRIPTION
Provision canisters but, ultimately did not deploy "console" because we have to deprecate the "observatory" that uses too much cycles. We will wait for the "index" canister instead.