### PR TITLE
feat: expose get_controllers for serverless functions

### DIFF
--- a/src/libs/satellite/src/controllers/store.rs
+++ b/src/libs/satellite/src/controllers/store.rs
@@ -24,10 +24,64 @@ pub fn delete_controllers(remove_controllers: &[ControllerId]) {
     })
 }
 
+/// Retrieve the controllers of the Satellite.
+///
+/// This function retrieves the list of controllers currently set for the application.
+/// A controller is represented as a key-value pair where the key is the `ControllerId`
+/// (a `Principal`) and the value is a `Controller` struct containing metadata and scope
+/// details about the controller.
+///
+/// # Returns
+/// - `Controllers`: A `HashMap` where:
+///   - The key is a `ControllerId` (type alias for `Principal`).
+///   - The value is a `Controller` struct that includes:
+///     - `metadata`: Additional metadata about the controller, such as name or description.
+///     - `created_at`: The timestamp when the controller was created.
+///     - `updated_at`: The timestamp when the controller was last updated.
+///     - `expires_at`: An optional timestamp indicating when the controller expires.
+///     - `scope`: The `ControllerScope`, which specifies the access level (`Write` or `Admin`).
+///
+/// # Example
+/// ```
+/// let controllers = get_controllers();
+/// for (controller_id, controller) in controllers.iter() {
+///     println!("Controller ID: {}", controller_id);
+///     println!("Scope: {:?}", controller.scope);
+///     if let Some(expires_at) = controller.expires_at {
+///         println!("Expires at: {}", expires_at);
+///     }
+/// }
+/// ```
+///
+/// This function is useful for checking the current permissions.
 pub fn get_controllers() -> Controllers {
     STATE.with(|state| state.borrow().heap.controllers.clone())
 }
 
+/// Retrieve the current admin controllers for a Satellite.
+///
+/// This function filters the list of controllers to include only those with the `Admin` scope.
+///
+/// # Returns
+/// - `Controllers`: A `HashMap` where:
+///   - The key is a `ControllerId` (type alias for `Principal`).
+///   - The value is a `Controller` struct that includes:
+///     - `metadata`: Additional metadata about the controller.
+///     - `created_at`: The timestamp when the controller was created.
+///     - `updated_at`: The timestamp when the controller was last updated.
+///     - `expires_at`: An optional timestamp indicating when the controller expires.
+///     - `scope`: Always `ControllerScope::Admin` for admin controllers.
+///
+/// # Example
+/// ```
+/// let admin_controllers = get_admin_controllers();
+/// for (controller_id, controller) in admin_controllers.iter() {
+///     println!("Admin Controller ID: {}", controller_id);
+///     println!("Created at: {}", controller.created_at);
+/// }
+/// ```
+///
+/// This function is useful for auditing or managing permissions for admin-level access.
 pub fn get_admin_controllers() -> Controllers {
     STATE.with(|state| filter_admin_controllers(&state.borrow().heap.controllers))
 }

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -16,6 +16,7 @@ mod types;
 mod version;
 
 use crate::auth::types::config::AuthenticationConfig;
+use crate::db::types::config::DbConfig;
 use crate::guards::{caller_is_admin_controller, caller_is_controller};
 use crate::types::interface::{Config, RulesType};
 use crate::version::SATELLITE_VERSION;
@@ -24,23 +25,34 @@ use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::interface::{DelRule, SetRule};
 use junobuild_collections::types::rules::Rule;
+use junobuild_shared::types::core::DomainName;
+use junobuild_shared::types::core::{Blob, Key};
+use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::interface::{
     DeleteControllersArgs, DepositCyclesArgs, MemorySize, SetControllersArgs,
 };
 use junobuild_shared::types::list::ListParams;
 use junobuild_shared::types::list::ListResults;
 use junobuild_shared::types::state::Controllers;
+use junobuild_storage::http::types::{
+    HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken,
+};
+use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::interface::{
     AssetNoContent, CommitBatch, InitAssetKey, InitUploadResult, UploadChunk, UploadChunkResult,
 };
+use junobuild_storage::types::state::FullPath;
 
-// Re-export types
-
+// ============================================================================================
+// START: Re-exported Types
+//
+// These types are made available for use in Serverless Functions.
+// ============================================================================================
+pub use crate::controllers::store::{get_admin_controllers, get_controllers};
 pub use crate::db::store::{
     count_collection_docs_store, count_docs_store, delete_doc_store, delete_docs_store,
     delete_filtered_docs_store, get_doc_store, list_docs_store, set_doc_store,
 };
-use crate::db::types::config::DbConfig;
 pub use crate::db::types::interface::{DelDoc, SetDoc};
 pub use crate::db::types::state::Doc;
 pub use crate::logs::loggers::{
@@ -59,14 +71,9 @@ pub use crate::types::hooks::{
     OnDeleteFilteredAssetsContext, OnDeleteFilteredDocsContext, OnDeleteManyAssetsContext,
     OnDeleteManyDocsContext, OnSetDocContext, OnSetManyDocsContext, OnUploadAssetContext,
 };
-use junobuild_shared::types::core::DomainName;
-pub use junobuild_shared::types::core::{Blob, Key};
-use junobuild_shared::types::domain::CustomDomains;
-use junobuild_storage::http::types::{
-    HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken,
-};
-use junobuild_storage::types::config::StorageConfig;
-use junobuild_storage::types::state::FullPath;
+// ============================================================================================
+// END: Re-exported Types
+// ============================================================================================
 
 ///
 /// Init and Upgrade


### PR DESCRIPTION
# Motivation

Resolves  #853 and a bit of clean-up (some exposed entities are actually already exposed by other crates such as shared).
