### PR TITLE
feat: list console payments

### DIFF
--- a/scripts/actor.mjs
+++ b/scripts/actor.mjs
@@ -59,7 +59,7 @@ export const localAgent = async () => {
 
 	console.log('Local identity:', identity.getPrincipal().toText());
 
-	const agent = new HttpAgent({ identity, fetch, host: 'http://127.0.0.1:8000/' });
+	const agent = new HttpAgent({ identity, fetch, host: 'http://127.0.0.1:5987/' });
 
 	await agent.fetchRootKey();
 

--- a/scripts/actor.mjs
+++ b/scripts/actor.mjs
@@ -6,22 +6,11 @@ import { idlFactory } from '../src/declarations/console/console.factory.did.mjs'
 import { idlFactory as icIdlFactory } from '../src/declarations/ic/ic.factory.did.mjs';
 import { idlFactory as observatoryIdlFactory } from '../src/declarations/observatory/observatory.factory.did.mjs';
 import { idlFactory as orbiterIdlFactory } from '../src/declarations/orbiter/orbiter.factory.did.mjs';
+import { CONSOLE_ID } from './constants.mjs';
 import { initIdentity } from './identity.utils.mjs';
 
 const { HttpAgent, Actor } = pkgAgent;
 const { Principal } = pkgPrincipal;
-
-const consolePrincipalIC = () => {
-	const buffer = readFileSync('./canister_ids.json');
-	const { console } = JSON.parse(buffer.toString('utf-8'));
-	return Principal.fromText(console.ic);
-};
-
-const consolePrincipalLocal = () => {
-	const buffer = readFileSync('./.dfx/local/canister_ids.json');
-	const { console } = JSON.parse(buffer.toString('utf-8'));
-	return Principal.fromText(console.local);
-};
 
 const observatoryPrincipalIC = () => {
 	const buffer = readFileSync('./canister_ids.json');
@@ -36,13 +25,11 @@ const observatoryPrincipalLocal = () => {
 };
 
 export const consoleActorIC = async () => {
-	const canisterId = consolePrincipalIC();
-
 	const agent = icAgent();
 
 	return Actor.createActor(idlFactory, {
 		agent,
-		canisterId
+		canisterId: CONSOLE_ID
 	});
 };
 
@@ -67,13 +54,11 @@ export const localAgent = async () => {
 };
 
 export const consoleActorLocal = async () => {
-	const canisterId = consolePrincipalLocal();
-
 	const agent = await localAgent(false);
 
 	return Actor.createActor(idlFactory, {
 		agent,
-		canisterId
+		canisterId: CONSOLE_ID
 	});
 };
 

--- a/scripts/console.payments.mjs
+++ b/scripts/console.payments.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import { jsonReplacer } from '@dfinity/utils';
+import { writeFile } from 'fs/promises';
+import { join } from 'node:path';
+import { consoleActorIC, consoleActorLocal } from './actor.mjs';
+
+/**
+ * A temporary script used to backup the payments of the console as we aim to migrate those from heap to stable.
+ * @param mainnet
+ * @returns {Promise<void>}
+ */
+const savePayments = async (mainnet) => {
+	const actor = await (mainnet ? consoleActorIC() : consoleActorLocal());
+
+	const payments = await actor.list_payments();
+
+	await writeFile(
+		join(process.cwd(), 'console.payments.json', JSON.stringify(payments, jsonReplacer, 2))
+	);
+};
+
+const mainnet = process.argv.find((arg) => arg.indexOf(`--mainnet`) > -1) !== undefined;
+
+await savePayments(mainnet);

--- a/scripts/console.payments.mjs
+++ b/scripts/console.payments.mjs
@@ -11,13 +11,16 @@ import { consoleActorIC, consoleActorLocal } from './actor.mjs';
  * @returns {Promise<void>}
  */
 const savePayments = async (mainnet) => {
-	const actor = await (mainnet ? consoleActorIC() : consoleActorLocal());
+	const { list_payments } = await (mainnet ? consoleActorIC() : consoleActorLocal());
 
-	const payments = await actor.list_payments();
+	const payments = await list_payments();
 
 	await writeFile(
-		join(process.cwd(), 'console.payments.json', JSON.stringify(payments, jsonReplacer, 2))
+		join(process.cwd(), 'console.payments.json'),
+		JSON.stringify(payments, jsonReplacer, 2)
 	);
+
+	console.log(`💰 ${payments.length} payments saved locally successfully.`);
 };
 
 const mainnet = process.argv.find((arg) => arg.indexOf(`--mainnet`) > -1) !== undefined;

--- a/scripts/constants.mjs
+++ b/scripts/constants.mjs
@@ -1,0 +1,3 @@
+import { Principal } from '@dfinity/principal';
+
+export const CONSOLE_ID = Principal.fromText('cokmz-oiaaa-aaaal-aby6q-cai');

--- a/src/console/console.did
+++ b/src/console/console.did
@@ -14,6 +14,15 @@ type MissionControl = record {
   owner : principal;
   created_at : nat64;
 };
+type Payment = record {
+  status : PaymentStatus;
+  updated_at : nat64;
+  block_index_payment : nat64;
+  mission_control_id : opt principal;
+  created_at : nat64;
+  block_index_refunded : opt nat64;
+};
+type PaymentStatus = variant { Refunded; Acknowledged; Completed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type ReleasesVersion = record {
   satellite : opt text;
@@ -44,6 +53,7 @@ service : () -> {
   get_releases_version : () -> (ReleasesVersion) query;
   get_user_mission_control_center : () -> (opt MissionControl) query;
   init_user_mission_control_center : () -> (MissionControl);
+  list_payments : () -> (vec record { nat64; Payment }) query;
   list_user_mission_control_centers : () -> (
       vec record { principal; MissionControl },
     ) query;

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -41,6 +41,8 @@ use junobuild_shared::types::interface::{
 use junobuild_shared::types::state::UserId;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use store::list_payments as list_user_payments;
+use types::state::Payments;
 
 thread_local! {
     static STATE: RefCell<State> = RefCell::default();
@@ -156,6 +158,13 @@ async fn init_user_mission_control_center() -> MissionControl {
     init_user_mission_control(&console, &caller)
         .await
         .unwrap_or_else(|e| trap(&e))
+}
+
+/// Transactions
+
+#[query(guard = "caller_is_admin_controller")]
+fn list_payments() -> Payments {
+    list_user_payments()
 }
 
 /// Satellites

--- a/src/console/src/store.rs
+++ b/src/console/src/store.rs
@@ -2,7 +2,7 @@ use crate::constants::E8S_PER_ICP;
 use crate::types::ledger::{Payment, PaymentStatus};
 use crate::types::state::{
     Fee, Fees, HeapState, InvitationCode, InvitationCodeRedeem, InvitationCodes, MissionControl,
-    MissionControls, Rate, RateConfig, Wasm,
+    MissionControls, Payments, Rate, RateConfig, Wasm,
 };
 use crate::STATE;
 use ic_cdk::api::time;
@@ -332,6 +332,14 @@ fn update_payment_refunded_impl(
             Ok(updated_payment)
         }
     }
+}
+
+pub fn list_payments() -> Payments {
+    STATE.with(|state| list_payments_impl(&state.borrow().heap))
+}
+
+fn list_payments_impl(state: &HeapState) -> Payments {
+    state.payments.clone()
 }
 
 /// Wasm

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -28,6 +28,15 @@ export interface MissionControl {
 	owner: Principal;
 	created_at: bigint;
 }
+export interface Payment {
+	status: PaymentStatus;
+	updated_at: bigint;
+	block_index_payment: bigint;
+	mission_control_id: [] | [Principal];
+	created_at: bigint;
+	block_index_refunded: [] | [bigint];
+}
+export type PaymentStatus = { Refunded: null } | { Acknowledged: null } | { Completed: null };
 export interface RateConfig {
 	max_tokens: bigint;
 	time_per_token_ns: bigint;
@@ -63,6 +72,7 @@ export interface _SERVICE {
 	get_releases_version: ActorMethod<[], ReleasesVersion>;
 	get_user_mission_control_center: ActorMethod<[], [] | [MissionControl]>;
 	init_user_mission_control_center: ActorMethod<[], MissionControl>;
+	list_payments: ActorMethod<[], Array<[bigint, Payment]>>;
 	list_user_mission_control_centers: ActorMethod<[], Array<[Principal, MissionControl]>>;
 	load_release: ActorMethod<[Segment, Uint8Array | number[], string], LoadRelease>;
 	reset_release: ActorMethod<[Segment], undefined>;

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -25,6 +25,19 @@ export const idlFactory = ({ IDL }) => {
 		owner: IDL.Principal,
 		created_at: IDL.Nat64
 	});
+	const PaymentStatus = IDL.Variant({
+		Refunded: IDL.Null,
+		Acknowledged: IDL.Null,
+		Completed: IDL.Null
+	});
+	const Payment = IDL.Record({
+		status: PaymentStatus,
+		updated_at: IDL.Nat64,
+		block_index_payment: IDL.Nat64,
+		mission_control_id: IDL.Opt(IDL.Principal),
+		created_at: IDL.Nat64,
+		block_index_refunded: IDL.Opt(IDL.Nat64)
+	});
 	const Segment = IDL.Variant({
 		Orbiter: IDL.Null,
 		MissionControl: IDL.Null,
@@ -61,6 +74,7 @@ export const idlFactory = ({ IDL }) => {
 		get_releases_version: IDL.Func([], [ReleasesVersion], ['query']),
 		get_user_mission_control_center: IDL.Func([], [IDL.Opt(MissionControl)], ['query']),
 		init_user_mission_control_center: IDL.Func([], [MissionControl], []),
+		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], ['query']),
 		list_user_mission_control_centers: IDL.Func(
 			[],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, MissionControl))],

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -25,6 +25,19 @@ export const idlFactory = ({ IDL }) => {
 		owner: IDL.Principal,
 		created_at: IDL.Nat64
 	});
+	const PaymentStatus = IDL.Variant({
+		Refunded: IDL.Null,
+		Acknowledged: IDL.Null,
+		Completed: IDL.Null
+	});
+	const Payment = IDL.Record({
+		status: PaymentStatus,
+		updated_at: IDL.Nat64,
+		block_index_payment: IDL.Nat64,
+		mission_control_id: IDL.Opt(IDL.Principal),
+		created_at: IDL.Nat64,
+		block_index_refunded: IDL.Opt(IDL.Nat64)
+	});
 	const Segment = IDL.Variant({
 		Orbiter: IDL.Null,
 		MissionControl: IDL.Null,
@@ -61,6 +74,7 @@ export const idlFactory = ({ IDL }) => {
 		get_releases_version: IDL.Func([], [ReleasesVersion], ['query']),
 		get_user_mission_control_center: IDL.Func([], [IDL.Opt(MissionControl)], ['query']),
 		init_user_mission_control_center: IDL.Func([], [MissionControl], []),
+		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], ['query']),
 		list_user_mission_control_centers: IDL.Func(
 			[],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, MissionControl))],


### PR DESCRIPTION
We are going to migrate payments and mission controls from heap to stable memory. Therefore, given that it is still not possible on the IC to make backup before upgrading, this PR exposes an admin endpoint that returns all the payments (public data) which I'll be able to save into a JSON file.