### PR TITLE
feat: gather subnets metadata and add european|fiduciary subnets to the list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@dfinity/agent": "^2.1.3",
 				"@dfinity/auth-client": "^2.1.3",
 				"@dfinity/candid": "^2.1.3",
-				"@dfinity/cmc": "^4.0.2",
+				"@dfinity/cmc": "^4.0.2-next-2024-12-04",
 				"@dfinity/ic-management": "^6.0.1",
 				"@dfinity/identity": "^2.1.3",
 				"@dfinity/ledger-icp": "^2.6.4",
@@ -728,15 +728,15 @@
 			}
 		},
 		"node_modules/@dfinity/cmc": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2.tgz",
-			"integrity": "sha512-RBf/Kl+LNxKWudOBawU7ZLrY+s0DAjL9P1+sap199isrL68eRSOhxm53DPBATF9oUJ2VzSYr0X49mvC0vCyO+Q==",
+			"version": "4.0.2-next-2024-12-04",
+			"resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2-next-2024-12-04.tgz",
+			"integrity": "sha512-/z3kb5GvUtPbI0OHTTv3VnG9R7vuAGM4HMMKcneeJXObciJZD49jbNuEAz+3B3KZ2/FjPPDUkxu4hE4ZtjValw==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "^2.0.0",
-				"@dfinity/candid": "^2.0.0",
-				"@dfinity/principal": "^2.0.0",
-				"@dfinity/utils": "^2.7.1"
+				"@dfinity/agent": "*",
+				"@dfinity/candid": "*",
+				"@dfinity/principal": "*",
+				"@dfinity/utils": "*"
 			}
 		},
 		"node_modules/@dfinity/eslint-config-oisy-wallet": {
@@ -11126,9 +11126,9 @@
 			"requires": {}
 		},
 		"@dfinity/cmc": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2.tgz",
-			"integrity": "sha512-RBf/Kl+LNxKWudOBawU7ZLrY+s0DAjL9P1+sap199isrL68eRSOhxm53DPBATF9oUJ2VzSYr0X49mvC0vCyO+Q==",
+			"version": "4.0.2-next-2024-12-04",
+			"resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-4.0.2-next-2024-12-04.tgz",
+			"integrity": "sha512-/z3kb5GvUtPbI0OHTTv3VnG9R7vuAGM4HMMKcneeJXObciJZD49jbNuEAz+3B3KZ2/FjPPDUkxu4hE4ZtjValw==",
 			"requires": {}
 		},
 		"@dfinity/eslint-config-oisy-wallet": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"@dfinity/agent": "^2.1.3",
 		"@dfinity/auth-client": "^2.1.3",
 		"@dfinity/candid": "^2.1.3",
-		"@dfinity/cmc": "^4.0.2",
+		"@dfinity/cmc": "^4.0.2-next-2024-12-04",
 		"@dfinity/ic-management": "^6.0.1",
 		"@dfinity/identity": "^2.1.3",
 		"@dfinity/ledger-icp": "^2.6.4",

--- a/scripts/cmc.subnets.mjs
+++ b/scripts/cmc.subnets.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { CMCCanister } from '@dfinity/cmc';
-import { jsonReplacer } from '@dfinity/utils';
+import { jsonReplacer, nonNullish } from '@dfinity/utils';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { icAnonymousAgent } from './actor.mjs';
@@ -48,8 +48,17 @@ const subnets = subnetIds.map((sId) => {
 
 	return {
 		subnetId,
-		type: metadata?.subnet_type,
-		specialization: metadata?.subnet_specialization
+		...(nonNullish(metadata) && {
+			type: metadata.subnet_type,
+			canisters: {
+				stopped: metadata.stopped_canisters,
+				running: metadata.running_canisters
+			},
+			nodes: {
+				up: metadata.up_nodes,
+				total: metadata.total_nodes
+			}
+		})
 	};
 });
 

--- a/src/frontend/src/lib/env/subnets.json
+++ b/src/frontend/src/lib/env/subnets.json
@@ -13,7 +13,7 @@
 	},
 	{
 		"subnetId": "4zbus-z2bmt-ilreg-xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe",
-		"type": "verified_application",
+		"type": "application",
 		"canisters": {
 			"stopped": 1,
 			"running": 111
@@ -172,7 +172,187 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 15,
-			"running": 52408
+			"running": 52409
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe",
+		"type": "application",
+		"canisters": {
+			"stopped": 112,
+			"running": 6717
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "4zbus-z2bmt-ilreg-xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe",
+		"type": "application",
+		"canisters": {
+			"stopped": 1,
+			"running": 111
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "brlsh-zidhj-3yy3e-6vqbz-7xnih-xeq2l-as5oc-g32c4-i5pdn-2wwof-oae",
+		"type": "application",
+		"canisters": {
+			"stopped": 28,
+			"running": 32822
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "cv73p-6v7zi-u67oy-7jc3h-qspsz-g5lrj-4fn7k-xrax3-thek2-sl46v-jae",
+		"type": "application",
+		"canisters": {
+			"stopped": 176,
+			"running": 50859
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "e66qm-3cydn-nkf4i-ml4rb-4ro6o-srm5s-x5hwq-hnprz-3meqp-s7vks-5qe",
+		"type": "application",
+		"canisters": {
+			"stopped": 83,
+			"running": 35333
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae",
+		"type": "application",
+		"canisters": {
+			"stopped": 0,
+			"running": 19857
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "gmq5v-hbozq-uui6y-o55wc-ihop3-562wb-3qspg-nnijg-npqp5-he3cj-3ae",
+		"type": "application",
+		"canisters": {
+			"stopped": 49,
+			"running": 33538
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "jtdsg-3h6gi-hs7o5-z2soi-43w3z-soyl3-ajnp3-ekni5-sw553-5kw67-nqe",
+		"type": "application",
+		"canisters": {
+			"stopped": 3,
+			"running": 26774
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "lspz2-jx4pu-k3e7p-znm7j-q4yum-ork6e-6w4q6-pijwq-znehu-4jabe-kqe",
+		"type": "application",
+		"canisters": {
+			"stopped": 86,
+			"running": 39353
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "mpubz-g52jc-grhjo-5oze5-qcj74-sex34-omprz-ivnsm-qvvhr-rfzpv-vae",
+		"type": "application",
+		"canisters": {
+			"stopped": 88,
+			"running": 54874
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "nl6hn-ja4yw-wvmpy-3z2jx-ymc34-pisx3-3cp5z-3oj4a-qzzny-jbsv3-4qe",
+		"type": "application",
+		"canisters": {
+			"stopped": 33,
+			"running": 31135
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "o3ow2-2ipam-6fcjo-3j5vt-fzbge-2g7my-5fz2m-p4o2t-dwlc4-gt2q7-5ae",
+		"type": "application",
+		"canisters": {
+			"stopped": 55,
+			"running": 56162
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "opn46-zyspe-hhmyp-4zu6u-7sbrh-dok77-m7dch-im62f-vyimr-a3n2c-4ae",
+		"type": "application",
+		"canisters": {
+			"stopped": 44,
+			"running": 39369
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "pjljw-kztyl-46ud4-ofrj6-nzkhm-3n4nt-wi3jt-ypmav-ijqkt-gjf66-uae",
+		"type": "application",
+		"canisters": {
+			"stopped": 63,
+			"running": 31671
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
+	},
+	{
+		"subnetId": "qdvhd-os4o2-zzrdw-xrcv4-gljou-eztdp-bj326-e6jgr-tkhuc-ql6v2-yqe",
+		"type": "application",
+		"canisters": {
+			"stopped": 15,
+			"running": 52409
 		},
 		"nodes": {
 			"up": 13,

--- a/src/frontend/src/lib/env/subnets.json
+++ b/src/frontend/src/lib/env/subnets.json
@@ -2,76 +2,181 @@
 	{
 		"subnetId": "4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 112,
+			"running": 6717
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "4zbus-z2bmt-ilreg-xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe",
 		"type": "verified_application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 1,
+			"running": 111
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "brlsh-zidhj-3yy3e-6vqbz-7xnih-xeq2l-as5oc-g32c4-i5pdn-2wwof-oae",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 28,
+			"running": 32822
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "cv73p-6v7zi-u67oy-7jc3h-qspsz-g5lrj-4fn7k-xrax3-thek2-sl46v-jae",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 176,
+			"running": 50859
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "e66qm-3cydn-nkf4i-ml4rb-4ro6o-srm5s-x5hwq-hnprz-3meqp-s7vks-5qe",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 83,
+			"running": 35333
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 0,
+			"running": 19857
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "gmq5v-hbozq-uui6y-o55wc-ihop3-562wb-3qspg-nnijg-npqp5-he3cj-3ae",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 49,
+			"running": 33538
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "jtdsg-3h6gi-hs7o5-z2soi-43w3z-soyl3-ajnp3-ekni5-sw553-5kw67-nqe",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 3,
+			"running": 26774
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "lspz2-jx4pu-k3e7p-znm7j-q4yum-ork6e-6w4q6-pijwq-znehu-4jabe-kqe",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 86,
+			"running": 39353
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "mpubz-g52jc-grhjo-5oze5-qcj74-sex34-omprz-ivnsm-qvvhr-rfzpv-vae",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 88,
+			"running": 54874
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "nl6hn-ja4yw-wvmpy-3z2jx-ymc34-pisx3-3cp5z-3oj4a-qzzny-jbsv3-4qe",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 33,
+			"running": 31135
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "o3ow2-2ipam-6fcjo-3j5vt-fzbge-2g7my-5fz2m-p4o2t-dwlc4-gt2q7-5ae",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 55,
+			"running": 56162
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "opn46-zyspe-hhmyp-4zu6u-7sbrh-dok77-m7dch-im62f-vyimr-a3n2c-4ae",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 44,
+			"running": 39369
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "pjljw-kztyl-46ud4-ofrj6-nzkhm-3n4nt-wi3jt-ypmav-ijqkt-gjf66-uae",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 63,
+			"running": 31671
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	},
 	{
 		"subnetId": "qdvhd-os4o2-zzrdw-xrcv4-gljou-eztdp-bj326-e6jgr-tkhuc-ql6v2-yqe",
 		"type": "application",
-		"specialization": ""
+		"canisters": {
+			"stopped": 15,
+			"running": 52408
+		},
+		"nodes": {
+			"up": 13,
+			"total": 13
+		}
 	}
 ]

--- a/src/frontend/src/lib/env/subnets.json
+++ b/src/frontend/src/lib/env/subnets.json
@@ -1,53 +1,77 @@
 [
 	{
-		"subnetId": "3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe"
+		"subnetId": "4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe"
+		"subnetId": "4zbus-z2bmt-ilreg-xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe",
+		"type": "verified_application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "6pbhf-qzpdk-kuqbr-pklfa-5ehhf-jfjps-zsj6q-57nrl-kzhpd-mu7hc-vae"
+		"subnetId": "brlsh-zidhj-3yy3e-6vqbz-7xnih-xeq2l-as5oc-g32c4-i5pdn-2wwof-oae",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "brlsh-zidhj-3yy3e-6vqbz-7xnih-xeq2l-as5oc-g32c4-i5pdn-2wwof-oae"
+		"subnetId": "cv73p-6v7zi-u67oy-7jc3h-qspsz-g5lrj-4fn7k-xrax3-thek2-sl46v-jae",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "cv73p-6v7zi-u67oy-7jc3h-qspsz-g5lrj-4fn7k-xrax3-thek2-sl46v-jae"
+		"subnetId": "e66qm-3cydn-nkf4i-ml4rb-4ro6o-srm5s-x5hwq-hnprz-3meqp-s7vks-5qe",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "e66qm-3cydn-nkf4i-ml4rb-4ro6o-srm5s-x5hwq-hnprz-3meqp-s7vks-5qe"
+		"subnetId": "fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae"
+		"subnetId": "gmq5v-hbozq-uui6y-o55wc-ihop3-562wb-3qspg-nnijg-npqp5-he3cj-3ae",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "gmq5v-hbozq-uui6y-o55wc-ihop3-562wb-3qspg-nnijg-npqp5-he3cj-3ae"
+		"subnetId": "jtdsg-3h6gi-hs7o5-z2soi-43w3z-soyl3-ajnp3-ekni5-sw553-5kw67-nqe",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "jtdsg-3h6gi-hs7o5-z2soi-43w3z-soyl3-ajnp3-ekni5-sw553-5kw67-nqe"
+		"subnetId": "lspz2-jx4pu-k3e7p-znm7j-q4yum-ork6e-6w4q6-pijwq-znehu-4jabe-kqe",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "lspz2-jx4pu-k3e7p-znm7j-q4yum-ork6e-6w4q6-pijwq-znehu-4jabe-kqe"
+		"subnetId": "mpubz-g52jc-grhjo-5oze5-qcj74-sex34-omprz-ivnsm-qvvhr-rfzpv-vae",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "mpubz-g52jc-grhjo-5oze5-qcj74-sex34-omprz-ivnsm-qvvhr-rfzpv-vae"
+		"subnetId": "nl6hn-ja4yw-wvmpy-3z2jx-ymc34-pisx3-3cp5z-3oj4a-qzzny-jbsv3-4qe",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "nl6hn-ja4yw-wvmpy-3z2jx-ymc34-pisx3-3cp5z-3oj4a-qzzny-jbsv3-4qe"
+		"subnetId": "o3ow2-2ipam-6fcjo-3j5vt-fzbge-2g7my-5fz2m-p4o2t-dwlc4-gt2q7-5ae",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "o3ow2-2ipam-6fcjo-3j5vt-fzbge-2g7my-5fz2m-p4o2t-dwlc4-gt2q7-5ae"
+		"subnetId": "opn46-zyspe-hhmyp-4zu6u-7sbrh-dok77-m7dch-im62f-vyimr-a3n2c-4ae",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "opn46-zyspe-hhmyp-4zu6u-7sbrh-dok77-m7dch-im62f-vyimr-a3n2c-4ae"
+		"subnetId": "pjljw-kztyl-46ud4-ofrj6-nzkhm-3n4nt-wi3jt-ypmav-ijqkt-gjf66-uae",
+		"type": "application",
+		"specialization": ""
 	},
 	{
-		"subnetId": "pjljw-kztyl-46ud4-ofrj6-nzkhm-3n4nt-wi3jt-ypmav-ijqkt-gjf66-uae"
-	},
-	{
-		"subnetId": "qdvhd-os4o2-zzrdw-xrcv4-gljou-eztdp-bj326-e6jgr-tkhuc-ql6v2-yqe"
-	},
-	{
-		"subnetId": "yinp6-35cfo-wgcd2-oc4ty-2kqpf-t4dul-rfk33-fsq3r-mfmua-m2ngh-jqe"
+		"subnetId": "qdvhd-os4o2-zzrdw-xrcv4-gljou-eztdp-bj326-e6jgr-tkhuc-ql6v2-yqe",
+		"type": "application",
+		"specialization": ""
 	}
 ]

--- a/src/frontend/src/lib/env/subnets.json
+++ b/src/frontend/src/lib/env/subnets.json
@@ -40,7 +40,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 176,
-			"running": 50859
+			"running": 50860
 		},
 		"nodes": {
 			"up": 13,
@@ -52,7 +52,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 83,
-			"running": 35333
+			"running": 35335
 		},
 		"nodes": {
 			"up": 13,
@@ -76,7 +76,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 49,
-			"running": 33538
+			"running": 33539
 		},
 		"nodes": {
 			"up": 13,
@@ -88,7 +88,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 3,
-			"running": 26774
+			"running": 26775
 		},
 		"nodes": {
 			"up": 13,
@@ -100,7 +100,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 86,
-			"running": 39353
+			"running": 39354
 		},
 		"nodes": {
 			"up": 13,
@@ -112,7 +112,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 88,
-			"running": 54874
+			"running": 54876
 		},
 		"nodes": {
 			"up": 13,
@@ -124,7 +124,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 33,
-			"running": 31135
+			"running": 31138
 		},
 		"nodes": {
 			"up": 13,
@@ -136,7 +136,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 55,
-			"running": 56162
+			"running": 56166
 		},
 		"nodes": {
 			"up": 13,
@@ -160,7 +160,7 @@
 		"type": "application",
 		"canisters": {
 			"stopped": 63,
-			"running": 31671
+			"running": 31676
 		},
 		"nodes": {
 			"up": 13,
@@ -180,11 +180,12 @@
 		}
 	},
 	{
-		"subnetId": "4ecnw-byqwz-dtgss-ua2mh-pfvs7-c3lct-gtf4e-hnu75-j7eek-iifqm-sqe",
+		"subnetId": "bkfrj-6k62g-dycql-7h53p-atvkj-zg4to-gaogh-netha-ptybj-ntsgw-rqe",
+		"specialization": "european",
 		"type": "application",
 		"canisters": {
-			"stopped": 112,
-			"running": 6717
+			"stopped": 6,
+			"running": 22789
 		},
 		"nodes": {
 			"up": 13,
@@ -192,171 +193,16 @@
 		}
 	},
 	{
-		"subnetId": "4zbus-z2bmt-ilreg-xakz4-6tyre-hsqj4-slb4g-zjwqo-snjcc-iqphi-3qe",
+		"subnetId": "pzp6e-ekpqk-3c5x7-2h6so-njoeq-mt45d-h3h6c-q3mxf-vpeq5-fk5o7-yae",
+		"specialization": "fiduciary",
 		"type": "application",
 		"canisters": {
-			"stopped": 1,
-			"running": 111
+			"stopped": 7,
+			"running": 716
 		},
 		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "brlsh-zidhj-3yy3e-6vqbz-7xnih-xeq2l-as5oc-g32c4-i5pdn-2wwof-oae",
-		"type": "application",
-		"canisters": {
-			"stopped": 28,
-			"running": 32822
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "cv73p-6v7zi-u67oy-7jc3h-qspsz-g5lrj-4fn7k-xrax3-thek2-sl46v-jae",
-		"type": "application",
-		"canisters": {
-			"stopped": 176,
-			"running": 50859
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "e66qm-3cydn-nkf4i-ml4rb-4ro6o-srm5s-x5hwq-hnprz-3meqp-s7vks-5qe",
-		"type": "application",
-		"canisters": {
-			"stopped": 83,
-			"running": 35333
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae",
-		"type": "application",
-		"canisters": {
-			"stopped": 0,
-			"running": 19857
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "gmq5v-hbozq-uui6y-o55wc-ihop3-562wb-3qspg-nnijg-npqp5-he3cj-3ae",
-		"type": "application",
-		"canisters": {
-			"stopped": 49,
-			"running": 33538
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "jtdsg-3h6gi-hs7o5-z2soi-43w3z-soyl3-ajnp3-ekni5-sw553-5kw67-nqe",
-		"type": "application",
-		"canisters": {
-			"stopped": 3,
-			"running": 26774
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "lspz2-jx4pu-k3e7p-znm7j-q4yum-ork6e-6w4q6-pijwq-znehu-4jabe-kqe",
-		"type": "application",
-		"canisters": {
-			"stopped": 86,
-			"running": 39353
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "mpubz-g52jc-grhjo-5oze5-qcj74-sex34-omprz-ivnsm-qvvhr-rfzpv-vae",
-		"type": "application",
-		"canisters": {
-			"stopped": 88,
-			"running": 54874
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "nl6hn-ja4yw-wvmpy-3z2jx-ymc34-pisx3-3cp5z-3oj4a-qzzny-jbsv3-4qe",
-		"type": "application",
-		"canisters": {
-			"stopped": 33,
-			"running": 31135
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "o3ow2-2ipam-6fcjo-3j5vt-fzbge-2g7my-5fz2m-p4o2t-dwlc4-gt2q7-5ae",
-		"type": "application",
-		"canisters": {
-			"stopped": 55,
-			"running": 56162
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "opn46-zyspe-hhmyp-4zu6u-7sbrh-dok77-m7dch-im62f-vyimr-a3n2c-4ae",
-		"type": "application",
-		"canisters": {
-			"stopped": 44,
-			"running": 39369
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "pjljw-kztyl-46ud4-ofrj6-nzkhm-3n4nt-wi3jt-ypmav-ijqkt-gjf66-uae",
-		"type": "application",
-		"canisters": {
-			"stopped": 63,
-			"running": 31671
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
-		}
-	},
-	{
-		"subnetId": "qdvhd-os4o2-zzrdw-xrcv4-gljou-eztdp-bj326-e6jgr-tkhuc-ql6v2-yqe",
-		"type": "application",
-		"canisters": {
-			"stopped": 15,
-			"running": 52409
-		},
-		"nodes": {
-			"up": 13,
-			"total": 13
+			"up": 34,
+			"total": 34
 		}
 	}
 ]


### PR DESCRIPTION
# Motivation

We would like to present more information in the Console about subnet. Like being able to say "this is application subnet, this is the european subnet".

Likewise, for the documentation, we want a source of data we can use to build a table.
