### PR TITLE
feat: replace @dfinity/nns with fork and @dfinity/ledger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@dfinity/identity": "^0.15.3",
 				"@dfinity/ledger": "^0.0.7",
 				"@dfinity/principal": "^0.15.3",
-				"@junobuild/ledger": "^0.0.1",
+				"@junobuild/ledger": "^0.0.2",
 				"buffer": "^6.0.3",
 				"idb-keyval": "^6.2.0",
 				"semver": "^7.3.8"
@@ -155,6 +155,7 @@
 			"version": "0.0.14",
 			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.14.tgz",
 			"integrity": "sha512-wSZOQHMmIPTW9LRpj6mMo0QKAYOBTkIRuoU6Mhbo3zH/TjszJTTbK1coIvneXHu9/HkdgzG7x4MWwJaUp8ZMZg==",
+			"peer": true,
 			"peerDependencies": {
 				"@dfinity/agent": "^0.15.4",
 				"@dfinity/candid": "^0.15.4",
@@ -637,17 +638,17 @@
 			}
 		},
 		"node_modules/@junobuild/ledger": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@junobuild/ledger/-/ledger-0.0.1.tgz",
-			"integrity": "sha512-tEDR+bkioQB6R4t9TzmuPbanf7m8+1ksSxJp8yRVFjtVKMSvLQj4ds1wm+zRBiv6+iPO4mfq30W88bb3QZ6foA==",
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@junobuild/ledger/-/ledger-0.0.2.tgz",
+			"integrity": "sha512-3dII3upuOO33fysCkDIxDEh9RZNdelsHXI9CEWd1j1PKrlWIT1xXP+rrX710jZUPe2o8JG/MIqTiCwyieISsZQ==",
 			"dependencies": {
-				"@dfinity/utils": "^0.0.14",
 				"js-sha256": "^0.9.0"
 			},
 			"peerDependencies": {
 				"@dfinity/agent": "^0.15.6",
 				"@dfinity/identity": "^0.15.6",
-				"@dfinity/principal": "^0.15.6"
+				"@dfinity/principal": "^0.15.6",
+				"@dfinity/utils": "^0.0.14"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -4627,6 +4628,7 @@
 			"version": "0.0.14",
 			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.14.tgz",
 			"integrity": "sha512-wSZOQHMmIPTW9LRpj6mMo0QKAYOBTkIRuoU6Mhbo3zH/TjszJTTbK1coIvneXHu9/HkdgzG7x4MWwJaUp8ZMZg==",
+			"peer": true,
 			"requires": {}
 		},
 		"@esbuild-plugins/node-modules-polyfill": {
@@ -4882,11 +4884,10 @@
 			}
 		},
 		"@junobuild/ledger": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@junobuild/ledger/-/ledger-0.0.1.tgz",
-			"integrity": "sha512-tEDR+bkioQB6R4t9TzmuPbanf7m8+1ksSxJp8yRVFjtVKMSvLQj4ds1wm+zRBiv6+iPO4mfq30W88bb3QZ6foA==",
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@junobuild/ledger/-/ledger-0.0.2.tgz",
+			"integrity": "sha512-3dII3upuOO33fysCkDIxDEh9RZNdelsHXI9CEWd1j1PKrlWIT1xXP+rrX710jZUPe2o8JG/MIqTiCwyieISsZQ==",
 			"requires": {
-				"@dfinity/utils": "^0.0.14",
 				"js-sha256": "^0.9.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,9 @@
 				"@dfinity/agent": "^0.15.3",
 				"@dfinity/auth-client": "^0.15.3",
 				"@dfinity/identity": "^0.15.3",
-				"@dfinity/nns": "^0.14.0",
+				"@dfinity/ledger": "^0.0.7",
 				"@dfinity/principal": "^0.15.3",
+				"@junobuild/ledger": "^0.0.1",
 				"buffer": "^6.0.3",
 				"idb-keyval": "^6.2.0",
 				"semver": "^7.3.8"
@@ -65,9 +66,9 @@
 			}
 		},
 		"node_modules/@dfinity/agent": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.3.tgz",
-			"integrity": "sha512-yjJnAWI2CQY9kAFgavXU4TiKjb3NwaKUpu2LwCfgtJM4k6ofKlW+7q0tBJNs5WvHqRcKRDdn4d6yXKQi+ubS+w==",
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.6.tgz",
+			"integrity": "sha512-Ch+tXAszPap0zwRgr/oFEgJLDld4RDwBdFDqR1JUg38xhHWTFMrTkjMT6uQFvqf6d2wDXnh3zwhqbg5P7OCv7A==",
 			"dependencies": {
 				"base64-arraybuffer": "^0.2.0",
 				"bignumber.js": "^9.0.0",
@@ -77,8 +78,8 @@
 				"ts-node": "^10.8.2"
 			},
 			"peerDependencies": {
-				"@dfinity/candid": "^0.15.3",
-				"@dfinity/principal": "^0.15.3"
+				"@dfinity/candid": "^0.15.6",
+				"@dfinity/principal": "^0.15.6"
 			}
 		},
 		"node_modules/@dfinity/auth-client": {
@@ -95,26 +96,26 @@
 			}
 		},
 		"node_modules/@dfinity/candid": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.3.tgz",
-			"integrity": "sha512-jbfA+kr+gCrBuwxWm/j4Vpqzbnh9bsyUWu9CjopJis8xdxH3FIfNDWOzHZ/QaW7Co+6UoON1wzxMiy91/W5DQA==",
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.6.tgz",
+			"integrity": "sha512-Q9PGvhTE/1dTLfSo0pu0+ifzA7NA4X1rgSy9TE6O1Glk6Kl8Nf+Pg2sCHS2hWt0RAiKfR2glEVlbUAm6S8vRxA==",
 			"peer": true,
 			"dependencies": {
 				"ts-node": "^10.8.2"
 			}
 		},
 		"node_modules/@dfinity/identity": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.15.3.tgz",
-			"integrity": "sha512-D5Sf01MvO3CO63nAYSdG2V8Ox4AEVAm+/O7oKU1oyg8m3z/9zklG6IyCOOKb6hQibWh81j+mduYuX4vYuEjSGw==",
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.15.6.tgz",
+			"integrity": "sha512-hzTyKXAWPHxkZkOWxGj4JUITwdv92VEKnh3l334Yk9h6aw3m7Gi/ujEBLfszsl0LUA82tV4W2MDIz99KMAuW+g==",
 			"dependencies": {
 				"borc": "^2.1.1",
 				"js-sha256": "^0.9.0",
 				"tweetnacl": "^1.0.1"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^0.15.3",
-				"@dfinity/principal": "^0.15.3",
+				"@dfinity/agent": "^0.15.6",
+				"@dfinity/principal": "^0.15.6",
 				"@peculiar/webcrypto": "^1.4.0"
 			}
 		},
@@ -130,35 +131,35 @@
 				"secp256k1": "^4.0.3"
 			}
 		},
-		"node_modules/@dfinity/nns": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.14.0.tgz",
-			"integrity": "sha512-qQ3SzihD9hL2Zo0pAC+Ip2snbEtLDL1Aq2JTnDMLur9DEpiCajzhjXfsOy+U1zeSTOc+RUBbbWeLbS5Edsxeig==",
-			"dependencies": {
-				"crc": "^4.3.2",
-				"crc-32": "^1.2.2",
-				"google-protobuf": "^3.21.2",
-				"js-sha256": "^0.9.0",
-				"randombytes": "^2.1.0"
-			},
+		"node_modules/@dfinity/ledger": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.7.tgz",
+			"integrity": "sha512-ZxFK28jI17OTn73I/xHaGRRjgyYUP7Fnxv9BfDKKQ/3B+5hcwU0rJrmCMhIZrdit3z7Ryzsj5NPa75sRKq2W/A==",
 			"peerDependencies": {
-				"@dfinity/utils": "^0.0.12"
+				"@dfinity/agent": "^0.15.4",
+				"@dfinity/candid": "^0.15.4",
+				"@dfinity/principal": "^0.15.4",
+				"@dfinity/utils": "^0.0.14"
 			}
 		},
 		"node_modules/@dfinity/principal": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.3.tgz",
-			"integrity": "sha512-XqHZVaJx/acmg6kFkF7PB156UwAquOS2WiAA753+nGKTG+TOC7OxbBXCr8vfEsd0mEzcmcLl+jLF8iUsC6Hk4w==",
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.6.tgz",
+			"integrity": "sha512-eMsS5YofRk5Hm6LlhzyBvw1RzDxM5FWPtepQuYeZbZyD/ztq4TrUiScqoKBFw/LLODd0znt8rGnNgqtt+7JnQA==",
 			"dependencies": {
 				"js-sha256": "^0.9.0",
 				"ts-node": "^10.8.2"
 			}
 		},
 		"node_modules/@dfinity/utils": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.12.tgz",
-			"integrity": "sha512-vAarfmHzt31saDjDyoeY1HnzumHEHwrLFr0UFLzONkFgjAf9o7Z+YNOHmY8EjiF3NbuQ0C09aamJ1xV8POs+KQ==",
-			"peer": true
+			"version": "0.0.14",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.14.tgz",
+			"integrity": "sha512-wSZOQHMmIPTW9LRpj6mMo0QKAYOBTkIRuoU6Mhbo3zH/TjszJTTbK1coIvneXHu9/HkdgzG7x4MWwJaUp8ZMZg==",
+			"peerDependencies": {
+				"@dfinity/agent": "^0.15.4",
+				"@dfinity/candid": "^0.15.4",
+				"@dfinity/principal": "^0.15.4"
+			}
 		},
 		"node_modules/@esbuild-plugins/node-modules-polyfill": {
 			"version": "0.2.2",
@@ -633,6 +634,20 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
+			}
+		},
+		"node_modules/@junobuild/ledger": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@junobuild/ledger/-/ledger-0.0.1.tgz",
+			"integrity": "sha512-tEDR+bkioQB6R4t9TzmuPbanf7m8+1ksSxJp8yRVFjtVKMSvLQj4ds1wm+zRBiv6+iPO4mfq30W88bb3QZ6foA==",
+			"dependencies": {
+				"@dfinity/utils": "^0.0.14",
+				"js-sha256": "^0.9.0"
+			},
+			"peerDependencies": {
+				"@dfinity/agent": "^0.15.6",
+				"@dfinity/identity": "^0.15.6",
+				"@dfinity/principal": "^0.15.6"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -1616,33 +1631,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/crc": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz",
-			"integrity": "sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A==",
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"buffer": ">=6.0.3"
-			},
-			"peerDependenciesMeta": {
-				"buffer": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/crc-32": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-			"bin": {
-				"crc32": "bin/crc32.njs"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -2373,11 +2361,6 @@
 			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
 			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
 			"dev": true
-		},
-		"node_modules/google-protobuf": {
-			"version": "3.21.2",
-			"resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-			"integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
@@ -3239,6 +3222,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -4573,9 +4557,9 @@
 			}
 		},
 		"@dfinity/agent": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.3.tgz",
-			"integrity": "sha512-yjJnAWI2CQY9kAFgavXU4TiKjb3NwaKUpu2LwCfgtJM4k6ofKlW+7q0tBJNs5WvHqRcKRDdn4d6yXKQi+ubS+w==",
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.6.tgz",
+			"integrity": "sha512-Ch+tXAszPap0zwRgr/oFEgJLDld4RDwBdFDqR1JUg38xhHWTFMrTkjMT6uQFvqf6d2wDXnh3zwhqbg5P7OCv7A==",
 			"requires": {
 				"base64-arraybuffer": "^0.2.0",
 				"bignumber.js": "^9.0.0",
@@ -4594,18 +4578,18 @@
 			}
 		},
 		"@dfinity/candid": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.3.tgz",
-			"integrity": "sha512-jbfA+kr+gCrBuwxWm/j4Vpqzbnh9bsyUWu9CjopJis8xdxH3FIfNDWOzHZ/QaW7Co+6UoON1wzxMiy91/W5DQA==",
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.6.tgz",
+			"integrity": "sha512-Q9PGvhTE/1dTLfSo0pu0+ifzA7NA4X1rgSy9TE6O1Glk6Kl8Nf+Pg2sCHS2hWt0RAiKfR2glEVlbUAm6S8vRxA==",
 			"peer": true,
 			"requires": {
 				"ts-node": "^10.8.2"
 			}
 		},
 		"@dfinity/identity": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.15.3.tgz",
-			"integrity": "sha512-D5Sf01MvO3CO63nAYSdG2V8Ox4AEVAm+/O7oKU1oyg8m3z/9zklG6IyCOOKb6hQibWh81j+mduYuX4vYuEjSGw==",
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.15.6.tgz",
+			"integrity": "sha512-hzTyKXAWPHxkZkOWxGj4JUITwdv92VEKnh3l334Yk9h6aw3m7Gi/ujEBLfszsl0LUA82tV4W2MDIz99KMAuW+g==",
 			"requires": {
 				"borc": "^2.1.1",
 				"js-sha256": "^0.9.0",
@@ -4624,32 +4608,26 @@
 				"secp256k1": "^4.0.3"
 			}
 		},
-		"@dfinity/nns": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.14.0.tgz",
-			"integrity": "sha512-qQ3SzihD9hL2Zo0pAC+Ip2snbEtLDL1Aq2JTnDMLur9DEpiCajzhjXfsOy+U1zeSTOc+RUBbbWeLbS5Edsxeig==",
-			"requires": {
-				"crc": "^4.3.2",
-				"crc-32": "^1.2.2",
-				"google-protobuf": "^3.21.2",
-				"js-sha256": "^0.9.0",
-				"randombytes": "^2.1.0"
-			}
+		"@dfinity/ledger": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.7.tgz",
+			"integrity": "sha512-ZxFK28jI17OTn73I/xHaGRRjgyYUP7Fnxv9BfDKKQ/3B+5hcwU0rJrmCMhIZrdit3z7Ryzsj5NPa75sRKq2W/A==",
+			"requires": {}
 		},
 		"@dfinity/principal": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.3.tgz",
-			"integrity": "sha512-XqHZVaJx/acmg6kFkF7PB156UwAquOS2WiAA753+nGKTG+TOC7OxbBXCr8vfEsd0mEzcmcLl+jLF8iUsC6Hk4w==",
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.6.tgz",
+			"integrity": "sha512-eMsS5YofRk5Hm6LlhzyBvw1RzDxM5FWPtepQuYeZbZyD/ztq4TrUiScqoKBFw/LLODd0znt8rGnNgqtt+7JnQA==",
 			"requires": {
 				"js-sha256": "^0.9.0",
 				"ts-node": "^10.8.2"
 			}
 		},
 		"@dfinity/utils": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.12.tgz",
-			"integrity": "sha512-vAarfmHzt31saDjDyoeY1HnzumHEHwrLFr0UFLzONkFgjAf9o7Z+YNOHmY8EjiF3NbuQ0C09aamJ1xV8POs+KQ==",
-			"peer": true
+			"version": "0.0.14",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.14.tgz",
+			"integrity": "sha512-wSZOQHMmIPTW9LRpj6mMo0QKAYOBTkIRuoU6Mhbo3zH/TjszJTTbK1coIvneXHu9/HkdgzG7x4MWwJaUp8ZMZg==",
+			"requires": {}
 		},
 		"@esbuild-plugins/node-modules-polyfill": {
 			"version": "0.2.2",
@@ -4901,6 +4879,15 @@
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
+			}
+		},
+		"@junobuild/ledger": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@junobuild/ledger/-/ledger-0.0.1.tgz",
+			"integrity": "sha512-tEDR+bkioQB6R4t9TzmuPbanf7m8+1ksSxJp8yRVFjtVKMSvLQj4ds1wm+zRBiv6+iPO4mfq30W88bb3QZ6foA==",
+			"requires": {
+				"@dfinity/utils": "^0.0.14",
+				"js-sha256": "^0.9.0"
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -5572,17 +5559,6 @@
 			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
 			"dev": true
 		},
-		"crc": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz",
-			"integrity": "sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A==",
-			"requires": {}
-		},
-		"crc-32": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
-		},
 		"create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -6141,11 +6117,6 @@
 			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
 			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
 			"dev": true
-		},
-		"google-protobuf": {
-			"version": "3.21.2",
-			"resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-			"integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
 		},
 		"graceful-fs": {
 			"version": "4.2.10",
@@ -6759,6 +6730,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -75,8 +75,9 @@
 		"@dfinity/agent": "^0.15.3",
 		"@dfinity/auth-client": "^0.15.3",
 		"@dfinity/identity": "^0.15.3",
-		"@dfinity/nns": "^0.14.0",
+		"@dfinity/ledger": "^0.0.7",
 		"@dfinity/principal": "^0.15.3",
+		"@junobuild/ledger": "^0.0.1",
 		"buffer": "^6.0.3",
 		"idb-keyval": "^6.2.0",
 		"semver": "^7.3.8"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"@dfinity/identity": "^0.15.3",
 		"@dfinity/ledger": "^0.0.7",
 		"@dfinity/principal": "^0.15.3",
-		"@junobuild/ledger": "^0.0.1",
+		"@junobuild/ledger": "^0.0.2",
 		"buffer": "^6.0.3",
 		"idb-keyval": "^6.2.0",
 		"semver": "^7.3.8"

--- a/scripts/ledger.sh
+++ b/scripts/ledger.sh
@@ -7,7 +7,7 @@ IC_VERSION=f02cc38677905e24a9016637fddc697039930808
 curl -o ledger.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ledger-canister_notify-method.wasm.gz"
 gunzip ledger.wasm.gz
 curl -o ledger.private.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/rosetta-api/ledger.did"
-curl -o ledger.public.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/rosetta-api/ledger_canister/ledger.did"
+curl -o ledger.public.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/rosetta-api/icp_ledger/ledger.did"
 
 dfx identity new minter
 dfx identity use minter

--- a/scripts/ledger.sh
+++ b/scripts/ledger.sh
@@ -3,7 +3,7 @@
 # Install ledger locally as documented in:
 # https://internetcomputer.org/docs/current/developer-docs/integrations/ledger/ledger-local-setup
 
-IC_VERSION=dd3a710b03bd3ae10368a91b255571d012d1ec2f
+IC_VERSION=f02cc38677905e24a9016637fddc697039930808
 curl -o ledger.wasm.gz "https://download.dfinity.systems/ic/$IC_VERSION/canisters/ledger-canister_notify-method.wasm.gz"
 gunzip ledger.wasm.gz
 curl -o ledger.private.did "https://raw.githubusercontent.com/dfinity/ic/$IC_VERSION/rs/rosetta-api/ledger.did"
@@ -18,7 +18,7 @@ dfx identity use default
 # LEDGER_ACC=$(dfx ledger account-id)
 LEDGER_ACC=1fac02b103220f2fe5ad314b98767db6ea7443cafc6a0a34c8adba4198a14d03
 
-dfx deploy ledger --argument '(record {minting_account = "'${MINT_ACC}'"; initial_values = vec { record { "'${LEDGER_ACC}'"; record { e8s=100_000_000_000 } }; }; send_whitelist = vec {}})'
+dfx deploy ledger --argument '(record {minting_account = "'${MINT_ACC}'"; initial_values = vec { record { "'${LEDGER_ACC}'"; record { e8s=100_000_000_000 } }; }; send_whitelist = vec {}})' --mode reinstall
 
 # Rust example to transfer ICP
 # https://github.com/dfinity/examples/tree/master/rust/tokens_transfer

--- a/scripts/ledger.sh
+++ b/scripts/ledger.sh
@@ -18,7 +18,7 @@ dfx identity use default
 # LEDGER_ACC=$(dfx ledger account-id)
 LEDGER_ACC=1fac02b103220f2fe5ad314b98767db6ea7443cafc6a0a34c8adba4198a14d03
 
-dfx deploy ledger --argument '(record {minting_account = "'${MINT_ACC}'"; initial_values = vec { record { "'${LEDGER_ACC}'"; record { e8s=100_000_000_000 } }; }; send_whitelist = vec {}})' --mode reinstall
+dfx deploy ledger --argument '(record {minting_account = "'${MINT_ACC}'"; initial_values = vec { record { "'${LEDGER_ACC}'"; record { e8s=100_000_000_000 } }; }; send_whitelist = vec {}})'
 
 # Rust example to transfer ICP
 # https://github.com/dfinity/examples/tree/master/rust/tokens_transfer

--- a/scripts/ledger.transfer.mjs
+++ b/scripts/ledger.transfer.mjs
@@ -1,20 +1,19 @@
-import { AccountIdentifier, LedgerCanister } from '@dfinity/nns';
+import { IcrcLedgerCanister } from '@dfinity/ledger';
+import { Principal } from '@dfinity/principal';
 import { localAgent } from './actor.mjs';
 import { LEDGER_CANISTER_ID_LOCAL } from './env.mjs';
 
 const transfer = async () => {
 	const agent = await localAgent();
 
-	const ledger = LedgerCanister.create({
+	const ledger = IcrcLedgerCanister.create({
 		agent,
 		canisterId: LEDGER_CANISTER_ID_LOCAL
 	});
 
 	return ledger.transfer({
 		amount: 5_500_010_000n,
-		to: AccountIdentifier.fromHex(
-			'f3a58ea11bc128ab8a455dd7bce0a29b0a20f400625d1a46871fbfe82efed38d'
-		)
+		to: { owner: Principal.fromText('qaa6y-5yaaa-aaaaa-aaafa-cai'), subaccount: [] }
 	});
 };
 

--- a/scripts/ledger.utils.mjs
+++ b/scripts/ledger.utils.mjs
@@ -1,4 +1,4 @@
-import { AccountIdentifier } from '@dfinity/nns';
+import { AccountIdentifier } from '@junobuild/ledger';
 import { initIdentity } from './identity.utils.mjs';
 
 export const accountIdentifier = (mainnet, principal) => {

--- a/src/declarations/ledger/ledger.did
+++ b/src/declarations/ledger/ledger.did
@@ -22,6 +22,13 @@ type SubAccount = blob;
 // Sequence number of a block produced by the ledger.
 type BlockIndex = nat64;
 
+type Transaction = record {
+    memo : Memo;
+    icrc1_memo: opt blob;
+    operation : opt Operation;
+    created_at_time : TimeStamp;
+};
+
 // An arbitrary number associated with a transaction.
 // The caller can set it in a `transfer` call as a correlation identifier.
 type Memo = nat64;
@@ -105,13 +112,23 @@ type Operation = variant {
         amount : Tokens;
         fee : Tokens;
     };
+    Approve : record {
+        from : AccountIdentifier;
+        spender : AccountIdentifier;
+        allowance_e8s : int;
+        fee : Tokens;
+        expires_at : opt TimeStamp;
+    };
+    TransferFrom : record {
+        from : AccountIdentifier;
+        to : AccountIdentifier;
+        spender : AccountIdentifier;
+        amount : Tokens;
+        fee : Tokens;
+    };
 };
 
-type Transaction = record {
-    memo : Memo;
-    operation : opt Operation;
-    created_at_time : TimeStamp;
-};
+ 
 
 type Block = record {
     parent_hash : opt blob;

--- a/src/declarations/ledger/ledger.did.d.ts
+++ b/src/declarations/ledger/ledger.did.d.ts
@@ -27,8 +27,15 @@ export interface GetBlocksArgs {
 export type Memo = bigint;
 export type Operation =
 	| {
-			Burn: { from: AccountIdentifier; amount: Tokens };
+			Approve: {
+				fee: Tokens;
+				from: AccountIdentifier;
+				allowance_e8s: bigint;
+				expires_at: [] | [TimeStamp];
+				spender: AccountIdentifier;
+			};
 	  }
+	| { Burn: { from: AccountIdentifier; amount: Tokens } }
 	| { Mint: { to: AccountIdentifier; amount: Tokens } }
 	| {
 			Transfer: {
@@ -36,6 +43,15 @@ export type Operation =
 				fee: Tokens;
 				from: AccountIdentifier;
 				amount: Tokens;
+			};
+	  }
+	| {
+			TransferFrom: {
+				to: AccountIdentifier;
+				fee: Tokens;
+				from: AccountIdentifier;
+				amount: Tokens;
+				spender: AccountIdentifier;
 			};
 	  };
 export type QueryArchiveError =
@@ -64,6 +80,7 @@ export interface Tokens {
 }
 export interface Transaction {
 	memo: Memo;
+	icrc1_memo: [] | [Uint8Array | number[]];
 	operation: [] | [Operation];
 	created_at_time: TimeStamp;
 }

--- a/src/declarations/ledger/ledger.factory.did.js
+++ b/src/declarations/ledger/ledger.factory.did.js
@@ -11,7 +11,15 @@ export const idlFactory = ({ IDL }) => {
 		length: IDL.Nat64
 	});
 	const Memo = IDL.Nat64;
+	const TimeStamp = IDL.Record({ timestamp_nanos: IDL.Nat64 });
 	const Operation = IDL.Variant({
+		Approve: IDL.Record({
+			fee: Tokens,
+			from: AccountIdentifier,
+			allowance_e8s: IDL.Int,
+			expires_at: IDL.Opt(TimeStamp),
+			spender: AccountIdentifier
+		}),
 		Burn: IDL.Record({ from: AccountIdentifier, amount: Tokens }),
 		Mint: IDL.Record({ to: AccountIdentifier, amount: Tokens }),
 		Transfer: IDL.Record({
@@ -19,11 +27,18 @@ export const idlFactory = ({ IDL }) => {
 			fee: Tokens,
 			from: AccountIdentifier,
 			amount: Tokens
+		}),
+		TransferFrom: IDL.Record({
+			to: AccountIdentifier,
+			fee: Tokens,
+			from: AccountIdentifier,
+			amount: Tokens,
+			spender: AccountIdentifier
 		})
 	});
-	const TimeStamp = IDL.Record({ timestamp_nanos: IDL.Nat64 });
 	const Transaction = IDL.Record({
 		memo: Memo,
+		icrc1_memo: IDL.Opt(IDL.Vec(IDL.Nat8)),
 		operation: IDL.Opt(Operation),
 		created_at_time: TimeStamp
 	});

--- a/src/frontend/src/lib/services/balance.services.ts
+++ b/src/frontend/src/lib/services/balance.services.ts
@@ -3,8 +3,8 @@ import { getAccountIdentifier, getBalance } from '$lib/api/ledger.api';
 import { i18n } from '$lib/stores/i18n.store';
 import { toasts } from '$lib/stores/toasts.store';
 import { isNullish } from '$lib/utils/utils';
-import type { AccountIdentifier } from '@dfinity/nns';
 import type { Principal } from '@dfinity/principal';
+import type { AccountIdentifier } from '@junobuild/ledger';
 import { get } from 'svelte/store';
 
 export interface MissionControlBalance {
@@ -23,7 +23,7 @@ export const getMissionControlBalance = async (
 	try {
 		const accountIdentifier = getAccountIdentifier(missionControlId);
 
-		const queryBalance = async (): Promise<bigint> => (await getBalance(accountIdentifier)).toE8s();
+		const queryBalance = async (): Promise<bigint> => await getBalance(missionControlId);
 
 		const [balance, credits] = await Promise.all([queryBalance(), getCredits()]);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,6 +54,7 @@ const config: UserConfig = {
 	},
 	build: {
 		target: 'es2020',
+		sourcemap: true,
 		rollupOptions: {
 			output: {
 				manualChunks: (id) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,7 +54,6 @@ const config: UserConfig = {
 	},
 	build: {
 		target: 'es2020',
-		sourcemap: true,
 		rollupOptions: {
 			output: {
 				manualChunks: (id) => {


### PR DESCRIPTION
That way, we spare half the size of the `vendor` bundle.

In the meantime, bump the local installation instruction to install a newer version of the ICP ledger that supports Icrc-1.

<img width="1536" alt="Capture d’écran 2023-05-01 à 15 36 34" src="https://user-images.githubusercontent.com/16886711/235469956-76f615d6-efee-4f6b-b66d-f17347a36324.png">
<img width="1536" alt="Capture d’écran 2023-05-01 à 15 45 06" src="https://user-images.githubusercontent.com/16886711/235469971-371bfbaa-f420-482c-ac77-2fc2513efec8.png">
