### PR TITLE
fix: memo sent displayed as received

### DIFF
--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -1,3 +1,4 @@
+import { getAccountIdentifier } from '$lib/api/icp-index.api';
 import {
 	MEMO_CANISTER_CREATE,
 	MEMO_CANISTER_TOP_UP,
@@ -42,7 +43,9 @@ export const transactionMemo = ({
 		case MEMO_CANISTER_TOP_UP:
 			return labels.wallet.memo_refund_top_up;
 		default:
-			if (from === missionControlId.toText()) {
+			const accountIdentifier = getAccountIdentifier(missionControlId);
+
+			if (from === missionControlId.toText() || from === accountIdentifier.toHex()) {
 				return labels.wallet.memo_sent;
 			}
 

--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -42,7 +42,7 @@ export const transactionMemo = ({
 			return labels.wallet.memo_refund_orbiter;
 		case MEMO_CANISTER_TOP_UP:
 			return labels.wallet.memo_refund_top_up;
-		default:
+		default: {
 			const accountIdentifier = getAccountIdentifier(missionControlId);
 
 			if (from === missionControlId.toText() || from === accountIdentifier.toHex()) {
@@ -50,6 +50,7 @@ export const transactionMemo = ({
 			}
 
 			return labels.wallet.memo_received;
+		}
 	}
 };
 


### PR DESCRIPTION
# Motivation

The "from" field is equals to the account identifier, not wallet id, as a result "Received" was displayed instead of "Sent" in the transactions table.
