### PR TITLE
feat: trailing slash default behavior set to never

### DIFF
--- a/src/satellite/src/storage/impls.rs
+++ b/src/satellite/src/storage/impls.rs
@@ -81,6 +81,6 @@ impl From<&Vec<Vec<u8>>> for AssetEncoding {
 
 impl Default for TrailingSlash {
     fn default() -> Self {
-        TrailingSlash::Always
+        TrailingSlash::Never
     }
 }


### PR DESCRIPTION
Default: `/about/ -> /about.html`