### PR TITLE
feat: remove print from macro

### DIFF
--- a/src/libs/macros/src/parser.rs
+++ b/src/libs/macros/src/parser.rs
@@ -153,7 +153,6 @@ fn parse_on_hook(
                 Ok(_) => {}
                 Err(e) => {
                     let error = format!("{}", e);
-                    ic_cdk::print(&error);
                     ic_cdk::trap(&error);
                 }
             }


### PR DESCRIPTION
When IC logs get collected, this would start duplicating entries given that it is followed by a trap.