### PR TITLE
feat: rename "Settings" page into "Preferences"

### DIFF
--- a/src/frontend/src/lib/components/core/User.svelte
+++ b/src/frontend/src/lib/components/core/User.svelte
@@ -62,9 +62,9 @@
 			<span>{$i18n.observatory.title}</span>
 		</a>
 
-		<a href="/settings" class="menu" role="menuitem" aria-haspopup="menu" on:click={close}>
+		<a href="/preferences" class="menu" role="menuitem" aria-haspopup="menu" on:click={close}>
 			<IconRaygun />
-			<span>{$i18n.settings.title}</span>
+			<span>{$i18n.preferences.title}</span>
 		</a>
 
 		<button type="button" role="menuitem" aria-haspopup="menu" on:click={signOutClose} class="menu">

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -519,8 +519,8 @@
 		"cycles_collected": "T Cycles collected",
 		"error_collecting_data": "There was an error collecting the data."
 	},
-	"settings": {
-		"title": "Settings",
+	"preferences": {
+		"title": "Preferences",
 		"dev_id": "Developer ID",
 		"session_expires_in": "Your session expires in"
 	},

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -519,8 +519,8 @@
 		"cycles_collected": "T Cycles 搜集",
 		"error_collecting_data": "搜集数据出错."
 	},
-	"settings": {
-		"title": "设置",
+	"preferences": {
+		"title": "Preferences",
 		"dev_id": "开发者 ID",
 		"session_expires_in": "会话将过期在"
 	},

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -546,7 +546,7 @@ interface I18nObservatory {
 	error_collecting_data: string;
 }
 
-interface I18nSettings {
+interface I18nPreferences {
 	title: string;
 	dev_id: string;
 	session_expires_in: string;
@@ -593,7 +593,7 @@ interface I18n {
 	filter: I18nFilter;
 	users: I18nUsers;
 	observatory: I18nObservatory;
-	settings: I18nSettings;
+	preferences: I18nPreferences;
 	examples: I18nExamples;
 	resources: I18nResources;
 }

--- a/src/frontend/src/routes/(sub)/preferences/+layout.svelte
+++ b/src/frontend/src/routes/(sub)/preferences/+layout.svelte
@@ -10,7 +10,7 @@
 
 	onMount(() =>
 		layoutTitle.set({
-			title: $i18n.settings.title,
+			title: $i18n.preferences.title,
 			icon: IconRaygun
 		})
 	);

--- a/src/frontend/src/routes/(sub)/preferences/+page.svelte
+++ b/src/frontend/src/routes/(sub)/preferences/+page.svelte
@@ -19,13 +19,13 @@
 <IdentityGuard>
 	<div class="card-container">
 		<Value>
-			<svelte:fragment slot="label">{$i18n.settings.dev_id}</svelte:fragment>
+			<svelte:fragment slot="label">{$i18n.preferences.dev_id}</svelte:fragment>
 			<Identifier identifier={$authStore.identity?.getPrincipal().toText() ?? ''} />
 		</Value>
 
 		<div class="session">
 			<Value>
-				<svelte:fragment slot="label">{$i18n.settings.session_expires_in}</svelte:fragment>
+				<svelte:fragment slot="label">{$i18n.preferences.session_expires_in}</svelte:fragment>
 				<p>
 					{#if nonNullish(remainingTimeMilliseconds)}
 						<output class="mr-1.5" in:fade>


### PR DESCRIPTION
We use "Settings" for the, well, settings of satellite, mission control and orbiter.

So it is useful to distinguish the developer settings related to the session on the Console. Therefore, we can rename the page to "Preferences" even it it leads to a small breaking changes in the routing.