### PR TITLE
fix: saving restored snapshot in idb

### DIFF
--- a/src/frontend/src/lib/components/modals/CanisterRestoreSnapshotModal.svelte
+++ b/src/frontend/src/lib/components/modals/CanisterRestoreSnapshotModal.svelte
@@ -40,7 +40,7 @@
 
 		const { success } = await restoreSnapshot({
 			canisterId,
-			snapshot,
+			snapshot: $state.snapshot(snapshot),
 			identity: $authStore.identity,
 			onProgress
 		});


### PR DESCRIPTION
# Motivation

With Svelte v5 states are proxied. This lead to an issue with the restore backup feature which updates idb with the snapshot selected in the UI. Idb keyval couldn't save a proxied object.
