### PR TITLE
fix: refresh cycles

### DIFF
--- a/src/frontend/src/lib/services/worker.statuses.services.ts
+++ b/src/frontend/src/lib/services/worker.statuses.services.ts
@@ -47,10 +47,10 @@ export const initStatusesWorker = async (): Promise<StatusesWorker> => {
 				msg: 'stopStatusesTimer'
 			});
 		},
-		restartStatusesTimer: (data) => {
+		restartStatusesTimer: ({ segments, missionControlId }) => {
 			statusesWorker.postMessage({
 				msg: 'restartStatusesTimer',
-				data
+				data: { segments, missionControlId: missionControlId.toText() }
 			});
 		}
 	};


### PR DESCRIPTION
# Motivation

I noticed that the cycles we not explicitely reloaded after transfering cycles because the worker expect a string and not a principal.

Maybe someday I should Zod to validate the post messages.
