### PR TITLE
feat: mission control store (all data) instead of just id

### DIFF
--- a/src/frontend/src/lib/derived/mission-control.derived.ts
+++ b/src/frontend/src/lib/derived/mission-control.derived.ts
@@ -5,10 +5,14 @@ import {
 import { fromNullable } from '@dfinity/utils';
 import { derived } from 'svelte/store';
 
-// TODO: find a better name but, I don't want to use missionControlId because it would clashes with the properties called missionControlId
-export const missionControlIdDerived = derived(
+export const missionControl = derived(
 	[missionControlDataStore],
 	([$missionControlDataStore]) => $missionControlDataStore?.data
+);
+
+// TODO: find a better name but, I don't want to use missionControlId because it would clashes with the properties called missionControlId
+export const missionControlIdDerived = derived([missionControl], ([$missionControl]) =>
+	fromNullable($missionControl?.mission_control_id ?? [])
 );
 
 export const missionControlSettings = derived(

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -429,6 +429,7 @@
 	},
 	"errors": {
 		"no_identity": "Unexpected error. No identity provided.",
+		"initializing_mission_control": "Mission control center cannot be initialized.",
 		"no_mission_control": "Mission control center is not initialized.",
 		"cli_missing_params": "Missing URL parameters. Either the redirection URL or principal is not provided.",
 		"cli_missing_selection": "No mission control or satellite(s) selected.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -429,6 +429,7 @@
 	},
 	"errors": {
 		"no_identity": "异常错误，没有提供 identity ",
+		"initializing_mission_control": "Mission control center cannot be initialized.",
 		"no_mission_control": "Mission 控制中心没有初始化.",
 		"cli_missing_params": "URL参数缺失，重定向URL或者 principal没有提供.",
 		"cli_missing_selection": "没选择 mission control 或 satellite(s) .",

--- a/src/frontend/src/lib/services/console.services.ts
+++ b/src/frontend/src/lib/services/console.services.ts
@@ -1,3 +1,4 @@
+import type { MissionControl } from '$declarations/console/console.did';
 import type { Orbiter } from '$declarations/mission_control/mission_control.did';
 import { initMissionControl as initMissionControlApi } from '$lib/api/console.api';
 import { missionControlVersion } from '$lib/api/mission-control.api';
@@ -20,17 +21,17 @@ export const initMissionControl = async ({
 	onInitMissionControlSuccess
 }: {
 	identity: Identity;
-	onInitMissionControlSuccess: (missionControlId: Principal) => Promise<void>;
+	onInitMissionControlSuccess: (missionControl: MissionControl) => void;
 	// eslint-disable-next-line no-async-promise-executor, require-await
 }) =>
 	// eslint-disable-next-line no-async-promise-executor, require-await
 	new Promise<void>(async (resolve, reject) => {
 		try {
-			const { missionControlId } = await getMissionControl({
+			const { missionControl } = await getMissionControl({
 				identity
 			});
 
-			if (isNullish(missionControlId)) {
+			if (isNullish(missionControl)) {
 				setTimeout(async () => {
 					try {
 						await initMissionControl({ identity, onInitMissionControlSuccess });
@@ -42,7 +43,7 @@ export const initMissionControl = async ({
 				return;
 			}
 
-			await onInitMissionControlSuccess(missionControlId);
+			onInitMissionControlSuccess(missionControl);
 
 			resolve();
 		} catch (err: unknown) {
@@ -55,20 +56,14 @@ const getMissionControl = async ({
 }: {
 	identity: Identity | undefined;
 }): Promise<{
-	missionControlId: Principal | undefined;
+	missionControl: MissionControl | undefined;
 }> => {
-	if (isNullish(identity)) {
-		throw new Error('Invalid identity.');
-	}
-
 	const mission_control = await initMissionControlApi(identity);
 
-	const missionControlId: Principal | undefined = fromNullable<Principal>(
-		mission_control.mission_control_id
-	);
+	const missionControlId = fromNullable<Principal>(mission_control.mission_control_id);
 
 	return {
-		missionControlId
+		missionControl: nonNullish(missionControlId) ? mission_control : missionControlId
 	};
 };
 

--- a/src/frontend/src/lib/services/console.services.ts
+++ b/src/frontend/src/lib/services/console.services.ts
@@ -60,10 +60,12 @@ const getMissionControl = async ({
 }> => {
 	const mission_control = await initMissionControlApi(identity);
 
-	const missionControlId = fromNullable<Principal>(mission_control.mission_control_id);
+	const missionControlId = fromNullable(mission_control.mission_control_id);
 
 	return {
-		missionControl: nonNullish(missionControlId) ? mission_control : missionControlId
+		// The backend creates an empty mission control entity and set the ID once the module has been successfully created.
+		// That's why, until the ID is set within the entity, we consider the mission control has undefined.
+		missionControl: nonNullish(missionControlId) ? mission_control : undefined
 	};
 };
 

--- a/src/frontend/src/lib/stores/mission-control.store.ts
+++ b/src/frontend/src/lib/stores/mission-control.store.ts
@@ -1,7 +1,7 @@
+import type { MissionControl } from '$declarations/console/console.did';
 import type { MissionControlSettings } from '$declarations/mission_control/mission_control.did';
 import { initDataStore } from '$lib/stores/data.store';
-import type { Principal } from '@dfinity/principal';
 
-export const missionControlDataStore = initDataStore<Principal>();
+export const missionControlDataStore = initDataStore<MissionControl>();
 
 export const missionControlSettingsDataStore = initDataStore<MissionControlSettings | undefined>();

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -445,6 +445,7 @@ interface I18nCli {
 
 interface I18nErrors {
 	no_identity: string;
+	initializing_mission_control: string;
 	no_mission_control: string;
 	cli_missing_params: string;
 	cli_missing_selection: string;

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -49,13 +49,11 @@
 			// Poll to init mission control center
 			await initMissionControl({
 				identity,
-				// eslint-disable-next-line require-await
-				onInitMissionControlSuccess: async (missionControlId) =>
-					missionControlDataStore.set(missionControlId)
+				onInitMissionControlSuccess: (missionControl) => missionControlDataStore.set(missionControl)
 			});
 		} catch (err: unknown) {
 			toasts.error({
-				text: `Error initializing the user.`,
+				text: $i18n.errors.initializing_mission_control,
 				detail: err
 			});
 


### PR DESCRIPTION
# Motivation

Since we are going to introduce "email" in the "metadata" of the mission control, we would like to old the all data / entity in store and not just trim its ID.
