### PR TITLE
feat: assert hooks

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,3 @@
+- ic_cdk::print
+- don't call hook on assert dapps
+- don't call hook on logs

--- a/TODO
+++ b/TODO
@@ -1,3 +1,0 @@
-- ic_cdk::print
-- don't call hook on assert dapps
-- don't call hook on logs

--- a/src/libs/macros/src/lib.rs
+++ b/src/libs/macros/src/lib.rs
@@ -309,3 +309,33 @@ pub fn assert_delete_doc(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn assert_upload_asset(attr: TokenStream, item: TokenStream) -> TokenStream {
     hook_macro(Hook::AssertUploadAsset, attr, item)
 }
+
+/// The `assert_delete_asset` function is a procedural macro attribute for asserting conditions before deleting an asset.
+/// It enables you to define custom validation logic to be executed prior to an asset being deleted.
+///
+/// Example:
+///
+/// ```rust
+/// #[assert_delete_asset]
+/// fn assert_delete_asset(context: AssertDeleteAssetContext) -> Result<(), String> {
+///     // Your assertion logic here
+/// }
+/// ```
+///
+/// When no attributes are provided, the assertion logic is applied to any asset deletion within any collection.
+/// You can scope the assertion to a particular list of collections.
+///
+/// Example:
+/// ```rust
+/// #[assert_delete_asset(collections = ["assets"])]
+/// fn juno_assert_delete_asset(context: AssertDeleteAssetContext) -> Result<(), String> {
+///     // Your assertion logic here, specific to the "assets" collection
+/// }
+/// ```
+///
+/// The attributes accept a list of comma-separated collections. If the attribute array is left empty, the assertion will always be evaluated.
+///
+#[proc_macro_attribute]
+pub fn assert_delete_asset(attr: TokenStream, item: TokenStream) -> TokenStream {
+    hook_macro(Hook::AssertDeleteAsset, attr, item)
+}

--- a/src/libs/macros/src/lib.rs
+++ b/src/libs/macros/src/lib.rs
@@ -219,3 +219,33 @@ pub fn on_delete_asset(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn on_delete_many_assets(attr: TokenStream, item: TokenStream) -> TokenStream {
     hook_macro(Hook::OnDeleteManyAssets, attr, item)
 }
+
+/// The `assert_set_doc` function is a procedural macro attribute for asserting conditions before setting a document.
+/// It enables you to define custom validation logic to be executed prior to a document creation or update.
+///
+/// Example:
+///
+/// ```rust
+/// #[assert_set_doc]
+/// fn assert_set_doc(context: AssertSetDocContext) -> Result<(), String> {
+///     // Your assertion logic here
+/// }
+/// ```
+///
+/// When no attributes are provided, the assertion logic is applied to any document set within any collection.
+/// You can scope the assertion to a particular list of collections.
+///
+/// Example:
+/// ```rust
+/// #[assert_set_doc(collections = ["demo"])]
+/// fn assert_set_doc(context: AssertSetDocContext) -> Result<(), String> {
+///     // Your assertion logic here
+/// }
+/// ```
+///
+/// The attributes accept a list of comma-separated collections. If the attribute array is left empty, the assertion will always be evaluated.
+///
+#[proc_macro_attribute]
+pub fn assert_set_doc(attr: TokenStream, item: TokenStream) -> TokenStream {
+    hook_macro(Hook::AssertSetDoc, attr, item)
+}

--- a/src/libs/macros/src/lib.rs
+++ b/src/libs/macros/src/lib.rs
@@ -249,3 +249,33 @@ pub fn on_delete_many_assets(attr: TokenStream, item: TokenStream) -> TokenStrea
 pub fn assert_set_doc(attr: TokenStream, item: TokenStream) -> TokenStream {
     hook_macro(Hook::AssertSetDoc, attr, item)
 }
+
+/// The `assert_delete_doc` function is a procedural macro attribute for asserting conditions before deleting a document.
+/// It enables you to define custom validation logic to be executed prior to a document deletion.
+///
+/// Example:
+///
+/// ```rust
+/// #[assert_delete_doc]
+/// fn assert_delete_doc(context: AssertDeleteDocContext) -> Result<(), String> {
+///     // Your assertion logic here
+/// }
+/// ```
+///
+/// When no attributes are provided, the assertion logic is applied to any document delete within any collection.
+/// You can scope the assertion to a particular list of collections.
+///
+/// Example:
+/// ```rust
+/// #[assert_delete_doc(collections = ["demo"])]
+/// fn assert_delete_doc(context: AssertDeleteDocContext) -> Result<(), String> {
+///     // Your assertion logic here, specific to the "demo" collection
+/// }
+/// ```
+///
+/// The attributes accept a list of comma-separated collections. If the attribute array is left empty, the assertion will always be evaluated.
+///
+#[proc_macro_attribute]
+pub fn assert_delete_doc(attr: TokenStream, item: TokenStream) -> TokenStream {
+    hook_macro(Hook::AssertDeleteDoc, attr, item)
+}

--- a/src/libs/macros/src/lib.rs
+++ b/src/libs/macros/src/lib.rs
@@ -279,3 +279,33 @@ pub fn assert_set_doc(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn assert_delete_doc(attr: TokenStream, item: TokenStream) -> TokenStream {
     hook_macro(Hook::AssertDeleteDoc, attr, item)
 }
+
+/// The `assert_upload_asset` function is a procedural macro attribute for asserting conditions before committing the upload of an asset.
+/// It enables you to define custom validation logic to be executed prior to an asset being committed.
+///
+/// Example:
+///
+/// ```rust
+/// #[assert_upload_asset]
+/// fn assert_upload_asset(context: AssertUploadAssetContext) -> Result<(), String> {
+///     // Your assertion logic here
+/// }
+/// ```
+///
+/// When no attributes are provided, the assertion logic is applied to any asset upload within any collection.
+/// You can scope the assertion to a particular list of collections.
+///
+/// Example:
+/// ```rust
+/// #[assert_upload_asset(collections = ["assets"])]
+/// fn juno_assert_upload_asset(context: AssertUploadAssetContext) -> Result<(), String> {
+///     // Your assertion logic here, specific to the "assets" collection
+/// }
+/// ```
+///
+/// The attributes accept a list of comma-separated collections. If the attribute array is left empty, the assertion will always be evaluated.
+///
+#[proc_macro_attribute]
+pub fn assert_upload_asset(attr: TokenStream, item: TokenStream) -> TokenStream {
+    hook_macro(Hook::AssertUploadAsset, attr, item)
+}

--- a/src/libs/macros/src/parser.rs
+++ b/src/libs/macros/src/parser.rs
@@ -23,6 +23,7 @@ pub enum Hook {
     OnDeleteAsset,
     OnDeleteManyAssets,
     AssertSetDoc,
+    AssertDeleteDoc,
 }
 
 const CONTEXT_PARAM: &str = "context";
@@ -37,6 +38,7 @@ fn map_hook_name(hook: Hook) -> String {
         Hook::OnDeleteAsset => "juno_on_delete_asset".to_string(),
         Hook::OnDeleteManyAssets => "juno_on_delete_many_assets".to_string(),
         Hook::AssertSetDoc => "juno_assert_set_doc".to_string(),
+        Hook::AssertDeleteDoc => "juno_assert_delete_doc".to_string(),
     }
 }
 
@@ -50,6 +52,7 @@ fn map_hook_collections(hook: Hook) -> String {
         Hook::OnDeleteAsset => "juno_on_delete_asset_collections".to_string(),
         Hook::OnDeleteManyAssets => "juno_on_delete_many_assets_collections".to_string(),
         Hook::AssertSetDoc => "juno_assert_set_doc_collections".to_string(),
+        Hook::AssertDeleteDoc => "juno_assert_delete_doc_collections".to_string(),
     }
 }
 
@@ -63,6 +66,7 @@ fn map_hook_type(hook: &Hook) -> String {
         Hook::OnDeleteAsset => "OnDeleteAssetContext".to_string(),
         Hook::OnDeleteManyAssets => "OnDeleteManyAssetsContext".to_string(),
         Hook::AssertSetDoc => "AssertSetDocContext".to_string(),
+        Hook::AssertDeleteDoc => "AssertDeleteDocContext".to_string(),
     }
 }
 
@@ -94,10 +98,11 @@ fn parse_hook(hook: &Hook, attr: TokenStream, item: TokenStream) -> Result<Token
         quote! { None }
     };
 
-    let hook_body = if matches!(hook, Hook::AssertSetDoc) {
-        parse_assert_hook(&signature, &hook_fn, &hook_param, &hook_param_type)
-    } else {
-        parse_on_hook(&signature, &hook_fn, &hook_param, &hook_param_type)
+    let hook_body = match hook {
+        Hook::AssertSetDoc | Hook::AssertDeleteDoc => {
+            parse_assert_hook(&signature, &hook_fn, &hook_param, &hook_param_type)
+        }
+        _ => parse_on_hook(&signature, &hook_fn, &hook_param, &hook_param_type),
     };
 
     let result = quote! {

--- a/src/libs/macros/src/parser.rs
+++ b/src/libs/macros/src/parser.rs
@@ -24,6 +24,7 @@ pub enum Hook {
     OnDeleteManyAssets,
     AssertSetDoc,
     AssertDeleteDoc,
+    AssertUploadAsset,
 }
 
 const CONTEXT_PARAM: &str = "context";
@@ -39,6 +40,7 @@ fn map_hook_name(hook: Hook) -> String {
         Hook::OnDeleteManyAssets => "juno_on_delete_many_assets".to_string(),
         Hook::AssertSetDoc => "juno_assert_set_doc".to_string(),
         Hook::AssertDeleteDoc => "juno_assert_delete_doc".to_string(),
+        Hook::AssertUploadAsset => "juno_assert_upload_asset".to_string(),
     }
 }
 
@@ -53,6 +55,7 @@ fn map_hook_collections(hook: Hook) -> String {
         Hook::OnDeleteManyAssets => "juno_on_delete_many_assets_collections".to_string(),
         Hook::AssertSetDoc => "juno_assert_set_doc_collections".to_string(),
         Hook::AssertDeleteDoc => "juno_assert_delete_doc_collections".to_string(),
+        Hook::AssertUploadAsset => "juno_assert_upload_asset_collections".to_string(),
     }
 }
 
@@ -67,6 +70,7 @@ fn map_hook_type(hook: &Hook) -> String {
         Hook::OnDeleteManyAssets => "OnDeleteManyAssetsContext".to_string(),
         Hook::AssertSetDoc => "AssertSetDocContext".to_string(),
         Hook::AssertDeleteDoc => "AssertDeleteDocContext".to_string(),
+        Hook::AssertUploadAsset => "AssertUploadAssetContext".to_string(),
     }
 }
 
@@ -99,7 +103,7 @@ fn parse_hook(hook: &Hook, attr: TokenStream, item: TokenStream) -> Result<Token
     };
 
     let hook_body = match hook {
-        Hook::AssertSetDoc | Hook::AssertDeleteDoc => {
+        Hook::AssertSetDoc | Hook::AssertDeleteDoc | Hook::AssertUploadAsset => {
             parse_assert_hook(&signature, &hook_fn, &hook_param, &hook_param_type)
         }
         _ => parse_on_hook(&signature, &hook_fn, &hook_param, &hook_param_type),

--- a/src/libs/macros/src/parser.rs
+++ b/src/libs/macros/src/parser.rs
@@ -25,6 +25,7 @@ pub enum Hook {
     AssertSetDoc,
     AssertDeleteDoc,
     AssertUploadAsset,
+    AssertDeleteAsset,
 }
 
 const CONTEXT_PARAM: &str = "context";
@@ -41,6 +42,7 @@ fn map_hook_name(hook: Hook) -> String {
         Hook::AssertSetDoc => "juno_assert_set_doc".to_string(),
         Hook::AssertDeleteDoc => "juno_assert_delete_doc".to_string(),
         Hook::AssertUploadAsset => "juno_assert_upload_asset".to_string(),
+        Hook::AssertDeleteAsset => "juno_assert_delete_asset".to_string(),
     }
 }
 
@@ -56,6 +58,7 @@ fn map_hook_collections(hook: Hook) -> String {
         Hook::AssertSetDoc => "juno_assert_set_doc_collections".to_string(),
         Hook::AssertDeleteDoc => "juno_assert_delete_doc_collections".to_string(),
         Hook::AssertUploadAsset => "juno_assert_upload_asset_collections".to_string(),
+        Hook::AssertDeleteAsset => "juno_assert_delete_asset_collections".to_string(),
     }
 }
 
@@ -71,6 +74,7 @@ fn map_hook_type(hook: &Hook) -> String {
         Hook::AssertSetDoc => "AssertSetDocContext".to_string(),
         Hook::AssertDeleteDoc => "AssertDeleteDocContext".to_string(),
         Hook::AssertUploadAsset => "AssertUploadAssetContext".to_string(),
+        Hook::AssertDeleteAsset => "AssertDeleteAssetContext".to_string(),
     }
 }
 
@@ -103,7 +107,10 @@ fn parse_hook(hook: &Hook, attr: TokenStream, item: TokenStream) -> Result<Token
     };
 
     let hook_body = match hook {
-        Hook::AssertSetDoc | Hook::AssertDeleteDoc | Hook::AssertUploadAsset => {
+        Hook::AssertSetDoc
+        | Hook::AssertDeleteDoc
+        | Hook::AssertUploadAsset
+        | Hook::AssertDeleteAsset => {
             parse_assert_hook(signature, &hook_fn, &hook_param, &hook_param_type)
         }
         _ => parse_on_hook(signature, &hook_fn, &hook_param, &hook_param_type),

--- a/src/libs/macros/src/parser.rs
+++ b/src/libs/macros/src/parser.rs
@@ -104,9 +104,9 @@ fn parse_hook(hook: &Hook, attr: TokenStream, item: TokenStream) -> Result<Token
 
     let hook_body = match hook {
         Hook::AssertSetDoc | Hook::AssertDeleteDoc | Hook::AssertUploadAsset => {
-            parse_assert_hook(&signature, &hook_fn, &hook_param, &hook_param_type)
+            parse_assert_hook(signature, &hook_fn, &hook_param, &hook_param_type)
         }
-        _ => parse_on_hook(&signature, &hook_fn, &hook_param, &hook_param_type),
+        _ => parse_on_hook(signature, &hook_fn, &hook_param, &hook_param_type),
     };
 
     let result = quote! {

--- a/src/libs/macros/src/parser.rs
+++ b/src/libs/macros/src/parser.rs
@@ -1,10 +1,11 @@
 use crate::error::MacroError;
 use proc_macro::TokenStream;
+use proc_macro2::Ident;
 use quote::quote;
 use serde::Deserialize;
 use serde_tokenstream::from_tokenstream;
 use std::string::ToString;
-use syn::{parse, ItemFn, ReturnType, Type};
+use syn::{parse, ItemFn, ReturnType, Signature, Type};
 
 #[derive(Default, Deserialize)]
 struct HookAttributes {
@@ -21,6 +22,7 @@ pub enum Hook {
     OnUploadAsset,
     OnDeleteAsset,
     OnDeleteManyAssets,
+    AssertSetDoc,
 }
 
 const CONTEXT_PARAM: &str = "context";
@@ -34,6 +36,7 @@ fn map_hook_name(hook: Hook) -> String {
         Hook::OnUploadAsset => "juno_on_upload_asset".to_string(),
         Hook::OnDeleteAsset => "juno_on_delete_asset".to_string(),
         Hook::OnDeleteManyAssets => "juno_on_delete_many_assets".to_string(),
+        Hook::AssertSetDoc => "juno_assert_set_doc".to_string(),
     }
 }
 
@@ -46,10 +49,11 @@ fn map_hook_collections(hook: Hook) -> String {
         Hook::OnUploadAsset => "juno_on_upload_asset_collections".to_string(),
         Hook::OnDeleteAsset => "juno_on_delete_asset_collections".to_string(),
         Hook::OnDeleteManyAssets => "juno_on_delete_many_assets_collections".to_string(),
+        Hook::AssertSetDoc => "juno_assert_set_doc_collections".to_string(),
     }
 }
 
-fn map_hook_type(hook: Hook) -> String {
+fn map_hook_type(hook: &Hook) -> String {
     match hook {
         Hook::OnSetDoc => "OnSetDocContext".to_string(),
         Hook::OnSetManyDocs => "OnSetManyDocsContext".to_string(),
@@ -58,14 +62,15 @@ fn map_hook_type(hook: Hook) -> String {
         Hook::OnUploadAsset => "OnUploadAssetContext".to_string(),
         Hook::OnDeleteAsset => "OnDeleteAssetContext".to_string(),
         Hook::OnDeleteManyAssets => "OnDeleteManyAssetsContext".to_string(),
+        Hook::AssertSetDoc => "AssertSetDocContext".to_string(),
     }
 }
 
 pub fn hook_macro(hook: Hook, attr: TokenStream, item: TokenStream) -> TokenStream {
-    parse_hook(hook, attr, item).map_or_else(|e| e.to_error(), Into::into)
+    parse_hook(&hook, attr, item).map_or_else(|e| e.to_error(), Into::into)
 }
 
-fn parse_hook(hook: Hook, attr: TokenStream, item: TokenStream) -> Result<TokenStream, String> {
+fn parse_hook(hook: &Hook, attr: TokenStream, item: TokenStream) -> Result<TokenStream, String> {
     let converted_attr: proc_macro2::TokenStream = attr.into();
     let attrs = from_tokenstream::<HookAttributes>(&converted_attr)
         .map_err(|_| "Expected valid attributes to register the hooks")?;
@@ -73,18 +78,50 @@ fn parse_hook(hook: Hook, attr: TokenStream, item: TokenStream) -> Result<TokenS
     let ast = parse::<ItemFn>(item).map_err(|_| "Expected a function to register the hooks")?;
 
     let signature = &ast.sig;
-    let func_name = &signature.ident;
-    let is_async = signature.asyncness.is_some();
 
-    let hook_fn =
-        proc_macro2::Ident::new(&map_hook_name(hook.clone()), proc_macro2::Span::call_site());
-    let hook_collections_fn = proc_macro2::Ident::new(
+    let hook_fn = Ident::new(&map_hook_name(hook.clone()), proc_macro2::Span::call_site());
+    let hook_collections_fn = Ident::new(
         &map_hook_collections(hook.clone()),
         proc_macro2::Span::call_site(),
     );
-    let hook_param = proc_macro2::Ident::new(CONTEXT_PARAM, proc_macro2::Span::call_site());
-    let hook_param_type =
-        proc_macro2::Ident::new(&map_hook_type(hook), proc_macro2::Span::call_site());
+    let hook_param = Ident::new(CONTEXT_PARAM, proc_macro2::Span::call_site());
+    let hook_param_type = Ident::new(&map_hook_type(hook), proc_macro2::Span::call_site());
+
+    let collections_tokens = if let Some(collections) = attrs.collections {
+        let tokens = collections.iter().map(|col| quote! { #col.to_string() });
+        quote! { Some(vec![#(#tokens,)*]) }
+    } else {
+        quote! { None }
+    };
+
+    let hook_body = if matches!(hook, Hook::AssertSetDoc) {
+        parse_assert_hook(&signature, &hook_fn, &hook_param, &hook_param_type)
+    } else {
+        parse_on_hook(&signature, &hook_fn, &hook_param, &hook_param_type)
+    };
+
+    let result = quote! {
+        #ast
+
+        #[no_mangle]
+        pub extern "Rust" fn #hook_collections_fn() -> Option<Vec<String>> {
+            #collections_tokens
+        }
+
+        #hook_body
+    };
+
+    Ok(result.into())
+}
+
+fn parse_on_hook(
+    signature: &Signature,
+    hook_fn: &Ident,
+    hook_param: &Ident,
+    hook_param_type: &Ident,
+) -> proc_macro2::TokenStream {
+    let func_name = &signature.ident;
+    let is_async = signature.asyncness.is_some();
 
     let return_length = match &signature.output {
         ReturnType::Default => 0,
@@ -115,21 +152,7 @@ fn parse_hook(hook: Hook, attr: TokenStream, item: TokenStream) -> Result<TokenS
         quote! { #func_name(#hook_param) }
     };
 
-    let collections_tokens = if let Some(collections) = attrs.collections {
-        let tokens = collections.iter().map(|col| quote! { #col.to_string() });
-        quote! { Some(vec![#(#tokens,)*]) }
-    } else {
-        quote! { None }
-    };
-
-    let result = quote! {
-        #ast
-
-        #[no_mangle]
-        pub extern "Rust" fn #hook_collections_fn() -> Option<Vec<String>> {
-            #collections_tokens
-        }
-
+    quote! {
         #[no_mangle]
         pub extern "Rust" fn #hook_fn(#hook_param: #hook_param_type) {
             ic_cdk::spawn(async {
@@ -137,7 +160,23 @@ fn parse_hook(hook: Hook, attr: TokenStream, item: TokenStream) -> Result<TokenS
                 #hook_return
             });
         }
-    };
+    }
+}
 
-    Ok(result.into())
+fn parse_assert_hook(
+    signature: &Signature,
+    hook_fn: &Ident,
+    hook_param: &Ident,
+    hook_param_type: &Ident,
+) -> proc_macro2::TokenStream {
+    let func_name = &signature.ident;
+
+    let function_call = quote! { #func_name(#hook_param) };
+
+    quote! {
+        #[no_mangle]
+        pub extern "Rust" fn #hook_fn(#hook_param: #hook_param_type) -> Result<(), String> {
+            #function_call
+        }
+    }
 }

--- a/src/libs/satellite/Cargo.toml
+++ b/src/libs/satellite/Cargo.toml
@@ -14,7 +14,7 @@ license-file = "LICENSE.md"
 targets = ["wasm32-unknown-unknown"]
 
 [features]
-default = ["on_set_doc", "on_set_many_docs", "on_delete_doc", "on_delete_many_docs", "on_upload_asset", "on_delete_asset", "on_delete_many_assets", "assert_set_doc", "assert_delete_doc", "assert_upload_asset"]
+default = ["on_set_doc", "on_set_many_docs", "on_delete_doc", "on_delete_many_docs", "on_upload_asset", "on_delete_asset", "on_delete_many_assets", "assert_set_doc", "assert_delete_doc", "assert_upload_asset", "assert_delete_asset"]
 on_set_doc = []
 on_set_many_docs = []
 on_delete_doc = []
@@ -25,6 +25,7 @@ on_delete_many_assets = []
 assert_set_doc = []
 assert_delete_doc = []
 assert_upload_asset = []
+assert_delete_asset = []
 
 [dependencies]
 candid.workspace = true

--- a/src/libs/satellite/Cargo.toml
+++ b/src/libs/satellite/Cargo.toml
@@ -14,7 +14,7 @@ license-file = "LICENSE.md"
 targets = ["wasm32-unknown-unknown"]
 
 [features]
-default = ["on_set_doc", "on_set_many_docs", "on_delete_doc", "on_delete_many_docs", "on_upload_asset", "on_delete_asset", "on_delete_many_assets"]
+default = ["on_set_doc", "on_set_many_docs", "on_delete_doc", "on_delete_many_docs", "on_upload_asset", "on_delete_asset", "on_delete_many_assets", "assert_set_doc"]
 on_set_doc = []
 on_set_many_docs = []
 on_delete_doc = []
@@ -22,6 +22,7 @@ on_delete_many_docs = []
 on_upload_asset = []
 on_delete_asset = []
 on_delete_many_assets = []
+assert_set_doc = []
 
 [dependencies]
 candid.workspace = true

--- a/src/libs/satellite/Cargo.toml
+++ b/src/libs/satellite/Cargo.toml
@@ -14,7 +14,7 @@ license-file = "LICENSE.md"
 targets = ["wasm32-unknown-unknown"]
 
 [features]
-default = ["on_set_doc", "on_set_many_docs", "on_delete_doc", "on_delete_many_docs", "on_upload_asset", "on_delete_asset", "on_delete_many_assets", "assert_set_doc", "assert_delete_doc"]
+default = ["on_set_doc", "on_set_many_docs", "on_delete_doc", "on_delete_many_docs", "on_upload_asset", "on_delete_asset", "on_delete_many_assets", "assert_set_doc", "assert_delete_doc", "assert_upload_asset"]
 on_set_doc = []
 on_set_many_docs = []
 on_delete_doc = []
@@ -24,6 +24,7 @@ on_delete_asset = []
 on_delete_many_assets = []
 assert_set_doc = []
 assert_delete_doc = []
+assert_upload_asset = []
 
 [dependencies]
 candid.workspace = true

--- a/src/libs/satellite/Cargo.toml
+++ b/src/libs/satellite/Cargo.toml
@@ -14,7 +14,7 @@ license-file = "LICENSE.md"
 targets = ["wasm32-unknown-unknown"]
 
 [features]
-default = ["on_set_doc", "on_set_many_docs", "on_delete_doc", "on_delete_many_docs", "on_upload_asset", "on_delete_asset", "on_delete_many_assets", "assert_set_doc"]
+default = ["on_set_doc", "on_set_many_docs", "on_delete_doc", "on_delete_many_docs", "on_upload_asset", "on_delete_asset", "on_delete_many_assets", "assert_set_doc", "assert_delete_doc"]
 on_set_doc = []
 on_set_many_docs = []
 on_delete_doc = []
@@ -23,6 +23,7 @@ on_upload_asset = []
 on_delete_asset = []
 on_delete_many_assets = []
 assert_set_doc = []
+assert_delete_doc = []
 
 [dependencies]
 candid.workspace = true

--- a/src/libs/satellite/src/db/types.rs
+++ b/src/libs/satellite/src/db/types.rs
@@ -2,6 +2,7 @@ pub mod state {
     use crate::rules::types::rules::Rules;
     use crate::types::core::{Blob, CollectionKey, Key};
     use crate::types::memory::Memory;
+    use crate::SetDoc;
     use candid::CandidType;
     use ic_stable_structures::StableBTreeMap;
     use junobuild_shared::types::state::UserId;
@@ -56,12 +57,18 @@ pub mod state {
         pub before: Option<Doc>,
         pub after: Doc,
     }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct DocAssert {
+        pub current: Option<Doc>,
+        pub proposed: SetDoc,
+    }
 }
 
 pub mod interface {
     use crate::types::core::Blob;
     use candid::CandidType;
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     /// Parameters for setting a document.
     ///
@@ -73,7 +80,7 @@ pub mod interface {
     /// - `description`: An optional `String` providing additional description for the document. This field is optional.
     ///
     /// `SetDoc` is used to provide parameters for setting or updating a document in the collection's store.
-    #[derive(Default, CandidType, Deserialize, Clone)]
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct SetDoc {
         pub updated_at: Option<u64>,
         pub data: Blob,

--- a/src/libs/satellite/src/db/types.rs
+++ b/src/libs/satellite/src/db/types.rs
@@ -2,7 +2,7 @@ pub mod state {
     use crate::rules::types::rules::Rules;
     use crate::types::core::{Blob, CollectionKey, Key};
     use crate::types::memory::Memory;
-    use crate::SetDoc;
+    use crate::{DelDoc, SetDoc};
     use candid::CandidType;
     use ic_stable_structures::StableBTreeMap;
     use junobuild_shared::types::state::UserId;
@@ -59,9 +59,15 @@ pub mod state {
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
-    pub struct DocAssert {
+    pub struct DocAssertSet {
         pub current: Option<Doc>,
         pub proposed: SetDoc,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct DocAssertDelete {
+        pub current: Option<Doc>,
+        pub proposed: DelDoc,
     }
 }
 
@@ -95,7 +101,7 @@ pub mod interface {
     ///   deletion consistency. This field is optional.
     ///
     /// `DelDoc` is used to provide deletion parameters when removing a document.
-    #[derive(Default, CandidType, Deserialize, Clone)]
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct DelDoc {
         pub updated_at: Option<u64>,
     }

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -57,7 +57,7 @@ use crate::storage::types::state::FullPath;
 pub use crate::types::core::{Blob, CollectionKey, Key};
 pub use crate::types::hooks::{
     HookContext, OnDeleteAssetContext, OnDeleteDocContext, OnDeleteManyAssetsContext,
-    OnDeleteManyDocsContext, OnSetDocContext, OnSetManyDocsContext, OnUploadAssetContext,
+    OnDeleteManyDocsContext, OnSetDocContext, OnSetManyDocsContext, OnUploadAssetContext, AssertSetDocContext, AssertDeleteDocContext, AssertUploadAssetContext, AssertDeleteAssetContext
 };
 
 ///

--- a/src/libs/satellite/src/storage/store.rs
+++ b/src/libs/satellite/src/storage/store.rs
@@ -1,6 +1,6 @@
 use crate::assert::assert_description_length;
 use crate::controllers::store::get_controllers;
-use crate::hooks::invoke_assert_upload_asset;
+use crate::hooks::{invoke_assert_delete_asset, invoke_assert_upload_asset};
 use crate::list::utils::list_values;
 use crate::memory::STATE;
 use crate::msg::{
@@ -368,6 +368,8 @@ fn delete_asset_impl(
             if !assert_permission(&rule.write, asset.key.owner, caller, controllers) {
                 return Err(ERROR_ASSET_NOT_FOUND.to_string());
             }
+
+            invoke_assert_delete_asset(&caller, &asset)?;
 
             let deleted = delete_state_asset(collection, &full_path, rule);
             delete_runtime_certified_asset(&asset);

--- a/src/libs/satellite/src/storage/store.rs
+++ b/src/libs/satellite/src/storage/store.rs
@@ -1,5 +1,6 @@
 use crate::assert::assert_description_length;
 use crate::controllers::store::get_controllers;
+use crate::hooks::invoke_assert_upload_asset;
 use crate::list::utils::list_values;
 use crate::memory::STATE;
 use crate::msg::{
@@ -44,7 +45,9 @@ use crate::storage::types::config::StorageConfig;
 use crate::storage::types::domain::{CustomDomain, CustomDomains, DomainName};
 use crate::storage::types::interface::{AssetNoContent, CommitBatch, InitAssetKey, UploadChunk};
 use crate::storage::types::state::FullPath;
-use crate::storage::types::store::{Asset, AssetEncoding, AssetKey, Batch, Chunk, EncodingType};
+use crate::storage::types::store::{
+    Asset, AssetAssertUpload, AssetEncoding, AssetKey, Batch, Chunk, EncodingType,
+};
 use crate::storage::utils::{filter_collection_values, filter_values, map_asset_no_content};
 use crate::types::core::{Blob, CollectionKey};
 use crate::types::list::{ListParams, ListResults};
@@ -644,7 +647,7 @@ fn secure_commit_chunks(
                 return Err(ERROR_CANNOT_COMMIT_BATCH.to_string());
             }
 
-            commit_chunks(commit_batch, batch, &rule)
+            commit_chunks(caller, commit_batch, batch, &rule, &None)
         }
         Some(current) => {
             secure_commit_chunks_update(caller, controllers, commit_batch, batch, rule, current)
@@ -669,17 +672,15 @@ fn secure_commit_chunks_update(
         return Err(ERROR_CANNOT_COMMIT_BATCH.to_string());
     }
 
-    commit_chunks(commit_batch, batch, &rule)
+    commit_chunks(caller, commit_batch, batch, &rule, &Some(current))
 }
 
 fn commit_chunks(
-    CommitBatch {
-        chunk_ids,
-        batch_id,
-        headers,
-    }: CommitBatch,
+    caller: Principal,
+    commit_batch: CommitBatch,
     batch: &Batch,
     rule: &Rule,
+    current: &Option<Asset>,
 ) -> Result<Asset, String> {
     let now = time();
 
@@ -687,6 +688,21 @@ fn commit_chunks(
         clear_expired_batches();
         return Err("Batch did not complete in time. Chunks cannot be committed.".to_string());
     }
+
+    invoke_assert_upload_asset(
+        &caller,
+        &AssetAssertUpload {
+            current: current.clone(),
+            batch: batch.clone(),
+            commit_batch: commit_batch.clone(),
+        },
+    )?;
+
+    let CommitBatch {
+        chunk_ids,
+        batch_id,
+        headers,
+    } = commit_batch;
 
     // Collect all chunks
     let mut chunks: Vec<Chunk> = vec![];
@@ -734,11 +750,7 @@ fn commit_chunks(
         updated_at: now,
     };
 
-    if let Some(existing_asset) = get_state_asset(
-        &batch.clone().key.collection,
-        &batch.clone().key.full_path,
-        rule,
-    ) {
+    if let Some(existing_asset) = current {
         asset.encodings = existing_asset.encodings.clone();
         asset.created_at = existing_asset.created_at;
     }

--- a/src/libs/satellite/src/storage/types.rs
+++ b/src/libs/satellite/src/storage/types.rs
@@ -57,6 +57,7 @@ pub mod state {
 
 pub mod store {
     use crate::storage::http::types::HeaderField;
+    use crate::storage::types::interface::CommitBatch;
     use crate::storage::types::state::FullPath;
     use crate::types::core::{Blob, CollectionKey};
     use candid::CandidType;
@@ -111,17 +112,25 @@ pub mod store {
         pub updated_at: u64,
     }
 
-    #[derive(CandidType, Deserialize, Clone)]
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct Batch {
         pub key: AssetKey,
         pub expires_at: u64,
         pub encoding_type: Option<EncodingType>,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct AssetAssertUpload {
+        pub current: Option<Asset>,
+        pub batch: Batch,
+        pub commit_batch: CommitBatch,
     }
 }
 
 pub mod interface {
     use candid::{CandidType, Deserialize};
     use ic_certification::Hash;
+    use serde::Serialize;
 
     use crate::storage::http::types::HeaderField;
     use crate::storage::types::state::FullPath;
@@ -155,7 +164,7 @@ pub mod interface {
         pub chunk_id: u128,
     }
 
-    #[derive(CandidType, Deserialize)]
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct CommitBatch {
         pub batch_id: u128,
         pub headers: Vec<HeaderField>,

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -149,7 +149,7 @@ pub mod memory {
 }
 
 pub mod hooks {
-    use crate::db::types::state::{DocAssert, DocContext, DocUpsert};
+    use crate::db::types::state::{DocAssertDelete, DocAssertSet, DocContext, DocUpsert};
     use crate::storage::types::store::Asset;
     use crate::Doc;
     use candid::{CandidType, Deserialize};
@@ -201,5 +201,8 @@ pub mod hooks {
     pub type OnDeleteManyAssetsContext = HookContext<Vec<Option<Asset>>>;
 
     /// A type alias for the context used in the `assert_set_doc` satellite hook.
-    pub type AssertSetDocContext = HookContext<DocContext<DocAssert>>;
+    pub type AssertSetDocContext = HookContext<DocContext<DocAssertSet>>;
+
+    /// A type alias for the context used in the `assert_delete_doc` satellite hook.
+    pub type AssertDeleteDocContext = HookContext<DocContext<DocAssertDelete>>;
 }

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -149,7 +149,7 @@ pub mod memory {
 }
 
 pub mod hooks {
-    use crate::db::types::state::{DocContext, DocUpsert};
+    use crate::db::types::state::{DocAssert, DocContext, DocUpsert};
     use crate::storage::types::store::Asset;
     use crate::Doc;
     use candid::{CandidType, Deserialize};
@@ -199,4 +199,7 @@ pub mod hooks {
 
     /// A type alias for the context used in the `on_delete_many_assets` satellite hook.
     pub type OnDeleteManyAssetsContext = HookContext<Vec<Option<Asset>>>;
+
+    /// A type alias for the context used in the `assert_set_doc` satellite hook.
+    pub type AssertSetDocContext = HookContext<DocContext<DocAssert>>;
 }

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -150,7 +150,7 @@ pub mod memory {
 
 pub mod hooks {
     use crate::db::types::state::{DocAssertDelete, DocAssertSet, DocContext, DocUpsert};
-    use crate::storage::types::store::Asset;
+    use crate::storage::types::store::{Asset, AssetAssertUpload};
     use crate::Doc;
     use candid::{CandidType, Deserialize};
     use junobuild_shared::types::state::UserId;
@@ -205,4 +205,7 @@ pub mod hooks {
 
     /// A type alias for the context used in the `assert_delete_doc` satellite hook.
     pub type AssertDeleteDocContext = HookContext<DocContext<DocAssertDelete>>;
+
+    /// A type alias for the context used in the `assert_upload_asset` satellite hook.
+    pub type AssertUploadAssetContext = HookContext<AssetAssertUpload>;
 }

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -208,4 +208,7 @@ pub mod hooks {
 
     /// A type alias for the context used in the `assert_upload_asset` satellite hook.
     pub type AssertUploadAssetContext = HookContext<AssetAssertUpload>;
+
+    /// A type alias for the context used in the `assert_delete_asset` satellite hook.
+    pub type AssertDeleteAssetContext = HookContext<Asset>;
 }


### PR DESCRIPTION
Discussed few times with the community, we would like to add assertions to the hooks capatibilities. That way developers can not "just" hooks after documents and assets have been modified but, also extend the assertion mechanism to checks before data are created or modified with their custom rules.