### PR TITLE
feat: add ic_cdk::is_controller to is user

### DIFF
--- a/src/mission_control/src/guards.rs
+++ b/src/mission_control/src/guards.rs
@@ -1,9 +1,8 @@
 use crate::store::get_user;
 use crate::STATE;
 use ic_cdk::caller;
-use junobuild_shared::controllers::{
-    caller_is_console, caller_is_observatory, is_admin_controller,
-};
+use ic_cdk::api::is_controller as ic_canister_controller;
+use junobuild_shared::controllers::{caller_is_console, caller_is_observatory, is_admin_controller, is_controller};
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_equal;
 
@@ -36,7 +35,7 @@ fn caller_is_user() -> bool {
     let caller = caller();
     let user = get_user();
 
-    principal_equal(caller, user)
+    principal_equal(caller, user) && ic_canister_controller(&caller)
 }
 
 fn caller_is_admin_controller() -> bool {

--- a/src/tests/mission-control.set-unset.spec.ts
+++ b/src/tests/mission-control.set-unset.spec.ts
@@ -98,7 +98,7 @@ describe('Mission Control', () => {
 
 			await expect(unset_satellite(satelliteId)).rejects.toThrow(CONTROLLER_ERROR_MSG);
 		});
-	}
+	};
 
 	describe('anonymous', () => {
 		beforeAll(() => {

--- a/src/tests/mission-control.set-unset.spec.ts
+++ b/src/tests/mission-control.set-unset.spec.ts
@@ -74,11 +74,7 @@ describe('Mission Control', () => {
 		await pic?.tearDown();
 	});
 
-	describe('anonymous', () => {
-		beforeAll(() => {
-			actor.setIdentity(new AnonymousIdentity());
-		});
-
+	const testIdentity = () => {
 		it('should throw errors on set orbiter', async () => {
 			const { set_orbiter } = actor;
 
@@ -102,6 +98,22 @@ describe('Mission Control', () => {
 
 			await expect(unset_satellite(satelliteId)).rejects.toThrow(CONTROLLER_ERROR_MSG);
 		});
+	}
+
+	describe('anonymous', () => {
+		beforeAll(() => {
+			actor.setIdentity(new AnonymousIdentity());
+		});
+
+		testIdentity();
+	});
+
+	describe('unknown identity', () => {
+		beforeAll(() => {
+			actor.setIdentity(Ed25519KeyIdentity.generate());
+		});
+
+		testIdentity();
 	});
 
 	describe('admin', () => {

--- a/src/tests/mission-control.user.spec.ts
+++ b/src/tests/mission-control.user.spec.ts
@@ -1,0 +1,86 @@
+import type { _SERVICE as MissionControlActor } from '$declarations/mission_control/mission_control.did';
+import { idlFactory as idlFactorMissionControl } from '$declarations/mission_control/mission_control.factory.did';
+import type { _SERVICE as OrbiterActor } from '$declarations/orbiter/orbiter.did';
+import { idlFactory as idlFactorOrbiter } from '$declarations/orbiter/orbiter.factory.did';
+import type { _SERVICE as SatelliteActor } from '$declarations/satellite/satellite.did';
+import { idlFactory as idlFactorSatellite } from '$declarations/satellite/satellite.factory.did';
+import { IDL } from '@dfinity/candid';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Principal } from '@dfinity/principal';
+import { PocketIc, type Actor } from '@hadronous/pic';
+import { afterAll, beforeAll, describe, expect, inject } from 'vitest';
+import { CONTROLLER_ERROR_MSG } from './constants/mission-control-tests.constants';
+import {
+	MISSION_CONTROL_WASM_PATH,
+	ORBITER_WASM_PATH,
+	SATELLITE_WASM_PATH,
+	controllersInitArgs
+} from './utils/setup-tests.utils';
+
+describe('Mission Control', () => {
+	let pic: PocketIc;
+	let actor: Actor<MissionControlActor>;
+
+	let orbiterId: Principal;
+	let satelliteId: Principal;
+
+	const incorrectUser = Ed25519KeyIdentity.generate();
+	const controller = Ed25519KeyIdentity.generate();
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const userInitArgs = (): ArrayBuffer =>
+			IDL.encode(
+				[
+					IDL.Record({
+						user: IDL.Principal
+					})
+				],
+				[{ user: incorrectUser.getPrincipal() }]
+			);
+
+		const { actor: c, canisterId: missionControlId } = await pic.setupCanister<MissionControlActor>(
+			{
+				idlFactory: idlFactorMissionControl,
+				wasm: MISSION_CONTROL_WASM_PATH,
+				arg: userInitArgs(),
+				sender: controller.getPrincipal()
+			}
+		);
+
+		actor = c;
+
+		const { canisterId } = await pic.setupCanister<OrbiterActor>({
+			idlFactory: idlFactorOrbiter,
+			wasm: ORBITER_WASM_PATH,
+			arg: controllersInitArgs([controller.getPrincipal(), missionControlId]),
+			sender: controller.getPrincipal()
+		});
+
+		orbiterId = canisterId;
+
+		const { canisterId: cId } = await pic.setupCanister<SatelliteActor>({
+			idlFactory: idlFactorSatellite,
+			wasm: SATELLITE_WASM_PATH,
+			arg: controllersInitArgs([controller.getPrincipal(), missionControlId]),
+			sender: controller.getPrincipal()
+		});
+
+		satelliteId = cId;
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	beforeEach(() => {
+		actor.setIdentity(controller);
+	});
+
+	it('should throw errors on set satellite because the user of the mission control has been incorrectly set to another identity than the controller', async () => {
+		const { set_satellite } = actor;
+
+		await expect(set_satellite(satelliteId, [])).rejects.toThrow(CONTROLLER_ERROR_MSG);
+	});
+});


### PR DESCRIPTION
# Motivation

The user of the mission control, it's owner, is set on `init` by the Console when creating new missin control. The Console also set that principal as a controller, therefore it is a controller. For future proof and to add an additional level of security if a bug someday is ever introduced we can also check if it is a controller at the ic level within the guard.