### PR TITLE
build: cleanup unused crates dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,24 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "ahash"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,12 +10,6 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anyhow"
@@ -64,12 +40,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "basic-toml"
@@ -104,12 +74,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,45 +97,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "cached"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b0116662497bc24e4b177c90eaf8870e39e2714c3fcfa296327a93f593fc21"
-dependencies = [
- "ahash",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "hashbrown",
- "instant",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c878c71c2821aa2058722038a59a67583a4240524687c6028571c9b395ded61f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "candid"
@@ -308,41 +233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,22 +262,6 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -544,16 +418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,30 +430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "http"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "ic-cbor"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1e30f631a2a5987d843721dd83b49908d0c0cdb21fbcbbb51c1548ff01d99c"
-dependencies = [
- "candid",
- "ic-certification",
- "leb128",
- "nom",
- "thiserror",
 ]
 
 [[package]]
@@ -634,25 +474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-certificate-verification"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769142849e241e6cf7f5611f9b04983e958729495ea67d2de95e5d9a9c687d9b"
-dependencies = [
- "cached",
- "candid",
- "ic-cbor",
- "ic-certification",
- "lazy_static",
- "leb128",
- "miracl_core_bls12381",
- "nom",
- "parking_lot",
- "sha2",
- "thiserror",
-]
-
-[[package]]
 name = "ic-certification"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,21 +483,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2",
-]
-
-[[package]]
-name = "ic-http-certification"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d4e5ef38b5315b0e619c8a50c2d3ce485d769dbe3eca88ef64165597056e24"
-dependencies = [
- "candid",
- "http",
- "ic-certification",
- "ic-representation-independent-hash",
- "serde",
- "thiserror",
- "urlencoding",
 ]
 
 [[package]]
@@ -702,30 +508,6 @@ checksum = "257c90372cfbf5bf5b7f473d034dac2fb344665015c582592b8b45d90b181c88"
 dependencies = [
  "leb128",
  "sha2",
-]
-
-[[package]]
-name = "ic-response-verification"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ce81210d3747a4e334a86851c57725a5ec4d2d0c40b05b5dc4f9114c19c78a"
-dependencies = [
- "base64 0.21.7",
- "candid",
- "flate2",
- "hex",
- "http",
- "ic-cbor",
- "ic-certificate-verification",
- "ic-certification",
- "ic-http-certification",
- "ic-representation-independent-hash",
- "leb128",
- "log",
- "nom",
- "sha2",
- "thiserror",
- "urlencoding",
 ]
 
 [[package]]
@@ -777,12 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,15 +566,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -831,8 +598,6 @@ version = "0.0.9"
 dependencies = [
  "candid",
  "ic-cdk",
- "ic-cdk-macros",
- "ic-cdk-timers",
  "junobuild-shared",
  "serde",
 ]
@@ -841,8 +606,6 @@ dependencies = [
 name = "junobuild-macros"
 version = "0.0.3"
 dependencies = [
- "candid",
- "ic-cdk",
  "proc-macro2",
  "quote",
  "serde",
@@ -869,7 +632,6 @@ dependencies = [
  "rand",
  "regex",
  "serde",
- "serde_cbor",
  "serde_json",
  "url",
 ]
@@ -882,7 +644,6 @@ dependencies = [
  "ciborium",
  "futures",
  "ic-cdk",
- "ic-cdk-macros",
  "ic-ledger-types",
  "ic-stable-structures",
  "icrc-ledger-types",
@@ -895,16 +656,13 @@ dependencies = [
 name = "junobuild-storage"
 version = "0.0.12"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "candid",
  "globset",
  "hex",
  "ic-cdk",
- "ic-cdk-macros",
- "ic-cdk-timers",
  "ic-certification",
  "ic-representation-independent-hash",
- "ic-response-verification",
  "ic-stable-structures",
  "junobuild-collections",
  "junobuild-shared",
@@ -962,16 +720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,27 +730,6 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miracl_core_bls12381"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07cbe42e2a8dd41df582fb8e00fc24d920b5561cc301fcb6d14e2e0434b500f"
 
 [[package]]
 name = "mission_control"
@@ -1016,16 +743,6 @@ dependencies = [
  "icrc-ledger-types",
  "junobuild-shared",
  "serde",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1074,7 +791,6 @@ dependencies = [
  "ic-cdk-timers",
  "junobuild-shared",
  "lazy_static",
- "serde",
 ]
 
 [[package]]
@@ -1094,33 +810,9 @@ dependencies = [
  "ic-stable-structures",
  "isbot",
  "junobuild-shared",
- "lazy_static",
  "regex",
  "serde",
  "url",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
 ]
 
 [[package]]
@@ -1228,15 +920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,20 +964,11 @@ checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 name = "satellite"
 version = "0.0.21"
 dependencies = [
- "candid",
  "ic-cdk",
- "ic-cdk-macros",
  "junobuild-macros",
  "junobuild-satellite",
  "junobuild-storage",
- "serde",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1394,12 +1068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
-
-[[package]]
 name = "stacker"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,12 +1079,6 @@ dependencies = [
  "psm",
  "winapi",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -1650,80 +1312,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 name = "satellite"
 version = "0.0.21"
 dependencies = [
+ "candid",
  "ic-cdk",
  "junobuild-macros",
  "junobuild-satellite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "ic-cdk-timers",
  "junobuild-shared",
  "lazy_static",
+ "serde",
 ]
 
 [[package]]

--- a/src/libs/collections/Cargo.toml
+++ b/src/libs/collections/Cargo.toml
@@ -16,7 +16,5 @@ targets = ["wasm32-unknown-unknown"]
 [dependencies]
 candid.workspace = true
 ic-cdk.workspace = true
-ic-cdk-macros.workspace = true
-ic-cdk-timers.workspace = true
 serde.workspace = true
 junobuild-shared = "0.0.22"

--- a/src/libs/macros/Cargo.toml
+++ b/src/libs/macros/Cargo.toml
@@ -21,6 +21,4 @@ serde.workspace = true
 serde_tokenstream = "0.2.0"
 
 [dev-dependencies]
-candid.workspace = true
-ic-cdk.workspace = true
 trybuild = "1.0.89"

--- a/src/libs/satellite/Cargo.toml
+++ b/src/libs/satellite/Cargo.toml
@@ -37,7 +37,6 @@ ic-cdk.workspace = true
 ic-cdk-macros.workspace = true
 ic-cdk-timers.workspace = true
 serde.workspace = true
-serde_cbor.workspace = true
 serde_json.workspace = true
 ic-stable-structures.workspace = true
 ciborium.workspace = true

--- a/src/libs/shared/Cargo.toml
+++ b/src/libs/shared/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["wasm32-unknown-unknown"]
 [dependencies]
 candid.workspace = true
 ic-cdk.workspace = true
-ic-cdk-macros.workspace = true
 ic-ledger-types.workspace = true
 icrc-ledger-types.workspace = true
 ic-stable-structures.workspace = true

--- a/src/libs/storage/Cargo.toml
+++ b/src/libs/storage/Cargo.toml
@@ -16,8 +16,6 @@ targets = ["wasm32-unknown-unknown"]
 [dependencies]
 candid.workspace = true
 ic-cdk.workspace = true
-ic-cdk-macros.workspace = true
-ic-cdk-timers.workspace = true
 serde.workspace = true
 serde_cbor.workspace = true
 ic-stable-structures.workspace = true
@@ -25,7 +23,6 @@ sha2.workspace = true
 hex.workspace = true
 serde_bytes = "0.11.12"
 ic-certification = "2.4.0"
-ic-response-verification = "2.4.0"
 ic-representation-independent-hash = "2.4.0"
 regex.workspace = true
 base64 = "0.13.1"

--- a/src/observatory/Cargo.toml
+++ b/src/observatory/Cargo.toml
@@ -12,6 +12,5 @@ candid.workspace = true
 ic-cdk.workspace = true
 ic-cdk-macros.workspace = true
 ic-cdk-timers.workspace = true
-serde.workspace = true
 lazy_static = "1.4.0"
 junobuild-shared = { path = "../libs/shared" }

--- a/src/observatory/Cargo.toml
+++ b/src/observatory/Cargo.toml
@@ -12,5 +12,6 @@ candid.workspace = true
 ic-cdk.workspace = true
 ic-cdk-macros.workspace = true
 ic-cdk-timers.workspace = true
+serde.workspace = true
 lazy_static = "1.4.0"
 junobuild-shared = { path = "../libs/shared" }

--- a/src/orbiter/Cargo.toml
+++ b/src/orbiter/Cargo.toml
@@ -13,7 +13,6 @@ ic-cdk.workspace = true
 ic-cdk-macros.workspace = true
 serde.workspace = true
 ic-stable-structures.workspace = true
-lazy_static = "1.4.0"
 ciborium.workspace = true
 isbot = "0.1.3"
 url = "2.4.0"

--- a/src/satellite/Cargo.toml
+++ b/src/satellite/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+candid.workspace = true
 ic-cdk.workspace = true
 junobuild-satellite = { path = "../libs/satellite", default-features = false, features = ["on_init"] }
 junobuild-storage = { path = "../libs/storage" }

--- a/src/satellite/Cargo.toml
+++ b/src/satellite/Cargo.toml
@@ -8,10 +8,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-candid.workspace = true
 ic-cdk.workspace = true
-ic-cdk-macros.workspace = true
-serde.workspace = true
 junobuild-satellite = { path = "../libs/satellite", default-features = false, features = ["on_init"] }
 junobuild-storage = { path = "../libs/storage" }
 junobuild-macros = { path = "../libs/macros" }


### PR DESCRIPTION
# Motivation

In various `Cargo.toml` there were some dependencies unused for the respective modules.
