### PR TITLE
Revert "feat: mission control store (all data) instead of just id"

### DIFF
--- a/src/frontend/src/lib/derived/mission-control.derived.ts
+++ b/src/frontend/src/lib/derived/mission-control.derived.ts
@@ -5,14 +5,10 @@ import {
 import { fromNullable } from '@dfinity/utils';
 import { derived } from 'svelte/store';
 
-export const missionControl = derived(
+// TODO: find a better name but, I don't want to use missionControlId because it would clashes with the properties called missionControlId
+export const missionControlIdDerived = derived(
 	[missionControlDataStore],
 	([$missionControlDataStore]) => $missionControlDataStore?.data
-);
-
-// TODO: find a better name but, I don't want to use missionControlId because it would clashes with the properties called missionControlId
-export const missionControlIdDerived = derived([missionControl], ([$missionControl]) =>
-	fromNullable($missionControl?.mission_control_id ?? [])
 );
 
 export const missionControlSettings = derived(

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -429,7 +429,6 @@
 	},
 	"errors": {
 		"no_identity": "Unexpected error. No identity provided.",
-		"initializing_mission_control": "Mission control center cannot be initialized.",
 		"no_mission_control": "Mission control center is not initialized.",
 		"cli_missing_params": "Missing URL parameters. Either the redirection URL or principal is not provided.",
 		"cli_missing_selection": "No mission control or satellite(s) selected.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -429,7 +429,6 @@
 	},
 	"errors": {
 		"no_identity": "异常错误，没有提供 identity ",
-		"initializing_mission_control": "Mission control center cannot be initialized.",
 		"no_mission_control": "Mission 控制中心没有初始化.",
 		"cli_missing_params": "URL参数缺失，重定向URL或者 principal没有提供.",
 		"cli_missing_selection": "没选择 mission control 或 satellite(s) .",

--- a/src/frontend/src/lib/stores/mission-control.store.ts
+++ b/src/frontend/src/lib/stores/mission-control.store.ts
@@ -1,7 +1,7 @@
-import type { MissionControl } from '$declarations/console/console.did';
 import type { MissionControlSettings } from '$declarations/mission_control/mission_control.did';
 import { initDataStore } from '$lib/stores/data.store';
+import type { Principal } from '@dfinity/principal';
 
-export const missionControlDataStore = initDataStore<MissionControl>();
+export const missionControlDataStore = initDataStore<Principal>();
 
 export const missionControlSettingsDataStore = initDataStore<MissionControlSettings | undefined>();

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -445,7 +445,6 @@ interface I18nCli {
 
 interface I18nErrors {
 	no_identity: string;
-	initializing_mission_control: string;
 	no_mission_control: string;
 	cli_missing_params: string;
 	cli_missing_selection: string;

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -49,11 +49,13 @@
 			// Poll to init mission control center
 			await initMissionControl({
 				identity,
-				onInitMissionControlSuccess: (missionControl) => missionControlDataStore.set(missionControl)
+				// eslint-disable-next-line require-await
+				onInitMissionControlSuccess: async (missionControlId) =>
+					missionControlDataStore.set(missionControlId)
 			});
 		} catch (err: unknown) {
 			toasts.error({
-				text: $i18n.errors.initializing_mission_control,
+				text: `Error initializing the user.`,
 				detail: err
 			});
 


### PR DESCRIPTION
Reverts junobuild/juno#982

I'm dumb. We need the metadata of the mission control not the "Mission control" entity from the console. So we do not really need this change and can keep just the ID in store.