### PR TITLE
feat: heap to stable migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ console.wasm
 mission_control.wasm
 observatory.wasm
 satellite.wasm
-satellite-v0.0.15.wasm.gz
+satellite-v*.wasm.gz
 out/

--- a/src/libs/satellite/src/rules/types.rs
+++ b/src/libs/satellite/src/rules/types.rs
@@ -22,7 +22,9 @@ pub mod rules {
 
     #[derive(CandidType, Serialize, Deserialize, Default, Clone, Debug)]
     pub enum Memory {
-        // Backwards compatibility for historical reason. If we do not keep Heap as default, data of Satellites with users and other collections on Heap will not get migrated.
+        // Backwards compatibility. Version of the Satellite <= v0.0.11 had no memory information and we originally introduced the option with Heap as default.
+        // If we set Stable as default, the state won't resolve the information correctly given that we use memory.clone().unwrap_or_default() to select which type of memory to read in the Datastore.
+        // We can potentially migrate the collections but, keeping it that way is a pragmatic solution given that even if set as optional, a rule must be set when creating a new collection.
         #[default]
         Heap,
         Stable,

--- a/src/libs/satellite/src/rules/types.rs
+++ b/src/libs/satellite/src/rules/types.rs
@@ -22,8 +22,9 @@ pub mod rules {
 
     #[derive(CandidType, Serialize, Deserialize, Default, Clone, Debug)]
     pub enum Memory {
-        Heap,
+        // Backwards compatibility for historical reason. If we do not keep Heap as default, data of Satellites with users and other collections on Heap will not get migrated.
         #[default]
+        Heap,
         Stable,
     }
 

--- a/src/tests/satellite.upgrade.spec.ts
+++ b/src/tests/satellite.upgrade.spec.ts
@@ -203,4 +203,33 @@ describe('satellite upgrade', () => {
 			{ timeout: 600000 }
 		);
 	});
+
+	describe('v0.0.16 -> v0.0.16', async () => {
+		beforeEach(async () => {
+			pic = await PocketIc.create();
+
+			const { actor: c, canisterId: cId } = await pic.setupCanister<SatelliteActor>({
+				idlFactory: idlFactorSatellite,
+				wasm: WASM_PATH,
+				arg: satelliteInitArgs(controller),
+				sender: controller.getPrincipal()
+			});
+
+			actor = c;
+			canisterId = cId;
+			actor.setIdentity(controller);
+		});
+
+		it('should keep users', async () => {
+			await initUsers();
+
+			const users = await initUsers();
+
+			await testUsers(users);
+
+			await upgrade();
+
+			await testUsers(users);
+		});
+	});
 });

--- a/src/tests/utils/satellite-tests.utils.ts
+++ b/src/tests/utils/satellite-tests.utils.ts
@@ -47,15 +47,18 @@ const downloadFromURL = async (url: string | RequestOptions): Promise<Buffer> =>
 	});
 };
 
-export const WASM_PATH_V0_0_15 = resolve(process.cwd(), 'satellite-v0.0.15.wasm.gz');
+export const downloadSatellite = async (version: string) => {
+	const destination = resolve(process.cwd(), `satellite-v${version}.wasm.gz`);
 
-export const downloadSatelliteV0_0_15 = async () => {
-	if (existsSync(WASM_PATH_V0_0_15)) {
-		return;
+	if (existsSync(destination)) {
+		return destination;
 	}
 
 	const buffer = await downloadFromURL(
-		'https://github.com/junobuild/juno/releases/download/v0.0.26/satellite-v0.0.15.wasm.gz'
+		`https://cdn.juno.build/releases/satellite-v${version}.wasm.gz`
 	);
-	writeFileSync(WASM_PATH_V0_0_15, buffer);
+
+	writeFileSync(destination, buffer);
+
+	return destination;
 };


### PR DESCRIPTION
While upgrading cycles.watch I freaking "lost" the users and heap data.

It turned out that the test for the migration from v0.0.15 to v0.0.16 was successfull but, if extended to old version of the satellite, v0.0.11, modifying the default memory from heap to stable had for effect to lead to loose the data because of the deserialization.

Fortunatelly this patch and updating cycles.watch with the patch fixed the issue.

It's because of `match memory.clone().unwrap_or_default() {`

i.e. that was a bug, no data loss.