### PR TITLE
feat: set again auth config

### DIFF
--- a/src/frontend/src/lib/services/auth.config.services.ts
+++ b/src/frontend/src/lib/services/auth.config.services.ts
@@ -72,9 +72,13 @@ const updateConfig = async ({
 	result: 'skip' | 'success' | 'error';
 	err?: unknown;
 }> => {
+	// TODO: Allowing the same host to be set again is currently useful
+	// because it triggers the regeneration of the /.well-known/ii-alternative-origins file.
+	// This is helpful when users add more domains, as they can be included in the updated file.
 	if (
+		isNullish(derivationOrigin?.host) &&
 		derivationOrigin?.host ===
-		fromNullable(fromNullable(config?.internet_identity ?? [])?.derivation_origin ?? [])
+			fromNullable(fromNullable(config?.internet_identity ?? [])?.derivation_origin ?? [])
 	) {
 		return { result: 'skip' };
 	}


### PR DESCRIPTION
# Motivation

Discussed today on [Discord](https://discord.com/channels/1076791076544847982/1309069050420133890/1309073963950936104). It's handy to be able to set again the auth config if new domain are added.

# TODO

For later work: #827