### PR TITLE
feat: use icp-api.io to instantiate the HttpAgent

### DIFF
--- a/scripts/actor.mjs
+++ b/scripts/actor.mjs
@@ -20,7 +20,11 @@ export const icAgent = async () => {
 };
 
 export const icAnonymousAgent = async () => {
-	return await HttpAgent.create({ identity: new AnonymousIdentity(), fetch, host: 'https://icp-api.io' });
+	return await HttpAgent.create({
+		identity: new AnonymousIdentity(),
+		fetch,
+		host: 'https://icp-api.io'
+	});
 };
 
 export const localAgent = async () => {

--- a/scripts/actor.mjs
+++ b/scripts/actor.mjs
@@ -16,11 +16,11 @@ export const icAgent = async () => {
 
 	console.log('IC identity:', identity.getPrincipal().toText());
 
-	return await HttpAgent.create({ identity, fetch, host: 'https://icp0.io' });
+	return await HttpAgent.create({ identity, fetch, host: 'https://icp-api.io' });
 };
 
 export const icAnonymousAgent = async () => {
-	return await HttpAgent.create({ identity: new AnonymousIdentity(), fetch, host: 'https://icp0.io' });
+	return await HttpAgent.create({ identity: new AnonymousIdentity(), fetch, host: 'https://icp-api.io' });
 };
 
 export const localAgent = async () => {

--- a/src/frontend/src/lib/utils/agent.utils.ts
+++ b/src/frontend/src/lib/utils/agent.utils.ts
@@ -12,7 +12,7 @@ export const getAgent = async (params: GetAgentParams): Promise<HttpAgent> => {
 };
 
 const getMainnetAgent = async (params: GetAgentParams) => {
-	const host = 'https://icp0.io';
+	const host = 'https://icp-api.io';
 	return await HttpAgent.create({ ...params, host });
 };
 


### PR DESCRIPTION
# Motivation

I already do so in Juno-js. This way it's consistent.
