### PR TITLE
feat: add ic_cdk::is_controller to admin

### DIFF
--- a/src/libs/shared/src/controllers.rs
+++ b/src/libs/shared/src/controllers.rs
@@ -100,14 +100,13 @@ pub fn is_controller(caller: UserId, controllers: &Controllers) -> bool {
 /// # Returns
 /// `true` if the caller is an admin controller, otherwise `false`.
 pub fn is_admin_controller(caller: UserId, controllers: &Controllers) -> bool {
-    principal_not_anonymous(caller)
+    is_canister_controller(&caller)
+        && principal_not_anonymous(caller)
         && controllers
             .iter()
             .any(|(&controller_id, controller)| match controller.scope {
                 ControllerScope::Write => false,
-                ControllerScope::Admin => {
-                    principal_equal(controller_id, caller) && is_canister_controller(&caller)
-                }
+                ControllerScope::Admin => principal_equal(controller_id, caller),
             })
 }
 

--- a/src/libs/shared/src/controllers.rs
+++ b/src/libs/shared/src/controllers.rs
@@ -4,7 +4,7 @@ use crate::types::interface::SetController;
 use crate::types::state::{Controller, ControllerId, ControllerScope, Controllers, UserId};
 use crate::utils::{principal_anonymous, principal_equal, principal_not_anonymous};
 use candid::Principal;
-use ic_cdk::api::time;
+use ic_cdk::api::{is_controller as is_canister_controller, time};
 use ic_cdk::id;
 use std::collections::HashMap;
 
@@ -105,7 +105,9 @@ pub fn is_admin_controller(caller: UserId, controllers: &Controllers) -> bool {
             .iter()
             .any(|(&controller_id, controller)| match controller.scope {
                 ControllerScope::Write => false,
-                ControllerScope::Admin => principal_equal(controller_id, caller),
+                ControllerScope::Admin => {
+                    principal_equal(controller_id, caller) && is_canister_controller(&caller)
+                }
             })
 }
 

--- a/src/mission_control/src/guards.rs
+++ b/src/mission_control/src/guards.rs
@@ -1,8 +1,10 @@
 use crate::store::get_user;
 use crate::STATE;
-use ic_cdk::caller;
 use ic_cdk::api::is_controller as ic_canister_controller;
-use junobuild_shared::controllers::{caller_is_console, caller_is_observatory, is_admin_controller, is_controller};
+use ic_cdk::caller;
+use junobuild_shared::controllers::{
+    caller_is_console, caller_is_observatory, is_admin_controller, is_controller,
+};
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_equal;
 

--- a/src/tests/constants/orbiter-tests.constants.ts
+++ b/src/tests/constants/orbiter-tests.constants.ts
@@ -1,0 +1,1 @@
+export const ORBITER_CONTROLLER_ERR_MSG = "Caller is not an admin controller of the orbiter."

--- a/src/tests/constants/satellite-tests.constants.ts
+++ b/src/tests/constants/satellite-tests.constants.ts
@@ -1,4 +1,4 @@
-export const ADMIN_ERROR_MSG = 'Caller is not an admin controller of the satellite.';
+export const SATELLITE_ADMIN_ERROR_MSG = 'Caller is not an admin controller of the satellite.';
 export const CONTROLLER_ERROR_MSG = 'Caller is not a controller of the satellite.';
 export const NO_TIMESTAMP_ERROR_MSG = 'error_no_timestamp_provided';
 export const INVALID_TIMESTAMP_ERROR_MSG = 'error_timestamp_outdated_or_future';

--- a/src/tests/mission-control.controllers.spec.ts
+++ b/src/tests/mission-control.controllers.spec.ts
@@ -1,0 +1,94 @@
+import type { _SERVICE as MissionControlActor } from '$declarations/mission_control/mission_control.did';
+import { idlFactory as idlFactorMissionControl } from '$declarations/mission_control/mission_control.factory.did';
+import type { _SERVICE as OrbiterActor } from '$declarations/orbiter/orbiter.did';
+import { idlFactory as idlFactorOrbiter } from '$declarations/orbiter/orbiter.factory.did';
+import type { _SERVICE as SatelliteActor } from '$declarations/satellite/satellite.did';
+import { idlFactory as idlFactorSatellite } from '$declarations/satellite/satellite.factory.did';
+import { IDL } from '@dfinity/candid';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Principal } from '@dfinity/principal';
+import { PocketIc, type Actor } from '@hadronous/pic';
+import { afterAll, beforeAll, describe, expect, inject } from 'vitest';
+import { ORBITER_CONTROLLER_ERR_MSG } from './constants/orbiter-tests.constants';
+import { SATELLITE_ADMIN_ERROR_MSG } from './constants/satellite-tests.constants';
+import {
+	MISSION_CONTROL_WASM_PATH,
+	ORBITER_WASM_PATH,
+	SATELLITE_WASM_PATH,
+	controllersInitArgs
+} from './utils/setup-tests.utils';
+
+describe('Mission Control', () => {
+	let pic: PocketIc;
+	let actor: Actor<MissionControlActor>;
+
+	let orbiterId: Principal;
+	let satelliteId: Principal;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const userInitArgs = (): ArrayBuffer =>
+			IDL.encode(
+				[
+					IDL.Record({
+						user: IDL.Principal
+					})
+				],
+				[{ user: controller.getPrincipal() }]
+			);
+
+		const { actor: c, canisterId: missionControlId } = await pic.setupCanister<MissionControlActor>(
+			{
+				idlFactory: idlFactorMissionControl,
+				wasm: MISSION_CONTROL_WASM_PATH,
+				arg: userInitArgs(),
+				sender: controller.getPrincipal()
+			}
+		);
+
+		actor = c;
+
+		const { canisterId } = await pic.setupCanister<OrbiterActor>({
+			idlFactory: idlFactorOrbiter,
+			wasm: ORBITER_WASM_PATH,
+			arg: controllersInitArgs([controller.getPrincipal(), missionControlId]),
+			sender: controller.getPrincipal()
+		});
+
+		orbiterId = canisterId;
+
+		const { canisterId: cId } = await pic.setupCanister<SatelliteActor>({
+			idlFactory: idlFactorSatellite,
+			wasm: SATELLITE_WASM_PATH,
+			arg: controllersInitArgs([controller.getPrincipal(), missionControlId]),
+			sender: controller.getPrincipal()
+		});
+
+		satelliteId = cId;
+
+		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	it('should not be able to set an orbiter because mission control is effectively not a controller', async () => {
+		const { set_orbiter } = actor;
+
+		await expect(set_orbiter(orbiterId, ['Hello'])).rejects.toThrowError(
+			new RegExp(ORBITER_CONTROLLER_ERR_MSG)
+		);
+	});
+
+	it('should not be able to set a satellite because mission control is effectively not a controller', async () => {
+		const { set_satellite } = actor;
+
+		await expect(set_satellite(satelliteId, ['Hello'])).rejects.toThrowError(
+			new RegExp(SATELLITE_ADMIN_ERROR_MSG)
+		);
+	});
+});

--- a/src/tests/mission-control.set-unset.spec.ts
+++ b/src/tests/mission-control.set-unset.spec.ts
@@ -51,10 +51,18 @@ describe('Mission Control', () => {
 
 		actor = c;
 
+		actor.setIdentity(controller);
+
 		const { canisterId } = await pic.setupCanister<OrbiterActor>({
 			idlFactory: idlFactorOrbiter,
 			wasm: ORBITER_WASM_PATH,
 			arg: controllersInitArgs([controller.getPrincipal(), missionControlId]),
+			sender: controller.getPrincipal()
+		});
+
+		await pic.updateCanisterSettings({
+			canisterId,
+			controllers: [controller.getPrincipal(), missionControlId],
 			sender: controller.getPrincipal()
 		});
 
@@ -64,6 +72,12 @@ describe('Mission Control', () => {
 			idlFactory: idlFactorSatellite,
 			wasm: SATELLITE_WASM_PATH,
 			arg: controllersInitArgs([controller.getPrincipal(), missionControlId]),
+			sender: controller.getPrincipal()
+		});
+
+		await pic.updateCanisterSettings({
+			canisterId: cId,
+			controllers: [controller.getPrincipal(), missionControlId],
 			sender: controller.getPrincipal()
 		});
 

--- a/src/tests/mission-control.set-unset.spec.ts
+++ b/src/tests/mission-control.set-unset.spec.ts
@@ -117,7 +117,7 @@ describe('Mission Control', () => {
 	});
 
 	describe('admin', () => {
-		beforeEach(() => {
+		beforeAll(() => {
 			actor.setIdentity(controller);
 		});
 

--- a/src/tests/mission-control.set-unset.spec.ts
+++ b/src/tests/mission-control.set-unset.spec.ts
@@ -117,7 +117,7 @@ describe('Mission Control', () => {
 	});
 
 	describe('admin', () => {
-		beforeAll(() => {
+		beforeEach(() => {
 			actor.setIdentity(controller);
 		});
 

--- a/src/tests/satellite.auth.spec.ts
+++ b/src/tests/satellite.auth.spec.ts
@@ -10,7 +10,7 @@ import { toNullable } from '@dfinity/utils';
 import { PocketIc, type Actor } from '@hadronous/pic';
 import { toArray } from '@junobuild/utils';
 import { afterAll, beforeAll, describe, expect, inject } from 'vitest';
-import { ADMIN_ERROR_MSG } from './constants/satellite-tests.constants';
+import { SATELLITE_ADMIN_ERROR_MSG } from './constants/satellite-tests.constants';
 import { SATELLITE_WASM_PATH, controllersInitArgs } from './utils/setup-tests.utils';
 
 describe('Satellite authentication', () => {
@@ -326,13 +326,13 @@ describe('Satellite authentication', () => {
 				set_auth_config({
 					internet_identity: [{ derivation_origin: ['demo.com'] }]
 				})
-			).rejects.toThrow(ADMIN_ERROR_MSG);
+			).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should throw errors on getting config', async () => {
 			const { get_auth_config } = actor;
 
-			await expect(get_auth_config()).rejects.toThrow(ADMIN_ERROR_MSG);
+			await expect(get_auth_config()).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should not create a user', async () => {

--- a/src/tests/satellite.custom-domains.spec.ts
+++ b/src/tests/satellite.custom-domains.spec.ts
@@ -5,7 +5,7 @@ import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { toNullable } from '@dfinity/utils';
 import { PocketIc, type Actor } from '@hadronous/pic';
 import { afterAll, beforeAll, describe, expect, inject } from 'vitest';
-import { ADMIN_ERROR_MSG } from './constants/satellite-tests.constants';
+import { SATELLITE_ADMIN_ERROR_MSG } from './constants/satellite-tests.constants';
 import {
 	adminCustomDomainsTests,
 	anonymousCustomDomainsTests
@@ -40,7 +40,7 @@ describe('Satellite custom domains', () => {
 			actor.setIdentity(new AnonymousIdentity());
 		});
 
-		anonymousCustomDomainsTests({ actor: () => actor, errorMsg: ADMIN_ERROR_MSG });
+		anonymousCustomDomainsTests({ actor: () => actor, errorMsg: SATELLITE_ADMIN_ERROR_MSG });
 	});
 
 	describe('admin', () => {

--- a/src/tests/satellite.spec.ts
+++ b/src/tests/satellite.spec.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, inject } from 'vitest';
 import {
-	ADMIN_ERROR_MSG,
+	SATELLITE_ADMIN_ERROR_MSG,
 	CONTROLLER_ERROR_MSG,
 	INVALID_VERSION_ERROR_MSG,
 	NO_VERSION_ERROR_MSG
@@ -195,20 +195,20 @@ describe('Satellite', () => {
 		it('should throw errors on creating collections', async () => {
 			const { set_rule } = actor;
 
-			await expect(set_rule({ Db: null }, 'user-test', setRule)).rejects.toThrow(ADMIN_ERROR_MSG);
+			await expect(set_rule({ Db: null }, 'user-test', setRule)).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should throw errors on list collections', async () => {
 			const { list_rules } = actor;
 
-			await expect(list_rules({ Db: null })).rejects.toThrow(ADMIN_ERROR_MSG);
+			await expect(list_rules({ Db: null })).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should throw errors on deleting collections', async () => {
 			const { del_rule } = actor;
 
 			await expect(del_rule({ Db: null }, 'test', { version: testRuleVersion })).rejects.toThrow(
-				ADMIN_ERROR_MSG
+				SATELLITE_ADMIN_ERROR_MSG
 			);
 		});
 
@@ -226,13 +226,13 @@ describe('Satellite', () => {
 						scope: { Admin: null }
 					}
 				})
-			).rejects.toThrow(ADMIN_ERROR_MSG);
+			).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should throw errors on list controllers', async () => {
 			const { list_controllers } = actor;
 
-			await expect(list_controllers()).rejects.toThrow(ADMIN_ERROR_MSG);
+			await expect(list_controllers()).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should throw errors on deleting controller', async () => {
@@ -242,7 +242,7 @@ describe('Satellite', () => {
 				del_controllers({
 					controllers: [controller.getPrincipal()]
 				})
-			).rejects.toThrow(ADMIN_ERROR_MSG);
+			).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should throw errors on deleting docs', async () => {
@@ -277,7 +277,7 @@ describe('Satellite', () => {
 					cycles: 123n,
 					destination_id: user.getPrincipal()
 				})
-			).rejects.toThrow(ADMIN_ERROR_MSG);
+			).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should throw errors on getting memory size', async () => {

--- a/src/tests/satellite.storage.spec.ts
+++ b/src/tests/satellite.storage.spec.ts
@@ -14,7 +14,7 @@ import { toArray } from '@junobuild/utils';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterAll, beforeAll, beforeEach, describe, expect, inject } from 'vitest';
-import { ADMIN_ERROR_MSG, CONTROLLER_ERROR_MSG } from './constants/satellite-tests.constants';
+import { SATELLITE_ADMIN_ERROR_MSG, CONTROLLER_ERROR_MSG } from './constants/satellite-tests.constants';
 import { SATELLITE_WASM_PATH, controllersInitArgs } from './utils/setup-tests.utils';
 
 describe('Satellite storage', () => {
@@ -65,13 +65,13 @@ describe('Satellite storage', () => {
 					raw_access: toNullable(),
 					max_memory_size: toNullable()
 				})
-			).rejects.toThrow(ADMIN_ERROR_MSG);
+			).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 
 		it('should throw errors on getting config', async () => {
 			const { get_config } = actor;
 
-			await expect(get_config()).rejects.toThrow(ADMIN_ERROR_MSG);
+			await expect(get_config()).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The current function that asserts if a caller is an admin controller is already fine given that the list of such controllers hold in memory is equals to the effective controllers. Nevertheless, effectivelly requesting the IC to assert the controller is an admin adds an extra layer of security in case a bug finds its way some day.