### PR TITLE
fix: http strategy certification

### DIFF
--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -35,7 +35,7 @@ use crate::storage::types::interface::{
 };
 use crate::storage::types::state::StorageStableState;
 use crate::storage::types::store::{Asset, Chunk};
-use crate::storage::types::url::PublicAsset;
+use crate::storage::types::http_request::PublicAsset;
 use crate::types::core::CollectionKey;
 use crate::types::interface::{Config, RulesType};
 use crate::types::list::ListResults;

--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -35,6 +35,7 @@ use crate::storage::types::interface::{
 };
 use crate::storage::types::state::StorageStableState;
 use crate::storage::types::store::{Asset, Chunk};
+use crate::storage::types::url::PublicAsset;
 use crate::types::core::CollectionKey;
 use crate::types::interface::{Config, RulesType};
 use crate::types::list::ListResults;
@@ -289,13 +290,16 @@ fn http_request(
     let result = get_public_asset_for_url(url);
 
     match result {
-        Ok(asset) => match asset {
+        Ok(PublicAsset {
+            asset,
+            url: custom_url,
+        }) => match asset {
             Some(asset) => {
                 let encodings = build_encodings(req_headers);
 
                 for encoding_type in encodings.iter() {
                     if let Some(encoding) = asset.encodings.get(encoding_type) {
-                        let headers = build_headers(&asset, encoding_type);
+                        let headers = build_headers(&custom_url, &asset, encoding_type);
 
                         let Asset {
                             key,

--- a/src/satellite/src/storage/http.rs
+++ b/src/satellite/src/storage/http.rs
@@ -8,6 +8,7 @@ use crate::storage::types::http::{
 };
 use crate::storage::types::state::StorageRuntimeState;
 use crate::storage::types::store::{Asset, AssetEncoding, AssetKey};
+use crate::storage::types::url::Url;
 use crate::STATE;
 
 pub fn streaming_strategy(
@@ -50,10 +51,11 @@ pub fn create_token(
 }
 
 pub fn build_headers(
+    url: &Url,
     asset: &Asset,
     encoding_type: &String,
 ) -> Result<Vec<HeaderField>, &'static str> {
-    let certified_header = build_certified_headers(asset);
+    let certified_header = build_certified_headers(url);
 
     match certified_header {
         Err(err) => Err(err),
@@ -81,21 +83,15 @@ pub fn build_headers(
     }
 }
 
-fn build_certified_headers(asset: &Asset) -> Result<HeaderField, &'static str> {
-    STATE.with(|state| build_certified_headers_impl(asset, &state.borrow().runtime.storage))
+fn build_certified_headers(url: &Url) -> Result<HeaderField, &'static str> {
+    STATE.with(|state| build_certified_headers_impl(url, &state.borrow().runtime.storage))
 }
 
 fn build_certified_headers_impl(
-    Asset {
-        key,
-        headers: _,
-        encodings: _,
-        created_at: _,
-        updated_at: _,
-    }: &Asset,
+    url: &Url,
     state: &StorageRuntimeState,
 ) -> Result<HeaderField, &'static str> {
-    build_asset_certificate_header(&state.asset_hashes, key.full_path.clone())
+    build_asset_certificate_header(&state.asset_hashes, url.requested_path.clone())
 }
 
 // Source: NNS-dapp

--- a/src/satellite/src/storage/http.rs
+++ b/src/satellite/src/storage/http.rs
@@ -8,7 +8,7 @@ use crate::storage::types::http::{
 };
 use crate::storage::types::state::StorageRuntimeState;
 use crate::storage::types::store::{Asset, AssetEncoding, AssetKey};
-use crate::storage::types::url::Url;
+use crate::storage::types::http_request::Url;
 use crate::STATE;
 
 pub fn streaming_strategy(

--- a/src/satellite/src/storage/store.rs
+++ b/src/satellite/src/storage/store.rs
@@ -21,7 +21,7 @@ use crate::storage::types::interface::{
 };
 use crate::storage::types::state::{Assets, FullPath, StorageRuntimeState, StorageStableState};
 use crate::storage::types::store::{Asset, AssetEncoding, AssetKey, Batch, Chunk};
-use crate::storage::types::url::PublicAsset;
+use crate::storage::types::http_request::PublicAsset;
 use crate::storage::url::parse_url;
 use crate::types::list::{ListParams, ListResults};
 use crate::types::state::{RuntimeState, State};

--- a/src/satellite/src/storage/store.rs
+++ b/src/satellite/src/storage/store.rs
@@ -21,7 +21,7 @@ use crate::storage::types::interface::{
 };
 use crate::storage::types::state::{Assets, FullPath, StorageRuntimeState, StorageStableState};
 use crate::storage::types::store::{Asset, AssetEncoding, AssetKey, Batch, Chunk};
-use crate::storage::types::url::Url;
+use crate::storage::types::url::PublicAsset;
 use crate::storage::url::parse_url;
 use crate::types::list::{ListParams, ListResults};
 use crate::types::state::{RuntimeState, State};
@@ -31,14 +31,16 @@ use crate::STATE;
 /// Getter, list and delete
 ///
 
-pub fn get_public_asset_for_url(url: String) -> Result<Option<Asset>, &'static str> {
+pub fn get_public_asset_for_url(url: String) -> Result<PublicAsset, &'static str> {
     if url.is_empty() {
         return Err("No url provided.");
     }
 
-    let Url { full_path, token } = parse_url(&url)?;
+    let url = parse_url(&url)?;
 
-    get_public_asset(full_path, token)
+    let asset = get_public_asset(url.full_path.clone(), url.token.clone())?;
+
+    Ok(PublicAsset { url, asset })
 }
 
 pub fn get_public_asset(

--- a/src/satellite/src/storage/types.rs
+++ b/src/satellite/src/storage/types.rs
@@ -212,9 +212,17 @@ pub mod config {
 }
 
 pub mod url {
+    use crate::storage::types::store::Asset;
+
     pub struct Url {
+        pub requested_path: String,
         pub full_path: String,
         pub token: Option<String>,
+    }
+
+    pub struct PublicAsset {
+        pub url: Url,
+        pub asset: Option<Asset>,
     }
 }
 

--- a/src/satellite/src/storage/types.rs
+++ b/src/satellite/src/storage/types.rs
@@ -211,7 +211,7 @@ pub mod config {
     }
 }
 
-pub mod url {
+pub mod http_request {
     use crate::storage::types::store::Asset;
 
     pub struct Url {

--- a/src/satellite/src/storage/url.rs
+++ b/src/satellite/src/storage/url.rs
@@ -1,5 +1,5 @@
 use crate::storage::types::config::{StorageConfig, TrailingSlash};
-use crate::storage::types::url::Url as CustomUrl;
+use crate::storage::types::http_request::Url as CustomUrl;
 use crate::STATE;
 use url::{ParseError, Url};
 

--- a/src/satellite/src/storage/url.rs
+++ b/src/satellite/src/storage/url.rs
@@ -11,10 +11,15 @@ pub fn parse_url(url: &String) -> Result<CustomUrl, &'static str> {
             let error = format!("Url {} cannot be parsed.", url.clone()).into_boxed_str();
             Err(Box::leak(error))
         }
-        Ok(parsed_url) => Ok(CustomUrl {
-            full_path: map_url(parsed_url.path()),
-            token: map_token(parsed_url),
-        }),
+        Ok(parsed_url) => {
+            let requested_path = parsed_url.path();
+
+            Ok(CustomUrl {
+                requested_path: requested_path.to_string(),
+                full_path: map_url(requested_path),
+                token: map_token(parsed_url),
+            })
+        }
     }
 }
 


### PR DESCRIPTION
The certification tree was incorrect.

If juno.build/docs/build/datastore was requested, the tree was resolved for it's asset.full_path /docs/build/datastore/index.html instead of the effective requested path