### PR TITLE
build: fix chunking - svelte loader script must be in body

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -42,7 +42,6 @@
 		<link crossorigin="anonymous" href="/manifest.webmanifest" rel="manifest" />
 		<meta content=#7888ff" name="theme-color" />
 
-		<!-- SCRIPT_LOADER -->
 		<!-- LINKS_PRELOADER -->
 
 		%sveltekit.head%
@@ -63,5 +62,7 @@
 	</head>
 	<body>
 		<div>%sveltekit.body%</div>
+
+		<!-- SCRIPT_LOADER -->
 	</body>
 </html>


### PR DESCRIPTION
Fix runtime error `"Cannot read properties of undefined (reading '$$')"`