### PR TITLE
refactor: extract STATE to memory module

### DIFF
--- a/src/mission_control/src/controllers/store.rs
+++ b/src/mission_control/src/controllers/store.rs
@@ -1,4 +1,4 @@
-use crate::STATE;
+use crate::memory::STATE;
 use junobuild_shared::controllers::{
     delete_controllers as delete_controllers_impl, filter_admin_controllers,
     set_controllers as set_controllers_impl,

--- a/src/mission_control/src/guards.rs
+++ b/src/mission_control/src/guards.rs
@@ -1,5 +1,5 @@
+use crate::memory::STATE;
 use crate::store::get_user;
-use crate::STATE;
 use ic_cdk::api::is_controller as ic_canister_controller;
 use ic_cdk::caller;
 use junobuild_shared::controllers::{

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -2,6 +2,7 @@ mod constants;
 mod controllers;
 mod guards;
 mod impls;
+mod memory;
 mod mgmt;
 mod segments;
 mod store;
@@ -20,6 +21,7 @@ use crate::controllers::store::get_controllers;
 use crate::guards::{
     caller_is_user_or_admin_controller, caller_is_user_or_admin_controller_or_juno,
 };
+use crate::memory::STATE;
 use crate::mgmt::status::collect_statuses;
 use crate::segments::orbiter::{
     attach_orbiter, create_orbiter as create_orbiter_console,
@@ -64,12 +66,7 @@ use segments::store::{
     get_satellites, set_orbiter_metadata as set_orbiter_metadata_store,
     set_satellite_metadata as set_satellite_metadata_store,
 };
-use std::cell::RefCell;
 use std::collections::HashMap;
-
-thread_local! {
-    static STATE: RefCell<State> = RefCell::default();
-}
 
 #[init]
 fn init() {

--- a/src/mission_control/src/memory.rs
+++ b/src/mission_control/src/memory.rs
@@ -1,0 +1,6 @@
+use crate::types::state::State;
+use std::cell::RefCell;
+
+thread_local! {
+    pub static STATE: RefCell<State> = RefCell::default();
+}

--- a/src/mission_control/src/segments/store.rs
+++ b/src/mission_control/src/segments/store.rs
@@ -1,6 +1,6 @@
+use crate::memory::STATE;
 use crate::types::core::Segment;
 use crate::types::state::{Orbiter, Orbiters, Satellite, Satellites};
-use crate::STATE;
 use junobuild_shared::types::state::{Metadata, OrbiterId, SatelliteId};
 use std::collections::HashMap;
 use std::hash::Hash;

--- a/src/mission_control/src/store.rs
+++ b/src/mission_control/src/store.rs
@@ -1,6 +1,6 @@
 use crate::constants::RETAIN_ARCHIVE_STATUSES_NS;
+use crate::memory::STATE;
 use crate::types::state::{ArchiveStatusesSegments, HeapState, Statuses, User};
-use crate::STATE;
 use candid::Principal;
 use ic_cdk::api::time;
 use junobuild_shared::types::state::{


### PR DESCRIPTION
# Motivation

Not sure that's something Rust developer do. Since I did this in other modules, I also move the STATE to its own memory module in the mission control.
