### PR TITLE
style: resolve sass deprecation

### DIFF
--- a/src/frontend/src/lib/components/canister/Canister.svelte
+++ b/src/frontend/src/lib/components/canister/Canister.svelte
@@ -102,6 +102,9 @@
 
 <style lang="scss">
 	p {
+		max-width: 300px;
+		color: var(--value-color);
+
 		&:not(:last-of-type) {
 			margin: 0 0 var(--padding-0_25x);
 		}
@@ -110,9 +113,6 @@
 		span::first-letter {
 			text-transform: uppercase;
 		}
-
-		max-width: 300px;
-		color: var(--value-color);
 	}
 
 	.cycles {

--- a/src/frontend/src/lib/components/launchpad/LaunchpadButton.svelte
+++ b/src/frontend/src/lib/components/launchpad/LaunchpadButton.svelte
@@ -45,11 +45,11 @@
 
 	.content,
 	.summary {
+		width: 100%;
+
 		:global(*::first-letter) {
 			text-transform: uppercase;
 		}
-
-		width: 100%;
 	}
 
 	.only {

--- a/src/frontend/src/lib/components/launchpad/LaunchpadLink.svelte
+++ b/src/frontend/src/lib/components/launchpad/LaunchpadLink.svelte
@@ -42,23 +42,23 @@
 
 	.content,
 	.summary {
+		width: 100%;
+
 		:global(*::first-letter) {
 			text-transform: uppercase;
 		}
-
-		width: 100%;
 	}
 
 	.row {
 		grid-column: 1 / 13;
+
+		height: auto;
 
 		@include media.min-width(medium) {
 			display: grid;
 			grid-template-columns: 30% auto;
 			grid-gap: var(--padding);
 		}
-
-		height: auto;
 
 		.content,
 		.summary {

--- a/src/frontend/src/lib/components/ui/Modal.svelte
+++ b/src/frontend/src/lib/components/ui/Modal.svelte
@@ -75,9 +75,8 @@
 
 	.modal {
 		position: fixed;
-		@include display.inset;
-
 		z-index: calc(var(--z-index) + 998);
+		@include display.inset;
 	}
 
 	.backdrop {
@@ -95,16 +94,18 @@
 		left: 50%;
 		transform: translate(-50%, -50%);
 
-		@include section.large;
+		overflow: hidden;
 		height: calc(min(100vh, 796px) - 2.75rem);
 
-		@supports (-webkit-touch-callout: none) {
-			max-height: -webkit-fill-available;
-		}
+		@include section.large;
 
 		@include shadow.strong-card;
 
-		overflow: hidden;
+		@supports (-webkit-touch-callout: none) {
+			& {
+				max-height: -webkit-fill-available;
+			}
+		}
 	}
 
 	.flex {

--- a/src/frontend/src/lib/components/ui/Toast.svelte
+++ b/src/frontend/src/lib/components/ui/Toast.svelte
@@ -86,11 +86,6 @@
 		left: 50%;
 		transform: translate(-50%, 0);
 
-		@include shadow.shadow;
-
-		background: var(--color-card);
-		color: var(--color-card-contrast);
-
 		width: calc(100% - (8 * var(--padding)));
 
 		padding: var(--padding) calc(var(--padding) * 2);
@@ -98,12 +93,14 @@
 
 		z-index: calc(var(--z-index) + 999);
 
+		background: var(--color-primary);
+		color: var(--color-primary-contrast);
+
+		@include shadow.shadow;
+
 		@media (min-width: 768px) {
 			max-width: var(--section-max-width);
 		}
-
-		background: var(--color-primary);
-		color: var(--color-primary-contrast);
 
 		&.error {
 			background: var(--color-error);

--- a/src/frontend/src/lib/styles/mixins/_overlay.scss
+++ b/src/frontend/src/lib/styles/mixins/_overlay.scss
@@ -17,9 +17,10 @@
 
 @mixin popover($backdrop: light) {
 	position: fixed;
-	@include display.inset;
 
 	z-index: calc(var(--z-index) + 997);
+
+	@include display.inset;
 
 	.backdrop {
 		position: absolute;
@@ -38,18 +39,10 @@
 
 		cursor: initial;
 
-		&.center {
-			top: 50%;
-			left: 50%;
-			transform: translate(-50%, -50%);
-		}
-
 		--size: min(var(--popover-min-size, 240px), calc(100vw - 0.45rem));
 
 		min-width: var(--size);
 		max-width: var(--size);
-
-		@include shadow.strong-card;
 
 		width: fit-content;
 		height: auto;
@@ -59,6 +52,14 @@
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
+
+		@include shadow.strong-card;
+
+		&.center {
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+		}
 	}
 
 	.close {

--- a/src/frontend/src/lib/styles/mixins/_shadow.scss
+++ b/src/frontend/src/lib/styles/mixins/_shadow.scss
@@ -1,8 +1,8 @@
 @mixin card {
-	@include shadow;
-
 	background: var(--color-card);
 	color: var(--color-card-contrast);
+
+	@include shadow;
 }
 
 @mixin base-card {
@@ -13,9 +13,9 @@
 }
 
 @mixin strong-card {
-	@include base-card;
-
 	border: 1px solid var(--color-card-contrast);
+
+	@include base-card;
 }
 
 @mixin shadow {
@@ -24,14 +24,14 @@
 }
 
 @mixin card-action {
-	@include card;
-
 	box-shadow: 2px 2px var(--color-card-contrast);
+
+	@include card;
 }
 
 @mixin strong-card-action {
-	@include base-card;
-
 	border: 2px solid var(--color-card-contrast);
 	box-shadow: 1px 1px var(--color-card-contrast);
+
+	@include base-card;
 }


### PR DESCRIPTION
e.g.

```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
53  │ ┌         &::before {
54  │ │             content: '\003E';
55  │ │             padding: 0 var(--padding) 0 0;
56  │ │         }
    │ └─── nested rule
... │
58  │           display: block;
    │           ^^^^^^^^^^^^^^ declaration
    ╵
    src/frontend/src/lib/components/collections/CollectionsNav.svelte 58:3  root stylesheet
```