### PR TITLE
feat: set_asset_handler accept Blob instead of String

### DIFF
--- a/src/libs/satellite/src/storage/handlers.rs
+++ b/src/libs/satellite/src/storage/handlers.rs
@@ -3,6 +3,7 @@ use crate::storage::state::{get_asset, get_config, get_rule, insert_asset, inser
 use ic_cdk::id;
 use junobuild_collections::assert_stores::assert_permission;
 use junobuild_collections::types::rules::Rule;
+use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::state::Controllers;
 use junobuild_storage::constants::ASSET_ENCODING_NO_COMPRESSION;
 use junobuild_storage::http::types::HeaderField;
@@ -37,7 +38,7 @@ use junobuild_storage::utils::{create_empty_asset, map_content_encoding};
 /// compression applied.
 pub fn set_asset_handler(
     key: &AssetKey,
-    content: &str,
+    content: &Blob,
     headers: &[HeaderField],
 ) -> Result<(), String> {
     let rule = get_rule(&key.collection)?;
@@ -61,7 +62,7 @@ pub fn set_asset_handler(
 fn set_asset_handler_impl(
     key: &AssetKey,
     existing_asset: &Option<Asset>,
-    content: &str,
+    content: &Blob,
     headers: &[HeaderField],
     rule: &Rule,
 ) -> Result<(), String> {

--- a/src/libs/storage/src/utils.rs
+++ b/src/libs/storage/src/utils.rs
@@ -16,6 +16,7 @@ use junobuild_shared::types::list::ListParams;
 use junobuild_shared::types::state::{Controllers, Timestamp, UserId, Version};
 use regex::Regex;
 use std::collections::HashMap;
+use junobuild_shared::types::core::Blob;
 
 pub fn map_asset_no_content(asset: &Asset) -> (FullPath, AssetNoContent) {
     (asset.key.full_path.clone(), AssetNoContent::from(asset))
@@ -131,10 +132,9 @@ pub fn map_content_type_headers(content_type: &str) -> Vec<HeaderField> {
     )]
 }
 
-pub fn map_content_encoding(content: &str) -> AssetEncoding {
+pub fn map_content_encoding(content: &Blob) -> AssetEncoding {
     let max_chunk_size = 1_900_000; // Max 1.9 MB per chunk
     let chunks = content
-        .as_bytes()
         .chunks(max_chunk_size)
         .map(|chunk| chunk.to_vec())
         .collect();
@@ -150,7 +150,7 @@ pub fn create_asset_with_content(
 ) -> Asset {
     let mut asset: Asset = create_empty_asset(headers, existing_asset, key);
 
-    let encoding = map_content_encoding(content);
+    let encoding = map_content_encoding(&content.as_bytes().to_vec());
 
     asset
         .encodings


### PR DESCRIPTION
This breaking change for Serverless Functions is useful that way the functions can also save data in the Storage that are bytes and not necessarely only a String source.