### PR TITLE
feat: rename get_monitoring_status with keyword current

### DIFF
--- a/src/declarations/mission_control/mission_control.did.d.ts
+++ b/src/declarations/mission_control/mission_control.did.d.ts
@@ -23,6 +23,13 @@ export interface CronJobStatusesConfig {
 	enabled: boolean;
 	cycles_threshold: [] | [bigint];
 }
+export interface CurrentCyclesMonitoringStatus {
+	monitored_ids: Array<Principal>;
+	running: boolean;
+}
+export interface CurrentMonitoringStatus {
+	cycles: [] | [CurrentCyclesMonitoringStatus];
+}
 export interface CyclesMonitoring {
 	strategy: [] | [CyclesMonitoringStrategy];
 	enabled: boolean;
@@ -31,10 +38,6 @@ export interface CyclesMonitoringStartConfig {
 	orbiters_strategy: [] | [SegmentsMonitoringStrategy];
 	mission_control_strategy: [] | [CyclesMonitoringStrategy];
 	satellites_strategy: [] | [SegmentsMonitoringStrategy];
-}
-export interface CyclesMonitoringStatus {
-	monitored_ids: Array<Principal>;
-	running: boolean;
 }
 export interface CyclesMonitoringStopConfig {
 	satellite_ids: [] | [Array<Principal>];
@@ -60,9 +63,6 @@ export interface Monitoring {
 }
 export interface MonitoringStartConfig {
 	cycles_config: [] | [CyclesMonitoringStartConfig];
-}
-export interface MonitoringStatus {
-	cycles: [] | [CyclesMonitoringStatus];
 }
 export interface MonitoringStopConfig {
 	cycles_config: [] | [CyclesMonitoringStopConfig];
@@ -181,7 +181,7 @@ export interface _SERVICE {
 	del_satellite: ActorMethod<[Principal, bigint], undefined>;
 	del_satellites_controllers: ActorMethod<[Array<Principal>, Array<Principal>], undefined>;
 	deposit_cycles: ActorMethod<[DepositCyclesArgs], undefined>;
-	get_monitoring_status: ActorMethod<[], MonitoringStatus>;
+	get_current_monitoring_status: ActorMethod<[], CurrentMonitoringStatus>;
 	get_settings: ActorMethod<[], [] | [MissionControlSettings]>;
 	get_user: ActorMethod<[], Principal>;
 	icp_transfer: ActorMethod<[TransferArgs], Result>;

--- a/src/declarations/mission_control/mission_control.factory.did.js
+++ b/src/declarations/mission_control/mission_control.factory.did.js
@@ -35,12 +35,12 @@ export const idlFactory = ({ IDL }) => {
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
 	});
-	const CyclesMonitoringStatus = IDL.Record({
+	const CurrentCyclesMonitoringStatus = IDL.Record({
 		monitored_ids: IDL.Vec(IDL.Principal),
 		running: IDL.Bool
 	});
-	const MonitoringStatus = IDL.Record({
-		cycles: IDL.Opt(CyclesMonitoringStatus)
+	const CurrentMonitoringStatus = IDL.Record({
+		cycles: IDL.Opt(CurrentCyclesMonitoringStatus)
 	});
 	const MissionControlSettings = IDL.Record({
 		updated_at: IDL.Nat64,
@@ -181,7 +181,7 @@ export const idlFactory = ({ IDL }) => {
 		del_satellite: IDL.Func([IDL.Principal, IDL.Nat], [], []),
 		del_satellites_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),
 		deposit_cycles: IDL.Func([DepositCyclesArgs], [], []),
-		get_monitoring_status: IDL.Func([], [MonitoringStatus], ['query']),
+		get_current_monitoring_status: IDL.Func([], [CurrentMonitoringStatus], ['query']),
 		get_settings: IDL.Func([], [IDL.Opt(MissionControlSettings)], ['query']),
 		get_user: IDL.Func([], [IDL.Principal], ['query']),
 		icp_transfer: IDL.Func([TransferArgs], [Result], []),

--- a/src/mission_control/mission_control.did
+++ b/src/mission_control/mission_control.did
@@ -16,6 +16,13 @@ type CronJobStatusesConfig = record {
   enabled : bool;
   cycles_threshold : opt nat64;
 };
+type CurrentCyclesMonitoringStatus = record {
+  monitored_ids : vec principal;
+  running : bool;
+};
+type CurrentMonitoringStatus = record {
+  cycles : opt CurrentCyclesMonitoringStatus;
+};
 type CyclesMonitoring = record {
   strategy : opt CyclesMonitoringStrategy;
   enabled : bool;
@@ -24,10 +31,6 @@ type CyclesMonitoringStartConfig = record {
   orbiters_strategy : opt SegmentsMonitoringStrategy;
   mission_control_strategy : opt CyclesMonitoringStrategy;
   satellites_strategy : opt SegmentsMonitoringStrategy;
-};
-type CyclesMonitoringStatus = record {
-  monitored_ids : vec principal;
-  running : bool;
 };
 type CyclesMonitoringStopConfig = record {
   satellite_ids : opt vec principal;
@@ -46,7 +49,6 @@ type Monitoring = record { cycles : opt CyclesMonitoring };
 type MonitoringStartConfig = record {
   cycles_config : opt CyclesMonitoringStartConfig;
 };
-type MonitoringStatus = record { cycles : opt CyclesMonitoringStatus };
 type MonitoringStopConfig = record {
   cycles_config : opt CyclesMonitoringStopConfig;
 };
@@ -156,7 +158,7 @@ service : () -> {
   del_satellite : (principal, nat) -> ();
   del_satellites_controllers : (vec principal, vec principal) -> ();
   deposit_cycles : (DepositCyclesArgs) -> ();
-  get_monitoring_status : () -> (MonitoringStatus) query;
+  get_current_monitoring_status : () -> (CurrentMonitoringStatus) query;
   get_settings : () -> (opt MissionControlSettings) query;
   get_user : () -> (principal) query;
   icp_transfer : (TransferArgs) -> (Result);

--- a/src/mission_control/src/cycles_monitoring/status.rs
+++ b/src/mission_control/src/cycles_monitoring/status.rs
@@ -1,16 +1,18 @@
 use crate::memory::RUNTIME_STATE;
-use crate::types::interface::CyclesMonitoringStatus;
+use crate::types::interface::CurrentCyclesMonitoringStatus;
 use crate::types::runtime::RuntimeState;
 
-pub fn get_cycles_monitoring_status() -> Option<CyclesMonitoringStatus> {
-    RUNTIME_STATE.with(|state| get_cycles_monitoring_status_impl(&state.borrow()))
+pub fn get_current_cycles_monitoring_status() -> Option<CurrentCyclesMonitoringStatus> {
+    RUNTIME_STATE.with(|state| get_current_cycles_monitoring_status_impl(&state.borrow()))
 }
 
-fn get_cycles_monitoring_status_impl(state: &RuntimeState) -> Option<CyclesMonitoringStatus> {
+fn get_current_cycles_monitoring_status_impl(
+    state: &RuntimeState,
+) -> Option<CurrentCyclesMonitoringStatus> {
     state
         .fund_manager
         .as_ref()
-        .map(|fund_manager| CyclesMonitoringStatus {
+        .map(|fund_manager| CurrentCyclesMonitoringStatus {
             running: fund_manager.is_running(),
             monitored_ids: fund_manager
                 .get_canisters()

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -26,7 +26,7 @@ use crate::guards::{
 use crate::memory::{init_runtime_state, STATE};
 use crate::mgmt::status::collect_statuses;
 use crate::monitoring::{
-    defer_restart_monitoring, get_monitoring_status as get_any_monitoring_status,
+    defer_restart_monitoring, get_current_monitoring_status as get_current_any_monitoring_status,
     start_monitoring as start_monitoring_with_current_config,
     stop_monitoring as stop_any_monitoring, update_and_start_monitoring_with_config,
     update_and_stop_monitoring_with_config,
@@ -49,7 +49,7 @@ use crate::store::{
     list_satellite_statuses as list_satellite_statuses_store, set_metadata as set_metadata_store,
 };
 use crate::types::interface::{
-    CreateCanisterConfig, MonitoringStartConfig, MonitoringStatus, MonitoringStopConfig,
+    CreateCanisterConfig, CurrentMonitoringStatus, MonitoringStartConfig, MonitoringStopConfig,
 };
 use crate::types::state::{
     HeapState, MissionControlSettings, Orbiter, Orbiters, Satellite, Satellites, State, Statuses,
@@ -423,8 +423,8 @@ fn update_and_stop_monitoring(config: MonitoringStopConfig) {
 }
 
 #[query(guard = "caller_is_user_or_admin_controller")]
-fn get_monitoring_status() -> MonitoringStatus {
-    get_any_monitoring_status()
+fn get_current_monitoring_status() -> CurrentMonitoringStatus {
+    get_current_any_monitoring_status()
 }
 
 // ---------------------------------------------------------

--- a/src/mission_control/src/monitoring.rs
+++ b/src/mission_control/src/monitoring.rs
@@ -2,9 +2,11 @@ use crate::cycles_monitoring::config::{
     register_and_start_cycles_monitoring, unregister_and_stop_cycles_monitoring,
 };
 use crate::cycles_monitoring::start::start_cycles_monitoring;
-use crate::cycles_monitoring::status::get_cycles_monitoring_status;
+use crate::cycles_monitoring::status::get_current_cycles_monitoring_status;
 use crate::cycles_monitoring::stop::stop_cycles_monitoring;
-use crate::types::interface::{MonitoringStartConfig, MonitoringStatus, MonitoringStopConfig};
+use crate::types::interface::{
+    CurrentMonitoringStatus, MonitoringStartConfig, MonitoringStopConfig,
+};
 use ic_cdk::spawn;
 use ic_cdk::trap;
 use ic_cdk_timers::set_timer;
@@ -44,8 +46,8 @@ pub fn update_and_stop_monitoring_with_config(config: &MonitoringStopConfig) -> 
     Ok(())
 }
 
-pub fn get_monitoring_status() -> MonitoringStatus {
-    MonitoringStatus {
-        cycles: get_cycles_monitoring_status(),
+pub fn get_current_monitoring_status() -> CurrentMonitoringStatus {
+    CurrentMonitoringStatus {
+        cycles: get_current_cycles_monitoring_status(),
     }
 }

--- a/src/mission_control/src/types.rs
+++ b/src/mission_control/src/types.rs
@@ -168,13 +168,13 @@ pub mod interface {
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
-    pub struct CyclesMonitoringStatus {
+    pub struct CurrentCyclesMonitoringStatus {
         pub running: bool,
         pub monitored_ids: Vec<SegmentId>,
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
-    pub struct MonitoringStatus {
-        pub cycles: Option<CyclesMonitoringStatus>,
+    pub struct CurrentMonitoringStatus {
+        pub cycles: Option<CurrentCyclesMonitoringStatus>,
     }
 }

--- a/src/tests/mission-control.monitoring.spec.ts
+++ b/src/tests/mission-control.monitoring.spec.ts
@@ -96,9 +96,9 @@ describe('Mission Control - Monitoring', () => {
 		});
 
 		it('should throw errors on get monitoring status', async () => {
-			const { get_monitoring_status } = actor;
+			const { get_current_monitoring_status } = actor;
 
-			await expect(get_monitoring_status()).rejects.toThrow(CONTROLLER_ERROR_MSG);
+			await expect(get_current_monitoring_status()).rejects.toThrow(CONTROLLER_ERROR_MSG);
 		});
 	};
 
@@ -138,9 +138,9 @@ describe('Mission Control - Monitoring', () => {
 		});
 
 		it('should have no monitoring status', async () => {
-			const { get_monitoring_status } = actor;
+			const { get_current_monitoring_status } = actor;
 
-			const { cycles } = await get_monitoring_status();
+			const { cycles } = await get_current_monitoring_status();
 
 			expect(fromNullable(cycles)).toBeUndefined();
 		});
@@ -283,9 +283,9 @@ describe('Mission Control - Monitoring', () => {
 		});
 
 		it('should have a running monitoring status', async () => {
-			const { get_monitoring_status } = actor;
+			const { get_current_monitoring_status } = actor;
 
-			const { cycles } = await get_monitoring_status();
+			const { cycles } = await get_current_monitoring_status();
 
 			expect(fromNullable(cycles)?.running === true).toBeTruthy();
 		});
@@ -488,9 +488,9 @@ describe('Mission Control - Monitoring', () => {
 		});
 
 		it('should have a stopped monitoring status', async () => {
-			const { get_monitoring_status } = actor;
+			const { get_current_monitoring_status } = actor;
 
-			const { cycles } = await get_monitoring_status();
+			const { cycles } = await get_current_monitoring_status();
 
 			expect(fromNullable(cycles)?.running === false).toBeTruthy();
 		});
@@ -506,9 +506,9 @@ describe('Mission Control - Monitoring', () => {
 		});
 
 		it('should have a running monitoring status', async () => {
-			const { get_monitoring_status } = actor;
+			const { get_current_monitoring_status } = actor;
 
-			const { cycles } = await get_monitoring_status();
+			const { cycles } = await get_current_monitoring_status();
 
 			expect(fromNullable(cycles)?.running === true).toBeTruthy();
 		});
@@ -524,9 +524,9 @@ describe('Mission Control - Monitoring', () => {
 		});
 
 		it('should have a stopped monitoring status', async () => {
-			const { get_monitoring_status } = actor;
+			const { get_current_monitoring_status } = actor;
 
-			const { cycles } = await get_monitoring_status();
+			const { cycles } = await get_current_monitoring_status();
 
 			expect(fromNullable(cycles)?.running === false).toBeTruthy();
 		});

--- a/src/tests/mission-control.monitoring.upgrade.spec.ts
+++ b/src/tests/mission-control.monitoring.upgrade.spec.ts
@@ -72,8 +72,11 @@ describe('Mission control upgrade', () => {
 	});
 
 	it('should restart monitoring after upgrade', async () => {
-		const { update_and_start_monitoring, get_monitoring_status, update_and_stop_monitoring } =
-			actor;
+		const {
+			update_and_start_monitoring,
+			get_current_monitoring_status,
+			update_and_stop_monitoring
+		} = actor;
 
 		// 1. Enable monitoring for everything
 		const config: MonitoringStartConfig = {
@@ -95,7 +98,7 @@ describe('Mission control upgrade', () => {
 		await update_and_start_monitoring(config);
 
 		// 2. Verify it started
-		const { cycles } = await get_monitoring_status();
+		const { cycles } = await get_current_monitoring_status();
 
 		expect(fromNullable(cycles)?.running === true).toBeTruthy();
 
@@ -128,7 +131,7 @@ describe('Mission control upgrade', () => {
 		// 5. Assert monitoring is running
 		await tick(pic);
 
-		const { cycles: newCycles } = await get_monitoring_status();
+		const { cycles: newCycles } = await get_current_monitoring_status();
 
 		expect(fromNullable(newCycles)?.running === true).toBeTruthy();
 


### PR DESCRIPTION
# Motivation

The name `get_monitoring_status` clashes with #935
