### PR TITLE
feat: remove edit derivation origin in hosting wizard

### DIFF
--- a/src/frontend/src/lib/components/hosting/AddCustomDomainAuth.svelte
+++ b/src/frontend/src/lib/components/hosting/AddCustomDomainAuth.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { fromNullable, nonNullish } from '@dfinity/utils';
-	import { createEventDispatcher } from 'svelte';
 	import type { AuthenticationConfig } from '$declarations/satellite/satellite.did';
 	import Html from '$lib/components/ui/Html.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -10,79 +8,45 @@
 	interface Props {
 		config: AuthenticationConfig | undefined;
 		domainNameInput: string;
+		next: (config: AuthenticationConfig | null) => void;
 	}
 
-	let { config, domainNameInput }: Props = $props();
-
-	let authDomain: string | undefined = $derived(
-		fromNullable(fromNullable(config?.internet_identity ?? [])?.derivation_origin ?? [])
-	);
-
-	let edit: boolean = $derived(nonNullish(authDomain));
-
-	const dispatch = createEventDispatcher();
+	let { config, domainNameInput, next }: Props = $props();
 
 	const yes = () => {
 		const payload = buildSetAuthenticationConfig({ config, domainName: domainNameInput });
 
-		dispatch('junoNext', payload);
+		next(payload);
 	};
 
-	const no = () => dispatch('junoNext', config);
+	const no = () => next(null);
 </script>
 
-<h2>{edit ? $i18n.hosting.update_auth_domain_title : $i18n.hosting.set_auth_domain_title}</h2>
+<h2>{$i18n.hosting.set_auth_domain_title}</h2>
 
 <p>
-	{#if edit}
-		<Html
-			text={i18nFormat($i18n.hosting.update_auth_domain_question, [
-				{
-					placeholder: '{0}',
-					value: domainNameInput
-				},
-				{
-					placeholder: '{1}',
-					value: authDomain ?? ''
-				}
-			])}
-		/>
-	{:else}
-		<Html
-			text={i18nFormat($i18n.hosting.set_auth_domain_question, [
-				{
-					placeholder: '{0}',
-					value: domainNameInput
-				},
-				{
-					placeholder: '{1}',
-					value: domainNameInput.startsWith('www')
-						? domainNameInput.replace('www.', '')
-						: `www.${domainNameInput}`
-				},
-				{
-					placeholder: '{2}',
-					value: domainNameInput
-				}
-			])}
-		/>{/if}
+	<Html
+		text={i18nFormat($i18n.hosting.set_auth_domain_question, [
+			{
+				placeholder: '{0}',
+				value: domainNameInput
+			},
+			{
+				placeholder: '{1}',
+				value: domainNameInput.startsWith('www')
+					? domainNameInput.replace('www.', '')
+					: `www.${domainNameInput}`
+			},
+			{
+				placeholder: '{2}',
+				value: domainNameInput
+			}
+		])}
+	/>
 </p>
 
 <div class="toolbar">
-	<button onclick={no}
-		>{#if edit}
-			<span
-				><Html
-					text={i18nFormat($i18n.hosting.no_keep_domain, [
-						{
-							placeholder: '{0}',
-							value: authDomain ?? ''
-						}
-					])}
-				/></span
-			>
-		{:else}{$i18n.core.no}{/if}</button
-	>
+	<button onclick={no}>{$i18n.core.no}</button>
 	<button onclick={yes}>{$i18n.core.yes}</button>
 </div>
 

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -344,10 +344,7 @@
 		"files_deployed": "files deployed",
 		"set_auth_domain_title": "Set domain for authentication",
 		"set_auth_domain_question": "Would you like to use <strong>{0}</strong> as the main domain for all user sign-ins?<br/><br/>This setting, also known as \"derivation origin\", ensures that users are recognized on your app, regardless of whether they use the default URL or any other custom domain you might configure later.<br><br>For example, a user signing on at {1} will receive the same identifier (principal) as when signing on at {2}.",
-		"update_auth_domain_title": "Update domain for authentication",
-		"update_auth_domain_question": "Your current domain for authentication is set to <strong>{1}</strong>. Would you like to change it to <strong>{0}</strong>?<br><br>If you answer \"Yes\", please be certain, as all existing users will no longer be recognized by your app.",
-		"domain_name": "Domain name",
-		"no_keep_domain": "No, keep {0}"
+		"domain_name": "Domain name"
 	},
 	"functions": {
 		"title": "Functions",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -344,10 +344,7 @@
 		"files_deployed": "文件已经部署",
 		"set_auth_domain_title": "设置用于认证的域名",
 		"set_auth_domain_question": "你想用 <strong>{0}</strong> 作为所有用户登录的主域名吗？?<br/><br/>这个设置就是熟知的 \"derivation origin\", 用来确保无论用户通过任何域名登录，都会被识别为相同的身份(principal).",
-		"update_auth_domain_title": "更新用于认证的域名",
-		"update_auth_domain_question": "你当前设置的用于认证的域名是 <strong>{1}</strong>. 你想更改为 <strong>{0}</strong>?<br><br>如果你回答 \"是\", 请注意，现有的用户身份信息将无法被识别.",
-		"domain_name": "域名",
-		"no_keep_domain": "不, 保留 {0}"
+		"domain_name": "域名"
 	},
 	"functions": {
 		"title": "功能",


### PR DESCRIPTION
# Motivation

We do not need editing derivation origin in the wizard because the option find now place in the authentication.
That's good because it was confusing.

#811
