### PR TITLE
fix: routing and headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +439,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -911,6 +934,7 @@ version = "0.0.3"
 dependencies = [
  "base64",
  "candid",
+ "globset",
  "ic-cdk",
  "ic-cdk-macros 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-certified-map",

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -117,7 +117,7 @@ export interface SetRule {
 	write: Permission;
 }
 export interface StorageConfig {
-	trailing_slash: TrailingSlash;
+	headers: Array<[string, Array<[string, string]>]>;
 }
 export interface StreamingCallbackHttpResponse {
 	token: [] | [StreamingCallbackToken];
@@ -137,7 +137,6 @@ export type StreamingStrategy = {
 		callback: [Principal, string];
 	};
 };
-export type TrailingSlash = { Never: null } | { Always: null };
 export interface UploadChunk {
 	chunk_id: bigint;
 }
@@ -148,6 +147,7 @@ export interface _SERVICE {
 	del_assets: ActorMethod<[[] | [string]], undefined>;
 	del_custom_domain: ActorMethod<[string], undefined>;
 	del_doc: ActorMethod<[string, string, DelDoc], undefined>;
+	get_config: ActorMethod<[], Config>;
 	get_doc: ActorMethod<[string, string], [] | [Doc]>;
 	http_request: ActorMethod<[HttpRequest], HttpResponse>;
 	http_request_streaming_callback: ActorMethod<

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -8,6 +8,10 @@ export const idlFactory = ({ IDL }) => {
 		chunk_ids: IDL.Vec(IDL.Nat)
 	});
 	const DelDoc = IDL.Record({ updated_at: IDL.Opt(IDL.Nat64) });
+	const StorageConfig = IDL.Record({
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))))
+	});
+	const Config = IDL.Record({ storage: StorageConfig });
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -110,12 +114,6 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		write: Permission
 	});
-	const TrailingSlash = IDL.Variant({
-		Never: IDL.Null,
-		Always: IDL.Null
-	});
-	const StorageConfig = IDL.Record({ trailing_slash: TrailingSlash });
-	const Config = IDL.Record({ storage: StorageConfig });
 	const SetDoc = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
 		data: IDL.Vec(IDL.Nat8)
@@ -138,6 +136,7 @@ export const idlFactory = ({ IDL }) => {
 		del_assets: IDL.Func([IDL.Opt(IDL.Text)], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		del_doc: IDL.Func([IDL.Text, IDL.Text, DelDoc], [], []),
+		get_config: IDL.Func([], [Config], []),
 		get_doc: IDL.Func([IDL.Text, IDL.Text], [IDL.Opt(Doc)], ['query']),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		http_request_streaming_callback: IDL.Func(

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -8,6 +8,10 @@ export const idlFactory = ({ IDL }) => {
 		chunk_ids: IDL.Vec(IDL.Nat)
 	});
 	const DelDoc = IDL.Record({ updated_at: IDL.Opt(IDL.Nat64) });
+	const StorageConfig = IDL.Record({
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))))
+	});
+	const Config = IDL.Record({ storage: StorageConfig });
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -110,12 +114,6 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		write: Permission
 	});
-	const TrailingSlash = IDL.Variant({
-		Never: IDL.Null,
-		Always: IDL.Null
-	});
-	const StorageConfig = IDL.Record({ trailing_slash: TrailingSlash });
-	const Config = IDL.Record({ storage: StorageConfig });
 	const SetDoc = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
 		data: IDL.Vec(IDL.Nat8)
@@ -138,6 +136,7 @@ export const idlFactory = ({ IDL }) => {
 		del_assets: IDL.Func([IDL.Opt(IDL.Text)], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		del_doc: IDL.Func([IDL.Text, IDL.Text, DelDoc], [], []),
+		get_config: IDL.Func([], [Config], []),
 		get_doc: IDL.Func([IDL.Text, IDL.Text], [IDL.Opt(Doc)], ['query']),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		http_request_streaming_callback: IDL.Func(

--- a/src/satellite/Cargo.toml
+++ b/src/satellite/Cargo.toml
@@ -20,4 +20,5 @@ ic-certified-map = "0.3.1"
 sha2 = "0.10.6"
 base64 = "0.13.1"
 url = "2.3.1"
+globset = "0.4.10"
 shared = { path = "../shared" }

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -90,7 +90,9 @@ type SetRule = record {
   read : Permission;
   write : Permission;
 };
-type StorageConfig = record { trailing_slash : TrailingSlash };
+type StorageConfig = record {
+  headers : vec record { text; vec record { text; text } };
+};
 type StreamingCallbackHttpResponse = record {
   token : opt StreamingCallbackToken;
   body : vec nat8;
@@ -109,7 +111,6 @@ type StreamingStrategy = variant {
     callback : func () -> ();
   };
 };
-type TrailingSlash = variant { Never; Always };
 type UploadChunk = record { chunk_id : nat };
 service : {
   add_controllers : (ControllersArgs) -> (vec principal);
@@ -118,6 +119,7 @@ service : {
   del_assets : (opt text) -> ();
   del_custom_domain : (text) -> ();
   del_doc : (text, text, DelDoc) -> ();
+  get_config : () -> (Config);
   get_doc : (text, text) -> (opt Doc) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   http_request_streaming_callback : (StreamingCallbackToken) -> (

--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -244,7 +244,7 @@ fn set_config(config: Config) {
 
 #[candid_method(update)]
 #[update(guard = "caller_is_controller")]
-fn get_config1() -> Config {
+fn get_config() -> Config {
     let storage = get_storage_config();
     Config { storage }
 }

--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -22,7 +22,7 @@ use crate::storage::http::{
 use crate::storage::store::{
     commit_batch, create_batch, create_chunk, delete_asset, delete_assets, delete_domain,
     get_custom_domains, get_public_asset, get_public_asset_for_url,
-    list_assets as list_assets_store, set_config as set_storage_config, set_domain,
+    list_assets as list_assets_store, set_domain,
 };
 use crate::storage::types::assets::AssetHashes;
 use crate::storage::types::config::StorageConfig;
@@ -292,14 +292,14 @@ fn http_request(
     match result {
         Ok(PublicAsset {
             asset,
-            url: custom_url,
+            requested_path,
         }) => match asset {
             Some(asset) => {
                 let encodings = build_encodings(req_headers);
 
                 for encoding_type in encodings.iter() {
                     if let Some(encoding) = asset.encodings.get(encoding_type) {
-                        let headers = build_headers(&custom_url, &asset, encoding_type);
+                        let headers = build_headers(&requested_path, &asset, encoding_type);
 
                         let Asset {
                             key,

--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -21,8 +21,9 @@ use crate::storage::http::{
 };
 use crate::storage::store::{
     commit_batch, create_batch, create_chunk, delete_asset, delete_assets, delete_domain,
-    get_custom_domains, get_public_asset, get_public_asset_for_url,
-    list_assets as list_assets_store, set_domain,
+    get_config as get_storage_config, get_custom_domains, get_public_asset,
+    get_public_asset_for_url, list_assets as list_assets_store, set_config as set_storage_config,
+    set_domain,
 };
 use crate::storage::types::assets::AssetHashes;
 use crate::storage::types::config::StorageConfig;
@@ -30,12 +31,12 @@ use crate::storage::types::domain::{CustomDomains, DomainName};
 use crate::storage::types::http::{
     HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken,
 };
+use crate::storage::types::http_request::PublicAsset;
 use crate::storage::types::interface::{
     AssetNoContent, CommitBatch, InitAssetKey, InitUploadResult, UploadChunk,
 };
 use crate::storage::types::state::StorageStableState;
 use crate::storage::types::store::{Asset, Chunk};
-use crate::storage::types::http_request::PublicAsset;
 use crate::types::core::CollectionKey;
 use crate::types::interface::{Config, RulesType};
 use crate::types::list::ListResults;
@@ -239,6 +240,13 @@ fn list_controllers() -> Controllers {
 #[update(guard = "caller_is_controller")]
 fn set_config(config: Config) {
     set_storage_config(&config.storage);
+}
+
+#[candid_method(update)]
+#[update(guard = "caller_is_controller")]
+fn get_config1() -> Config {
+    let storage = get_storage_config();
+    Config { storage }
 }
 
 ///

--- a/src/satellite/src/storage/http.rs
+++ b/src/satellite/src/storage/http.rs
@@ -8,7 +8,6 @@ use crate::storage::types::http::{
 };
 use crate::storage::types::state::StorageRuntimeState;
 use crate::storage::types::store::{Asset, AssetEncoding, AssetKey};
-use crate::storage::types::http_request::Url;
 use crate::STATE;
 
 pub fn streaming_strategy(
@@ -51,11 +50,11 @@ pub fn create_token(
 }
 
 pub fn build_headers(
-    url: &Url,
+    requested_path: &String,
     asset: &Asset,
     encoding_type: &String,
 ) -> Result<Vec<HeaderField>, &'static str> {
-    let certified_header = build_certified_headers(url);
+    let certified_header = build_certified_headers(requested_path);
 
     match certified_header {
         Err(err) => Err(err),
@@ -83,15 +82,15 @@ pub fn build_headers(
     }
 }
 
-fn build_certified_headers(url: &Url) -> Result<HeaderField, &'static str> {
-    STATE.with(|state| build_certified_headers_impl(url, &state.borrow().runtime.storage))
+fn build_certified_headers(requested_path: &String) -> Result<HeaderField, &'static str> {
+    STATE.with(|state| build_certified_headers_impl(requested_path, &state.borrow().runtime.storage))
 }
 
 fn build_certified_headers_impl(
-    url: &Url,
+    requested_path: &String,
     state: &StorageRuntimeState,
 ) -> Result<HeaderField, &'static str> {
-    build_asset_certificate_header(&state.asset_hashes, url.requested_path.clone())
+    build_asset_certificate_header(&state.asset_hashes, requested_path.clone())
 }
 
 // Source: NNS-dapp

--- a/src/satellite/src/storage/store.rs
+++ b/src/satellite/src/storage/store.rs
@@ -16,12 +16,12 @@ use crate::storage::constants::{
 use crate::storage::custom_domains::map_custom_domains_asset;
 use crate::storage::types::config::StorageConfig;
 use crate::storage::types::domain::{CustomDomain, CustomDomains, DomainName};
+use crate::storage::types::http_request::PublicAsset;
 use crate::storage::types::interface::{
     AssetEncodingNoContent, AssetNoContent, CommitBatch, InitAssetKey,
 };
 use crate::storage::types::state::{Assets, FullPath, StorageRuntimeState, StorageStableState};
 use crate::storage::types::store::{Asset, AssetEncoding, AssetKey, Batch, Chunk};
-use crate::storage::types::http_request::{PublicAsset};
 use crate::storage::url::map_url;
 use crate::types::list::{ListParams, ListResults};
 use crate::types::state::{RuntimeState, State};
@@ -57,7 +57,7 @@ pub fn get_public_asset_for_url(url: String) -> Result<PublicAsset, &'static str
         }
     }
 
-    let asset: Option<Asset> = get_public_asset(url.clone(), map_url.token.clone())?;
+    let asset: Option<Asset> = get_public_asset(url.clone(), map_url.token)?;
     Ok(PublicAsset {
         requested_path: url,
         asset,
@@ -618,6 +618,10 @@ pub fn set_config(config: &StorageConfig) {
 
 fn set_config_impl(config: &StorageConfig, state: &mut StorageStableState) {
     state.config = config.clone();
+}
+
+pub fn get_config() -> StorageConfig {
+    STATE.with(|state| state.borrow().stable.storage.config.clone())
 }
 
 ///

--- a/src/satellite/src/storage/store.rs
+++ b/src/satellite/src/storage/store.rs
@@ -21,8 +21,8 @@ use crate::storage::types::interface::{
 };
 use crate::storage::types::state::{Assets, FullPath, StorageRuntimeState, StorageStableState};
 use crate::storage::types::store::{Asset, AssetEncoding, AssetKey, Batch, Chunk};
-use crate::storage::types::http_request::PublicAsset;
-use crate::storage::url::parse_url;
+use crate::storage::types::http_request::{PublicAsset};
+use crate::storage::url::map_url;
 use crate::types::list::{ListParams, ListResults};
 use crate::types::state::{RuntimeState, State};
 use crate::STATE;
@@ -36,11 +36,28 @@ pub fn get_public_asset_for_url(url: String) -> Result<PublicAsset, &'static str
         return Err("No url provided.");
     }
 
-    let url = parse_url(&url)?;
+    let map_url = map_url(&url)?;
 
-    let asset = get_public_asset(url.full_path.clone(), url.token.clone())?;
+    for alternative_path in map_url.alternative_full_paths {
+        let asset: Option<Asset> = get_public_asset(alternative_path, map_url.token.clone())?;
 
-    Ok(PublicAsset { url, asset })
+        // We return the first match
+        match asset {
+            None => (),
+            Some(_) => {
+                return Ok(PublicAsset {
+                    requested_path: url,
+                    asset,
+                });
+            }
+        }
+    }
+
+    let asset: Option<Asset> = get_public_asset(url.clone(), map_url.token.clone())?;
+    Ok(PublicAsset {
+        requested_path: url,
+        asset,
+    })
 }
 
 pub fn get_public_asset(
@@ -209,7 +226,6 @@ fn secure_delete_asset_impl(
             &rule.write,
             &mut state.stable.storage.assets,
             &mut state.runtime,
-            &state.stable.storage.config,
         ),
     }
 }
@@ -221,7 +237,6 @@ fn delete_asset_impl(
     rule: &Permission,
     assets: &mut Assets,
     runtime: &mut RuntimeState,
-    config: &StorageConfig,
 ) -> Result<Option<Asset>, &'static str> {
     let asset = assets.get_mut(&full_path);
 
@@ -233,7 +248,7 @@ fn delete_asset_impl(
             }
 
             let deleted = assets.remove(&*full_path);
-            delete_certified_asset(runtime, &full_path, config);
+            delete_certified_asset(runtime, &full_path);
             Ok(deleted)
         }
     }
@@ -251,7 +266,7 @@ fn delete_assets_impl(collection: String, state: &mut State) {
 
     for full_path in full_paths {
         state.stable.storage.assets.remove(&full_path);
-        delete_certified_asset(&mut state.runtime, &full_path, &state.stable.storage.config);
+        delete_certified_asset(&mut state.runtime, &full_path);
     }
 }
 
@@ -412,7 +427,7 @@ fn commit_batch_impl(
             match asset {
                 Err(err) => Err(err),
                 Ok(asset) => {
-                    update_certified_asset(state, &asset, &state.stable.storage.config.clone());
+                    update_certified_asset(state, &asset);
                     Ok(())
                 }
             }
@@ -640,7 +655,7 @@ fn update_custom_domains_asset(state: &mut State) {
         .assets
         .insert(full_path.clone(), asset.clone());
 
-    update_certified_asset(state, &asset, &state.stable.storage.config.clone());
+    update_certified_asset(state, &asset);
 }
 
 fn set_stable_domain_impl(domain_name: &DomainName, bn_id: &Option<String>, state: &mut State) {
@@ -682,17 +697,17 @@ pub fn get_custom_domains() -> CustomDomains {
 
 /// Certified assets
 
-fn update_certified_asset(state: &mut State, asset: &Asset, config: &StorageConfig) {
+fn update_certified_asset(state: &mut State, asset: &Asset) {
     // 1. Replace or insert the new asset in tree
-    state.runtime.storage.asset_hashes.insert(asset, config);
+    state.runtime.storage.asset_hashes.insert(asset);
 
     // 2. Update the root hash and the canister certified data
     update_certified_data(&state.runtime.storage.asset_hashes);
 }
 
-fn delete_certified_asset(runtime: &mut RuntimeState, full_path: &String, config: &StorageConfig) {
+fn delete_certified_asset(runtime: &mut RuntimeState, full_path: &String) {
     // 1. Remove the asset in tree
-    runtime.storage.asset_hashes.delete(full_path, config);
+    runtime.storage.asset_hashes.delete(full_path);
 
     // 2. Update the root hash and the canister certified data
     update_certified_data(&runtime.storage.asset_hashes);

--- a/src/satellite/src/storage/store.rs
+++ b/src/satellite/src/storage/store.rs
@@ -38,6 +38,10 @@ pub fn get_public_asset_for_url(url: String) -> Result<PublicAsset, &'static str
 
     let map_url = map_url(&url)?;
 
+    // ⚠️ Limitation: requesting an url without extension try to resolve first a corresponding asset
+    // e.g. /.well-known/hello -> try to find /.well-known/hello.html
+    // Therefore if a file without extension is uploaded to the storage, it is important to not upload an .html file with the same name next to it or a folder/index.html
+
     for alternative_path in map_url.alternative_full_paths {
         let asset: Option<Asset> = get_public_asset(alternative_path, map_url.token.clone())?;
 

--- a/src/satellite/src/storage/types.rs
+++ b/src/satellite/src/storage/types.rs
@@ -201,27 +201,23 @@ pub mod config {
 
     #[derive(Default, CandidType, Deserialize, Clone)]
     pub struct StorageConfig {
-        pub trailing_slash: TrailingSlash,
-    }
-
-    #[derive(CandidType, Deserialize, Clone)]
-    pub enum TrailingSlash {
-        Never,
-        Always,
+        // TODO
     }
 }
 
 pub mod http_request {
+    use candid::{CandidType, Deserialize};
     use crate::storage::types::store::Asset;
 
-    pub struct Url {
-        pub requested_path: String,
-        pub full_path: String,
+    #[derive(CandidType, Deserialize, Clone)]
+    pub struct MapUrl {
         pub token: Option<String>,
+        pub alternative_full_paths: Vec<String>,
     }
 
+    #[derive(CandidType, Deserialize, Clone)]
     pub struct PublicAsset {
-        pub url: Url,
+        pub requested_path: String,
         pub asset: Option<Asset>,
     }
 }

--- a/src/satellite/src/storage/types.rs
+++ b/src/satellite/src/storage/types.rs
@@ -197,17 +197,21 @@ pub mod http {
 }
 
 pub mod config {
+    use crate::storage::types::http::HeaderField;
     use candid::{CandidType, Deserialize};
+    use std::collections::HashMap;
+
+    pub type StorageConfigHeaders = HashMap<String, Vec<HeaderField>>;
 
     #[derive(Default, CandidType, Deserialize, Clone)]
     pub struct StorageConfig {
-        // TODO
+        pub headers: StorageConfigHeaders,
     }
 }
 
 pub mod http_request {
-    use candid::{CandidType, Deserialize};
     use crate::storage::types::store::Asset;
+    use candid::{CandidType, Deserialize};
 
     #[derive(CandidType, Deserialize, Clone)]
     pub struct MapUrl {

--- a/src/satellite/src/storage/url.rs
+++ b/src/satellite/src/storage/url.rs
@@ -13,10 +13,12 @@ pub fn map_url(url: &String) -> Result<MapUrl, &'static str> {
         Ok(parsed_url) => {
             let requested_path = parsed_url.path();
 
+            // The requested path is /something.js or without file extension (/something or /something/)?
             let extension = Path::new(requested_path).extension();
 
             let token = map_token(parsed_url.clone());
 
+            // No alternative path if requested url target an exact file with extension
             match extension {
                 Some(_) => Ok(MapUrl {
                     token,
@@ -36,7 +38,6 @@ pub fn map_url(url: &String) -> Result<MapUrl, &'static str> {
     }
 }
 
-/// if an HTML is added to the assets, then according config we map it for the certified_assets
 pub fn alternative_paths(full_path: &String) -> Option<Vec<String>> {
     // e.g. search to split index.js or index.html or .well-known
     let extensions: Vec<&str> = full_path.split('.').collect();

--- a/src/satellite/src/storage/url.rs
+++ b/src/satellite/src/storage/url.rs
@@ -1,5 +1,5 @@
+use crate::storage::types::http_request::MapUrl;
 use std::path::Path;
-use crate::storage::types::http_request::{MapUrl};
 use url::{ParseError, Url};
 
 pub fn map_url(url: &String) -> Result<MapUrl, &'static str> {
@@ -30,7 +30,7 @@ pub fn map_url(url: &String) -> Result<MapUrl, &'static str> {
 
                     Ok(MapUrl {
                         token,
-                        alternative_full_paths: alternative_urls
+                        alternative_full_paths: alternative_urls,
                     })
                 }
             }
@@ -53,7 +53,7 @@ pub fn alternative_paths(full_path: &String) -> Option<Vec<String>> {
         return Some(Vec::from(["/".to_string()]));
     }
 
-    aliased_by(&full_path)
+    aliased_by(full_path)
 }
 
 /// BEGIN: From DFINITY certified asset canister

--- a/src/satellite/src/storage/url.rs
+++ b/src/satellite/src/storage/url.rs
@@ -1,9 +1,8 @@
-use crate::storage::types::config::{StorageConfig, TrailingSlash};
-use crate::storage::types::http_request::Url as CustomUrl;
-use crate::STATE;
+use std::path::Path;
+use crate::storage::types::http_request::{MapUrl};
 use url::{ParseError, Url};
 
-pub fn parse_url(url: &String) -> Result<CustomUrl, &'static str> {
+pub fn map_url(url: &String) -> Result<MapUrl, &'static str> {
     let parsed_url = build_url(url);
 
     match parsed_url {
@@ -14,20 +13,31 @@ pub fn parse_url(url: &String) -> Result<CustomUrl, &'static str> {
         Ok(parsed_url) => {
             let requested_path = parsed_url.path();
 
-            Ok(CustomUrl {
-                requested_path: requested_path.to_string(),
-                full_path: map_url(requested_path),
-                token: map_token(parsed_url),
-            })
+            let extension = Path::new(requested_path).extension();
+
+            let token = map_token(parsed_url.clone());
+
+            match extension {
+                Some(_) => Ok(MapUrl {
+                    token,
+                    alternative_full_paths: Vec::new(),
+                }),
+                None => {
+                    // Url has no extension - e.g. is not something.js but /about or /about/
+                    let alternative_urls = aliases_of(&requested_path.to_string());
+
+                    Ok(MapUrl {
+                        token,
+                        alternative_full_paths: alternative_urls
+                    })
+                }
+            }
         }
     }
 }
 
 /// if an HTML is added to the assets, then according config we map it for the certified_assets
-pub fn alternative_path(
-    full_path: &String,
-    StorageConfig { trailing_slash }: &StorageConfig,
-) -> Option<String> {
+pub fn alternative_paths(full_path: &String) -> Option<Vec<String>> {
     // e.g. search to split index.js or index.html or .well-known
     let extensions: Vec<&str> = full_path.split('.').collect();
 
@@ -39,15 +49,42 @@ pub fn alternative_path(
 
     // regardless of the configuration, the root file matches always /
     if full_path == "/index.html" {
-        return Some("/".to_string());
+        return Some(Vec::from(["/".to_string()]));
     }
 
-    // if .html then /something/index.html then if trailing slash always the /something/ else /something
-    match trailing_slash {
-        TrailingSlash::Always => Some(full_path.clone().replace("index.html", "")),
-        TrailingSlash::Never => Some(full_path.clone().replace(".html", "")),
+    aliased_by(&full_path)
+}
+
+/// BEGIN: From DFINITY certified asset canister
+
+// path like /path/to/my/asset should also be valid for /path/to/my/asset.html or /path/to/my/asset/index.html
+fn aliases_of(key: &String) -> Vec<String> {
+    if key.ends_with('/') {
+        vec![format!("{}index.html", key)]
+    } else if !key.ends_with(".html") {
+        vec![format!("{}.html", key), format!("{}/index.html", key)]
+    } else {
+        Vec::new()
     }
 }
+
+// Determines possible original keys in case the supplied key is being aliaseded to.
+// Sort-of a reverse operation of `alias_of`
+fn aliased_by(key: &String) -> Option<Vec<String>> {
+    if key.ends_with("/index.html") {
+        Some(vec![
+            key[..(key.len() - 5)].into(),
+            key[..(key.len() - 10)].into(),
+            key[..(key.len() - 11)].to_string(),
+        ])
+    } else if key.ends_with(".html") {
+        Some(vec![key[..(key.len() - 5)].to_string()])
+    } else {
+        None
+    }
+}
+
+/// END
 
 pub fn build_url(url: &String) -> Result<Url, ParseError> {
     let separator = separator(url);
@@ -62,52 +99,6 @@ fn separator(url: &str) -> &str {
     } else {
         "/"
     }
-}
-
-///
-/// Make storage / CDN a bit clever when it comes to resolving HTML resources
-///
-fn map_url(full_path: &str) -> String {
-    let StorageConfig { trailing_slash } =
-        STATE.with(|state| state.borrow().stable.storage.config.clone());
-
-    let mapped_full_path: String = map_trailing_slash(full_path);
-
-    match trailing_slash {
-        TrailingSlash::Always => map_trailing_slash_always(&mapped_full_path),
-        TrailingSlash::Never => map_trailing_slash_never(&mapped_full_path),
-    }
-}
-
-/// if requested URL ends with a / we map to /index.html. e.g. https://papy.rs/about/ -> https://papy.rs/about/index.html
-/// this is also useful to always map the root. e.g. https://papy.rs/ -> https://papy.rs/index.html
-fn map_trailing_slash(full_path: &str) -> String {
-    if full_path.ends_with('/') {
-        return full_path.to_owned() + "index.html";
-    }
-
-    full_path.to_string()
-}
-
-/// if a requested URL has no extension we map to /index.html. e.g. https://papy.rs/about -> https://papy.rs/about/index.html
-fn map_trailing_slash_always(full_path: &str) -> String {
-    map_trailing_slash_extension(full_path, "/index.html")
-}
-
-/// if a requested URL has no extension we map to .html. e.g. https://papy.rs/about -> https://papy.rs/about.html
-fn map_trailing_slash_never(full_path: &str) -> String {
-    map_trailing_slash_extension(full_path, ".html")
-}
-
-fn map_trailing_slash_extension(full_path: &str, add_ons: &str) -> String {
-    // e.g. search to split index.js or index.html or .well-known
-    let extensions = full_path.split('.');
-
-    if extensions.count() == 1 {
-        return full_path.to_owned() + add_ons;
-    }
-
-    full_path.to_string()
 }
 
 /// Find reserved query keyword "token" for protected assets


### PR DESCRIPTION
The certification of the assets was still not perfect. Handling various configuration was also a bit complicated.

Therefore this PR copy the approach of the certified asset canister to handle dynamically any url alternative paths.

It also deprecates the trailing slash option.

Finally it introduces a new option to configure assets for the storage, that way developers can safely set headers that cannot be hacked on the client side. 