### PR TITLE
feat: use `addr_of!` instead to create a raw pointer

### DIFF
--- a/src/libs/storage/src/store.rs
+++ b/src/libs/storage/src/store.rs
@@ -30,6 +30,7 @@ use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_not_equal;
 use std::collections::HashMap;
+use std::ptr::addr_of;
 
 ///
 /// Upload batch and chunks
@@ -88,7 +89,7 @@ fn create_batch_impl(
         };
 
         insert_runtime_batch(
-            &NEXT_BATCH_ID,
+            &*addr_of!(NEXT_BATCH_ID),
             Batch {
                 key,
                 reference_id,
@@ -136,7 +137,7 @@ pub fn create_chunk(
                 NEXT_CHUNK_ID += 1;
 
                 insert_runtime_chunk(
-                    &NEXT_CHUNK_ID,
+                    &*addr_of!(NEXT_CHUNK_ID),
                     Chunk {
                         batch_id,
                         content,


### PR DESCRIPTION
❯ npm run build:console

> @junobuild/juno@0.0.34 build:console
> scripts/cargo.sh console

warning: creating a shared reference to mutable static is discouraged
  --> src/libs/storage/src/store.rs:91:13
   |
91 |             &NEXT_BATCH_ID,
   |             ^^^^^^^^^^^^^^ shared reference to mutable static
   |
   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
   = note: this will be a hard error in the 2024 edition
   = note: this shared reference has lifetime `'static`, but if the static ever gets mutated, or a mutable reference is created, then any further use of this shared reference is Undefined Behavior
   = note: `#[warn(static_mut_refs)]` on by default
help: use `addr_of!` instead to create a raw pointer
   |
91 |             addr_of!(NEXT_BATCH_ID),
   |             ~~~~~~~~~~~~~~~~~~~~~~~

warning: creating a shared reference to mutable static is discouraged
   --> src/libs/storage/src/store.rs:139:21
    |
139 |                     &NEXT_CHUNK_ID,
    |                     ^^^^^^^^^^^^^^ shared reference to mutable static
    |
    = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
    = note: this will be a hard error in the 2024 edition
    = note: this shared reference has lifetime `'static`, but if the static ever gets mutated, or a mutable reference is created, then any further use of this shared reference is Undefined Behavior
help: use `addr_of!` instead to create a raw pointer
    |
139 |                     addr_of!(NEXT_CHUNK_ID),
    |                     ~~~~~~~~~~~~~~~~~~~~~~~
