### PR TITLE
feat: display subnet ID in overview

### DIFF
--- a/src/frontend/src/lib/api/ic.api.ts
+++ b/src/frontend/src/lib/api/ic.api.ts
@@ -141,13 +141,15 @@ export const subnetId = async ({
 }): Promise<string | undefined> => {
 	const agent = await getAgent({ identity: new AnonymousIdentity() });
 
+	const path = 'subnet' as const;
+
 	const result = await AgentCanisterStatus.request({
 		canisterId: Principal.from(canisterId),
 		agent,
-		paths: ['subnet']
+		paths: [path]
 	});
 
-	const subnet: AgentCanisterStatus.Status | undefined = result.get('subnet');
+	const subnet: AgentCanisterStatus.Status | undefined = result.get(path);
 
 	const isSubnetStatus = (
 		subnet: AgentCanisterStatus.Status | undefined

--- a/src/frontend/src/lib/api/ic.api.ts
+++ b/src/frontend/src/lib/api/ic.api.ts
@@ -149,7 +149,10 @@ export const subnetId = async ({
 
 	const subnet: AgentCanisterStatus.Status | undefined = result.get('subnet');
 
-	return nonNullish(subnet) && 'subnetId' in (subnet as unknown as AgentCanisterStatus.SubnetStatus)
-		? (subnet as unknown as AgentCanisterStatus.SubnetStatus).subnetId
-		: undefined;
+	const isSubnetStatus = (
+		subnet: AgentCanisterStatus.Status | undefined
+	): subnet is AgentCanisterStatus.SubnetStatus =>
+		nonNullish(subnet) && typeof subnet === 'object' && 'subnetId' in subnet;
+
+	return isSubnetStatus(subnet) ? subnet.subnetId : undefined;
 };

--- a/src/frontend/src/lib/api/ic.api.ts
+++ b/src/frontend/src/lib/api/ic.api.ts
@@ -134,7 +134,7 @@ export const canisterUpdateSettings = async ({
 	return update_settings({ canister_id: canisterId, sender_canister_version: [], settings });
 };
 
-export const subnetId = async ({
+export const getSubnetId = async ({
 	canisterId
 }: {
 	canisterId: string;

--- a/src/frontend/src/lib/api/ic.api.ts
+++ b/src/frontend/src/lib/api/ic.api.ts
@@ -5,8 +5,14 @@ import type {
 } from '$declarations/ic/ic.did';
 import type { CanisterInfo, CanisterLogVisibility, CanisterStatus } from '$lib/types/canister';
 import { getICActor } from '$lib/utils/actor.ic.utils';
-import type { Identity } from '@dfinity/agent';
+import { getAgent } from '$lib/utils/agent.utils';
+import {
+	CanisterStatus as AgentCanisterStatus,
+	AnonymousIdentity,
+	type Identity
+} from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
+import { nonNullish } from '@dfinity/utils';
 
 const toStatus = (
 	status: { stopped: null } | { stopping: null } | { running: null }
@@ -126,4 +132,24 @@ export const canisterUpdateSettings = async ({
 }): Promise<void> => {
 	const { update_settings } = await getICActor({ identity });
 	return update_settings({ canister_id: canisterId, sender_canister_version: [], settings });
+};
+
+export const subnetId = async ({
+	canisterId
+}: {
+	canisterId: string;
+}): Promise<string | undefined> => {
+	const agent = await getAgent({ identity: new AnonymousIdentity() });
+
+	const result = await AgentCanisterStatus.request({
+		canisterId: Principal.from(canisterId),
+		agent,
+		paths: ['subnet']
+	});
+
+	const subnet: AgentCanisterStatus.Status | undefined = result.get('subnet');
+
+	return nonNullish(subnet) && 'subnetId' in (subnet as unknown as AgentCanisterStatus.SubnetStatus)
+		? (subnet as unknown as AgentCanisterStatus.SubnetStatus).subnetId
+		: undefined;
 };

--- a/src/frontend/src/lib/components/canister/CanisterSubnet.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterSubnet.svelte
@@ -19,7 +19,7 @@
 		});
 	});
 
-	let subnet: Subnet | undefined;
+	let subnet: Subnet | null | undefined;
 	$: subnet = $subnetsStore[canisterId.toText()];
 
 	let subnetId: PrincipalText | undefined;

--- a/src/frontend/src/lib/components/canister/CanisterSubnet.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterSubnet.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { Principal } from '@dfinity/principal';
+	import { onMount } from 'svelte';
+	import { loadSubnetId } from '$lib/services/ic.services';
+	import Value from '$lib/components/ui/Value.svelte';
+	import Identifier from '$lib/components/ui/Identifier.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { nonNullish } from '@dfinity/utils';
+    import SkeletonText from "$lib/components/ui/SkeletonText.svelte";
+    import type {PrincipalText} from "$lib/types/itentity";
+    import { subnetsStore } from '$lib/stores/subnets.store'
+    import type {Subnet} from "$lib/types/subnet";
+
+	export let canisterId: Principal;
+
+	onMount(async () => {
+		await loadSubnetId({
+			canisterId
+		});
+	});
+
+    let subnet: Subnet | undefined;
+    $: subnet = $subnetsStore[canisterId.toText()];
+
+    let subnetId: PrincipalText | undefined;
+    $: subnetId = subnet?.subnetId;
+</script>
+
+<div>
+	<Value>
+		<svelte:fragment slot="label">{$i18n.canisters.subnet_id}</svelte:fragment>
+		{#if nonNullish(subnetId)}
+			<Identifier identifier={subnetId} small={false} />
+		{:else}
+            <SkeletonText />
+		{/if}
+	</Value>
+</div>

--- a/src/frontend/src/lib/components/canister/CanisterSubnet.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterSubnet.svelte
@@ -6,10 +6,10 @@
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { nonNullish } from '@dfinity/utils';
-    import SkeletonText from "$lib/components/ui/SkeletonText.svelte";
-    import type {PrincipalText} from "$lib/types/itentity";
-    import { subnetsStore } from '$lib/stores/subnets.store'
-    import type {Subnet} from "$lib/types/subnet";
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import type { PrincipalText } from '$lib/types/itentity';
+	import { subnetsStore } from '$lib/stores/subnets.store';
+	import type { Subnet } from '$lib/types/subnet';
 
 	export let canisterId: Principal;
 
@@ -19,11 +19,11 @@
 		});
 	});
 
-    let subnet: Subnet | undefined;
-    $: subnet = $subnetsStore[canisterId.toText()];
+	let subnet: Subnet | undefined;
+	$: subnet = $subnetsStore[canisterId.toText()];
 
-    let subnetId: PrincipalText | undefined;
-    $: subnetId = subnet?.subnetId;
+	let subnetId: PrincipalText | undefined;
+	$: subnetId = subnet?.subnetId;
 </script>
 
 <div>
@@ -32,7 +32,7 @@
 		{#if nonNullish(subnetId)}
 			<Identifier identifier={subnetId} small={false} />
 		{:else}
-            <SkeletonText />
+			<SkeletonText />
 		{/if}
 	</Value>
 </div>

--- a/src/frontend/src/lib/components/canister/CanisterSubnets.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterSubnets.svelte
@@ -6,7 +6,7 @@
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { DEV, JUNO_SUBNET_ID } from '$lib/constants/constants';
 	import { getDefaultSubnets } from '$lib/api/cmc.api';
-	import type {Subnet} from "$lib/types/subnet";
+	import type { Subnet } from '$lib/types/subnet';
 
 	export let subnetId: PrincipalText | undefined;
 

--- a/src/frontend/src/lib/components/canister/CanisterSubnets.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterSubnets.svelte
@@ -6,17 +6,14 @@
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { DEV, JUNO_SUBNET_ID } from '$lib/constants/constants';
 	import { getDefaultSubnets } from '$lib/api/cmc.api';
-
-	interface SubnetMetadata {
-		subnetId: PrincipalText;
-	}
+	import type {Subnet} from "$lib/types/subnet";
 
 	export let subnetId: PrincipalText | undefined;
 
-	let filteredSubnets: SubnetMetadata[];
+	let filteredSubnets: Subnet[];
 	$: filteredSubnets = subnets.filter(({ subnetId }) => subnetId !== JUNO_SUBNET_ID);
 
-	let extendedSubnets: SubnetMetadata[] = [];
+	let extendedSubnets: Subnet[] = [];
 
 	const extendSubnets = async () => {
 		if (!DEV) {

--- a/src/frontend/src/lib/components/mission-control/MissionControl.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControl.svelte
@@ -10,6 +10,7 @@
 	import { versionStore } from '$lib/stores/version.store';
 	import { fade } from 'svelte/transition';
 	import MissionControlStatuses from '$lib/components/mission-control/MissionControlStatuses.svelte';
+	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
 </script>
 
 {#if $authSignedInStore}
@@ -20,8 +21,12 @@
 			<div class="id">
 				<Value>
 					<svelte:fragment slot="label">{$i18n.mission_control.id}</svelte:fragment>
-					<Identifier identifier={$missionControlStore?.toText() ?? ''} shorten={false} />
+					<Identifier identifier={$missionControlStore?.toText() ?? ''} shorten={false} small={false} />
 				</Value>
+
+				{#if nonNullish($missionControlStore)}
+					<CanisterSubnet canisterId={$missionControlStore} />
+				{/if}
 			</div>
 
 			<div>

--- a/src/frontend/src/lib/components/mission-control/MissionControl.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControl.svelte
@@ -21,7 +21,11 @@
 			<div class="id">
 				<Value>
 					<svelte:fragment slot="label">{$i18n.mission_control.id}</svelte:fragment>
-					<Identifier identifier={$missionControlStore?.toText() ?? ''} shorten={false} small={false} />
+					<Identifier
+						identifier={$missionControlStore?.toText() ?? ''}
+						shorten={false}
+						small={false}
+					/>
 				</Value>
 
 				{#if nonNullish($missionControlStore)}

--- a/src/frontend/src/lib/components/modals/SendTokensModal.svelte
+++ b/src/frontend/src/lib/components/modals/SendTokensModal.svelte
@@ -76,11 +76,6 @@
 		}
 	}
 
-	form {
-		display: flex;
-		flex-direction: column;
-	}
-
 	button {
 		margin-top: var(--padding-2x);
 	}

--- a/src/frontend/src/lib/components/orbiter/Orbiter.svelte
+++ b/src/frontend/src/lib/components/orbiter/Orbiter.svelte
@@ -7,7 +7,7 @@
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
 	import OrbiterActions from '$lib/components/orbiter/OrbiterActions.svelte';
 	import CanisterJunoStatuses from '$lib/components/canister/CanisterJunoStatuses.svelte';
-	import CanisterSubnet from "$lib/components/canister/CanisterSubnet.svelte";
+	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
 
 	export let orbiter: Orbiter;
 </script>

--- a/src/frontend/src/lib/components/orbiter/Orbiter.svelte
+++ b/src/frontend/src/lib/components/orbiter/Orbiter.svelte
@@ -7,6 +7,7 @@
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
 	import OrbiterActions from '$lib/components/orbiter/OrbiterActions.svelte';
 	import CanisterJunoStatuses from '$lib/components/canister/CanisterJunoStatuses.svelte';
+	import CanisterSubnet from "$lib/components/canister/CanisterSubnet.svelte";
 
 	export let orbiter: Orbiter;
 </script>
@@ -20,6 +21,8 @@
 				<svelte:fragment slot="label">{$i18n.analytics.id}</svelte:fragment>
 				<Identifier identifier={orbiter.orbiter_id.toText()} shorten={false} small={false} />
 			</Value>
+
+			<CanisterSubnet canisterId={orbiter.orbiter_id} />
 		</div>
 
 		<div>

--- a/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
@@ -10,7 +10,7 @@
 	import SatelliteOverviewVersion from '$lib/components/satellites/SatelliteOverviewVersion.svelte';
 	import CanisterJunoStatuses from '$lib/components/canister/CanisterJunoStatuses.svelte';
 	import SatelliteOverviewCustomDomain from '$lib/components/satellites/SatelliteOverviewCustomDomain.svelte';
-	import CanisterSubnet from "$lib/components/canister/CanisterSubnet.svelte";
+	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
 
 	export let satellite: Satellite;
 

--- a/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
@@ -10,6 +10,7 @@
 	import SatelliteOverviewVersion from '$lib/components/satellites/SatelliteOverviewVersion.svelte';
 	import CanisterJunoStatuses from '$lib/components/canister/CanisterJunoStatuses.svelte';
 	import SatelliteOverviewCustomDomain from '$lib/components/satellites/SatelliteOverviewCustomDomain.svelte';
+	import CanisterSubnet from "$lib/components/canister/CanisterSubnet.svelte";
 
 	export let satellite: Satellite;
 
@@ -28,6 +29,8 @@
 				<svelte:fragment slot="label">{$i18n.satellites.id}</svelte:fragment>
 				<Identifier identifier={satelliteId} shorten={false} small={false} />
 			</Value>
+
+			<CanisterSubnet canisterId={satellite.satellite_id} />
 
 			<SatelliteOverviewCustomDomain {satellite} />
 		</div>

--- a/src/frontend/src/lib/components/satellites/SatelliteOverviewVersion.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteOverviewVersion.svelte
@@ -21,33 +21,45 @@
 </script>
 
 {#if !extended}
-	<Value>
-		<svelte:fragment slot="label">{$i18n.core.version}</svelte:fragment>
-		<p>v{$versionStore?.satellites[satelliteId]?.current ?? '...'}</p>
-	</Value>
+	<div>
+		<Value>
+			<svelte:fragment slot="label">{$i18n.core.version}</svelte:fragment>
+			<p>v{$versionStore?.satellites[satelliteId]?.current ?? '...'}</p>
+		</Value>
+	</div>
 {:else}
-	<Value>
-		<svelte:fragment slot="label">{$i18n.satellites.stock_version}</svelte:fragment>
-		<p>v{$versionStore?.satellites[satelliteId]?.current ?? '...'}</p>
-	</Value>
+	<div>
+		<Value>
+			<svelte:fragment slot="label">{$i18n.satellites.stock_version}</svelte:fragment>
+			<p>v{$versionStore?.satellites[satelliteId]?.current ?? '...'}</p>
+		</Value>
+	</div>
 
-	<Value>
-		<svelte:fragment slot="label">{$i18n.satellites.extended_version}</svelte:fragment>
-		<p>v{$versionStore?.satellites[satelliteId]?.currentBuild ?? '...'}</p>
-	</Value>
+	<div>
+		<Value>
+			<svelte:fragment slot="label">{$i18n.satellites.extended_version}</svelte:fragment>
+			<p>v{$versionStore?.satellites[satelliteId]?.currentBuild ?? '...'}</p>
+		</Value>
+	</div>
 {/if}
 
-<Value>
-	<svelte:fragment slot="label">{$i18n.satellites.build}</svelte:fragment>
-	<p class="build">
-		{#if nonNullish(build)}
-			<span in:fade>{build}</span>
-		{/if}
-	</p>
-</Value>
+<div>
+	<Value>
+		<svelte:fragment slot="label">{$i18n.satellites.build}</svelte:fragment>
+		<p class="build">
+			{#if nonNullish(build)}
+				<span in:fade>{build}</span>
+			{/if}
+		</p>
+	</Value>
+</div>
 
 <style lang="scss">
 	.build {
 		text-transform: capitalize;
+	}
+
+	div:not(:first-of-type) {
+		padding: var(--padding) 0 0;
 	}
 </style>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -140,7 +140,8 @@
 		"public": "Public",
 		"advanced_options": "Advanced Options",
 		"subnet": "Subnet",
-		"default_subnet": "Default (same as Juno)"
+		"default_subnet": "Default (same as Juno)",
+		"subnet_id": "Subnet ID"
 	},
 	"sign_in": {
 		"quote_1": "Stars can't shine without darkness.",
@@ -435,7 +436,8 @@
 		"empty_amount": "Please enter an amount for the transfer.",
 		"invalid_amount": "The amount should be greater than zero and less than your balance minus the fee.",
 		"empty_balance": "Your wallet does not have any available funds.",
-		"sending_error": "Unexpected error(s) while sending the tokens."
+		"sending_error": "Unexpected error(s) while sending the tokens.",
+		"subnet_loading_errors": "Error while loading the subnet ID of the module."
 	},
 	"document": {
 		"owner": "Owner",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -140,7 +140,8 @@
 		"public": "公开",
 		"advanced_options": "Advanced Options",
 		"subnet": "Subnet",
-		"default_subnet": "Default (same as Juno)"
+		"default_subnet": "Default (same as Juno)",
+		"subnet_id": "Subnet ID"
 	},
 	"sign_in": {
 		"quote_1": "Stars can't shine without darkness.",
@@ -435,7 +436,8 @@
 		"empty_amount": "Please enter an amount for the transfer.",
 		"invalid_amount": "The amount should be greater than zero and less than your balance minus the fee.",
 		"empty_balance": "Your wallet does not have any available funds.",
-		"sending_error": "Unexpected error(s) while sending the tokens."
+		"sending_error": "Unexpected error(s) while sending the tokens.",
+		"subnet_loading_errors": "Error while loading the subnet ID of the module."
 	},
 	"document": {
 		"owner": "拥有者",

--- a/src/frontend/src/lib/services/ic.services.ts
+++ b/src/frontend/src/lib/services/ic.services.ts
@@ -1,0 +1,49 @@
+import { getSubnetId } from '$lib/api/ic.api';
+import { i18n } from '$lib/stores/i18n.store';
+import { subnetsStore } from '$lib/stores/subnets.store';
+import { toasts } from '$lib/stores/toasts.store';
+import type { Principal } from '@dfinity/principal';
+import { nonNullish } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+export const loadSubnetId = async ({
+	canisterId,
+	reload = false
+}: {
+	canisterId: Principal;
+	reload?: boolean;
+}): Promise<{ success: boolean }> => {
+    const canisterIdText = canisterId.toText();
+
+    try {
+        const store = get(subnetsStore);
+		if (nonNullish(store[canisterIdText]) && !reload) {
+			return { success: true };
+		}
+
+		const subnetId = await getSubnetId({
+			canisterId: canisterId.toText()
+		});
+
+		subnetsStore.setSubnets({
+			canisterId: canisterIdText,
+			subnet: nonNullish(subnetId) ? { subnetId } : undefined
+		});
+
+		return { success: true };
+	} catch (err: unknown) {
+		const labels = get(i18n);
+
+		toasts.error({
+			text: labels.errors.hosting_loading_errors,
+			detail: err
+		});
+
+        subnetsStore.setSubnets({
+            canisterId: canisterIdText,
+            subnet: null
+        });
+
+		return { success: false };
+	}
+};

--- a/src/frontend/src/lib/services/ic.services.ts
+++ b/src/frontend/src/lib/services/ic.services.ts
@@ -13,10 +13,10 @@ export const loadSubnetId = async ({
 	canisterId: Principal;
 	reload?: boolean;
 }): Promise<{ success: boolean }> => {
-    const canisterIdText = canisterId.toText();
+	const canisterIdText = canisterId.toText();
 
-    try {
-        const store = get(subnetsStore);
+	try {
+		const store = get(subnetsStore);
 		if (nonNullish(store[canisterIdText]) && !reload) {
 			return { success: true };
 		}
@@ -39,10 +39,10 @@ export const loadSubnetId = async ({
 			detail: err
 		});
 
-        subnetsStore.setSubnets({
-            canisterId: canisterIdText,
-            subnet: null
-        });
+		subnetsStore.setSubnets({
+			canisterId: canisterIdText,
+			subnet: null
+		});
 
 		return { success: false };
 	}

--- a/src/frontend/src/lib/stores/subnets.store.ts
+++ b/src/frontend/src/lib/stores/subnets.store.ts
@@ -1,0 +1,31 @@
+import type { PrincipalText } from '$lib/types/itentity';
+import type { Subnet } from '$lib/types/subnet';
+import { writable, type Readable } from 'svelte/store';
+
+export type SubnetsData = Record<PrincipalText, Subnet | undefined | null>;
+
+export interface SubnetsStore extends Readable<SubnetsData> {
+	setSubnets: (params: { canisterId: PrincipalText; subnet: Subnet | undefined | null }) => void;
+	reset: () => void;
+}
+
+const initSubnetsStore = (): SubnetsStore => {
+	const INITIAL: SubnetsData = {};
+
+	const { subscribe, update, set } = writable<SubnetsData>(INITIAL);
+
+	return {
+		subscribe,
+
+		setSubnets({ canisterId, subnet }) {
+			update((state) => ({
+				...state,
+				[canisterId]: subnet
+			}));
+		},
+
+		reset: () => set(INITIAL)
+	};
+};
+
+export const subnetsStore = initSubnetsStore();

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -145,6 +145,7 @@ interface I18nCanisters {
 	advanced_options: string;
 	subnet: string;
 	default_subnet: string;
+	subnet_id: string;
 }
 
 interface I18nSign_in {
@@ -452,6 +453,7 @@ interface I18nErrors {
 	invalid_amount: string;
 	empty_balance: string;
 	sending_error: string;
+	subnet_loading_errors: string;
 }
 
 interface I18nDocument {

--- a/src/frontend/src/lib/types/subnet.ts
+++ b/src/frontend/src/lib/types/subnet.ts
@@ -1,6 +1,5 @@
-import type {PrincipalText} from "$lib/types/itentity";
+import type { PrincipalText } from '$lib/types/itentity';
 
 export interface Subnet {
-    subnetId: PrincipalText;
+	subnetId: PrincipalText;
 }
-

--- a/src/frontend/src/lib/types/subnet.ts
+++ b/src/frontend/src/lib/types/subnet.ts
@@ -1,0 +1,6 @@
+import type {PrincipalText} from "$lib/types/itentity";
+
+export interface Subnet {
+    subnetId: PrincipalText;
+}
+

--- a/src/frontend/src/lib/workers/cycles.worker.ts
+++ b/src/frontend/src/lib/workers/cycles.worker.ts
@@ -1,6 +1,6 @@
 import type { MemorySize } from '$declarations/satellite/satellite.did';
 import { icpXdrConversionRate } from '$lib/api/cmc.api';
-import { canisterStatus, subnetId } from '$lib/api/ic.api';
+import { canisterStatus } from '$lib/api/ic.api';
 import { memorySize as memorySizeOrbiter } from '$lib/api/orbiter.worker.api';
 import { memorySize as memorySizeSatellite } from '$lib/api/satellites.worker.api';
 import {
@@ -107,9 +107,8 @@ const syncIcStatusCanisters = async ({
 	await Promise.allSettled(
 		segments.map(async ({ canisterId, segment }) => {
 			try {
-				const [canisterResult, subnet, memorySizeResult] = await Promise.allSettled([
+				const [canisterResult, memorySizeResult] = await Promise.allSettled([
 					canisterStatus({ canisterId, identity }),
-					subnetId({ canisterId }),
 					...(segment === 'satellite'
 						? [memorySizeSatellite({ satelliteId: canisterId, identity })]
 						: segment === 'orbiter'

--- a/src/frontend/src/lib/workers/cycles.worker.ts
+++ b/src/frontend/src/lib/workers/cycles.worker.ts
@@ -1,6 +1,6 @@
 import type { MemorySize } from '$declarations/satellite/satellite.did';
 import { icpXdrConversionRate } from '$lib/api/cmc.api';
-import { canisterStatus } from '$lib/api/ic.api';
+import { canisterStatus, subnetId } from '$lib/api/ic.api';
 import { memorySize as memorySizeOrbiter } from '$lib/api/orbiter.worker.api';
 import { memorySize as memorySizeSatellite } from '$lib/api/satellites.worker.api';
 import {
@@ -107,8 +107,9 @@ const syncIcStatusCanisters = async ({
 	await Promise.allSettled(
 		segments.map(async ({ canisterId, segment }) => {
 			try {
-				const [canisterResult, memorySizeResult] = await Promise.allSettled([
+				const [canisterResult, subnet, memorySizeResult] = await Promise.allSettled([
 					canisterStatus({ canisterId, identity }),
+					subnetId({ canisterId }),
 					...(segment === 'satellite'
 						? [memorySizeSatellite({ satelliteId: canisterId, identity })]
 						: segment === 'orbiter'


### PR DESCRIPTION
# Motivation

Given that Satellites and Orbiters can be spinned in selected subnet, we should display the information in the overview.
