### PR TITLE
fix: popover position

### DIFF
--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { quintOut } from 'svelte/easing';
 	import { stopPropagation } from 'svelte/legacy';
@@ -32,13 +33,22 @@
 	let right: number = $state(0);
 	let innerWidth = $state(0);
 
+	let attached = $state(false);
+
 	const initPosition = () =>
-		({ bottom, left, right } = anchor
+		({ bottom, left, right } = nonNullish(anchor)
 			? anchor.getBoundingClientRect()
 			: { bottom: 0, left: 0, right: 0 });
 
 	$effect(() => {
+		if (visible === false) {
+			attached = false;
+			return;
+		}
+
 		initPosition();
+
+		attached = true;
 	});
 
 	const close = () => (visible = false);
@@ -46,7 +56,7 @@
 
 <svelte:window onresize={initPosition} bind:innerWidth />
 
-{#if visible}
+{#if visible && attached}
 	<div
 		role="menu"
 		aria-orientation="vertical"


### PR DESCRIPTION
# Motivation

The popover position did not adjust for the scroll length. As a result, depending on the position of the anchor for the popover—such as the backup function towards the end of the page—and the zoom level, the popover might have been misplaced.
