### PR TITLE
feat: controllers write permission check

### DIFF
--- a/src/console/src/mission_control.rs
+++ b/src/console/src/mission_control.rs
@@ -24,7 +24,7 @@ pub async fn init_user_mission_control(
                 increment_mission_controls_rate()?;
 
                 create_mission_control(caller, console).await
-            },
+            }
         },
     }
 }

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -184,7 +184,7 @@
 		"public": "Public",
 		"private": "Private",
 		"managed": "Managed",
-		"controllers": "controllers",
+		"controllers": "Controllers",
 		"empty": "Your collection <strong>{0}</strong> is empty."
 	},
 	"sort": {

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -17,7 +17,7 @@ use crate::controllers::satellite::{
     remove_satellite_controllers as remove_satellite_controllers_impl, set_satellite_controllers,
 };
 use crate::controllers::store::get_controllers;
-use crate::guards::{caller_is_user_or_controller_or_juno, caller_is_user_or_controller};
+use crate::guards::{caller_is_user_or_controller, caller_is_user_or_controller_or_juno};
 use crate::mgmt::canister::top_up_canister;
 use crate::mgmt::status::collect_statuses;
 use crate::satellites::satellite::create_satellite as create_satellite_console;

--- a/src/mission_control/src/upgrade/impls.rs
+++ b/src/mission_control/src/upgrade/impls.rs
@@ -1,4 +1,4 @@
-use crate::types::state::{StableState};
+use crate::types::state::StableState;
 use crate::upgrade::types::upgrade::UpgradeStableState;
 
 ///

--- a/src/satellite/src/db/store.rs
+++ b/src/satellite/src/db/store.rs
@@ -3,7 +3,7 @@ use crate::db::types::state::{Collection, Db, Doc};
 use crate::db::utils::filter_values;
 use crate::list::utils::list_values;
 use crate::rules::types::rules::Permission;
-use crate::rules::utils::{assert_rule, public_rule};
+use crate::rules::utils::{assert_create_rule, assert_rule, public_rule};
 use crate::types::list::{ListParams, ListResults};
 use crate::types::state::State;
 use crate::STATE;
@@ -331,7 +331,11 @@ fn assert_write_permission(
     // For existing collection and document, check user editing is the caller
     if !public_rule(rule) {
         match current_doc {
-            None => (),
+            None => {
+                if !assert_create_rule(rule, caller, controllers) {
+                    return Err(ERROR_CANNOT_WRITE.to_string());
+                }
+            }
             Some(current_doc) => {
                 if !assert_rule(rule, current_doc.owner, caller, controllers) {
                     return Err(ERROR_CANNOT_WRITE.to_string());

--- a/src/satellite/src/rules/utils.rs
+++ b/src/satellite/src/rules/utils.rs
@@ -20,6 +20,17 @@ pub fn assert_rule(
     }
 }
 
+/// If a document or asset is about to be created for the first time, it can be initialized without further rules unless the collection is set as controller and the caller is not a controller.
+/// This can be useful e.g. when a collection read permission is set to public but only the administrator can add content.
+pub fn assert_create_rule(rule: &Permission, caller: Principal, controllers: &Controllers) -> bool {
+    match rule {
+        Permission::Public => true,
+        Permission::Private => true,
+        Permission::Managed => true,
+        Permission::Controllers => is_controller(caller, controllers),
+    }
+}
+
 pub fn public_rule(rule: &Permission) -> bool {
     matches!(rule, Permission::Public)
 }


### PR DESCRIPTION
Resolves #99

Every body, as long as signed-in or anonymous, can create (= initialize) new document or asset.

This PR has for goal to restrict this initialization in case the collection's "write" permission is set to "controllers".
In that case, only controllers can create a new entity as well.