### PR TITLE
test: fix timestamps

### DIFF
--- a/src/tests/mission-control.monitoring.history.spec.ts
+++ b/src/tests/mission-control.monitoring.history.spec.ts
@@ -211,6 +211,8 @@ describe('Mission Control - History', () => {
 
 			describe('second round', () => {
 				beforeAll(async () => {
+					await tick(pic);
+
 					await pic.advanceTime(30000);
 
 					await tick(pic);
@@ -270,7 +272,7 @@ describe('Mission Control - History', () => {
 				const thirtyDays = 1000 * 60 * 60 * 24 * 30;
 
 				// We want to keep the history for the first round and second round but, clean up the start
-				await pic.advanceTime(thirtyDays - 30000);
+				await pic.advanceTime(thirtyDays - (2 * 30000));
 
 				await tick(pic);
 			});


### PR DESCRIPTION
# Motivation

The test was not accurate because the timestamps of the last entries were equals - i.e. some ticks were missing.
