### PR TITLE
fix: reload backup list after upgrade

### DIFF
--- a/src/frontend/src/lib/components/modals/CanisterUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/CanisterUpgradeModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Principal } from '@dfinity/principal';
 	import { nonNullish } from '@dfinity/utils';
 	import {
 		type BuildType,
@@ -16,7 +17,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Wasm } from '$lib/types/upgrade';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
-	import type { Principal } from '@dfinity/principal';
 
 	interface Props {
 		currentVersion: string;

--- a/src/frontend/src/lib/components/modals/CanisterUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/CanisterUpgradeModal.svelte
@@ -16,6 +16,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Wasm } from '$lib/types/upgrade';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import type { Principal } from '@dfinity/principal';
 
 	interface Props {
 		currentVersion: string;
@@ -27,6 +28,7 @@
 		}: Pick<UpgradeCodeParams, 'wasmModule' | 'takeSnapshot'>) => Promise<void>;
 		intro?: Snippet;
 		onclose: () => void;
+		canisterId: Principal;
 	}
 
 	let {
@@ -36,7 +38,8 @@
 		segment,
 		upgrade,
 		intro,
-		onclose
+		onclose,
+		canisterId
 	}: Props = $props();
 
 	let buildExtended = $derived(nonNullish(build) && build === 'extended');
@@ -103,6 +106,7 @@
 			{onProgress}
 			{onclose}
 			{takeSnapshot}
+			{canisterId}
 		/>
 	{:else if steps === 'confirm'}
 		<ConfirmUpgradeVersion {segment} {onclose} oncontinue={() => (steps = 'init')} {intro} />

--- a/src/frontend/src/lib/components/modals/MissionControlUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/MissionControlUpgradeModal.svelte
@@ -40,6 +40,7 @@
 		{currentVersion}
 		upgrade={upgradeMissionControlWasm}
 		segment="mission_control"
+		canisterId={$missionControlStore}
 	>
 		{#snippet intro()}
 			<h2>

--- a/src/frontend/src/lib/components/modals/OrbiterUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterUpgradeModal.svelte
@@ -38,6 +38,8 @@
 		{currentVersion}
 		upgrade={upgradeOrbiterWasm}
 		segment="orbiter"
+		,
+		canisterId={$orbiterStore.orbiter_id}
 	>
 		{#snippet intro()}
 			<h2>

--- a/src/frontend/src/lib/components/modals/OrbiterUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterUpgradeModal.svelte
@@ -38,7 +38,6 @@
 		{currentVersion}
 		upgrade={upgradeOrbiterWasm}
 		segment="orbiter"
-		,
 		canisterId={$orbiterStore.orbiter_id}
 	>
 		{#snippet intro()}

--- a/src/frontend/src/lib/components/modals/SatelliteUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteUpgradeModal.svelte
@@ -48,6 +48,7 @@
 	{build}
 	upgrade={upgradeSatelliteWasm}
 	segment="satellite"
+	canisterId={satellite.satellite_id}
 >
 	{#snippet intro()}
 		<h2>

--- a/src/frontend/src/lib/components/upgrade/ReviewUpgradeVersion.svelte
+++ b/src/frontend/src/lib/components/upgrade/ReviewUpgradeVersion.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
+	import type { Principal } from '@dfinity/principal';
 	import { isNullish } from '@dfinity/utils';
 	import { type UpgradeCodeParams, type UpgradeCodeProgress } from '@junobuild/admin';
 	import Html from '$lib/components/ui/Html.svelte';
+	import { loadSnapshots } from '$lib/services/snapshots.services';
+	import { authStore } from '$lib/stores/auth.store';
 	import { wizardBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toasts } from '$lib/stores/toasts.store';
 	import type { Wasm } from '$lib/types/upgrade';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
-	import { loadSnapshots } from '$lib/services/snapshots.services';
-	import { authStore } from '$lib/stores/auth.store';
-	import type { Principal } from '@dfinity/principal';
 
 	interface Props {
 		upgrade: ({

--- a/src/frontend/src/lib/components/upgrade/ReviewUpgradeVersion.svelte
+++ b/src/frontend/src/lib/components/upgrade/ReviewUpgradeVersion.svelte
@@ -8,6 +8,9 @@
 	import type { Wasm } from '$lib/types/upgrade';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import { loadSnapshots } from '$lib/services/snapshots.services';
+	import { authStore } from '$lib/stores/auth.store';
+	import type { Principal } from '@dfinity/principal';
 
 	interface Props {
 		upgrade: ({
@@ -21,9 +24,11 @@
 		onclose: () => void;
 		onProgress: (progress: UpgradeCodeProgress | undefined) => void;
 		takeSnapshot: boolean;
+		canisterId: Principal;
 	}
 
-	let { upgrade, segment, wasm, takeSnapshot, nextSteps, onProgress, onclose }: Props = $props();
+	let { upgrade, segment, wasm, takeSnapshot, canisterId, nextSteps, onProgress, onclose }: Props =
+		$props();
 
 	const onSubmit = async ($event: SubmitEvent) => {
 		$event.preventDefault();
@@ -48,6 +53,14 @@
 			const wasmModule = new Uint8Array(await wasm.wasm.arrayBuffer());
 
 			await upgrade({ wasmModule, takeSnapshot, onProgress });
+
+			if (takeSnapshot) {
+				await loadSnapshots({
+					canisterId,
+					identity: $authStore.identity,
+					reload: true
+				});
+			}
 
 			emit({ message: 'junoReloadVersions' });
 


### PR DESCRIPTION
# Motivation

In Juno Live today we had a race condition in the UI: https://www.youtube.com/watch?v=CrZPaNfX2cA

That's because now the backup are not loaded everytime you browse the backups tabs, this for performance reason. So we have to explicitely reload the backups list after upgrade. 
