### PR TITLE
refactor: rename missionControlStore

### DIFF
--- a/src/frontend/src/lib/components/analytics/AnalyticsNew.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsNew.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { getCreateOrbiterFeeBalance } from '$lib/services/wizard.services';
 	import { authStore } from '$lib/stores/auth.store';
 	import { busy } from '$lib/stores/busy.store';
@@ -12,7 +12,7 @@
 
 		const { result, error } = await getCreateOrbiterFeeBalance({
 			identity: $authStore.identity,
-			missionControlId: $missionControlStore
+			missionControlId: $missionControlIdDerived
 		});
 
 		busy.stop();

--- a/src/frontend/src/lib/components/canister/CanisterAttach.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterAttach.svelte
@@ -4,7 +4,7 @@
 	import { type Snippet } from 'svelte';
 	import { run, preventDefault } from 'svelte/legacy';
 	import Popover from '$lib/components/ui/Popover.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toasts } from '$lib/stores/toasts.store';
@@ -47,7 +47,7 @@
 			return;
 		}
 
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -58,7 +58,7 @@
 
 		try {
 			await setFn({
-				missionControlId: $missionControlStore,
+				missionControlId: $missionControlIdDerived,
 				canisterId: Principal.fromText(canisterId)
 			});
 

--- a/src/frontend/src/lib/components/canister/CanisterDeleteWizard.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterDeleteWizard.svelte
@@ -11,7 +11,7 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import { ONE_TRILLION, DEFAULT_TCYCLES_TO_RETAIN_ON_DELETION } from '$lib/constants/constants';
 	import { authSignedOut } from '$lib/derived/auth.derived';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { loadSatellites } from '$lib/services/satellites.services';
 	import { isBusy, wizardBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -60,7 +60,7 @@
 			return;
 		}
 
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -80,12 +80,12 @@
 
 		try {
 			await deleteFn({
-				missionControlId: $missionControlStore,
+				missionControlId: $missionControlIdDerived,
 				cyclesToDeposit
 			});
 
 			await loadSatellites({
-				missionControl: $missionControlStore,
+				missionControl: $missionControlIdDerived,
 				reload: true
 			});
 

--- a/src/frontend/src/lib/components/canister/CanistersPicker.svelte
+++ b/src/frontend/src/lib/components/canister/CanistersPicker.svelte
@@ -3,7 +3,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
 	import type { Satellite } from '$declarations/mission_control/mission_control.did';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { satellitesStore } from '$lib/derived/satellite.derived';
 	import { loadOrbiters } from '$lib/services/orbiters.services';
@@ -29,8 +29,8 @@
 	onMount(
 		async () =>
 			await Promise.all([
-				loadOrbiters({ missionControl: $missionControlStore }),
-				loadSatellites({ missionControl: $missionControlStore })
+				loadOrbiters({ missionControl: $missionControlIdDerived }),
+				loadSatellites({ missionControl: $missionControlIdDerived })
 			])
 	);
 </script>
@@ -40,8 +40,8 @@
 		<option value={undefined}>{$i18n.canisters.select_destination}</option>
 	{/if}
 
-	{#if nonNullish($missionControlStore) && $missionControlStore.toText() !== excludeSegmentIdText}
-		<option value={$missionControlStore.toText()}>{$i18n.mission_control.title}</option>
+	{#if nonNullish($missionControlIdDerived) && $missionControlIdDerived.toText() !== excludeSegmentIdText}
+		<option value={$missionControlIdDerived.toText()}>{$i18n.mission_control.title}</option>
 	{/if}
 
 	{#if nonNullish($orbiterStore) && $orbiterStore.orbiter_id.toText() !== excludeSegmentIdText}

--- a/src/frontend/src/lib/components/canister/SegmentDetach.svelte
+++ b/src/frontend/src/lib/components/canister/SegmentDetach.svelte
@@ -6,7 +6,7 @@
 	import IconLinkOff from '$lib/components/icons/IconLinkOff.svelte';
 	import Text from '$lib/components/ui/Text.svelte';
 	import { authSignedOut } from '$lib/derived/auth.derived';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { detachOrbiter, detachSatellite } from '$lib/services/mission-control.services';
 	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -33,7 +33,7 @@
 			return;
 		}
 
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -47,7 +47,7 @@
 
 			await fn({
 				canisterId: segmentId,
-				missionControlId: $missionControlStore
+				missionControlId: $missionControlIdDerived
 			});
 
 			await goto('/', { replaceState: true });

--- a/src/frontend/src/lib/components/canister/TopUp.svelte
+++ b/src/frontend/src/lib/components/canister/TopUp.svelte
@@ -2,7 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import IconPublish from '$lib/components/icons/IconPublish.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { getMissionControlBalance } from '$lib/services/balance.services';
 	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -23,7 +23,7 @@
 
 		busy.start();
 
-		const { result, error } = await getMissionControlBalance($missionControlStore);
+		const { result, error } = await getMissionControlBalance($missionControlIdDerived);
 
 		busy.stop();
 

--- a/src/frontend/src/lib/components/cli/CliAdd.svelte
+++ b/src/frontend/src/lib/components/cli/CliAdd.svelte
@@ -6,7 +6,7 @@
 	import SegmentsTable from '$lib/components/segments/SegmentsTable.svelte';
 	import Collapsible from '$lib/components/ui/Collapsible.svelte';
 	import { REVOKED_CONTROLLERS } from '$lib/constants/constants';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import {
 		setMissionControlControllerForVersion,
 		setSatellitesForVersion
@@ -43,7 +43,7 @@
 			return;
 		}
 
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -71,7 +71,7 @@
 				...(selectedMissionControl
 					? [
 							setMissionControlControllerForVersion({
-								missionControlId: $missionControlStore,
+								missionControlId: $missionControlIdDerived,
 								controllerId: principal,
 								profile,
 								scope: 'admin'
@@ -81,7 +81,7 @@
 				...(selectedSatellites.length > 0
 					? [
 							setSatellitesForVersion({
-								missionControlId: $missionControlStore,
+								missionControlId: $missionControlIdDerived,
 								controllerId: principal,
 								satelliteIds: selectedSatellites.map((s) => s[0]),
 								profile,
@@ -92,7 +92,7 @@
 				...(selectedOrbiters.length > 0
 					? [
 							setOrbitersController({
-								missionControlId: $missionControlStore,
+								missionControlId: $missionControlIdDerived,
 								controllerId: principal,
 								orbiterIds: selectedOrbiters.map((s) => s[0]),
 								profile,
@@ -126,7 +126,7 @@
 							)
 						)}`
 					: undefined,
-				selectedMissionControl ? `mission_control=${$missionControlStore.toText()}` : undefined,
+				selectedMissionControl ? `mission_control=${$missionControlIdDerived.toText()}` : undefined,
 				profile !== '' ? `profile=${profile}` : undefined
 			].filter((param) => nonNullish(param));
 

--- a/src/frontend/src/lib/components/controllers/ControllerDelete.svelte
+++ b/src/frontend/src/lib/components/controllers/ControllerDelete.svelte
@@ -4,7 +4,7 @@
 	import type { Controller } from '$declarations/satellite/satellite.did';
 	import Confirmation from '$lib/components/core/Confirmation.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toasts } from '$lib/stores/toasts.store';
@@ -31,7 +31,7 @@
 			return;
 		}
 
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -42,7 +42,7 @@
 
 		try {
 			await remove({
-				missionControlId: $missionControlStore,
+				missionControlId: $missionControlIdDerived,
 				controller: selectedController[0]
 			});
 		} catch (err: unknown) {

--- a/src/frontend/src/lib/components/controllers/Controllers.svelte
+++ b/src/frontend/src/lib/components/controllers/Controllers.svelte
@@ -8,7 +8,7 @@
 	import ControllerInfo from '$lib/components/controllers/ControllerInfo.svelte';
 	import ButtonTableAction from '$lib/components/ui/ButtonTableAction.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toasts } from '$lib/stores/toasts.store';
@@ -52,8 +52,8 @@
 
 	const canEdit = (controllerId: Principal): boolean =>
 		nonNullish($authStore.identity) &&
-		nonNullish($missionControlStore) &&
-		![$missionControlStore.toText(), $authStore.identity.getPrincipal().toText()].includes(
+		nonNullish($missionControlIdDerived) &&
+		![$missionControlIdDerived.toText(), $authStore.identity.getPrincipal().toText()].includes(
 			controllerId.toText()
 		);
 </script>

--- a/src/frontend/src/lib/components/core/NavbarCockpit.svelte
+++ b/src/frontend/src/lib/components/core/NavbarCockpit.svelte
@@ -10,7 +10,7 @@
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
 	import IconWallet from '$lib/components/icons/IconWallet.svelte';
 	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { loadOrbiters } from '$lib/services/orbiters.services';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -23,21 +23,21 @@
 
 	run(() => {
 		// @ts-expect-error TODO: to be migrated to Svelte v5
-		$missionControlStore,
-			(async () => await loadOrbiters({ missionControl: $missionControlStore }))();
+		$missionControlIdDerived,
+			(async () => await loadOrbiters({ missionControl: $missionControlIdDerived }))();
 	});
 </script>
 
-{#if nonNullish($missionControlStore)}
+{#if nonNullish($missionControlIdDerived)}
 	<Canister
-		canisterId={$missionControlStore}
+		canisterId={$missionControlIdDerived}
 		segment="mission_control"
 		display={false}
 		bind:data={missionControlData}
 	/>
 {/if}
 
-{#if nonNullish($missionControlStore) && nonNullish(missionControlData)}
+{#if nonNullish($missionControlIdDerived) && nonNullish(missionControlData)}
 	<div in:slide={{ axis: 'x' }} class="container">
 		<NavbarLink
 			href="/mission-control"
@@ -69,8 +69,8 @@
 	</div>
 {/if}
 
-{#if nonNullish($missionControlStore)}
-	<WalletLoader missionControlId={$missionControlStore} bind:balance>
+{#if nonNullish($missionControlIdDerived)}
+	<WalletLoader missionControlId={$missionControlIdDerived} bind:balance>
 		{#if nonNullish(balance)}
 			<div in:slide={{ axis: 'x' }} class="container wallet">
 				<NavbarLink href="/wallet" ariaLabel={`${$i18n.satellites.open}: ${$i18n.wallet.title}`}>

--- a/src/frontend/src/lib/components/guards/MissionControlGuard.svelte
+++ b/src/frontend/src/lib/components/guards/MissionControlGuard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import SpinnerParagraph from '$lib/components/ui/SpinnerParagraph.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
@@ -11,9 +11,9 @@
 	let { children }: Props = $props();
 </script>
 
-{#if $missionControlStore === undefined}
+{#if $missionControlIdDerived === undefined}
 	<SpinnerParagraph>{$i18n.mission_control.loading}</SpinnerParagraph>
-{:else if $missionControlStore === null}
+{:else if $missionControlIdDerived === null}
 	<p>{$i18n.mission_control.not_found}</p>
 {:else}
 	{@render children()}

--- a/src/frontend/src/lib/components/launchpad/Cockpit.svelte
+++ b/src/frontend/src/lib/components/launchpad/Cockpit.svelte
@@ -7,7 +7,7 @@
 	import IconAnalytics from '$lib/components/icons/IconAnalytics.svelte';
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
 	import LaunchpadLink from '$lib/components/launchpad/LaunchpadLink.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { loadOrbiters } from '$lib/services/orbiters.services';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -15,17 +15,17 @@
 
 	run(() => {
 		// @ts-expect-error TODO: to be migrated to Svelte v5
-		$missionControlStore,
-			(async () => await loadOrbiters({ missionControl: $missionControlStore }))();
+		$missionControlIdDerived,
+			(async () => await loadOrbiters({ missionControl: $missionControlIdDerived }))();
 	});
 
 	let missionControlData: CanisterData | undefined = $state(undefined);
 	let orbiterData: CanisterData | undefined = $state(undefined);
 </script>
 
-{#if nonNullish($missionControlStore)}
+{#if nonNullish($missionControlIdDerived)}
 	<Canister
-		canisterId={$missionControlStore}
+		canisterId={$missionControlIdDerived}
 		segment="mission_control"
 		display={false}
 		bind:data={missionControlData}

--- a/src/frontend/src/lib/components/loaders/CanisterMonitoringLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/CanisterMonitoringLoader.svelte
@@ -5,7 +5,7 @@
 	import { onDestroy, onMount, type Snippet } from 'svelte';
 	import { run } from 'svelte/legacy';
 	import { MISSION_CONTROL_v0_0_13 } from '$lib/constants/version.constants';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { missionControlVersion } from '$lib/derived/version.derived';
 	import {
 		initStatusesWorker,
@@ -46,11 +46,11 @@
 		// @ts-expect-error TODO: to be migrated to Svelte v5
 		worker,
 			canisterId,
-			$missionControlStore,
+			$missionControlIdDerived,
 			$missionControlVersion,
 			(() => {
 				// We wait until mission control is loaded
-				if (isNullish($missionControlStore)) {
+				if (isNullish($missionControlIdDerived)) {
 					return;
 				}
 
@@ -66,7 +66,7 @@
 							segment
 						}
 					],
-					missionControlId: $missionControlStore,
+					missionControlId: $missionControlIdDerived,
 					withMonitoringHistory:
 						compare($missionControlVersion.current ?? '0.0.0', MISSION_CONTROL_v0_0_13) >= 0,
 					callback: syncCanister
@@ -83,7 +83,7 @@
 			return;
 		}
 
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -97,7 +97,7 @@
 					segment
 				}
 			],
-			missionControlId: $missionControlStore
+			missionControlId: $missionControlIdDerived
 		});
 	};
 </script>

--- a/src/frontend/src/lib/components/loaders/OrbitersLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/OrbitersLoader.svelte
@@ -2,7 +2,7 @@
 	import type { Principal } from '@dfinity/principal';
 	import type { Snippet } from 'svelte';
 	import type { Orbiter } from '$declarations/mission_control/mission_control.did';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { loadOrbiterVersion } from '$lib/services/console.services';
 	import { loadOrbiters } from '$lib/services/orbiters.services';
@@ -34,7 +34,7 @@
 	};
 
 	$effect(() => {
-		load($missionControlStore);
+		load($missionControlIdDerived);
 	});
 
 	$effect(() => {

--- a/src/frontend/src/lib/components/loaders/SatellitesLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/SatellitesLoader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
 	import type { Snippet } from 'svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { loadSatellites } from '$lib/services/satellites.services';
 	import type { Option } from '$lib/types/utils';
 
@@ -16,7 +16,7 @@
 	};
 
 	$effect(() => {
-		load($missionControlStore);
+		load($missionControlIdDerived);
 	});
 </script>
 

--- a/src/frontend/src/lib/components/mission-control/MissionControlICPInfo.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlICPInfo.svelte
@@ -3,7 +3,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
@@ -14,7 +14,7 @@
 	let { accountIdentifier, onclose }: Props = $props();
 </script>
 
-{#if nonNullish($missionControlStore) && nonNullish(accountIdentifier)}
+{#if nonNullish($missionControlIdDerived) && nonNullish(accountIdentifier)}
 	<p class="account-identifier">
 		{$i18n.wallet.transfer_to_account_identifier}
 		<strong><Identifier identifier={accountIdentifier.toHex()} small={false} /></strong>.

--- a/src/frontend/src/lib/components/modals/CanisterTopUpModal.svelte
+++ b/src/frontend/src/lib/components/modals/CanisterTopUpModal.svelte
@@ -13,7 +13,7 @@
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { E8S_PER_ICP, IC_TRANSACTION_FEE_ICP } from '$lib/constants/constants';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { authStore } from '$lib/stores/auth.store';
 	import { wizardBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -65,7 +65,7 @@
 	});
 
 	const onSubmit = async () => {
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -85,7 +85,7 @@
 		try {
 			await topUp({
 				canisterId,
-				missionControlId: $missionControlStore,
+				missionControlId: $missionControlIdDerived,
 				e8s: BigInt(icp * Number(E8S_PER_ICP)),
 				identity: $authStore.identity
 			});
@@ -173,7 +173,7 @@
 
 				<button
 					type="submit"
-					disabled={isNullish($missionControlStore) || !validIcp || !validCycles}
+					disabled={isNullish($missionControlIdDerived) || !validIcp || !validCycles}
 					>{$i18n.canisters.top_up}</button
 				>
 			</form>

--- a/src/frontend/src/lib/components/modals/ControllerCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/ControllerCreateModal.svelte
@@ -9,7 +9,7 @@
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { REVOKED_CONTROLLERS } from '$lib/constants/constants';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { wizardBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toasts } from '$lib/stores/toasts.store';
@@ -47,7 +47,7 @@
 	};
 
 	const addController = async () => {
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -75,7 +75,7 @@
 
 		try {
 			await add({
-				missionControlId: $missionControlStore,
+				missionControlId: $missionControlIdDerived,
 				controllerId: controller,
 				profile: undefined,
 				scope

--- a/src/frontend/src/lib/components/modals/MissionControlTopUpModal.svelte
+++ b/src/frontend/src/lib/components/modals/MissionControlTopUpModal.svelte
@@ -4,7 +4,7 @@
 	import { run } from 'svelte/legacy';
 	import CanisterTopUpModal from '$lib/components/modals/CanisterTopUpModal.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalDetail, JunoModalTopUpMissionControlDetail } from '$lib/types/modal';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
@@ -25,10 +25,10 @@
 	});
 </script>
 
-{#if nonNullish($missionControlStore)}
+{#if nonNullish($missionControlIdDerived)}
 	<CanisterTopUpModal
 		segment="mission_control"
-		canisterId={$missionControlStore}
+		canisterId={$missionControlIdDerived}
 		{balance}
 		{accountIdentifier}
 		on:junoClose

--- a/src/frontend/src/lib/components/modals/MissionControlTransferCyclesModal.svelte
+++ b/src/frontend/src/lib/components/modals/MissionControlTransferCyclesModal.svelte
@@ -3,7 +3,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { depositCycles } from '$lib/api/mission-control.api';
 	import CanisterTransferCyclesModal from '$lib/components/modals/CanisterTransferCyclesModal.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalCycles, JunoModalDetail } from '$lib/types/modal';
 
@@ -20,17 +20,17 @@
 			async (params: { cycles: bigint; destinationId: Principal }) =>
 				await depositCycles({
 					...params,
-					missionControlId: $missionControlStore!,
+					missionControlId: $missionControlIdDerived!,
 					identity: $authStore.identity
 				})
 		);
 </script>
 
-{#if nonNullish($missionControlStore)}
+{#if nonNullish($missionControlIdDerived)}
 	<CanisterTransferCyclesModal
 		{transferFn}
 		{currentCycles}
-		canisterId={$missionControlStore}
+		canisterId={$missionControlIdDerived}
 		on:junoClose
 		segment="mission_control"
 	/>

--- a/src/frontend/src/lib/components/modals/MissionControlUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/MissionControlUpgradeModal.svelte
@@ -4,7 +4,7 @@
 	import { type UpgradeCodeParams, upgradeMissionControl } from '@junobuild/admin';
 	import CanisterUpgradeModal from '$lib/components/modals/CanisterUpgradeModal.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalDetail, JunoModalUpgradeDetail } from '$lib/types/modal';
@@ -25,7 +25,7 @@
 	) =>
 		await upgradeMissionControl({
 			missionControl: {
-				missionControlId: $missionControlStore!.toText(),
+				missionControlId: $missionControlIdDerived!.toText(),
 				identity: $authStore.identity ?? new AnonymousIdentity(),
 				...container()
 			},
@@ -33,14 +33,14 @@
 		});
 </script>
 
-{#if nonNullish($missionControlStore)}
+{#if nonNullish($missionControlIdDerived)}
 	<CanisterUpgradeModal
 		{onclose}
 		{newerReleases}
 		{currentVersion}
 		upgrade={upgradeMissionControlWasm}
 		segment="mission_control"
-		canisterId={$missionControlStore}
+		canisterId={$missionControlIdDerived}
 	>
 		{#snippet intro()}
 			<h2>

--- a/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
@@ -7,7 +7,7 @@
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
 	import { authSignedOut } from '$lib/derived/auth.derived';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import {
 		createOrbiter,
 		createOrbiterWithConfig,
@@ -40,14 +40,14 @@
 			const fn = nonNullish(subnetId) ? createOrbiterWithConfig : createOrbiter;
 
 			await fn({
-				missionControl: $missionControlStore,
+				missionControl: $missionControlIdDerived,
 				config: {
 					...(nonNullish(subnetId) && { subnetId: Principal.fromText(subnetId) })
 				}
 			});
 
 			// Reload list of orbiters before navigation
-			await loadOrbiters({ missionControl: $missionControlStore, reload: true });
+			await loadOrbiters({ missionControl: $missionControlIdDerived, reload: true });
 
 			steps = 'ready';
 		} catch (err) {
@@ -97,7 +97,7 @@
 
 				<button
 					type="submit"
-					disabled={$authSignedOut || isNullish($missionControlStore) || insufficientFunds}
+					disabled={$authSignedOut || isNullish($missionControlIdDerived) || insufficientFunds}
 					>{$i18n.analytics.create}</button
 				>
 			</form>

--- a/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
@@ -9,7 +9,7 @@
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { authSignedOut } from '$lib/derived/auth.derived';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import {
 		createSatellite,
 		createSatelliteWithConfig,
@@ -51,7 +51,7 @@
 			const fn = nonNullish(subnetId) ? createSatelliteWithConfig : createSatellite;
 
 			satellite = await fn({
-				missionControl: $missionControlStore,
+				missionControl: $missionControlIdDerived,
 				config: {
 					name: satelliteName,
 					...(nonNullish(subnetId) && { subnetId: Principal.fromText(subnetId) })
@@ -59,7 +59,7 @@
 			});
 
 			// Reload list of satellites before navigation
-			await loadSatellites({ missionControl: $missionControlStore, reload: true });
+			await loadSatellites({ missionControl: $missionControlIdDerived, reload: true });
 
 			steps = 'ready';
 		} catch (err) {
@@ -127,7 +127,7 @@
 
 				<button
 					type="submit"
-					disabled={$authSignedOut || isNullish($missionControlStore) || insufficientFunds}
+					disabled={$authSignedOut || isNullish($missionControlIdDerived) || insufficientFunds}
 					>{$i18n.satellites.create}</button
 				>
 			</form>

--- a/src/frontend/src/lib/components/modals/SatelliteUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteUpgradeModal.svelte
@@ -6,7 +6,7 @@
 	import CanisterUpgradeModal from '$lib/components/modals/CanisterUpgradeModal.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import { SATELLITE_v0_0_7, SATELLITE_v0_0_9 } from '$lib/constants/version.constants';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalDetail, JunoModalUpgradeSatelliteDetail } from '$lib/types/modal';
@@ -35,7 +35,7 @@
 				...container()
 			},
 			...params,
-			...(nonNullish($missionControlStore) && { missionControlId: $missionControlStore }),
+			...(nonNullish($missionControlIdDerived) && { missionControlId: $missionControlIdDerived }),
 			// TODO: option to be removed
 			deprecated: compare(currentVersion, SATELLITE_v0_0_7) < 0,
 			deprecatedNoScope: compare(currentVersion, SATELLITE_v0_0_9) < 0

--- a/src/frontend/src/lib/components/modals/SendTokensModal.svelte
+++ b/src/frontend/src/lib/components/modals/SendTokensModal.svelte
@@ -7,7 +7,7 @@
 	import Confetti from '$lib/components/ui/Confetti.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalDetail, JunoModalSendTokensDetail } from '$lib/types/modal';
 
@@ -35,7 +35,7 @@
 
 <svelte:window onjunoSyncBalance={({ detail: syncBalance }) => (balance = syncBalance)} />
 
-{#if nonNullish($missionControlStore)}
+{#if nonNullish($missionControlIdDerived)}
 	<Modal on:junoClose>
 		{#if steps === 'ready'}
 			<Confetti />
@@ -51,7 +51,7 @@
 		{:else if steps === 'review'}
 			<div in:fade>
 				<SendTokensReview
-					missionControlId={$missionControlStore}
+					missionControlId={$missionControlIdDerived}
 					{balance}
 					bind:amount
 					bind:destination

--- a/src/frontend/src/lib/components/satellites/SatelliteName.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteName.svelte
@@ -4,7 +4,7 @@
 	import IconEdit from '$lib/components/icons/IconEdit.svelte';
 	import Popover from '$lib/components/ui/Popover.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { setSatelliteName } from '$lib/services/mission-control.services';
 	import { busy, isBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -34,7 +34,7 @@
 			return;
 		}
 
-		if (isNullish($missionControlStore)) {
+		if (isNullish($missionControlIdDerived)) {
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
@@ -45,7 +45,7 @@
 
 		try {
 			await setSatelliteName({
-				missionControlId: $missionControlStore,
+				missionControlId: $missionControlIdDerived,
 				satellite,
 				satelliteName: satName
 			});

--- a/src/frontend/src/lib/components/satellites/SatelliteNew.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteNew.svelte
@@ -2,7 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import IconNew from '$lib/components/icons/IconNew.svelte';
 	import LaunchpadButton from '$lib/components/launchpad/LaunchpadButton.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { getCreateSatelliteFeeBalance } from '$lib/services/wizard.services';
 	import { authStore } from '$lib/stores/auth.store';
 	import { busy } from '$lib/stores/busy.store';
@@ -20,7 +20,7 @@
 
 		const { result, error } = await getCreateSatelliteFeeBalance({
 			identity: $authStore.identity,
-			missionControlId: $missionControlStore
+			missionControlId: $missionControlIdDerived
 		});
 
 		busy.stop();

--- a/src/frontend/src/lib/components/warning/VersionWarnings.svelte
+++ b/src/frontend/src/lib/components/warning/VersionWarnings.svelte
@@ -6,7 +6,7 @@
 	import type { Satellite } from '$declarations/mission_control/mission_control.did';
 	import IconNewReleases from '$lib/components/icons/IconNewReleases.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { missionControlVersion } from '$lib/derived/version.derived';
 	import { loadVersion } from '$lib/services/console.services';
 	import { newerReleases } from '$lib/services/upgrade.services';
@@ -24,13 +24,13 @@
 	const load = async (skipReload: boolean) =>
 		await loadVersion({
 			satelliteId: satellite?.satellite_id,
-			missionControlId: $missionControlStore,
+			missionControlId: $missionControlIdDerived,
 			skipReload
 		});
 
 	run(() => {
 		// @ts-expect-error TODO: to be migrated to Svelte v5
-		$missionControlStore, satellite, (async () => await load(true))();
+		$missionControlIdDerived, satellite, (async () => await load(true))();
 	});
 
 	let satVersion: string | undefined = $derived(

--- a/src/frontend/src/lib/components/warning/Warnings.svelte
+++ b/src/frontend/src/lib/components/warning/Warnings.svelte
@@ -4,7 +4,7 @@
 	import CanisterWarnings from '$lib/components/canister/CanisterWarnings.svelte';
 	import LoaderWarnings from '$lib/components/warning/LoaderWarnings.svelte';
 	import VersionWarnings from '$lib/components/warning/VersionWarnings.svelte';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 
@@ -17,8 +17,8 @@
 
 <VersionWarnings {satellite} />
 
-{#if nonNullish($missionControlStore)}
-	<LoaderWarnings canisterId={$missionControlStore}>
+{#if nonNullish($missionControlIdDerived)}
+	<LoaderWarnings canisterId={$missionControlIdDerived}>
 		{#snippet cycles()}
 			{$i18n.canisters.warning_mission_control_low_cycles}
 		{/snippet}

--- a/src/frontend/src/lib/derived/mission-control.derived.ts
+++ b/src/frontend/src/lib/derived/mission-control.derived.ts
@@ -5,8 +5,8 @@ import {
 import { fromNullable } from '@dfinity/utils';
 import { derived } from 'svelte/store';
 
-// TODO: rename store to shorten but find a good naming idea that does not conflicts with local variable
-export const missionControlStore = derived(
+// TODO: find a better name but, I don't want to use missionControlId because it would clashes with the properties called missionControlId
+export const missionControlIdDerived = derived(
 	[missionControlDataStore],
 	([$missionControlDataStore]) => $missionControlDataStore?.data
 );

--- a/src/frontend/src/routes/(split)/mission-control/+page.svelte
+++ b/src/frontend/src/routes/(split)/mission-control/+page.svelte
@@ -10,7 +10,7 @@
 	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import Warnings from '$lib/components/warning/Warnings.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import {
 		type Tab,
 		TABS_CONTEXT_KEY,
@@ -54,11 +54,11 @@
 
 		<SatellitesLoader>
 			<MissionControlGuard>
-				{#if nonNullish($missionControlStore)}
+				{#if nonNullish($missionControlIdDerived)}
 					{#if $store.tabId === $store.tabs[0].id}
-						<MissionControl missionControlId={$missionControlStore} />
+						<MissionControl missionControlId={$missionControlIdDerived} />
 					{:else if $store.tabId === $store.tabs[1].id}
-						<MissionControlSettings missionControlId={$missionControlStore} />
+						<MissionControlSettings missionControlId={$missionControlIdDerived} />
 					{/if}
 				{/if}
 			</MissionControlGuard>

--- a/src/frontend/src/routes/(split)/monitoring/+page.svelte
+++ b/src/frontend/src/routes/(split)/monitoring/+page.svelte
@@ -14,7 +14,7 @@
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import {
 		missionControlMonitored,
-		missionControlStore
+		missionControlIdDerived
 	} from '$lib/derived/mission-control.derived';
 	import {
 		type Tab,
@@ -69,12 +69,12 @@
 		<SatellitesLoader>
 			<OrbitersLoader>
 				<MissionControlGuard>
-					{#if nonNullish($missionControlStore)}
-						<MissionControlSettingsLoader missionControlId={$missionControlStore}>
+					{#if nonNullish($missionControlIdDerived)}
+						<MissionControlSettingsLoader missionControlId={$missionControlIdDerived}>
 							{#if $store.tabId === $store.tabs[0].id}
-								<MonitoringDashboard missionControlId={$missionControlStore} />
+								<MonitoringDashboard missionControlId={$missionControlIdDerived} />
 							{:else if $store.tabId === $store.tabs[1].id && $missionControlMonitored}
-								<MonitoringSettings missionControlId={$missionControlStore} />
+								<MonitoringSettings missionControlId={$missionControlIdDerived} />
 							{/if}
 						</MissionControlSettingsLoader>
 					{/if}

--- a/src/frontend/src/routes/(split)/wallet/+page.svelte
+++ b/src/frontend/src/routes/(split)/wallet/+page.svelte
@@ -8,7 +8,7 @@
 	import Wallet from '$lib/components/wallet/Wallet.svelte';
 	import Warnings from '$lib/components/warning/Warnings.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import {
 		type Tab,
 		TABS_CONTEXT_KEY,
@@ -43,9 +43,9 @@
 		{/snippet}
 
 		<MissionControlGuard>
-			{#if nonNullish($missionControlStore)}
+			{#if nonNullish($missionControlIdDerived)}
 				{#if $store.tabId === $store.tabs[0].id}
-					<Wallet missionControlId={$missionControlStore} />
+					<Wallet missionControlId={$missionControlIdDerived} />
 				{/if}
 			{/if}
 		</MissionControlGuard>

--- a/src/frontend/src/routes/(standalone)/cli/+page.svelte
+++ b/src/frontend/src/routes/(standalone)/cli/+page.svelte
@@ -4,7 +4,7 @@
 	import CliAdd from '$lib/components/cli/CliAdd.svelte';
 	import MissionControlGuard from '$lib/components/guards/MissionControlGuard.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
-	import { missionControlStore } from '$lib/derived/mission-control.derived';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { signIn } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Option } from '$lib/types/utils';
@@ -25,9 +25,9 @@
 {#if nonNullish(redirect_uri) && nonNullish(principal) && notEmptyString(redirect_uri) && notEmptyString(principal)}
 	{#if $authSignedIn}
 		<MissionControlGuard>
-			{#if nonNullish($missionControlStore)}
+			{#if nonNullish($missionControlIdDerived)}
 				<div in:fade>
-					<CliAdd {principal} {redirect_uri} missionControlId={$missionControlStore} />
+					<CliAdd {principal} {redirect_uri} missionControlId={$missionControlIdDerived} />
 				</div>
 			{/if}
 		</MissionControlGuard>


### PR DESCRIPTION
# Motivation

We want to keep in store the mission control with metadata and not just id, so I'll have to refactor a bit of code. Starting with the derived store which actually is the id.
