### PR TITLE
Add CI Job to check generate file changes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,12 +32,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Add Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
       - name: Install dependencies
         run: npm ci
+      - name: Add didc dependency
+        run: |
+          release=$(curl --silent "https://api.github.com/repos/dfinity/candid/releases/latest" | grep -e '"tag_name"' | cut -c 16-25)
+          curl -SL https://github.com/dfinity/candid/releases/download/$release/didc-linux64 > /usr/local/bin/didc
+          chmod +x /usr/local/bin/didc
+      - name: Install candid-extractor
+        run: cargo install candid-extractor
       - name: Generating candids
-        run: npm run generate
-      - name: Check if dirty
-        run: if [[ -n $(git status --porcelain) ]]; then exit 1; fi
+        run: ENV=github npm run generate
+      - name: Check if files are touched
+        run: if [[ -n $(git status --porcelain) ]]; then echo "Files diff. Failed. Exiting" >&2 && exit 1; else echo "PASSED"; fi
 
   may-merge:
     needs: ['check', 'lint', 'generate']

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,8 +26,21 @@ jobs:
       - name: Lint
         run: npm run check
 
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm ci
+      - name: Generating candids
+        run: npm run generate
+      - name: Check if dirty
+        run: if [[ -n $(git status --porcelain) ]]; then exit 1; fi
+
   may-merge:
-    needs: ['check', 'lint']
+    needs: ['check', 'lint', 'generate']
     runs-on: ubuntu-latest
     steps:
       - name: Cleared for merging

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,6 +32,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Restore Cargo cache
+        id: cargo-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Add Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -39,15 +50,43 @@ jobs:
           targets: wasm32-unknown-unknown
       - name: Install dependencies
         run: npm ci
-      - name: Add didc dependency
+      - name: Set env
         run: |
           release=$(curl --silent "https://api.github.com/repos/dfinity/candid/releases/latest" | grep -e '"tag_name"' | cut -c 16-25)
-          curl -SL https://github.com/dfinity/candid/releases/download/$release/didc-linux64 > /usr/local/bin/didc
+          echo "DIDC_RELEASE=$(echo $release)" >> $GITHUB_ENV
+      - name: Restore didc cache
+        id: didc-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /usr/local/bin/didc
+          key: ${{ runner.os }}-didc-${{ env.DIDC_RELEASE }}
+      - name: Add didc dependency
+        if: steps.didc-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -SL https://github.com/dfinity/candid/releases/download/$DIDC_RELEASE/didc-linux64 > /usr/local/bin/didc
           chmod +x /usr/local/bin/didc
+      - name: Save didc
+        uses: actions/cache/save@v4
+        if: steps.didc-cache.outputs.cache-hit != 'true'
+        with: 
+          path: /usr/local/bin/didc
+          key: ${{ runner.os }}-didc-${{ env.DIDC_RELEASE }}
       - name: Install candid-extractor
+        if: steps.cargo-cache.outputs.cache-hit != 'true'
         run: cargo install candid-extractor
       - name: Generating candids
         run: ENV=github npm run generate
+      - name: Save Cargo
+        uses: actions/cache/save@v4
+        if: steps.cargo-cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check if files are touched
         run: if [[ -n $(git status --porcelain) ]]; then echo "Files diff. Failed. Exiting" >&2 && exit 1; else echo "PASSED"; fi
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -7,6 +7,7 @@ This document explains how to run locally [Juno](https://juno.build).
 - [Run locally](#run-locally)
 - [Development](#development)
 - [Top-up](#top-up)
+- [Troubleshooting](#troubleshooting)
 
 ## Run locally
 
@@ -75,4 +76,24 @@ Top-up the local console with some cycles:
 
 ```
 npm run console:topup
+```
+
+## Troubleshooting
+
+### didc command not found
+
+Go to [Candid releases](https://github.com/dfinity/candid/releases) page to download your OS version didc.
+
+Example, for macos
+
+```sh
+release=$(curl --silent "https://api.github.com/repos/dfinity/candid/releases/latest" | grep -e '"tag_name"' | cut -c 16-25)
+curl -fsSL https://github.com/dfinity/candid/releases/download/$release/didc-macos > ~/.cargo/bin/didc
+chmod 755 ~/.cargo/bin/didc
+```
+
+### candid-extractor command not found
+
+```sh
+cargo install candid-extractor
 ```

--- a/scripts/did.idl.sh
+++ b/scripts/did.idl.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 function generate_did_idl() {
   local canister=$1
   local canister_root=$2
@@ -20,6 +22,10 @@ done
 
 generate_did_idl "cmc" "candid"
 generate_did_idl "ic" "candid"
-generate_did_idl "index" "."
-generate_did_idl "ledger" "."
-generate_did_idl "internet_identity" "."
+
+if [ "$ENV" != "github" ]
+then 
+  generate_did_idl "index" "."
+  generate_did_idl "ledger" "."
+  generate_did_idl "internet_identity" "."
+fi


### PR DESCRIPTION
Having issues to generate `internet_identity.did` locally, the checks.yml scripts should be fine. PR to test.

probably related: 
```js
export const initIdentity = (mainnet) => {
    const file = `/Users/daviddalbusco/.config/dfx/identity/${
        mainnet ? 'juno' : 'default'
    }/identity.pem`;
```
https://github.com/junobuild/juno/blob/f8e20817885f5954c681d18c846777e0bae953b5/scripts/identity.utils.mjs#L32:L35

ref: #338 