### PR TITLE
feat: dapp collection read permission set as controllers

### DIFF
--- a/src/satellite/src/rules/constants.rs
+++ b/src/satellite/src/rules/constants.rs
@@ -1,5 +1,5 @@
 use crate::rules::types::interface::SetRule;
-use crate::rules::types::rules::Permission::{Controllers, Managed, Public};
+use crate::rules::types::rules::Permission::{Controllers, Managed};
 
 pub const SYS_COLLECTION_PREFIX: char = '#';
 
@@ -16,7 +16,7 @@ pub const DEFAULT_DB_COLLECTIONS: [(&str, SetRule); 1] = [(
 pub const DEFAULT_ASSETS_COLLECTIONS: [(&str, SetRule); 1] = [(
     "#dapp",
     SetRule {
-        read: Public,
+        read: Controllers,
         write: Controllers,
         max_size: None,
         updated_at: None,

--- a/src/satellite/src/upgrade/impls.rs
+++ b/src/satellite/src/upgrade/impls.rs
@@ -1,22 +1,49 @@
+use crate::rules::constants::DEFAULT_ASSETS_COLLECTIONS;
+use crate::rules::types::rules::{Rule, Rules};
 use crate::storage::types::state::StorageStableState;
 use crate::types::state::StableState;
 use crate::upgrade::types::upgrade::UpgradeStableState;
+use ic_cdk::api::time;
+use std::collections::HashMap;
 
 ///
-/// v0.0.3 -> v0.0.4
+/// v0.0.4 -> v0.0.5
 ///
-/// - users assets must be prefixed by their respective collections
-///   e.g. /yolo.jpg in collection images => /images/yolo.jpg
+/// - #dapp collections read permission can be set as controllers now that the CLI and beta has started
 ///
 ///
 impl From<&UpgradeStableState> for StableState {
     fn from(state: &UpgradeStableState) -> Self {
+        let mut rules: Rules = HashMap::new();
+
+        let dapp_collection = DEFAULT_ASSETS_COLLECTIONS[0].0;
+        let dapp_rule = DEFAULT_ASSETS_COLLECTIONS[0].1.clone();
+
+        let now = time();
+
+        for (key, rule) in state.storage.rules.iter() {
+            if key != dapp_collection {
+                rules.insert(key.clone(), rule.clone());
+            } else {
+                rules.insert(
+                    dapp_collection.to_owned(),
+                    Rule {
+                        read: dapp_rule.read.clone(),
+                        write: dapp_rule.write.clone(),
+                        max_size: None,
+                        created_at: rule.created_at,
+                        updated_at: now,
+                    },
+                );
+            }
+        }
+
         StableState {
             controllers: state.controllers.clone(),
             db: state.db.clone(),
             storage: StorageStableState {
                 assets: state.storage.assets.clone(),
-                rules: state.storage.rules.clone(),
+                rules: rules.clone(),
                 config: state.storage.config.clone(),
                 custom_domains: state.storage.custom_domains.clone(),
             },

--- a/src/satellite/src/upgrade/types.rs
+++ b/src/satellite/src/upgrade/types.rs
@@ -1,7 +1,7 @@
 ///
 /// Upgrade structure:
 ///
-/// v0.0.4 -> v0.0.x
+/// v0.0.4 -> v0.0.5 (no changes)
 ///
 pub mod upgrade {
     use crate::db::types::state::DbStableState;


### PR DESCRIPTION
Historically for development purpose the internal collection #dapp had read permission set to true for, development and debug purpose. This collection contains the list of assets of devs apps (html, js etc.).

Because implementation works fine, we can now set the read permissions to "Controllers".