### PR TITLE
fix: url with dot

### DIFF
--- a/src/satellite/src/storage/rewrites.rs
+++ b/src/satellite/src/storage/rewrites.rs
@@ -21,11 +21,6 @@ pub fn rewrite_source_to_path(source: &String) -> String {
         .replace('*', "")
 }
 
-pub fn is_html_route(path: &str) -> bool {
-    let re = Regex::new(r"^(?:/|(/[^/.]*(\.(html|htm))?(/[^/.]*)?)*)$").unwrap();
-    re.is_match(path)
-}
-
 pub fn is_root_path(path: &str) -> bool {
     ROOT_PATHS.contains(&path)
 }

--- a/src/satellite/src/storage/rewrites.rs
+++ b/src/satellite/src/storage/rewrites.rs
@@ -1,7 +1,6 @@
 use crate::storage::constants::ROOT_PATHS;
 use crate::storage::types::config::{StorageConfig, StorageConfigRedirect};
 use crate::storage::url::{matching_urls as matching_urls_utils, separator};
-use regex::Regex;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 

--- a/src/satellite/src/storage/routing.rs
+++ b/src/satellite/src/storage/routing.rs
@@ -28,6 +28,16 @@ pub fn get_routing(
 
     let MapUrl { path, token } = map_url(&url)?;
 
+    // We return the asset that matches the effective path
+    let asset: Option<(Asset, Memory)> = get_public_asset(path.clone(), token.clone());
+
+    match asset {
+        None => (),
+        Some(_) => {
+            return Ok(Routing::Default(RoutingDefault { url: path, asset }));
+        }
+    }
+
     // ⚠️ Limitation: requesting an url without extension try to resolve first a corresponding asset
     // e.g. /.well-known/hello -> try to find /.well-known/hello.html
     // Therefore if a file without extension is uploaded to the storage, it is important to not upload an .html file with the same name next to it or a folder/index.html
@@ -39,16 +49,6 @@ pub fn get_routing(
                 url: path.clone(),
                 asset: Some(alternative_asset),
             }));
-        }
-    }
-
-    // We return the asset that matches the effective path
-    let asset: Option<(Asset, Memory)> = get_public_asset(path.clone(), token.clone());
-
-    match asset {
-        None => (),
-        Some(_) => {
-            return Ok(Routing::Default(RoutingDefault { url: path, asset }));
         }
     }
 

--- a/src/satellite/src/storage/routing.rs
+++ b/src/satellite/src/storage/routing.rs
@@ -28,16 +28,6 @@ pub fn get_routing(
 
     let MapUrl { path, token } = map_url(&url)?;
 
-    // We return the asset that matches the effective path
-    let asset: Option<(Asset, Memory)> = get_public_asset(path.clone(), token.clone());
-
-    match asset {
-        None => (),
-        Some(_) => {
-            return Ok(Routing::Default(RoutingDefault { url: path, asset }));
-        }
-    }
-
     // ⚠️ Limitation: requesting an url without extension try to resolve first a corresponding asset
     // e.g. /.well-known/hello -> try to find /.well-known/hello.html
     // Therefore if a file without extension is uploaded to the storage, it is important to not upload an .html file with the same name next to it or a folder/index.html
@@ -49,6 +39,16 @@ pub fn get_routing(
                 url: path.clone(),
                 asset: Some(alternative_asset),
             }));
+        }
+    }
+
+    // We return the asset that matches the effective path
+    let asset: Option<(Asset, Memory)> = get_public_asset(path.clone(), token.clone());
+
+    match asset {
+        None => (),
+        Some(_) => {
+            return Ok(Routing::Default(RoutingDefault { url: path, asset }));
         }
     }
 

--- a/src/satellite/src/storage/routing.rs
+++ b/src/satellite/src/storage/routing.rs
@@ -2,7 +2,7 @@ use crate::rules::types::rules::Memory;
 use crate::storage::constants::{
     RESPONSE_STATUS_CODE_200, RESPONSE_STATUS_CODE_404, ROOT_404_HTML, ROOT_INDEX_HTML, ROOT_PATH,
 };
-use crate::storage::rewrites::{is_html_route, is_root_path, redirect_url, rewrite_url};
+use crate::storage::rewrites::{is_root_path, redirect_url, rewrite_url};
 use crate::storage::state::get_config;
 use crate::storage::store::get_public_asset;
 use crate::storage::types::http_request::{
@@ -157,7 +157,7 @@ fn get_routing_rewrite(path: &FullPath, token: &Option<String>) -> Option<Routin
 }
 
 fn get_routing_root_rewrite(path: &FullPath) -> Option<Routing> {
-    if is_html_route(path) && !is_root_path(path) {
+    if !is_root_path(path) {
         // Search for potential /404.html to rewrite to
         let asset_404: Option<(Asset, Memory)> = get_public_asset(ROOT_404_HTML.to_string(), None);
 

--- a/src/satellite/src/storage/url.rs
+++ b/src/satellite/src/storage/url.rs
@@ -2,7 +2,6 @@ use crate::storage::types::http_request::MapUrl;
 use crate::storage::types::state::FullPath;
 use globset::Glob;
 use std::collections::HashMap;
-use std::path::Path;
 use url::{ParseError, Url};
 
 pub fn map_url(url: &String) -> Result<MapUrl, &'static str> {
@@ -28,17 +27,7 @@ pub fn map_url(url: &String) -> Result<MapUrl, &'static str> {
 }
 
 pub fn map_alternative_paths(path: &String) -> Vec<String> {
-    // The requested path is /something.js or without file extension (/something or /something/)?
-    let extension = Path::new(path).extension();
-
-    // No alternative path if requested url target an exact file with extension
-    match extension {
-        Some(_) => Vec::new(),
-        None => {
-            // Url has no extension - e.g. is not something.js but /about or /about/
-            aliases_of(&path.to_string())
-        }
-    }
+    aliases_of(&path.to_string())
 }
 
 pub fn alternative_paths(full_path: &FullPath) -> Option<Vec<String>> {


### PR DESCRIPTION
This fixes two issues with URL with dots:

1. SSG issue: A file `/hello.world.html` generates aliases `/hello.word` however when access in the browser, the satellite identifies `.world` as an extension and for that reason, no aliases were resolved.

2. SPA issue: Getting `/hello.world` does not fallback on the rewrite to 404|index.html because `.world` was not identified as an HTML extension. To solve the issue we decided to rewrite all URLs - regardless if html, js, png or else - given that it's the last resort and given that web2 servers does the same.
