### PR TITLE
fix: pagination

### DIFF
--- a/src/frontend/src/lib/components/auth/Users.svelte
+++ b/src/frontend/src/lib/components/auth/Users.svelte
@@ -64,7 +64,7 @@
 					<User {user} />
 				{/each}
 
-				{#if !empty && ($paginationStore.pages ?? 0) > 0}
+				{#if !empty && ($paginationStore.pages ?? 0) > 1}
 					<tr><td colspan="4"><DataPaginator /></td></tr>
 				{/if}
 

--- a/src/frontend/src/lib/components/data/DataPaginator.svelte
+++ b/src/frontend/src/lib/components/data/DataPaginator.svelte
@@ -29,7 +29,7 @@
 		>
 		<button
 			on:click={next}
-			class:visible={$store.pages > $store.selectedPage}
+			class:visible={$store.pages > $store.selectedPage + 1}
 			aria-label="Next page of data"
 			class="square"><IconNavigateNext /></button
 		>

--- a/src/frontend/src/lib/stores/pagination.store.ts
+++ b/src/frontend/src/lib/stores/pagination.store.ts
@@ -47,7 +47,7 @@ export const initPaginationContext = <T>(): Omit<PaginationContext<T>, 'list'> =
 				...data,
 				items,
 				pages: nonNullish(matches_length)
-					? Math.ceil(Number(matches_length / PAGINATION))
+					? Math.ceil(Number(matches_length) / Number(PAGINATION))
 					: undefined
 			}));
 		}

--- a/src/satellite/src/list/utils.rs
+++ b/src/satellite/src/list/utils.rs
@@ -11,9 +11,9 @@ pub fn list_values<T: Clone + Compare>(
 ) -> ListResults<T> {
     let matches_length = matches.len();
 
-    let start = start_at(&matches, filters);
-
     let ordered = order_values(matches, filters);
+
+    let start = start_at(&ordered, filters);
 
     let paginated = paginate_values(ordered, filters, &start);
 


### PR DESCRIPTION
Resolves #143

The issue was introduced in the refactoring of the pagination of [v0.0.12](https://github.com/buildwithjuno/juno/releases/tag/v0.0.12). The `start_at` value was not calculated on the ordered list anymore but on the filtered values, therefore when data were listed, if such option was used, the list wasn't accurate.