### PR TITLE
fix: buy cycles typo in url

### DIFF
--- a/src/frontend/src/lib/components/canister/CanisterBuyCycleExpress.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterBuyCycleExpress.svelte
@@ -23,7 +23,7 @@
 		busy.show();
 
 		const popup = window.open(
-			`https://cycle.express/to=${canisterId.toText()}`,
+			`https://cycle.express/?to=${canisterId.toText()}`,
 			'cycle.express',
 			popupCenter({ width: 576, height: 650 })
 		);


### PR DESCRIPTION
# Motivation

Small typo in the URL provided in #832. `to` is a query param.
