### PR TITLE
feat: set 1.1 GB as wasm_memory_limit for new canisters

### DIFF
--- a/src/libs/shared/src/constants.rs
+++ b/src/libs/shared/src/constants.rs
@@ -1,3 +1,4 @@
+use candid::Nat;
 use crate::types::state::Version;
 use ic_ledger_types::{Memo, Tokens};
 
@@ -42,3 +43,8 @@ pub const REVOKED_CONTROLLERS: [&str; 1] =
 
 // The default version number when a new entity is persisted for the first time.
 pub const INITIAL_VERSION: Version = 1;
+
+// The upper limit on the WASM heap memory consumption of the canister per default on the IC is now 3_221_225_472 (3 GiB).
+// According to our experience, we start noticing issue when we upgrade canister at 1 GB. That's why the Juno CLI and Console already warn when this limited is reached.
+// To enforce this limit, we set per default 1_073_741_824 (1 GiB) + 10%.
+pub const WASM_MEMORY_LIMIT: u32 = 1_181_116_006;

--- a/src/libs/shared/src/ic.rs
+++ b/src/libs/shared/src/ic.rs
@@ -1,10 +1,10 @@
-use crate::constants::CREATE_CANISTER_CYCLES;
+use crate::constants::{CREATE_CANISTER_CYCLES, WASM_MEMORY_LIMIT};
 use crate::types::ic::WasmArg;
 use crate::types::interface::DepositCyclesArgs;
 use crate::types::state::{
     SegmentCanisterSettings, SegmentCanisterStatus, SegmentStatus, SegmentStatusResult,
 };
-use candid::Principal;
+use candid::{Nat, Principal};
 use ic_cdk::api::call::CallResult;
 use ic_cdk::api::management_canister::main::{
     canister_status as ic_canister_status, create_canister, delete_canister,
@@ -37,7 +37,7 @@ pub async fn create_canister_install_code(
                 memory_allocation: None,
                 freezing_threshold: None,
                 reserved_cycles_limit: None,
-                wasm_memory_limit: None,
+                wasm_memory_limit: Some(Nat::from(WASM_MEMORY_LIMIT)),
             }),
         },
         CREATE_CANISTER_CYCLES + cycles,
@@ -95,6 +95,8 @@ pub async fn update_canister_controllers(
     canister_id: Principal,
     controllers: Vec<Principal>,
 ) -> CallResult<()> {
+    // Not including a setting in the settings record means not changing that field.
+    // In other words, setting wasm_memory_limit to None here means keeping the actual value of wasm_memory_limit.
     let arg = UpdateSettingsArgument {
         canister_id,
         settings: CanisterSettings {


### PR DESCRIPTION
Resolves  #542