### PR TITLE
feat: load orbiter config and fetch analytics accordingly

### DIFF
--- a/src/frontend/src/app.d.ts
+++ b/src/frontend/src/app.d.ts
@@ -23,7 +23,6 @@ declare namespace svelteHTML {
 		onjunoCloseActions?: (event: CustomEvent<any>) => void;
 		onjunoRegistrationState?: (event: CustomEvent<any>) => void;
 		onjunoSyncBalance?: (event: CustomEvent<any>) => void;
-		onjunoReloadOrbiterConfig?: (event: CustomEvent<any>) => void;
 		onjunoReloadAuthConfig?: (event: CustomEvent<any>) => void;
 	}
 }

--- a/src/frontend/src/lib/components/analytics/Analytics.svelte
+++ b/src/frontend/src/lib/components/analytics/Analytics.svelte
@@ -19,7 +19,8 @@
 	import {
 		getAnalyticsPageViews,
 		getAnalyticsPerformanceMetrics,
-		getAnalyticsTrackEvents
+		getAnalyticsTrackEvents,
+		loadOrbiterConfigs
 	} from '$lib/services/orbiters.services';
 	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -50,6 +51,16 @@
 		}
 
 		if (isNullish($versionStore.orbiter) || isNullish($versionStore.orbiter?.current)) {
+			return;
+		}
+
+		const { result } = await loadOrbiterConfigs({
+			orbiterId: $orbiterStore.orbiter_id,
+			orbiterVersion: $versionStore.orbiter.current,
+			reload: false
+		});
+
+		if (result === 'error') {
 			return;
 		}
 

--- a/src/frontend/src/lib/components/analytics/Analytics.svelte
+++ b/src/frontend/src/lib/components/analytics/Analytics.svelte
@@ -16,6 +16,7 @@
 	import AnalyticsPerformanceMetrics from '$lib/components/analytics/AnalyticsPerformanceMetrics.svelte';
 	import NoAnalytics from '$lib/components/analytics/NoAnalytics.svelte';
 	import SpinnerParagraph from '$lib/components/ui/SpinnerParagraph.svelte';
+	import { orbiterFeatures } from '$lib/derived/orbiter-satellites.derived';
 	import {
 		getAnalyticsPageViews,
 		getAnalyticsPerformanceMetrics,
@@ -33,10 +34,6 @@
 		PageViewsParams,
 		PageViewsPeriod
 	} from '$lib/types/ortbiter';
-	import {
-		orbiterFeatures,
-		orbiterSatellitesConfig
-	} from '$lib/derived/orbiter-satellites.derived';
 
 	let loading = $state(true);
 

--- a/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
@@ -18,6 +18,7 @@
 	import type { OrbiterSatelliteConfigEntry } from '$lib/types/ortbiter';
 	import type { SatelliteIdText } from '$lib/types/satellite';
 	import { emit } from '$lib/utils/events.utils';
+	import { orbitersConfigsStore } from '$lib/stores/orbiter-configs.store';
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -127,7 +128,10 @@
 				orbiterVersion: $versionStore.orbiter.current
 			});
 
-			emit({ message: 'junoReloadOrbiterConfig', detail: results });
+			orbitersConfigsStore.setConfigs({
+				orbiterId: orbiterId.toText(),
+				configs: results
+			});
 
 			steps = 'ready';
 		} catch (err: unknown) {

--- a/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
@@ -12,13 +12,12 @@
 	import { authStore } from '$lib/stores/auth.store';
 	import { isBusy, wizardBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { orbitersConfigsStore } from '$lib/stores/orbiter-configs.store';
 	import { toasts } from '$lib/stores/toasts.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import type { JunoModalDetail, JunoModalEditOrbiterConfigDetail } from '$lib/types/modal';
 	import type { OrbiterSatelliteConfigEntry } from '$lib/types/ortbiter';
 	import type { SatelliteIdText } from '$lib/types/satellite';
-	import { emit } from '$lib/utils/events.utils';
-	import { orbitersConfigsStore } from '$lib/stores/orbiter-configs.store';
 
 	interface Props {
 		detail: JunoModalDetail;

--- a/src/frontend/src/lib/components/orbiter/OrbiterConfig.svelte
+++ b/src/frontend/src/lib/components/orbiter/OrbiterConfig.svelte
@@ -12,7 +12,10 @@
 	import { versionStore } from '$lib/stores/version.store';
 	import { emit } from '$lib/utils/events.utils';
 	import { first } from '$lib/utils/utils';
-	import { orbiterSatellitesConfig } from '$lib/derived/orbiter-satellites.derived';
+	import {
+		orbiterFeatures,
+		orbiterSatellitesConfig
+	} from '$lib/derived/orbiter-satellites.derived';
 
 	interface Props {
 		orbiterId: Principal;
@@ -44,14 +47,6 @@
 			.join(', ')
 	);
 
-	let features: OrbiterSatelliteFeatures | undefined = $derived(
-		fromNullable(
-			first(
-				Object.entries($orbiterSatellitesConfig).filter(([_, { enabled }]) => enabled) ?? []
-			)?.[1]?.config?.features ?? []
-		)
-	);
-
 	const openModal = () => {
 		emit({
 			message: 'junoModal',
@@ -59,7 +54,7 @@
 				type: 'edit_orbiter_config',
 				detail: {
 					config: $orbiterSatellitesConfig,
-					features,
+					features: $orbiterFeatures,
 					orbiterId
 				}
 			}
@@ -89,7 +84,9 @@
 					{/snippet}
 
 					<p class="satellites">
-						{features?.page_views === true ? $i18n.analytics.enabled : $i18n.analytics.disabled}
+						{$orbiterFeatures?.page_views === true
+							? $i18n.analytics.enabled
+							: $i18n.analytics.disabled}
 					</p>
 				</Value>
 			</div>
@@ -101,7 +98,9 @@
 					{/snippet}
 
 					<p class="satellites">
-						{features?.track_events === true ? $i18n.analytics.enabled : $i18n.analytics.disabled}
+						{$orbiterFeatures?.track_events === true
+							? $i18n.analytics.enabled
+							: $i18n.analytics.disabled}
 					</p>
 				</Value>
 			</div>
@@ -113,7 +112,7 @@
 					{/snippet}
 
 					<p class="satellites">
-						{features?.performance_metrics === true
+						{$orbiterFeatures?.performance_metrics === true
 							? $i18n.analytics.enabled
 							: $i18n.analytics.disabled}
 					</p>

--- a/src/frontend/src/lib/components/orbiter/OrbiterConfig.svelte
+++ b/src/frontend/src/lib/components/orbiter/OrbiterConfig.svelte
@@ -1,24 +1,18 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
-	import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+	import { fromNullable, isNullish } from '@dfinity/utils';
 	import { run } from 'svelte/legacy';
 	import { fade } from 'svelte/transition';
-	import type {
-		OrbiterSatelliteConfig,
-		OrbiterSatelliteFeatures
-	} from '$declarations/orbiter/orbiter.did';
+	import type { OrbiterSatelliteFeatures } from '$declarations/orbiter/orbiter.did';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { listOrbiterSatelliteConfigs } from '$lib/services/orbiters.services';
-	import { authStore } from '$lib/stores/auth.store';
+	import { loadOrbiterConfigs } from '$lib/services/orbiters.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { satellitesStore } from '$lib/stores/satellite.store';
 	import { toasts } from '$lib/stores/toasts.store';
 	import { versionStore } from '$lib/stores/version.store';
-	import type { OrbiterSatelliteConfigEntry } from '$lib/types/ortbiter';
-	import type { SatelliteIdText } from '$lib/types/satellite';
 	import { emit } from '$lib/utils/events.utils';
-	import { satelliteName } from '$lib/utils/satellite.utils';
 	import { first } from '$lib/utils/utils';
+	import { orbiterSatellitesConfig } from '$lib/derived/orbiter-satellites.derived';
 
 	interface Props {
 		orbiterId: Principal;
@@ -26,46 +20,16 @@
 
 	let { orbiterId }: Props = $props();
 
-	let config: Record<SatelliteIdText, OrbiterSatelliteConfigEntry> = $state({});
-
-	const list = (orbiterVersion: string): Promise<[Principal, OrbiterSatelliteConfig][]> =>
-		listOrbiterSatelliteConfigs({ orbiterId, identity: $authStore.identity, orbiterVersion });
-
 	const load = async () => {
 		if (isNullish($versionStore.orbiter?.current)) {
 			return;
 		}
 
-		try {
-			const configs = await list($versionStore.orbiter.current);
-
-			loadConfig(configs);
-		} catch (err: unknown) {
-			toasts.error({
-				text: $i18n.errors.orbiter_configuration_listing,
-				detail: err
-			});
-		}
-	};
-
-	const loadConfig = (configs: [Principal, OrbiterSatelliteConfig][]) => {
-		config = ($satellitesStore ?? []).reduce((acc, satellite) => {
-			const config: [Principal, OrbiterSatelliteConfig] | undefined = (configs ?? []).find(
-				([satelliteId, _]) => satelliteId.toText() === satellite.satellite_id.toText()
-			);
-
-			const entry = config?.[1];
-			const enabled = nonNullish(fromNullable(entry?.features ?? []));
-
-			return {
-				...acc,
-				[satellite.satellite_id.toText()]: {
-					name: satelliteName(satellite),
-					enabled,
-					config: config?.[1]
-				}
-			};
-		}, {});
+		await loadOrbiterConfigs({
+			orbiterId,
+			orbiterVersion: $versionStore.orbiter.current,
+			reload: true
+		});
 	};
 
 	run(() => {
@@ -73,13 +37,8 @@
 		$versionStore, (async () => await load())();
 	});
 
-	// [Principal, SatelliteConfig]
-	const onUpdate = ({ detail }: CustomEvent<[Principal, OrbiterSatelliteConfig][]>) => {
-		loadConfig(detail);
-	};
-
 	let enabledSatellites = $derived(
-		Object.entries(config)
+		Object.entries($orbiterSatellitesConfig)
 			.filter(([_, { enabled }]) => enabled)
 			.map(([_, { name }]) => name)
 			.join(', ')
@@ -87,8 +46,9 @@
 
 	let features: OrbiterSatelliteFeatures | undefined = $derived(
 		fromNullable(
-			first(Object.entries(config).filter(([_, { enabled }]) => enabled) ?? [])?.[1]?.config
-				?.features ?? []
+			first(
+				Object.entries($orbiterSatellitesConfig).filter(([_, { enabled }]) => enabled) ?? []
+			)?.[1]?.config?.features ?? []
 		)
 	);
 
@@ -98,7 +58,7 @@
 			detail: {
 				type: 'edit_orbiter_config',
 				detail: {
-					config,
+					config: $orbiterSatellitesConfig,
 					features,
 					orbiterId
 				}
@@ -106,8 +66,6 @@
 		});
 	};
 </script>
-
-<svelte:window onjunoReloadOrbiterConfig={onUpdate} />
 
 <div class="card-container with-title">
 	<span class="title">{$i18n.core.config}</span>

--- a/src/frontend/src/lib/components/orbiter/OrbiterConfig.svelte
+++ b/src/frontend/src/lib/components/orbiter/OrbiterConfig.svelte
@@ -1,21 +1,18 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
-	import { fromNullable, isNullish } from '@dfinity/utils';
+	import { isNullish } from '@dfinity/utils';
 	import { run } from 'svelte/legacy';
 	import { fade } from 'svelte/transition';
-	import type { OrbiterSatelliteFeatures } from '$declarations/orbiter/orbiter.did';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { loadOrbiterConfigs } from '$lib/services/orbiters.services';
-	import { i18n } from '$lib/stores/i18n.store';
-	import { satellitesStore } from '$lib/stores/satellite.store';
-	import { toasts } from '$lib/stores/toasts.store';
-	import { versionStore } from '$lib/stores/version.store';
-	import { emit } from '$lib/utils/events.utils';
-	import { first } from '$lib/utils/utils';
 	import {
 		orbiterFeatures,
 		orbiterSatellitesConfig
 	} from '$lib/derived/orbiter-satellites.derived';
+	import { loadOrbiterConfigs } from '$lib/services/orbiters.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { satellitesStore } from '$lib/stores/satellite.store';
+	import { versionStore } from '$lib/stores/version.store';
+	import { emit } from '$lib/utils/events.utils';
 
 	interface Props {
 		orbiterId: Principal;

--- a/src/frontend/src/lib/derived/orbiter-satellites.derived.ts
+++ b/src/frontend/src/lib/derived/orbiter-satellites.derived.ts
@@ -1,0 +1,31 @@
+import type { OrbiterSatelliteConfig } from '$declarations/orbiter/orbiter.did';
+import { orbiterConfigs } from '$lib/derived/orbiter.derived';
+import { satellitesStore } from '$lib/stores/satellite.store';
+import type { OrbiterSatelliteConfigEntry } from '$lib/types/ortbiter';
+import type { SatelliteIdText } from '$lib/types/satellite';
+import { satelliteName } from '$lib/utils/satellite.utils';
+import type { Principal } from '@dfinity/principal';
+import { fromNullable, nonNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const orbiterSatellitesConfig: Readable<
+	Record<SatelliteIdText, OrbiterSatelliteConfigEntry>
+> = derived([orbiterConfigs, satellitesStore], ([orbiterConfigsStore, satellitesStore]) =>
+	(satellitesStore ?? []).reduce((acc, satellite) => {
+		const config: [Principal, OrbiterSatelliteConfig] | undefined = (
+			orbiterConfigsStore ?? []
+		).find(([satelliteId, _]) => satelliteId.toText() === satellite.satellite_id.toText());
+
+		const entry = config?.[1];
+		const enabled = nonNullish(fromNullable(entry?.features ?? []));
+
+		return {
+			...acc,
+			[satellite.satellite_id.toText()]: {
+				name: satelliteName(satellite),
+				enabled,
+				config: config?.[1]
+			}
+		};
+	}, {})
+);

--- a/src/frontend/src/lib/derived/orbiter-satellites.derived.ts
+++ b/src/frontend/src/lib/derived/orbiter-satellites.derived.ts
@@ -1,9 +1,13 @@
-import type { OrbiterSatelliteConfig } from '$declarations/orbiter/orbiter.did';
+import type {
+	OrbiterSatelliteConfig,
+	OrbiterSatelliteFeatures
+} from '$declarations/orbiter/orbiter.did';
 import { orbiterConfigs } from '$lib/derived/orbiter.derived';
 import { satellitesStore } from '$lib/stores/satellite.store';
 import type { OrbiterSatelliteConfigEntry } from '$lib/types/ortbiter';
 import type { SatelliteIdText } from '$lib/types/satellite';
 import { satelliteName } from '$lib/utils/satellite.utils';
+import { first } from '$lib/utils/utils';
 import type { Principal } from '@dfinity/principal';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
@@ -28,4 +32,15 @@ export const orbiterSatellitesConfig: Readable<
 			}
 		};
 	}, {})
+);
+
+// Currently we duplicate the configuration for each Satellites that way the UI remains simple - a single configuration for the features
+export const orbiterFeatures: Readable<OrbiterSatelliteFeatures | undefined> = derived(
+	[orbiterSatellitesConfig],
+	([orbiterSatellitesConfig]) =>
+		fromNullable(
+			first(
+				Object.entries(orbiterSatellitesConfig).filter(([_, { enabled }]) => enabled) ?? []
+			)?.[1]?.config?.features ?? []
+		)
 );

--- a/src/frontend/src/lib/derived/orbiter.derived.ts
+++ b/src/frontend/src/lib/derived/orbiter.derived.ts
@@ -1,0 +1,10 @@
+import { type OrbiterConfigs, orbitersConfigsStore } from '$lib/stores/orbiter-configs.store';
+import { orbiterStore } from '$lib/stores/orbiter.store';
+import { nonNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const orbiterConfigs: Readable<OrbiterConfigs | undefined> = derived(
+	[orbiterStore, orbitersConfigsStore],
+	([orbiterStore, orbitersConfigsStore]) =>
+		nonNullish(orbiterStore) ? orbitersConfigsStore?.[orbiterStore.orbiter_id.toText()] : undefined
+);

--- a/src/frontend/src/lib/stores/orbiter-configs.store.ts
+++ b/src/frontend/src/lib/stores/orbiter-configs.store.ts
@@ -1,0 +1,34 @@
+import type { OrbiterSatelliteConfig } from '$declarations/orbiter/orbiter.did';
+import type { OrbiterIdText } from '$lib/types/ortbiter';
+import type { Principal } from '@dfinity/principal';
+import { type Readable, writable } from 'svelte/store';
+
+export type OrbiterConfigs = [Principal, OrbiterSatelliteConfig][];
+
+export type OrbitersConfigsData = Record<OrbiterIdText, OrbiterConfigs>;
+
+export interface OrbitersConfigsStore extends Readable<OrbitersConfigsData> {
+	setConfigs: (params: { orbiterId: OrbiterIdText; configs: OrbiterConfigs }) => void;
+	reset: () => void;
+}
+
+const initOrbitersConfigsStore = (): OrbitersConfigsStore => {
+	const INITIAL: OrbitersConfigsData = {};
+
+	const { subscribe, update, set } = writable<OrbitersConfigsData>(INITIAL);
+
+	return {
+		subscribe,
+
+		setConfigs({ orbiterId, configs }) {
+			update((state) => ({
+				...state,
+				[orbiterId]: configs
+			}));
+		},
+
+		reset: () => set(INITIAL)
+	};
+};
+
+export const orbitersConfigsStore = initOrbitersConfigsStore();

--- a/src/frontend/src/lib/types/ortbiter.ts
+++ b/src/frontend/src/lib/types/ortbiter.ts
@@ -5,7 +5,7 @@ import type {
 	AnalyticsTop10PageViews,
 	OrbiterSatelliteConfig as SatelliteConfig
 } from '$declarations/orbiter/orbiter.did';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { OptionIdentity, PrincipalText } from '$lib/types/itentity';
 import { Principal } from '@dfinity/principal';
 
 export interface PageViewsPeriod {
@@ -41,3 +41,5 @@ export interface OrbiterSatelliteConfigEntry {
 	enabled: boolean;
 	config?: SatelliteConfig;
 }
+
+export type OrbiterIdText = PrincipalText;


### PR DESCRIPTION
# Motivation

Right now, if a particular metrics is given issue due to the amount of data it could be interesting to be able to disable it and not fetch the data.
