### PR TITLE
refactor: use Duration::ZERO

### DIFF
--- a/src/libs/satellite/src/hooks.rs
+++ b/src/libs/satellite/src/hooks.rs
@@ -66,7 +66,7 @@ pub fn invoke_on_set_doc(caller: &UserId, doc: &DocContext<DocUpsert>) {
             let collections = juno_on_set_doc_collections();
 
             if should_invoke_doc_hook(collections, &context) {
-                set_timer(Duration::from_nanos(0), || {
+                set_timer(Duration::ZERO, || {
                     juno_on_set_doc(context);
                 });
             }
@@ -89,7 +89,7 @@ pub fn invoke_on_set_many_docs(caller: &UserId, docs: &[DocContext<DocUpsert>]) 
                     data: filtered_docs.clone(),
                 };
 
-                set_timer(Duration::from_nanos(0), || {
+                set_timer(Duration::ZERO, || {
                     juno_on_set_many_docs(context);
                 });
             }
@@ -110,7 +110,7 @@ pub fn invoke_on_delete_doc(caller: &UserId, doc: &DocContext<Option<Doc>>) {
             let collections = juno_on_delete_doc_collections();
 
             if should_invoke_doc_hook(collections, &context) {
-                set_timer(Duration::from_nanos(0), || {
+                set_timer(Duration::ZERO, || {
                     juno_on_delete_doc(context);
                 });
             }
@@ -133,7 +133,7 @@ pub fn invoke_on_delete_many_docs(caller: &UserId, docs: &[DocContext<Option<Doc
                     data: filtered_docs.clone(),
                 };
 
-                set_timer(Duration::from_nanos(0), || {
+                set_timer(Duration::ZERO, || {
                     juno_on_delete_many_docs(context);
                 });
             }
@@ -156,7 +156,7 @@ pub fn invoke_on_delete_filtered_docs(caller: &UserId, docs: &[DocContext<Option
                     data: filtered_docs.clone(),
                 };
 
-                set_timer(Duration::from_nanos(0), || {
+                set_timer(Duration::ZERO, || {
                     juno_on_delete_filtered_docs(context);
                 });
             }
@@ -182,7 +182,7 @@ pub fn invoke_upload_asset(caller: &UserId, asset: &Asset) {
             let collections = juno_on_upload_asset_collections();
 
             if should_invoke_asset_hook(collections, &context.data.key.collection) {
-                set_timer(Duration::from_nanos(0), || {
+                set_timer(Duration::ZERO, || {
                     juno_on_upload_asset(context);
                 });
             }
@@ -212,7 +212,7 @@ pub fn invoke_on_delete_asset(caller: &UserId, asset: &Option<Asset>) {
                     data: asset.clone(),
                 };
 
-                set_timer(Duration::from_nanos(0), || {
+                set_timer(Duration::ZERO, || {
                     juno_on_delete_asset(context);
                 });
             }
@@ -235,7 +235,7 @@ pub fn invoke_on_delete_many_assets(caller: &UserId, assets: &[Option<Asset>]) {
                     data: filtered_assets.clone(),
                 };
 
-                set_timer(Duration::from_nanos(0), || {
+                set_timer(Duration::ZERO, || {
                     juno_on_delete_many_assets(context);
                 });
             }
@@ -351,7 +351,7 @@ pub fn invoke_on_post_upgrade() {
     #[cfg(feature = "on_post_upgrade")]
     {
         unsafe {
-            set_timer(Duration::from_nanos(0), || {
+            set_timer(Duration::ZERO, || {
                 juno_on_post_upgrade();
             });
         }


### PR DESCRIPTION
# Motivation

I was literally telling yesterday about `Duration::ZERO` and it turns out, I don't even use it everywhere in Juno's codebase 😄.
