### PR TITLE
feat: show analytics filter even if load failed

### DIFF
--- a/src/frontend/src/lib/components/analytics/Analytics.svelte
+++ b/src/frontend/src/lib/components/analytics/Analytics.svelte
@@ -113,17 +113,21 @@
 		$orbiterStore, $satelliteStore, $versionStore, period, debouncePageViews();
 	});
 
-	const selectPeriod = ({ detail }: CustomEvent<PageViewsPeriod>) => (period = detail);
+	const selectPeriod = (detail: PageViewsPeriod) => (period = detail);
 </script>
 
 {#if loading}
-	<SpinnerParagraph>{$i18n.analytics.loading}</SpinnerParagraph>
+	<div class="loading">
+		<SpinnerParagraph>{$i18n.analytics.loading}</SpinnerParagraph>
+	</div>
 {:else}
+	{#if nonNullish($orbiterStore)}
+		<AnalyticsFilter {selectPeriod} />
+	{/if}
+
 	{#if isNullish($orbiterStore) || isNullish(pageViews)}
 		<NoAnalytics />
 	{:else}
-		<AnalyticsFilter on:junoPeriod={selectPeriod} />
-
 		<AnalyticsChart data={pageViews} />
 
 		<AnalyticsMetrics {pageViews} />
@@ -149,3 +153,9 @@
 		<AnalyticsNew />
 	{/if}
 {/if}
+
+<style lang="scss">
+	.loading {
+		margin: calc(var(--padding-3x) + var(--padding-0_5x)) 0 0;
+	}
+</style>

--- a/src/frontend/src/lib/components/analytics/AnalyticsFilter.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsFilter.svelte
@@ -1,23 +1,26 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { addMonths, format } from 'date-fns';
-	import { createEventDispatcher } from 'svelte';
 	import AnalyticsSatellitesPicker from '$lib/components/analytics/AnalyticsSatellitesPicker.svelte';
 	import AnalyticsToolbar from '$lib/components/analytics/AnalyticsToolbar.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { PageViewsPeriod } from '$lib/types/ortbiter';
 
+	interface Props {
+		selectPeriod: (period: PageViewsPeriod) => void;
+	}
+
+	let { selectPeriod }: Props = $props();
+
 	let from = $state(format(addMonths(new Date(), -1), 'yyyy-MM-dd'));
 	let to = $state('');
 
-	const dispatch = createEventDispatcher();
-
 	const onChange = () =>
-		dispatch('junoPeriod', {
+		selectPeriod({
 			from: nonNullish(from) && from !== '' ? new Date(from) : undefined,
 			to: nonNullish(to) && to !== '' ? new Date(to) : undefined
-		} as PageViewsPeriod);
+		});
 </script>
 
 <AnalyticsToolbar>

--- a/src/frontend/src/lib/components/analytics/AnalyticsSatellitesPicker.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsSatellitesPicker.svelte
@@ -36,7 +36,7 @@
 	);
 </script>
 
-<select id="satellite" name="satellite" bind:value={satelliteIdText} onchange={navigate}>
+<select id="satellite" name="satellite" class="big" bind:value={satelliteIdText} onchange={navigate}>
 	<option value={undefined}>{$i18n.analytics.all_satellites}</option>
 
 	{#each satellites as { satelliteId, satName }}

--- a/src/frontend/src/lib/components/analytics/AnalyticsSatellitesPicker.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsSatellitesPicker.svelte
@@ -36,7 +36,13 @@
 	);
 </script>
 
-<select id="satellite" name="satellite" class="big" bind:value={satelliteIdText} onchange={navigate}>
+<select
+	id="satellite"
+	name="satellite"
+	class="big"
+	bind:value={satelliteIdText}
+	onchange={navigate}
+>
 	<option value={undefined}>{$i18n.analytics.all_satellites}</option>
 
 	{#each satellites as { satelliteId, satName }}


### PR DESCRIPTION
# Motivation

It's currently possible that the analytics fail because to many data since the statistics are currently calculated on the fly. So it would be handy to be able to refine the filter to try to query a smaller subnet however currently, the filter are only displayed if all calls succeeded.
