### PR TITLE
feat: wallet send always enabled

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -277,7 +277,10 @@
 		"or_connect_wallet": "Or connect wallet",
 		"connecting_wallet": "Connecting wallet...",
 		"wallet_approve": "Approve the transaction in your OISY wallet...",
-		"wallet_missing_account": "No account available to request the transaction. Have you connected your wallet?"
+		"wallet_missing_account": "No account available to request the transaction. Have you connected your wallet?",
+		"balance_not_loaded": "Please wait, your balance is not yet loaded.",
+		"balance_zero": "Your balance is zero. Get some tokens to start sending.",
+		"wallet_upgrade": "Please upgrade your wallet to enable the sending feature."
 	},
 	"authentication": {
 		"title": "Authentication",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -277,7 +277,10 @@
 		"or_connect_wallet": "或者链接钱包",
 		"connecting_wallet": "正在连接钱包...",
 		"wallet_approve": "用你的OISY钱包批准交易 ...",
-		"wallet_missing_account": "没有有效的账户来处理交易，你确定链接你的钱包了吗?"
+		"wallet_missing_account": "没有有效的账户来处理交易，你确定链接你的钱包了吗?",
+		"balance_not_loaded": "Please wait, your balance is not yet loaded.",
+		"balance_zero": "Your balance is zero. Get some tokens to start sending.",
+		"wallet_upgrade": "Please upgrade your wallet to enable the sending feature."
 	},
 	"authentication": {
 		"title": "认证",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -286,6 +286,9 @@ interface I18nWallet {
 	connecting_wallet: string;
 	wallet_approve: string;
 	wallet_missing_account: string;
+	balance_not_loaded: string;
+	balance_zero: string;
+	wallet_upgrade: string;
 }
 
 interface I18nAuthentication {


### PR DESCRIPTION
# Motivation

Positive UX instead of hidding the send button of the wallet if loading or so.
