### PR TITLE
build: ic-wasm --keep-name-section

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -141,21 +141,22 @@ function build_canister() {
       ic-wasm \
           "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" \
           -o "./$canister.wasm" \
-          shrink
+          shrink \
+          --keep-name-section
 
       # adds the content of $canister.did to the `icp:public candid:service` custom section of the public metadata in the wasm
-      ic-wasm "$canister.wasm" -o "$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public
+      ic-wasm "$canister.wasm" -o "$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public --keep-name-section
 
       if [ "$canister" == "satellite" ]
       then
         # add the type of build "stock" to the satellite. This way, we can identify whether it's the standard canister ("stock") or a custom build ("extended") of the developer.
-        ic-wasm "$canister.wasm" -o "$canister.wasm" metadata juno:build -d "stock" -v public
+        ic-wasm "$canister.wasm" -o "$canister.wasm" metadata juno:build -d "stock" -v public --keep-name-section
       fi
 
       if [ "$canister" == "satellite" ] || [ "$canister" == "console" ];
       then
         # indicate support for certificate version 1 and 2 in the canister metadata
-        ic-wasm "$canister.wasm" -o "$canister.wasm" metadata supported_certificate_versions -d "1,2" -v public
+        ic-wasm "$canister.wasm" -o "$canister.wasm" metadata supported_certificate_versions -d "1,2" -v public --keep-name-section
       fi
 
       gzip --no-name --force "./$canister.wasm"

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -42,21 +42,22 @@ candid-extractor "${RELEASE_DIR}/${WASM_MODULE}" > "${DID_DIR}/${WASM_MODULE}.di
 ic-wasm \
     "${RELEASE_DIR}/${WASM_MODULE}" \
     -o "${WASM_DIR}/${WASM_MODULE}" \
-    shrink
+    shrink \
+    --keep-name-section
 
 # adds the content of did to the `icp:public candid:service` custom section of the public metadata in the wasm
-ic-wasm "${WASM_DIR}/${WASM_MODULE}" -o "${WASM_DIR}/${WASM_MODULE}" metadata candid:service -f "${DID_DIR}/${WASM_MODULE}.did" -v public
+ic-wasm "${WASM_DIR}/${WASM_MODULE}" -o "${WASM_DIR}/${WASM_MODULE}" metadata candid:service -f "${DID_DIR}/${WASM_MODULE}.did" -v public --keep-name-section
 
 if [ "${WASM_MODULE}" == "satellite" ]
 then
   # add the type of build "stock" to the satellite. This way, we can identify whether it's the standard canister ("stock") or a custom build ("extended") of the developer.
-  ic-wasm "${WASM_DIR}/${WASM_MODULE}" -o "${WASM_DIR}/${WASM_MODULE}" metadata juno:build -d "stock" -v public
+  ic-wasm "${WASM_DIR}/${WASM_MODULE}" -o "${WASM_DIR}/${WASM_MODULE}" metadata juno:build -d "stock" -v public --keep-name-section
 fi
 
 if [ "${MODULE}" == "satellite" ] || [ "${MODULE}" == "console" ];
 then
   # indicate support for certificate version 1 and 2 in the canister metadata
-  ic-wasm "${WASM_DIR}/${WASM_MODULE}" -o "${WASM_DIR}/${WASM_MODULE}" metadata supported_certificate_versions -d "1,2" -v public
+  ic-wasm "${WASM_DIR}/${WASM_MODULE}" -o "${WASM_DIR}/${WASM_MODULE}" metadata supported_certificate_versions -d "1,2" -v public --keep-name-section
 fi
 
 gzip -c --no-name --force "${WASM_DIR}/${WASM_MODULE}" > "${DEPLOY_DIR}/${WASM_MODULE}.tmp.gz"


### PR DESCRIPTION
We need to add `--keep-name-section` to `ic-wasm` if we want to enjoy the upcoming "Canister Backtraces" feature

Source: https://forum.dfinity.org/t/canister-backtraces/35298/9?u=peterparker