### PR TITLE
feat: review mission control get user

### DIFF
--- a/src/declarations/mission_control/mission_control.did.d.ts
+++ b/src/declarations/mission_control/mission_control.did.d.ts
@@ -152,6 +152,12 @@ export type TransferError_1 =
 	| { CreatedInFuture: { ledger_time: bigint } }
 	| { TooOld: null }
 	| { InsufficientFunds: { balance: bigint } };
+export interface User {
+	updated_at: bigint;
+	metadata: Array<[string, string]>;
+	user: [] | [Principal];
+	created_at: bigint;
+}
 export interface _SERVICE {
 	add_mission_control_controllers: ActorMethod<[Array<Principal>], undefined>;
 	add_satellites_controllers: ActorMethod<[Array<Principal>, Array<Principal>], undefined>;
@@ -171,7 +177,8 @@ export interface _SERVICE {
 	>;
 	get_monitoring_status: ActorMethod<[], MonitoringStatus>;
 	get_settings: ActorMethod<[], [] | [MissionControlSettings]>;
-	get_user: ActorMethod<[], Principal>;
+	get_user: ActorMethod<[], User>;
+	get_user_id: ActorMethod<[], Principal>;
 	icp_transfer: ActorMethod<[TransferArgs], Result>;
 	icrc_transfer: ActorMethod<[Principal, TransferArg], Result_1>;
 	list_mission_control_controllers: ActorMethod<[], Array<[Principal, Controller]>>;

--- a/src/declarations/mission_control/mission_control.factory.did.js
+++ b/src/declarations/mission_control/mission_control.factory.did.js
@@ -68,6 +68,12 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		monitoring: IDL.Opt(Monitoring)
 	});
+	const User = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		user: IDL.Opt(IDL.Principal),
+		created_at: IDL.Nat64
+	});
 	const Tokens = IDL.Record({ e8s: IDL.Nat64 });
 	const Timestamp = IDL.Record({ timestamp_nanos: IDL.Nat64 });
 	const TransferArgs = IDL.Record({
@@ -168,7 +174,8 @@ export const idlFactory = ({ IDL }) => {
 		),
 		get_monitoring_status: IDL.Func([], [MonitoringStatus], ['query']),
 		get_settings: IDL.Func([], [IDL.Opt(MissionControlSettings)], ['query']),
-		get_user: IDL.Func([], [IDL.Principal], ['query']),
+		get_user: IDL.Func([], [User], ['query']),
+		get_user_id: IDL.Func([], [IDL.Principal], ['query']),
 		icp_transfer: IDL.Func([TransferArgs], [Result], []),
 		icrc_transfer: IDL.Func([IDL.Principal, TransferArg], [Result_1], []),
 		list_mission_control_controllers: IDL.Func(

--- a/src/mission_control/mission_control.did
+++ b/src/mission_control/mission_control.did
@@ -122,6 +122,12 @@ type TransferError_1 = variant {
   TooOld;
   InsufficientFunds : record { balance : nat };
 };
+type User = record {
+  updated_at : nat64;
+  metadata : vec record { text; text };
+  user : opt principal;
+  created_at : nat64;
+};
 service : () -> {
   add_mission_control_controllers : (vec principal) -> ();
   add_satellites_controllers : (vec principal, vec principal) -> ();
@@ -140,7 +146,8 @@ service : () -> {
     ) query;
   get_monitoring_status : () -> (MonitoringStatus) query;
   get_settings : () -> (opt MissionControlSettings) query;
-  get_user : () -> (principal) query;
+  get_user : () -> (User) query;
+  get_user_id : () -> (principal) query;
   icp_transfer : (TransferArgs) -> (Result);
   icrc_transfer : (principal, TransferArg) -> (Result_1);
   list_mission_control_controllers : () -> (

--- a/src/mission_control/src/controllers/mission_control.rs
+++ b/src/mission_control/src/controllers/mission_control.rs
@@ -1,5 +1,5 @@
 use crate::controllers::store::{delete_controllers, get_admin_controllers, set_controllers};
-use crate::store::get_user;
+use crate::store::get_user_id;
 use ic_cdk::id;
 use junobuild_shared::constants::MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS;
 use junobuild_shared::controllers::{
@@ -49,7 +49,7 @@ async fn update_controllers_settings(controllers: &Controllers) -> Result<(), St
     let mission_control_id = id();
 
     // So do the owner / user
-    let user = get_user();
+    let user = get_user_id();
 
     let controller_ids = into_controller_ids(controllers);
 

--- a/src/mission_control/src/guards.rs
+++ b/src/mission_control/src/guards.rs
@@ -1,5 +1,5 @@
 use crate::memory::STATE;
-use crate::store::get_user;
+use crate::store::get_user_id;
 use ic_cdk::api::is_controller as ic_canister_controller;
 use ic_cdk::caller;
 use junobuild_shared::controllers::is_admin_controller;
@@ -16,7 +16,7 @@ pub fn caller_is_user_or_admin_controller() -> Result<(), String> {
 
 fn caller_is_user() -> bool {
     let caller = caller();
-    let user = get_user();
+    let user = get_user_id();
 
     principal_equal(caller, user) && ic_canister_controller(&caller)
 }

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -34,17 +34,14 @@ use crate::segments::satellite::{
 };
 use crate::segments::store::get_orbiters;
 use crate::store::{
-    get_settings as get_settings_store, get_user as get_user_store,
-    set_metadata as set_metadata_store,
+    get_settings as get_settings_store, get_user_id as get_user_id_store,
+    set_metadata as set_metadata_store, get_user as get_users_store,
 };
 use crate::types::interface::{
     CreateCanisterConfig, GetMonitoringHistory, MonitoringStartConfig, MonitoringStatus,
     MonitoringStopConfig,
 };
-use crate::types::state::{
-    HeapState, MissionControlSettings, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters,
-    Satellite, Satellites, State,
-};
+use crate::types::state::{HeapState, MissionControlSettings, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters, Satellite, Satellites, State, User};
 use candid::Principal;
 use ciborium::into_writer;
 use ic_cdk::api::call::{arg_data, ArgDecoderConfig};
@@ -364,8 +361,13 @@ fn list_mission_control_controllers() -> Controllers {
 // ---------------------------------------------------------
 
 #[query(guard = "caller_is_user_or_admin_controller")]
-fn get_user() -> UserId {
-    get_user_store()
+fn get_user_id() -> UserId {
+    get_user_id_store()
+}
+
+#[query(guard = "caller_is_user_or_admin_controller")]
+fn get_user() -> User {
+    get_users_store()
 }
 
 #[query(guard = "caller_is_user_or_admin_controller")]

--- a/src/mission_control/src/monitoring/cycles/notification.rs
+++ b/src/mission_control/src/monitoring/cycles/notification.rs
@@ -1,7 +1,7 @@
 use crate::monitoring::cycles::utils::get_deposited_cycles;
 use crate::monitoring::observatory::notify_observatory;
 use crate::segments::store::{get_orbiter, get_satellite};
-use crate::store::{get_metadata, get_user};
+use crate::store::{get_metadata, get_user_id};
 use canfund::manager::record::CanisterRecord;
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_cdk::{id, print, spawn};
@@ -41,7 +41,7 @@ fn prepare_args(canister_id: &CanisterId, deposited_cycles: &CyclesBalance) -> O
 
     let segment = get_segment(canister_id)?;
 
-    let user = get_user();
+    let user = get_user_id();
 
     Some(NotifyArgs {
         user,

--- a/src/mission_control/src/segments/canister.rs
+++ b/src/mission_control/src/segments/canister.rs
@@ -1,4 +1,4 @@
-use crate::store::get_user;
+use crate::store::get_user_id;
 use crate::types::interface::CreateCanisterConfig;
 use candid::Principal;
 use ic_cdk::api::call::CallResult;
@@ -22,7 +22,7 @@ where
     Fut: Future<Output = Result<T, String>>,
 {
     let console = Principal::from_text(CONSOLE).unwrap();
-    let user: UserId = get_user();
+    let user: UserId = get_user_id();
 
     let args = GetCreateCanisterFeeArgs { user };
 

--- a/src/mission_control/src/store.rs
+++ b/src/mission_control/src/store.rs
@@ -3,8 +3,12 @@ use crate::types::state::{HeapState, MissionControlSettings, User};
 use ic_cdk::api::time;
 use junobuild_shared::types::state::{Metadata, UserId};
 
-pub fn get_user() -> UserId {
+pub fn get_user_id() -> UserId {
     STATE.with(|state| state.borrow().heap.user.user).unwrap()
+}
+
+pub fn get_user() -> User {
+    STATE.with(|state| state.borrow().heap.user.clone())
 }
 
 pub fn get_settings() -> Option<MissionControlSettings> {

--- a/src/tests/mission-control.controllers.spec.ts
+++ b/src/tests/mission-control.controllers.spec.ts
@@ -18,7 +18,7 @@ import {
 	controllersInitArgs
 } from './utils/setup-tests.utils';
 
-describe('Mission Control', () => {
+describe('Mission Control - Controllers', () => {
 	let pic: PocketIc;
 	let actor: Actor<MissionControlActor>;
 

--- a/src/tests/mission-control.spec.ts
+++ b/src/tests/mission-control.spec.ts
@@ -1,0 +1,77 @@
+import type { _SERVICE as MissionControlActor } from '$declarations/mission_control/mission_control.did';
+import { idlFactory as idlFactorMissionControl } from '$declarations/mission_control/mission_control.factory.did';
+import { AnonymousIdentity } from '@dfinity/agent';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { PocketIc, type Actor } from '@hadronous/pic';
+import { afterAll, beforeAll, describe, expect, inject } from 'vitest';
+import { CONTROLLER_ERROR_MSG } from './constants/mission-control-tests.constants';
+import { missionControlUserInitArgs } from './utils/mission-control-tests.utils';
+import { MISSION_CONTROL_WASM_PATH } from './utils/setup-tests.utils';
+
+describe('Mission Control', () => {
+	let pic: PocketIc;
+	let actor: Actor<MissionControlActor>;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const userInitArgs = (): ArrayBuffer => missionControlUserInitArgs(controller.getPrincipal());
+
+		const { actor: c, canisterId: missionControlId } = await pic.setupCanister<MissionControlActor>(
+			{
+				idlFactory: idlFactorMissionControl,
+				wasm: MISSION_CONTROL_WASM_PATH,
+				arg: userInitArgs(),
+				sender: controller.getPrincipal()
+			}
+		);
+
+		actor = c;
+
+		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	const testGuards = () => {
+		it('should throw errors on get user id', async () => {
+			const { get_user_id } = actor;
+
+			await expect(get_user_id()).rejects.toThrow(CONTROLLER_ERROR_MSG);
+		});
+
+		it('should throw errors on get user', async () => {
+			const { get_user } = actor;
+
+			await expect(get_user()).rejects.toThrow(CONTROLLER_ERROR_MSG);
+		});
+
+		it('should throw errors on get settings', async () => {
+			const { get_settings } = actor;
+
+			await expect(get_settings()).rejects.toThrow(CONTROLLER_ERROR_MSG);
+		});
+	};
+
+	describe('anonymous', () => {
+		beforeAll(() => {
+			actor.setIdentity(new AnonymousIdentity());
+		});
+
+		testGuards();
+	});
+
+	describe('user', () => {
+		const user = Ed25519KeyIdentity.generate();
+
+		beforeAll(() => {
+			actor.setIdentity(user);
+		});
+
+		testGuards();
+	});
+});


### PR DESCRIPTION
# Motivation

`get_user` was returning the the `UserId` probably just for historical reason. To makes things a bit cleaner and since we are allowing breaking changes in the next release, this PR cleans the end point by renaming it to `get_user_id` and introduces a new `get_user` that returns the `User`.

# Notes

The `User` contains a `user` - i.e. `UserId` - that can be optional but, is actually never optional. Here too, probably a mistake that was made a long time ago. Let's live with it.
