### PR TITLE
build: npm audit fix cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2334,9 +2334,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.7.3.tgz",
-			"integrity": "sha512-Vx7nq5MJ86I8qXYsVidC5PX6xm+uxt8DydvOdmJoyOK7LvGP18OFEG359yY+aa51t6pENvqZAMqAREQQx1OI2Q==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.8.5.tgz",
+			"integrity": "sha512-5ry1jPd4r9knsphDK2eTYUFPhFZMqF0PHFfa8MdMQCqWaKwLSXdFMU/Vevih1I7C1/VNB5MvTuFl1kXu5vx8UA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -3707,9 +3707,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3717,10 +3717,11 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -10932,13 +10933,13 @@
 			"requires": {}
 		},
 		"@sveltejs/kit": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.7.3.tgz",
-			"integrity": "sha512-Vx7nq5MJ86I8qXYsVidC5PX6xm+uxt8DydvOdmJoyOK7LvGP18OFEG359yY+aa51t6pENvqZAMqAREQQx1OI2Q==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.8.5.tgz",
+			"integrity": "sha512-5ry1jPd4r9knsphDK2eTYUFPhFZMqF0PHFfa8MdMQCqWaKwLSXdFMU/Vevih1I7C1/VNB5MvTuFl1kXu5vx8UA==",
 			"dev": true,
 			"requires": {
 				"@types/cookie": "^0.6.0",
-				"cookie": "^0.6.0",
+				"cookie": "^0.7.0",
 				"devalue": "^5.1.0",
 				"esm-env": "^1.0.0",
 				"import-meta-resolve": "^4.1.0",
@@ -11814,15 +11815,15 @@
 			"dev": true
 		},
 		"cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -107,5 +107,8 @@
 	},
 	"engines": {
 		"node": "^22"
+	},
+	"overrides": {
+		"cookie": "^0.7.0"
 	}
 }


### PR DESCRIPTION
# Motivation

There is a low security issue about `cookie` which is reported by `npm audit fix` but, won't be addressed in current version of SvelteKit (I reported the security [issue](https://github.com/sveltejs/kit/security/advisories/GHSA-fcpm-cfj3-v9vr) which is set to private). That's why this PR resolves the audit by overring the version.

Security advisory: https://github.com/advisories/GHSA-pxg6-pf52-xh8x