### PR TITLE
feat: if no mission control skip loading

### DIFF
--- a/src/frontend/src/lib/services/orbiters.services.ts
+++ b/src/frontend/src/lib/services/orbiters.services.ts
@@ -96,8 +96,7 @@ export const loadOrbiters = async ({
 	reload?: boolean;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
 	if (isNullish(missionControl)) {
-		orbitersDataStore.reset();
-		return { result: 'error' };
+		return { result: 'skip' };
 	}
 
 	// We load only once

--- a/src/frontend/src/lib/services/satellites.services.ts
+++ b/src/frontend/src/lib/services/satellites.services.ts
@@ -62,8 +62,7 @@ export const loadSatellites = async ({
 	reload?: boolean;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
 	if (isNullish(missionControl)) {
-		satellitesDataStore.reset();
-		return { result: 'error' };
+		return { result: 'skip' };
 	}
 
 	// We load only once


### PR DESCRIPTION
# Motivation

This better align the use of the stores which is undefined per default and null on explicit reset - i.e. we do not need to load until a mission control is set.

We also need this for #986.
