### PR TITLE
style: inputs height

### DIFF
--- a/src/frontend/src/lib/styles/global/input.scss
+++ b/src/frontend/src/lib/styles/global/input.scss
@@ -49,8 +49,12 @@ input[type='radio'] {
 	margin: var(--padding-1_5x) 0;
 }
 
-input[type='date'] {
-	height: 40px;
+input:not([type="checkbox"]):not([type="radio"]), select {
+	height: 34px;
+
+	&[type='date'], &.big {
+		height: 40px;
+	}
 }
 
 input[disabled] {

--- a/src/frontend/src/lib/styles/global/input.scss
+++ b/src/frontend/src/lib/styles/global/input.scss
@@ -49,10 +49,12 @@ input[type='radio'] {
 	margin: var(--padding-1_5x) 0;
 }
 
-input:not([type="checkbox"]):not([type="radio"]), select {
+input:not([type='checkbox']):not([type='radio']),
+select {
 	height: 34px;
 
-	&[type='date'], &.big {
+	&[type='date'],
+	&.big {
 		height: 40px;
 	}
 }


### PR DESCRIPTION
# Motivation

On the analytics page in Safari, the select for the satellite is smaller as the input fields next to it, it's annoying.
