### PR TITLE
feat: save mission controls locally in JSON file

### DIFF
--- a/scripts/console.mission-controls.mjs
+++ b/scripts/console.mission-controls.mjs
@@ -10,8 +10,10 @@ import { consoleActorIC, consoleActorLocal } from './actor.mjs';
  * @param mainnet
  * @returns {Promise<void>}
  */
-const savePayments = async (mainnet) => {
-	const { list_user_mission_control_centers } = await (mainnet ? consoleActorIC() : consoleActorLocal());
+const saveMissionControls = async (mainnet) => {
+	const { list_user_mission_control_centers } = await (mainnet
+		? consoleActorIC()
+		: consoleActorLocal());
 
 	const users = await list_user_mission_control_centers();
 
@@ -25,4 +27,4 @@ const savePayments = async (mainnet) => {
 
 const mainnet = process.argv.find((arg) => arg.indexOf(`--mainnet`) > -1) !== undefined;
 
-await savePayments(mainnet);
+await saveMissionControls(mainnet);

--- a/scripts/console.mission-controls.mjs
+++ b/scripts/console.mission-controls.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { jsonReplacer } from '@dfinity/utils';
+import { writeFile } from 'fs/promises';
+import { join } from 'node:path';
+import { consoleActorIC, consoleActorLocal } from './actor.mjs';
+
+/**
+ * A temporary script used to backup the mission controls of the console as we aim to migrate those from heap to stable.
+ * @param mainnet
+ * @returns {Promise<void>}
+ */
+const savePayments = async (mainnet) => {
+	const { list_user_mission_control_centers } = await (mainnet ? consoleActorIC() : consoleActorLocal());
+
+	const users = await list_user_mission_control_centers();
+
+	await writeFile(
+		join(process.cwd(), 'console.mission-controls.json'),
+		JSON.stringify(users, jsonReplacer, 2)
+	);
+
+	console.log(`👩‍🚀🧑‍🚀 ${users.length} mission controls saved locally successfully.`);
+};
+
+const mainnet = process.argv.find((arg) => arg.indexOf(`--mainnet`) > -1) !== undefined;
+
+await savePayments(mainnet);


### PR DESCRIPTION
We are going to migrate mission controls (the keyed list of user IDs <> mission control IDs)from heap to stable memory. Therefore, given that it is still not possible on the IC to make backup before upgrading, this PR exposes an admin endpoint that returns all the mission controls (public keys and data) which I'll be able to save into a JSON file.