### PR TITLE
feat: split junobuild_satellite and satellite version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "junobuild-satellite"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "base64 0.13.1",
  "candid",

--- a/src/libs/satellite/Cargo.toml
+++ b/src/libs/satellite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "junobuild-satellite"
-version = "0.0.15"
+version = "0.0.16"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/libs/satellite/src/constants.rs
+++ b/src/libs/satellite/src/constants.rs
@@ -1,0 +1,1 @@
+pub const SATELLITE_VERSION: &str = "0.0.15";

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod assert;
+mod constants;
 mod controllers;
 mod db;
 mod guards;
@@ -14,6 +15,7 @@ mod satellite;
 mod storage;
 mod types;
 
+use crate::constants::SATELLITE_VERSION;
 use crate::guards::{caller_is_admin_controller, caller_is_controller};
 use crate::rules::types::interface::{DelRule, SetRule};
 use crate::rules::types::rules::Rule;
@@ -308,7 +310,7 @@ pub async fn deposit_cycles(args: DepositCyclesArgs) {
 #[doc(hidden)]
 #[query]
 pub fn version() -> String {
-    env!("CARGO_PKG_VERSION").to_string()
+    SATELLITE_VERSION.to_string()
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
No other choice to release patches. The crate has to have its own version number and juno its own semver.