### PR TITLE
feat: cache agent per module

### DIFF
--- a/src/frontend/src/lib/api/agent/agent.api.ts
+++ b/src/frontend/src/lib/api/agent/agent.api.ts
@@ -1,11 +1,32 @@
 import { DEV } from '$lib/constants/constants';
+import type { Option } from '$lib/types/utils';
 import { HttpAgent, type Identity } from '@dfinity/agent';
+import { isNullish } from '@dfinity/utils';
 
 export interface GetAgentParams {
 	identity: Identity;
 }
 
-export const getAgent = async (params: GetAgentParams): Promise<HttpAgent> => {
+let agents: Option<Record<string, HttpAgent>> = undefined;
+
+export const getAgent = async ({ identity }: GetAgentParams): Promise<HttpAgent> => {
+	const key = identity.getPrincipal().toText();
+
+	if (isNullish(agents) || isNullish(agents[key])) {
+		const agent = await createAgent({ identity });
+
+		agents = {
+			...(agents ?? {}),
+			[key]: agent
+		};
+
+		return agent;
+	}
+
+	return agents[key];
+};
+
+const createAgent = async (params: GetAgentParams): Promise<HttpAgent> => {
 	if (DEV) {
 		return await getLocalAgent(params);
 	}
@@ -28,3 +49,6 @@ const getLocalAgent = async (params: GetAgentParams) => {
 
 	return agent;
 };
+
+// Unused because currently we do a window.location.reload after logout
+export const clearAgents = () => (agents = null);


### PR DESCRIPTION
# Motivation

When initialized the agent-js does all kind of stuffs so caching it per module reduces a bit the overhead.
