### PR TITLE
feat: transaction timestamp

### DIFF
--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -13,7 +13,7 @@ import { fromNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 export const transactionTimestamp = (transaction: Transaction): bigint | undefined =>
-	fromNullable(transaction.created_at_time)?.timestamp_nanos;
+	fromNullable(transaction.timestamp)?.timestamp_nanos;
 
 export const transactionFrom = (transaction: Transaction): string =>
 	'Transfer' in transaction.operation ? transaction.operation.Transfer.from : '';


### PR DESCRIPTION
# Motivation

At some point the ICP index canister was extended to provided the `timestamp` of the transaction as well. That's why, instead of using the creation time which is not always given and used for deduplication, we can use the timestamp information.
