### PR TITLE
feat: use ciborium::from_reader to read post_upgrade state in console

### DIFF
--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -46,7 +46,7 @@ use crate::types::state::{
     ProposalType, Rates, ReleasesMetadata, State,
 };
 use candid::Principal;
-use ciborium::into_writer;
+use ciborium::{from_reader, into_writer};
 use ic_cdk::api::call::ManualReply;
 use ic_cdk::api::caller;
 use ic_cdk::{id, trap};
@@ -77,7 +77,6 @@ use junobuild_storage::types::interface::{
     AssetNoContent, CommitBatch, InitAssetKey, InitUploadResult, UploadChunk, UploadChunkResult,
 };
 use memory::{get_memory_upgrades, init_stable_state};
-use serde_cbor::from_reader;
 use std::collections::HashMap;
 use types::state::Payments;
 


### PR DESCRIPTION
# Motivation

Equivalent to `serde_cbor` but for consistency with other modules, let's use ciborium in the post_upgrade of the console. Plus we already use it for write.
