### PR TITLE
feat: deprecate features for statuses

### DIFF
--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -403,21 +403,37 @@ fn version() -> String {
 // Observatory
 // ---------------------------------------------------------
 
+#[deprecated(
+    since = "0.0.14",
+    note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+)]
 #[update(guard = "caller_is_user_or_admin_controller_or_juno")]
 async fn status(config: StatusesArgs) -> SegmentsStatuses {
     collect_statuses(&id(), &config).await
 }
 
+#[deprecated(
+    since = "0.0.14",
+    note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+)]
 #[query(guard = "caller_is_user_or_admin_controller")]
 fn list_mission_control_statuses() -> Statuses {
     list_mission_control_statuses_store()
 }
 
+#[deprecated(
+    since = "0.0.14",
+    note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+)]
 #[query(guard = "caller_is_user_or_admin_controller")]
 fn list_satellite_statuses(satellite_id: SatelliteId) -> Option<Statuses> {
     list_satellite_statuses_store(&satellite_id)
 }
 
+#[deprecated(
+    since = "0.0.14",
+    note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+)]
 #[query(guard = "caller_is_user_or_admin_controller")]
 fn list_orbiter_statuses(orbiter_id: OrbiterId) -> Option<Statuses> {
     list_orbiter_statuses_store(&orbiter_id)

--- a/src/mission_control/src/types.rs
+++ b/src/mission_control/src/types.rs
@@ -36,6 +36,7 @@ pub mod state {
         pub user: User,
         pub satellites: Satellites,
         pub controllers: Controllers,
+        #[deprecated(note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities.")]
         pub archive: Archive,
         pub orbiters: Orbiters,
         pub settings: Option<MissionControlSettings>,


### PR DESCRIPTION
# Motivation

We used to collect statuses on an hourly basis to send an email to the dev if the cycles were under threshold. We also used this features to collect information to display how cycles evolve in the UI. Given that we are introducing a new monitoring features, we deprecate those features.
