### PR TITLE
fix: build reproducibility

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -158,7 +158,7 @@ function build_canister() {
         ic-wasm "$canister.wasm" -o "$canister.wasm" metadata supported_certificate_versions -d "1,2" -v public
       fi
 
-      gzip "./$canister.wasm"
+      gzip --no-name --force "./$canister.wasm"
     fi
 }
 

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -59,7 +59,7 @@ then
   ic-wasm "${WASM_DIR}/${WASM_MODULE}" -o "${WASM_DIR}/${WASM_MODULE}" metadata supported_certificate_versions -d "1,2" -v public
 fi
 
-gzip -c "${WASM_DIR}/${WASM_MODULE}" > "${DEPLOY_DIR}/${WASM_MODULE}.tmp.gz"
+gzip -c --no-name --force "${WASM_DIR}/${WASM_MODULE}" > "${DEPLOY_DIR}/${WASM_MODULE}.tmp.gz"
 
 mv "${DEPLOY_DIR}/${WASM_MODULE}.tmp.gz" "${DEPLOY_DIR}/${WASM_MODULE}.gz"
 


### PR DESCRIPTION
> By default, gzip stores the original filename and timestamp within the .gz file, but --no-name disables this behavior, which can be useful if you want to ensure that the compressed file does not contain metadata about the original file.