### PR TITLE
feat: buy cycles with cycle.express

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 VITE_BN_REGISTRATIONS_URL=https://icp0.io/registrations
 VITE_JUNO_CDN_URL=https://cdn.juno.build
+VITE_CYCLE_EXPRESS_URL=https://cycle.express/

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 VITE_BN_REGISTRATIONS_URL=https://icp0.io/registrations
 VITE_JUNO_CDN_URL=https://cdn.juno.build
+VITE_CYCLE_EXPRESS_URL=https://cycle.express/

--- a/src/frontend/src/lib/components/canister/CanisterBuyCycleExpress.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterBuyCycleExpress.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-	import IconShoppingCart from '$lib/components/icons/IconShoppingCart.svelte';
-	import { i18n } from '$lib/stores/i18n.store';
 	import type { Principal } from '@dfinity/principal';
-	import { popupCenter } from '$lib/utils/window.utils';
-	import { AUTH_POPUP_HEIGHT, AUTH_POPUP_WIDTH } from '$lib/constants/constants';
-	import { onDestroy } from 'svelte';
-	import { emit } from '$lib/utils/events.utils';
-	import { busy } from '$lib/stores/busy.store';
 	import { nonNullish } from '@dfinity/utils';
+	import { onDestroy } from 'svelte';
+	import IconShoppingCart from '$lib/components/icons/IconShoppingCart.svelte';
+	import { busy } from '$lib/stores/busy.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { emit } from '$lib/utils/events.utils';
+	import { popupCenter } from '$lib/utils/window.utils';
 
 	interface Props {
 		canisterId: Principal;
@@ -19,6 +18,7 @@
 
 	const clear = () => clearInterval(interval);
 
+	// eslint-disable-next-line require-await
 	const buyCycles = async () => {
 		busy.show();
 

--- a/src/frontend/src/lib/components/canister/CanisterBuyCycleExpress.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterBuyCycleExpress.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import IconShoppingCart from '$lib/components/icons/IconShoppingCart.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { Principal } from '@dfinity/principal';
+	import { popupCenter } from '$lib/utils/window.utils';
+	import { AUTH_POPUP_HEIGHT, AUTH_POPUP_WIDTH } from '$lib/constants/constants';
+	import { onDestroy } from 'svelte';
+	import { emit } from '$lib/utils/events.utils';
+	import { busy } from '$lib/stores/busy.store';
+	import { nonNullish } from '@dfinity/utils';
+
+	interface Props {
+		canisterId: Principal;
+	}
+
+	let { canisterId }: Props = $props();
+
+	let interval: NodeJS.Timeout | undefined = $state(undefined);
+
+	const clear = () => clearInterval(interval);
+
+	const buyCycles = async () => {
+		busy.show();
+
+		const popup = window.open(
+			`https://cycle.express/to=${canisterId.toText()}`,
+			'cycle.express',
+			popupCenter({ width: 576, height: 650 })
+		);
+
+		const reloadCycles = () => {
+			if (popup?.closed === false) {
+				return;
+			}
+
+			clear();
+
+			emit({ message: 'junoRestartCycles', detail: { canisterId } });
+
+			busy.stop();
+		};
+
+		interval = setInterval(reloadCycles, 1000);
+	};
+
+	onDestroy(clear);
+
+	const CYCLE_EXPRESS_URL = import.meta.env.VITE_CYCLE_EXPRESS_URL;
+</script>
+
+{#if nonNullish(CYCLE_EXPRESS_URL)}
+	<button onclick={buyCycles} class="menu"><IconShoppingCart /> {$i18n.canisters.buy_cycles}</button
+	>
+{/if}

--- a/src/frontend/src/lib/components/icons/IconShoppingCart.svelte
+++ b/src/frontend/src/lib/components/icons/IconShoppingCart.svelte
@@ -1,0 +1,19 @@
+<!-- source: https://fonts.google.com/icons?selected=Material+Symbols+Outlined:shopping_cart:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24&icon.color=%23000000&icon.query=buy&icon.set=Material+Symbols&icon.style=Outlined -->
+<script lang="ts">
+	interface Props {
+		size?: string;
+	}
+
+	let { size = '24px' }: Props = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	height={size}
+	width={size}
+	fill="currentColor"
+	viewBox="0 -960 960 960"
+	><path
+		d="M280-80q-33 0-56.5-23.5T200-160q0-33 23.5-56.5T280-240q33 0 56.5 23.5T360-160q0 33-23.5 56.5T280-80Zm400 0q-33 0-56.5-23.5T600-160q0-33 23.5-56.5T680-240q33 0 56.5 23.5T760-160q0 33-23.5 56.5T680-80ZM246-720l96 200h280l110-200H246Zm-38-80h590q23 0 35 20.5t1 41.5L692-482q-11 20-29.5 31T622-440H324l-44 80h480v80H280q-45 0-68-39.5t-2-78.5l54-98-144-304H40v-80h130l38 80Zm134 280h280-280Z"
+	/></svg
+>

--- a/src/frontend/src/lib/components/mission-control/MissionControlActions.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlActions.svelte
@@ -7,6 +7,7 @@
 	import MissionControlAttachSatellite from '$lib/components/mission-control/MissionControlAttachSatellite.svelte';
 	import type { CanisterIcStatus } from '$lib/types/canister';
 	import { emit } from '$lib/utils/events.utils';
+	import CanisterBuyCycleExpress from '$lib/components/canister/CanisterBuyCycleExpress.svelte';
 
 	interface Props {
 		missionControlId: Principal;
@@ -52,6 +53,8 @@
 	<TopUp type="topup_mission_control" on:junoTopUp={close} />
 
 	<CanisterTransferCycles {canister} onclick={onTransferCycles} />
+
+	<CanisterBuyCycleExpress canisterId={missionControlId} />
 
 	<hr />
 

--- a/src/frontend/src/lib/components/mission-control/MissionControlActions.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
+	import CanisterBuyCycleExpress from '$lib/components/canister/CanisterBuyCycleExpress.svelte';
 	import CanisterTransferCycles from '$lib/components/canister/CanisterTransferCycles.svelte';
 	import TopUp from '$lib/components/canister/TopUp.svelte';
 	import Actions from '$lib/components/core/Actions.svelte';
@@ -7,7 +8,6 @@
 	import MissionControlAttachSatellite from '$lib/components/mission-control/MissionControlAttachSatellite.svelte';
 	import type { CanisterIcStatus } from '$lib/types/canister';
 	import { emit } from '$lib/utils/events.utils';
-	import CanisterBuyCycleExpress from '$lib/components/canister/CanisterBuyCycleExpress.svelte';
 
 	interface Props {
 		missionControlId: Principal;

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -121,6 +121,7 @@
 		"detach_success": "{0} detached.",
 		"delete_success": "{0} deleted.",
 		"transfer_cycles": "Transfer cycles",
+		"buy_cycles": "Buy cycles",
 		"transfer_cycles_description": "You can manage your cycles by moving them between your satellite, mission control, and analytics, ensuring your resources are where you need them most",
 		"select_destination": "Select the destination",
 		"destination": "Destination for the transfer",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -121,6 +121,7 @@
 		"detach_success": "{0} 已解绑的.",
 		"delete_success": "{0} 已删除.",
 		"transfer_cycles": "转移 cycles",
+		"buy_cycles": "Buy cycles",
 		"transfer_cycles_description": "你可以通过在 satellite, mission control, 和 analytics 之间转移 cycles 来管理他们的使用分配",
 		"select_destination": "选择目的地",
 		"destination": "转移目的地",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -125,6 +125,7 @@ interface I18nCanisters {
 	detach_success: string;
 	delete_success: string;
 	transfer_cycles: string;
+	buy_cycles: string;
 	transfer_cycles_description: string;
 	select_destination: string;
 	destination: string;


### PR DESCRIPTION
# Motivation

It can be helpful for developers, particularly newcomers, to directly purchase cycles without already owning ICP. [cycles.express](https://cycle.express/) addresses this by integrating Stripe on their end to facilitate the exchange for cycles.

This is why this PR adds a "Buy Cycles" link to Mission Control.

# Notes

The integration on our side is still rough around the edges as we do not currently provide any information in the UI. I'll add documentation on the website, and we may iterate on the UI in the future.
