### PR TITLE
fix: identity usage in deprecated api

### DIFF
--- a/src/frontend/src/lib/api/actors/actor.deprecated.api.ts
+++ b/src/frontend/src/lib/api/actors/actor.deprecated.api.ts
@@ -21,7 +21,7 @@ const orbiter007Actor = new ActorApi<OrbiterActor007>();
 /**
  * @deprecated TODO: to be remove - backwards compatibility
  */
-export const getMissionControlActor004 = async ({
+export const getMissionControlActor004 = ({
 	identity,
 	missionControlId
 }: {
@@ -37,14 +37,14 @@ export const getMissionControlActor004 = async ({
 /**
  * @deprecated TODO: to be remove - backwards compatibility
  */
-export const getMissionControlActor0013 = async ({
+export const getMissionControlActor0013 = ({
 	identity,
 	missionControlId
 }: {
 	missionControlId: Principal;
 	identity: OptionIdentity;
 }): Promise<MissionControlActor0013> =>
-	await missionControl0013Actor.getActor({
+	missionControl0013Actor.getActor({
 		canisterId: missionControlId,
 		idlFactory: idlFactorMissionControl0013,
 		identity
@@ -85,14 +85,14 @@ export const getSatelliteActor009 = ({
 /**
  * @deprecated TODO: to be remove - backwards compatibility
  */
-export const getOrbiterActor007 = async ({
+export const getOrbiterActor007 = ({
 	orbiterId,
 	identity
 }: {
 	orbiterId: Principal;
 	identity: OptionIdentity;
 }): Promise<OrbiterActor007> =>
-	await orbiter007Actor.getActor({
+	orbiter007Actor.getActor({
 		canisterId: orbiterId,
 		idlFactory: idlFactorOrbiter007,
 		identity

--- a/src/frontend/src/lib/api/actors/actor.deprecated.api.ts
+++ b/src/frontend/src/lib/api/actors/actor.deprecated.api.ts
@@ -9,11 +9,8 @@ import { idlFactory as idlFactorSatellite008 } from '$declarations/deprecated/sa
 import type { _SERVICE as SatelliteActor009 } from '$declarations/deprecated/satellite-0-0-9.did';
 import { idlFactory as idlFactorSatellite009 } from '$declarations/deprecated/satellite-0-0-9.factory.did';
 import { ActorApi } from '$lib/api/actors/actor.api';
-import { authStore } from '$lib/stores/auth.store';
 import type { OptionIdentity } from '$lib/types/itentity';
 import type { Principal } from '@dfinity/principal';
-// eslint-disable-next-line local-rules/no-svelte-store-in-api
-import { get } from 'svelte/store';
 
 const missionControl004Actor = new ActorApi<MissionControlActor004>();
 const missionControl0013Actor = new ActorApi<MissionControlActor0013>();
@@ -24,17 +21,18 @@ const orbiter007Actor = new ActorApi<OrbiterActor007>();
 /**
  * @deprecated TODO: to be remove - backwards compatibility
  */
-export const getMissionControlActor004 = async (
-	canisterId: Principal
-): Promise<MissionControlActor004> => {
-	const identity: OptionIdentity = get(authStore).identity;
-
-	return await missionControl004Actor.getActor({
-		canisterId,
+export const getMissionControlActor004 = async ({
+	identity,
+	missionControlId
+}: {
+	missionControlId: Principal;
+	identity: OptionIdentity;
+}): Promise<MissionControlActor004> =>
+	missionControl004Actor.getActor({
+		canisterId: missionControlId,
 		idlFactory: idlFactorMissionControl004,
 		identity
 	});
-};
 
 /**
  * @deprecated TODO: to be remove - backwards compatibility
@@ -55,28 +53,34 @@ export const getMissionControlActor0013 = async ({
 /**
  * @deprecated TODO: to be remove - backwards compatibility
  */
-export const getSatelliteActor008 = (canisterId: Principal): Promise<SatelliteActor008> => {
-	const identity: OptionIdentity = get(authStore).identity;
-
-	return satellite008Actor.getActor({
-		canisterId,
+export const getSatelliteActor008 = ({
+	satelliteId,
+	identity
+}: {
+	satelliteId: Principal;
+	identity: OptionIdentity;
+}): Promise<SatelliteActor008> =>
+	satellite008Actor.getActor({
+		canisterId: satelliteId,
 		idlFactory: idlFactorSatellite008,
 		identity
 	});
-};
 
 /**
  * @deprecated TODO: to be remove - backwards compatibility
  */
-export const getSatelliteActor009 = (canisterId: Principal): Promise<SatelliteActor009> => {
-	const identity: OptionIdentity = get(authStore).identity;
-
-	return satellite009Actor.getActor({
-		canisterId,
+export const getSatelliteActor009 = ({
+	satelliteId,
+	identity
+}: {
+	satelliteId: Principal;
+	identity: OptionIdentity;
+}): Promise<SatelliteActor009> =>
+	satellite009Actor.getActor({
+		canisterId: satelliteId,
 		idlFactory: idlFactorSatellite009,
 		identity
 	});
-};
 
 /**
  * @deprecated TODO: to be remove - backwards compatibility

--- a/src/frontend/src/lib/api/mission-control.deprecated.api.ts
+++ b/src/frontend/src/lib/api/mission-control.deprecated.api.ts
@@ -22,12 +22,14 @@ const toSetController = ({
 export const setMissionControlController004 = async ({
 	missionControlId,
 	controllerId,
+	identity,
 	...rest
 }: {
 	missionControlId: Principal;
+	identity: OptionIdentity;
 } & SetControllerParams) => {
 	try {
-		const actor = await getMissionControlActor004(missionControlId);
+		const actor = await getMissionControlActor004({ missionControlId, identity });
 		await actor.set_mission_control_controllers(
 			[Principal.fromText(controllerId)],
 			toSetController(rest)

--- a/src/frontend/src/lib/api/satellites.deprecated.api.ts
+++ b/src/frontend/src/lib/api/satellites.deprecated.api.ts
@@ -9,6 +9,7 @@ import type {
 } from '$declarations/satellite/satellite.did';
 import { getSatelliteActor008, getSatelliteActor009 } from '$lib/api/actors/actor.deprecated.api';
 import { PAGINATION } from '$lib/constants/constants';
+import type { OptionIdentity } from '$lib/types/itentity';
 import type { ListParams } from '$lib/types/list';
 import { toListParams } from '$lib/utils/satellite.utils';
 import { Principal } from '@dfinity/principal';
@@ -46,13 +47,15 @@ const toListParams008 = ({
 export const listDocs008 = async ({
 	satelliteId,
 	collection,
-	params
+	params,
+	identity
 }: {
 	satelliteId: Principal;
 	collection: string;
 	params: ListParams;
+	identity: OptionIdentity;
 }): Promise<ListDocs> => {
-	const actor = await getSatelliteActor008(satelliteId);
+	const actor = await getSatelliteActor008({ satelliteId, identity });
 	const {
 		items,
 		length: items_length,
@@ -73,13 +76,15 @@ export const listDocs008 = async ({
 export const listAssets008 = async ({
 	satelliteId,
 	collection,
-	params
+	params,
+	identity
 }: {
 	satelliteId: Principal;
 	collection: string;
 	params: ListParams;
+	identity: OptionIdentity;
 }): Promise<ListAssets> => {
-	const actor = await getSatelliteActor008(satelliteId);
+	const actor = await getSatelliteActor008({ satelliteId, identity });
 	const {
 		items,
 		length: items_length,
@@ -100,13 +105,15 @@ export const listAssets008 = async ({
 export const listAssets009 = async ({
 	satelliteId,
 	collection,
-	params
+	params,
+	identity
 }: {
 	satelliteId: Principal;
 	collection: string;
 	params: ListParams;
+	identity: OptionIdentity;
 }): Promise<ListAssets> => {
-	const actor = await getSatelliteActor009(satelliteId);
+	const actor = await getSatelliteActor009({ satelliteId, identity });
 	const { items, ...rest } = await actor.list_assets(toNullable(collection), toListParams(params));
 	return {
 		items: items.map(([key, asset]) => [key, { ...asset, version: [] }]),
@@ -119,12 +126,14 @@ export const listAssets009 = async ({
  */
 export const listRulesDeprecated = async ({
 	satelliteId,
-	type
+	type,
+	identity
 }: {
 	satelliteId: Principal;
 	type: RulesType;
+	identity: OptionIdentity;
 }): Promise<[string, Rule][]> => {
-	const actor = await getSatelliteActor008(satelliteId);
+	const actor = await getSatelliteActor008({ satelliteId, identity });
 	const rules = await actor.list_rules(type);
 	return rules.map(([key, rule]) => [
 		key,

--- a/src/frontend/src/lib/utils/rules.utils.ts
+++ b/src/frontend/src/lib/utils/rules.utils.ts
@@ -80,7 +80,7 @@ export const reloadContextRules = async ({
 	} catch (err: unknown) {
 		// TODO: remove backward compatibility stuffs
 		try {
-			const rules = await listRulesDeprecated({ satelliteId, type });
+			const rules = await listRulesDeprecated({ satelliteId, identity, type });
 			store.set({ satelliteId, rules, rule: undefined });
 			return;
 		} catch (_: unknown) {


### PR DESCRIPTION
# Motivation

The FE build fails because of the usage of a Svelte store to get the identity in the deprecated api (since I moved the list statuses there).
