### PR TITLE
build: gzip wasm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: console.wasm
+          - name: console.wasm.gz
             target: scratch_console
 
-          - name: mission_control.wasm
+          - name: mission_control.wasm.gz
             target: scratch_mission_control
 
-          - name: satellite.wasm
+          - name: satellite.wasm.gz
             target: scratch_satellite
 
     steps:
@@ -100,18 +100,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Download console.wasm
+      - name: Download console.wasm.gz
         uses: actions/download-artifact@v3
         with:
-          name: console.wasm
-      - name: Download mission_control.wasm
+          name: console.wasm.gz
+      - name: Download mission_control.wasm.gz
         uses: actions/download-artifact@v3
         with:
-          name: mission_control.wasm
-      - name: Download satellite.wasm
+          name: mission_control.wasm.gz
+      - name: Download satellite.wasm.gz
         uses: actions/download-artifact@v3
         with:
-          name: satellite.wasm
+          name: satellite.wasm.gz
       - name: Download metadata.json
         uses: actions/download-artifact@v3
         with:
@@ -127,7 +127,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ./console*.wasm
-            ./mission_control*.wasm
-            ./satellite*.wasm
+            ./console*.wasm.gz
+            ./mission_control*.wasm.gz
+            ./satellite*.wasm.gz
             ./metadata.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN touch src/shared/src/lib.rs
 RUN npm ci
 
 RUN ./docker/build
-RUN sha256sum /mission_control.wasm
+RUN sha256sum /mission_control.wasm.gz
 
 FROM deps as build_satellite
 
@@ -80,7 +80,7 @@ RUN touch src/satellite/src/lib.rs
 RUN touch src/shared/src/lib.rs
 
 RUN ./docker/build --satellite
-RUN sha256sum /satellite.wasm
+RUN sha256sum /satellite.wasm.gz
 
 FROM deps as build_console
 
@@ -92,13 +92,13 @@ RUN touch src/satellite/src/lib.rs
 RUN touch src/shared/src/lib.rs
 
 RUN ./docker/build --console
-RUN sha256sum /console.wasm
+RUN sha256sum /console.wasm.gz
 
 FROM scratch AS scratch_mission_control
-COPY --from=build_mission_control /mission_control.wasm /
+COPY --from=build_mission_control /mission_control.wasm.gz /
 
 FROM scratch AS scratch_satellite
-COPY --from=build_satellite /satellite.wasm /
+COPY --from=build_satellite /satellite.wasm.gz /
 
 FROM scratch AS scratch_console
-COPY --from=build_console /console.wasm /
+COPY --from=build_console /console.wasm.gz /

--- a/docker/build
+++ b/docker/build
@@ -129,6 +129,8 @@ function build_canister() {
         ic-cdk-optimizer \
             "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" \
             -o "./$canister.wasm"
+
+        gzip "./$canister.wasm"
     fi
 }
 

--- a/docker/prepare
+++ b/docker/prepare
@@ -9,7 +9,7 @@ function prepare_metadata() {
     local version=($(jq -r ".\"${canister}\"" $METADATA))
 
     echo "Renaming $canister v$version"
-    mv -f "$canister.wasm" "$canister-v$version.wasm" 2>/dev/null; true
+    mv -f "$canister.wasm.gz" "$canister-v$version.wasm.gz" 2>/dev/null; true
 }
 
 for canister in $(echo $CANISTERS | sed "s/,/ /g")


### PR DESCRIPTION
Satellite wasm is too big since we can only upload up to 2mb we need to gzip it.

Fortunatelly it is supported out of the box

https://internetcomputer.org/docs/current/developer-docs/production/larger-wasm