### PR TITLE
feat: check for max number of controllers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,7 +679,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mission_control"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "candid",
  "futures",

--- a/src/mission_control/Cargo.toml
+++ b/src/mission_control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mission_control"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/mission_control/src/controllers/mission_control.rs
+++ b/src/mission_control/src/controllers/mission_control.rs
@@ -1,10 +1,20 @@
 use crate::controllers::store::{add_controllers, get_controllers, remove_controllers};
 use crate::store::get_user;
 use ic_cdk::id;
+use shared::constants::MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS;
 use shared::ic::update_canister_controllers;
 use shared::types::interface::{Controllers, UserId};
 
 pub async fn add_mission_control_controllers(controllers: &[UserId]) -> Result<(), String> {
+    let current_controllers = get_controllers();
+
+    if current_controllers.len() >= MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS {
+        return Err(format!(
+            "Maximum number of controllers ({}) is already reached.",
+            MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS
+        ));
+    }
+
     add_controllers(controllers);
 
     let updated_controllers = get_controllers();

--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -53,6 +53,7 @@ use ic_cdk::export::candid::{candid_method, export_service};
 use ic_cdk::storage::{stable_restore, stable_save};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use rules::constants::DEFAULT_DB_COLLECTIONS;
+use shared::constants::MAX_NUMBER_OF_SATELLITE_CONTROLLERS;
 use shared::types::interface::{Controllers, ControllersArgs, SatelliteArgs};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -219,6 +220,15 @@ fn set_rule(rules_type: RulesType, collection: CollectionKey, rule: SetRule) {
 #[candid_method(update)]
 #[update(guard = "caller_is_controller")]
 fn add_controllers(ControllersArgs { controllers }: ControllersArgs) -> Controllers {
+    let current_controllers = get_controllers();
+
+    if current_controllers.len() >= MAX_NUMBER_OF_SATELLITE_CONTROLLERS {
+        trap(&format!(
+            "Maximum number of controllers ({}) is already reached.",
+            MAX_NUMBER_OF_SATELLITE_CONTROLLERS
+        ));
+    }
+
     add_controllers_store(&controllers);
     get_controllers()
 }

--- a/src/shared/Cargo.toml
+++ b/src/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/shared/src/constants.rs
+++ b/src/shared/src/constants.rs
@@ -15,3 +15,9 @@ pub const MEMO_CANISTER_CREATE: Memo = Memo(0x41455243); // == 'CREA'
 pub const MEMO_CANISTER_TOP_UP: Memo = Memo(0x50555054); // == 'TPUP'
 
 pub const MEMO_SATELLITE_CREATE_REFUND: Memo = Memo(0x44464552544153); // == 'SATREFD'
+
+// 10 controllers max on the IC - the canister itself and user of the console because these two are not added to the mission control state controllers
+pub const MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS: usize = 8;
+
+// 10 controllers max on the IC. User and mission control principals are copied in satellite state controllers
+pub const MAX_NUMBER_OF_SATELLITE_CONTROLLERS: usize = 10;


### PR DESCRIPTION
The IC limits the number of controllers to 10, so we have to limit the number of controllers that can be added to avoid "weird issue" like not being able to add another controller for some reason.

Satellite are limited to 10. Mission control to 8 because we do not add in the memory the canister itself and user of the console.