### PR TITLE
feat: develop Juno locally with Docker and without dfx

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,3 @@
-VITE_IC_CMC_CANISTER_ID=rkp4c-7iaaa-aaaaa-aaaca-cai
 VITE_BN_REGISTRATIONS_URL=https://icp0.io/registrations
 VITE_JUNO_CDN_URL=https://cdn.juno.build
 VITE_DEV_FEATURES=true

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,3 @@
-VITE_IC_CMC_CANISTER_ID=rkp4c-7iaaa-aaaaa-aaaca-cai
-VITE_LEDGER_CANISTER_ID=ryjl3-tyaaa-aaaaa-aaaba-cai
 VITE_BN_REGISTRATIONS_URL=https://icp0.io/registrations
 VITE_JUNO_CDN_URL=https://cdn.juno.build
 VITE_DEV_FEATURES=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   juno-console:
-    image: juno-console
+    image: junobuild/console:latest
     ports:
       - 5987:5987
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  juno-console:
+    image: juno-console
+    ports:
+      - 5987:5987
+    volumes:
+      - juno_console:/juno/.juno
+      - ./target/deploy:/juno/target/deploy/
+
+volumes:
+  juno_console:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
 		"i18n": "node scripts/i18n.mjs && prettier --write ./src/frontend/src/lib/types/i18n.d.ts",
 		"observatory:statuses": "node scripts/observatory.statuses.mjs",
 		"clippy": "cargo clippy --target=wasm32-unknown-unknown",
-		"test": "vitest"
+		"test": "vitest",
+		"cargo:console": "scripts/cargo.sh console",
+		"cargo:observatory": "scripts/cargo.sh observatory",
+		"docker": "docker compose up"
 	},
 	"devDependencies": {
 		"@dfinity/identity-secp256k1": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,12 @@
 		"observatory:statuses": "node scripts/observatory.statuses.mjs",
 		"clippy": "cargo clippy --target=wasm32-unknown-unknown",
 		"test": "vitest",
-		"cargo:console": "scripts/cargo.sh console",
-		"cargo:observatory": "scripts/cargo.sh observatory",
-		"docker": "docker compose up"
+		"build:console": "scripts/cargo.sh console",
+		"build:observatory": "scripts/cargo.sh observatory",
+		"build:satellite": "scripts/cargo.sh satellite",
+		"build:mission-control": "scripts/cargo.sh mission_control",
+		"build:orbiter": "scripts/cargo.sh orbiter",
+		"emulator": "docker compose up"
 	},
 	"devDependencies": {
 		"@dfinity/identity-secp256k1": "^1.3.0",

--- a/scripts/cargo.metadata.mjs
+++ b/scripts/cargo.metadata.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const [moduleName, moduleVersion] = process.argv.slice(2);
+
+const metadataFilePath = join(process.cwd(), 'target', 'deploy', 'metadata.json');
+
+const readMetadataFile = async () => {
+	try {
+		return JSON.parse(await readFile(metadataFilePath, 'utf8'));
+	} catch (_error) {
+		return {};
+	}
+};
+
+const updateMetadata = async () => {
+	const metadata = await readMetadataFile();
+
+	const updateMetadata = {
+		...metadata,
+		[moduleName]: moduleVersion
+	};
+
+	await writeFile(metadataFilePath, JSON.stringify(updateMetadata, null, 2), 'utf8');
+};
+
+await updateMetadata();

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -10,6 +10,10 @@ WASM_MODULE="${MODULE}.wasm"
 
 cargo build --target wasm32-unknown-unknown -p $MODULE  --release --locked
 
+# Metadata for Docker image
+VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "'"$MODULE"'") | .version')
+node ./scripts/cargo.metadata.mjs "$MODULE" "$VERSION"
+
 # TODO: did
 
 # TODO: ic-wasm

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <module_name>"
+  exit 1
+fi
+
+MODULE=$1
+WASM_MODULE="${MODULE}.wasm"
+
+cargo build --target wasm32-unknown-unknown -p $MODULE  --release --locked
+
+# TODO: did
+
+# TODO: ic-wasm
+
+mkdir -p ./target/deploy
+
+gzip -c "./target/wasm32-unknown-unknown/release/${WASM_MODULE}" > "./target/deploy/${WASM_MODULE}.tmp.gz"
+
+mv "./target/deploy/${WASM_MODULE}.tmp.gz" "./target/deploy/${WASM_MODULE}.gz"

--- a/src/frontend/src/lib/constants/constants.ts
+++ b/src/frontend/src/lib/constants/constants.ts
@@ -36,9 +36,9 @@ export const PAGINATION = 10n;
 
 export const DEV_FEATURES = import.meta.env.VITE_DEV_FEATURES === 'true';
 
-export const CMC_CANISTER_ID = "rkp4c-7iaaa-aaaaa-aaaca-cai";
-export const CONSOLE_CANISTER_ID = "cokmz-oiaaa-aaaal-aby6q-cai";
-export const OBSERVATORY_CANISTER_ID = "klbfr-lqaaa-aaaak-qbwsa-cai";
+export const CMC_CANISTER_ID = 'rkp4c-7iaaa-aaaaa-aaaca-cai';
+export const CONSOLE_CANISTER_ID = 'cokmz-oiaaa-aaaal-aby6q-cai';
+export const OBSERVATORY_CANISTER_ID = 'klbfr-lqaaa-aaaak-qbwsa-cai';
 
 /**
  * Revoked principals that must not be used.

--- a/src/frontend/src/lib/constants/constants.ts
+++ b/src/frontend/src/lib/constants/constants.ts
@@ -36,6 +36,10 @@ export const PAGINATION = 10n;
 
 export const DEV_FEATURES = import.meta.env.VITE_DEV_FEATURES === 'true';
 
+export const CMC_CANISTER_ID = "rkp4c-7iaaa-aaaaa-aaaca-cai";
+export const CONSOLE_CANISTER_ID = "cokmz-oiaaa-aaaal-aby6q-cai";
+export const OBSERVATORY_CANISTER_ID = "klbfr-lqaaa-aaaak-qbwsa-cai";
+
 /**
  * Revoked principals that must not be used.
  *

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -50,7 +50,7 @@ const initAuthStore = (): AuthStore => {
 				authClient = authClient ?? (await createAuthClient());
 
 				const identityProvider = nonNullish(localIdentityCanisterId)
-					? `http://${localIdentityCanisterId}.localhost:8000`
+					? `http://${localIdentityCanisterId}.localhost:5987`
 					: `https://identity.${domain ?? 'internetcomputer.org'}`;
 
 				await authClient?.login({

--- a/src/frontend/src/lib/utils/actor.ic.utils.ts
+++ b/src/frontend/src/lib/utils/actor.ic.utils.ts
@@ -2,6 +2,7 @@ import type { _SERVICE as CMCActor } from '$declarations/cmc/cmc.did';
 import { idlFactory as idlFactorCMC } from '$declarations/cmc/cmc.factory.did';
 import type { _SERVICE as ICActor } from '$declarations/ic/ic.did';
 import { idlFactory as idlFactorIC } from '$declarations/ic/ic.factory.did';
+import { CMC_CANISTER_ID } from '$lib/constants/constants';
 import { createActor } from '$lib/utils/actor.utils';
 import { getAgent, type GetAgentParams } from '$lib/utils/agent.utils';
 import type { CallConfig } from '@dfinity/agent';
@@ -9,14 +10,11 @@ import { Actor, AnonymousIdentity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 
 export const getCMCActor = async (): Promise<CMCActor> => {
-	// Canister IDs are automatically expanded to .env config - see vite.config.ts
-	const canisterId = import.meta.env.VITE_IC_CMC_CANISTER_ID;
-
 	const agent = await getAgent({ identity: new AnonymousIdentity() });
 
 	return Actor.createActor(idlFactorCMC, {
 		agent,
-		canisterId
+		canisterId: CMC_CANISTER_ID
 	});
 };
 

--- a/src/frontend/src/lib/utils/actor.juno.utils.ts
+++ b/src/frontend/src/lib/utils/actor.juno.utils.ts
@@ -12,17 +12,15 @@ import type { OptionIdentity } from '$lib/types/itentity';
 import { createActor } from '$lib/utils/actor.utils';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
+import {CONSOLE_CANISTER_ID, OBSERVATORY_CANISTER_ID} from "$lib/constants/constants";
 
 export const getConsoleActor = async (identity: OptionIdentity): Promise<ConsoleActor> => {
 	if (isNullish(identity)) {
 		throw new Error('No internet identity.');
 	}
 
-	// Canister IDs are automatically expanded to .env config - see vite.config.ts
-	const canisterId = import.meta.env.VITE_CONSOLE_CANISTER_ID;
-
 	return createActor({
-		canisterId,
+		canisterId: CONSOLE_CANISTER_ID,
 		idlFactory: idlFactorConsole,
 		identity
 	});
@@ -33,11 +31,8 @@ export const getObservatoryActor = async (identity: OptionIdentity): Promise<Obs
 		throw new Error('No internet identity.');
 	}
 
-	// Canister IDs are automatically expanded to .env config - see vite.config.ts
-	const canisterId = import.meta.env.VITE_OBSERVATORY_CANISTER_ID;
-
 	return createActor({
-		canisterId,
+		canisterId: OBSERVATORY_CANISTER_ID,
 		idlFactory: idlFactorObservatory,
 		identity
 	});

--- a/src/frontend/src/lib/utils/actor.juno.utils.ts
+++ b/src/frontend/src/lib/utils/actor.juno.utils.ts
@@ -8,11 +8,11 @@ import type { _SERVICE as OrbiterActor } from '$declarations/orbiter/orbiter.did
 import { idlFactory as idlFactorOrbiter } from '$declarations/orbiter/orbiter.factory.did';
 import type { _SERVICE as SatelliteActor } from '$declarations/satellite/satellite.did';
 import { idlFactory as idlFactorSatellite } from '$declarations/satellite/satellite.factory.did';
+import { CONSOLE_CANISTER_ID, OBSERVATORY_CANISTER_ID } from '$lib/constants/constants';
 import type { OptionIdentity } from '$lib/types/itentity';
 import { createActor } from '$lib/utils/actor.utils';
 import type { Principal } from '@dfinity/principal';
 import { isNullish } from '@dfinity/utils';
-import {CONSOLE_CANISTER_ID, OBSERVATORY_CANISTER_ID} from "$lib/constants/constants";
 
 export const getConsoleActor = async (identity: OptionIdentity): Promise<ConsoleActor> => {
 	if (isNullish(identity)) {

--- a/src/frontend/src/lib/utils/agent.utils.ts
+++ b/src/frontend/src/lib/utils/agent.utils.ts
@@ -20,7 +20,7 @@ const getMainnetAgent = async (params: GetAgentParams) => {
 };
 
 const getLocalAgent = async (params: GetAgentParams) => {
-	const host = 'http://localhost:8000/';
+	const host = 'http://localhost:5987/';
 
 	const agent: HttpAgent = new HttpAgent({ ...params, host });
 

--- a/src/frontend/src/lib/utils/juno.utils.ts
+++ b/src/frontend/src/lib/utils/juno.utils.ts
@@ -1,4 +1,4 @@
 import type { ActorParameters } from '@junobuild/admin';
 
 export const container = (): Partial<Pick<ActorParameters, 'container'>> =>
-	import.meta.env.DEV ? { container: 'http://localhost:8000' } : {};
+	import.meta.env.DEV ? { container: 'http://localhost:5987' } : {};

--- a/src/frontend/src/lib/utils/satellite.utils.ts
+++ b/src/frontend/src/lib/utils/satellite.utils.ts
@@ -8,7 +8,7 @@ import { isNullish, nonNullish, toNullable } from '@dfinity/utils';
 
 export const satelliteUrl = (satelliteId: string): string => {
 	if (nonNullish(localIdentityCanisterId)) {
-		return `http://${satelliteId}.localhost:8000`;
+		return `http://${satelliteId}.localhost:5987`;
 	}
 
 	return `https://${satelliteId}.icp0.io`;


### PR DESCRIPTION
Use [juno-docker](https://github.com/junobuild/juno-docker) to develop Juno.

This will remove the need of dfx to develop locally. Will remains the deployment to mainnet which will be removed later on. One step closer to ditch dfx.