### PR TITLE
feat: init monitoring configuration

### DIFF
--- a/src/declarations/mission_control/mission_control.did.d.ts
+++ b/src/declarations/mission_control/mission_control.did.d.ts
@@ -26,6 +26,10 @@ export interface CyclesMonitoring {
 	strategy: [] | [CyclesMonitoringStrategy];
 	enabled: boolean;
 }
+export interface CyclesMonitoringConfig {
+	notification: [] | [DepositedCyclesEmailNotification];
+	default_strategy: [] | [CyclesMonitoringStrategy];
+}
 export interface CyclesMonitoringStartConfig {
 	orbiters_strategy: [] | [SegmentsMonitoringStrategy];
 	mission_control_strategy: [] | [CyclesMonitoringStrategy];
@@ -49,6 +53,10 @@ export interface DepositCyclesArgs {
 	cycles: bigint;
 	destination_id: Principal;
 }
+export interface DepositedCyclesEmailNotification {
+	to: [] | [string];
+	enabled: boolean;
+}
 export interface GetMonitoringHistory {
 	to: [] | [bigint];
 	from: [] | [bigint];
@@ -56,11 +64,15 @@ export interface GetMonitoringHistory {
 }
 export interface MissionControlSettings {
 	updated_at: bigint;
+	monitoring_config: [] | [MonitoringConfig];
 	created_at: bigint;
 	monitoring: [] | [Monitoring];
 }
 export interface Monitoring {
 	cycles: [] | [CyclesMonitoring];
+}
+export interface MonitoringConfig {
+	cycles: [] | [CyclesMonitoringConfig];
 }
 export interface MonitoringHistory {
 	cycles: [] | [MonitoringHistoryCycles];
@@ -182,6 +194,7 @@ export interface _SERVICE {
 	remove_satellites_controllers: ActorMethod<[Array<Principal>, Array<Principal>], undefined>;
 	set_metadata: ActorMethod<[Array<[string, string]>], undefined>;
 	set_mission_control_controllers: ActorMethod<[Array<Principal>, SetController], undefined>;
+	set_monitoring_config: ActorMethod<[[] | [MonitoringConfig]], undefined>;
 	set_orbiter: ActorMethod<[Principal, [] | [string]], Orbiter>;
 	set_orbiter_metadata: ActorMethod<[Principal, Array<[string, string]>], Orbiter>;
 	set_orbiters_controllers: ActorMethod<

--- a/src/declarations/mission_control/mission_control.factory.did.js
+++ b/src/declarations/mission_control/mission_control.factory.did.js
@@ -63,8 +63,20 @@ export const idlFactory = ({ IDL }) => {
 	const MonitoringStatus = IDL.Record({
 		cycles: IDL.Opt(CyclesMonitoringStatus)
 	});
+	const DepositedCyclesEmailNotification = IDL.Record({
+		to: IDL.Opt(IDL.Text),
+		enabled: IDL.Bool
+	});
+	const CyclesMonitoringConfig = IDL.Record({
+		notification: IDL.Opt(DepositedCyclesEmailNotification),
+		default_strategy: IDL.Opt(CyclesMonitoringStrategy)
+	});
+	const MonitoringConfig = IDL.Record({
+		cycles: IDL.Opt(CyclesMonitoringConfig)
+	});
 	const MissionControlSettings = IDL.Record({
 		updated_at: IDL.Nat64,
+		monitoring_config: IDL.Opt(MonitoringConfig),
 		created_at: IDL.Nat64,
 		monitoring: IDL.Opt(Monitoring)
 	});
@@ -187,6 +199,7 @@ export const idlFactory = ({ IDL }) => {
 		),
 		set_metadata: IDL.Func([IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], [], []),
 		set_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal), SetController], [], []),
+		set_monitoring_config: IDL.Func([IDL.Opt(MonitoringConfig)], [], []),
 		set_orbiter: IDL.Func([IDL.Principal, IDL.Opt(IDL.Text)], [Orbiter], []),
 		set_orbiter_metadata: IDL.Func(
 			[IDL.Principal, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],

--- a/src/mission_control/mission_control.did
+++ b/src/mission_control/mission_control.did
@@ -16,6 +16,10 @@ type CyclesMonitoring = record {
   strategy : opt CyclesMonitoringStrategy;
   enabled : bool;
 };
+type CyclesMonitoringConfig = record {
+  notification : opt DepositedCyclesEmailNotification;
+  default_strategy : opt CyclesMonitoringStrategy;
+};
 type CyclesMonitoringStartConfig = record {
   orbiters_strategy : opt SegmentsMonitoringStrategy;
   mission_control_strategy : opt CyclesMonitoringStrategy;
@@ -33,6 +37,10 @@ type CyclesMonitoringStopConfig = record {
 type CyclesMonitoringStrategy = variant { BelowThreshold : CyclesThreshold };
 type CyclesThreshold = record { fund_cycles : nat; min_cycles : nat };
 type DepositCyclesArgs = record { cycles : nat; destination_id : principal };
+type DepositedCyclesEmailNotification = record {
+  to : opt text;
+  enabled : bool;
+};
 type GetMonitoringHistory = record {
   to : opt nat64;
   from : opt nat64;
@@ -40,10 +48,12 @@ type GetMonitoringHistory = record {
 };
 type MissionControlSettings = record {
   updated_at : nat64;
+  monitoring_config : opt MonitoringConfig;
   created_at : nat64;
   monitoring : opt Monitoring;
 };
 type Monitoring = record { cycles : opt CyclesMonitoring };
+type MonitoringConfig = record { cycles : opt CyclesMonitoringConfig };
 type MonitoringHistory = record { cycles : opt MonitoringHistoryCycles };
 type MonitoringHistoryCycles = record {
   deposited_cycles : opt CyclesBalance;
@@ -153,6 +163,7 @@ service : () -> {
   remove_satellites_controllers : (vec principal, vec principal) -> ();
   set_metadata : (vec record { text; text }) -> ();
   set_mission_control_controllers : (vec principal, SetController) -> ();
+  set_monitoring_config : (opt MonitoringConfig) -> ();
   set_orbiter : (principal, opt text) -> (Orbiter);
   set_orbiter_metadata : (principal, vec record { text; text }) -> (Orbiter);
   set_orbiters_controllers : (

--- a/src/mission_control/src/impls.rs
+++ b/src/mission_control/src/impls.rs
@@ -1,11 +1,7 @@
 use crate::memory::init_stable_state;
 use crate::types::core::{Segment, SettingsMonitoring};
 use crate::types::state::CyclesMonitoringStrategy::BelowThreshold;
-use crate::types::state::{
-    Archive, ArchiveStatuses, CyclesMonitoring, CyclesMonitoringStrategy, HeapState,
-    MissionControlSettings, Monitoring, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters,
-    Satellite, Settings, State, User,
-};
+use crate::types::state::{Archive, ArchiveStatuses, CyclesMonitoring, CyclesMonitoringStrategy, HeapState, MissionControlSettings, Monitoring, MonitoringConfig, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters, Satellite, Settings, State, User};
 use canfund::manager::options::{CyclesThreshold, FundStrategy};
 use ic_cdk::api::time;
 use ic_stable_structures::storable::Bound;
@@ -239,11 +235,23 @@ impl CyclesMonitoringStrategy {
 }
 
 impl MissionControlSettings {
-    pub fn from(strategy: &CyclesMonitoringStrategy) -> Self {
+    pub fn from_strategy(strategy: &CyclesMonitoringStrategy) -> Self {
         let now = time();
 
         MissionControlSettings {
             monitoring: Some(Monitoring::from(strategy)),
+            monitoring_config: None,
+            updated_at: now,
+            created_at: now,
+        }
+    }
+
+    pub fn from_config(config: &Option<MonitoringConfig>) -> Self {
+        let now = time();
+
+        MissionControlSettings {
+            monitoring: None,
+            monitoring_config: config.clone(),
             updated_at: now,
             created_at: now,
         }
@@ -254,6 +262,16 @@ impl MissionControlSettings {
 
         MissionControlSettings {
             monitoring: Some(Monitoring::from(strategy)),
+            updated_at: now,
+            ..self.clone()
+        }
+    }
+
+    pub fn clone_with_config(&self, config: &Option<MonitoringConfig>) -> Self {
+        let now = time();
+
+        MissionControlSettings {
+            monitoring_config: config.clone(),
             updated_at: now,
             ..self.clone()
         }

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -41,10 +41,7 @@ use crate::types::interface::{
     CreateCanisterConfig, GetMonitoringHistory, MonitoringStartConfig, MonitoringStatus,
     MonitoringStopConfig,
 };
-use crate::types::state::{
-    HeapState, MissionControlSettings, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters,
-    Satellite, Satellites, State,
-};
+use crate::types::state::{HeapState, MissionControlSettings, MonitoringConfig, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters, Satellite, Satellites, State};
 use candid::Principal;
 use ciborium::into_writer;
 use ic_cdk::api::call::{arg_data, ArgDecoderConfig};
@@ -75,6 +72,7 @@ use segments::store::{
     set_satellite_metadata as set_satellite_metadata_store,
 };
 use std::collections::HashMap;
+use crate::monitoring::monitor::update_monitoring_config;
 
 #[init]
 fn init() {
@@ -436,6 +434,11 @@ fn get_monitoring_history(
     filter: GetMonitoringHistory,
 ) -> Vec<(MonitoringHistoryKey, MonitoringHistory)> {
     get_any_monitoring_history(&filter)
+}
+
+#[update(guard = "caller_is_user_or_admin_controller")]
+fn set_monitoring_config(config: Option<MonitoringConfig>) {
+    update_monitoring_config(&config);
 }
 
 // ---------------------------------------------------------

--- a/src/mission_control/src/monitoring/monitor.rs
+++ b/src/mission_control/src/monitoring/monitor.rs
@@ -8,11 +8,12 @@ use crate::monitoring::store::stable::get_monitoring_history as get_monitoring_h
 use crate::types::interface::{
     GetMonitoringHistory, MonitoringStartConfig, MonitoringStatus, MonitoringStopConfig,
 };
-use crate::types::state::{MonitoringHistory, MonitoringHistoryKey};
+use crate::types::state::{MonitoringConfig, MonitoringHistory, MonitoringHistoryKey};
 use ic_cdk::spawn;
 use ic_cdk::trap;
 use ic_cdk_timers::set_timer;
 use std::time::Duration;
+use crate::monitoring::store::heap::set_mission_control_config;
 
 pub fn defer_restart_monitoring() {
     set_timer(Duration::ZERO, || spawn(restart_monitoring()));
@@ -58,4 +59,8 @@ pub fn get_monitoring_history(
     filter: &GetMonitoringHistory,
 ) -> Vec<(MonitoringHistoryKey, MonitoringHistory)> {
     get_monitoring_history_store(filter)
+}
+
+pub fn update_monitoring_config(config: &Option<MonitoringConfig>) {
+    set_mission_control_config(config);
 }

--- a/src/mission_control/src/monitoring/store/heap.rs
+++ b/src/mission_control/src/monitoring/store/heap.rs
@@ -1,11 +1,13 @@
 use crate::memory::STATE;
-use crate::types::state::{
-    CyclesMonitoringStrategy, HeapState, MissionControlSettings, Orbiters, Satellites, Settings,
-};
+use crate::types::state::{CyclesMonitoringStrategy, HeapState, MissionControlSettings, MonitoringConfig, Orbiters, Satellites, Settings};
 use junobuild_shared::types::state::{OrbiterId, SatelliteId};
 
 pub fn set_mission_control_strategy(strategy: &CyclesMonitoringStrategy) {
-    STATE.with(|state| set_mission_control_setting_impl(strategy, &mut state.borrow_mut().heap))
+    STATE.with(|state| set_mission_control_strategy_impl(strategy, &mut state.borrow_mut().heap))
+}
+
+pub fn set_mission_control_config(config: &Option<MonitoringConfig>) {
+    STATE.with(|state| set_mission_control_config_impl(config, &mut state.borrow_mut().heap))
 }
 
 pub fn enable_mission_control_monitoring() -> Result<(), String> {
@@ -70,13 +72,23 @@ pub fn disable_orbiter_monitoring(orbiter_id: &OrbiterId) -> Result<(), String> 
     })
 }
 
-fn set_mission_control_setting_impl(strategy: &CyclesMonitoringStrategy, state: &mut HeapState) {
+fn set_mission_control_strategy_impl(strategy: &CyclesMonitoringStrategy, state: &mut HeapState) {
     state.settings = Some(
         state
             .settings
             .as_ref()
             .map(|settings| settings.clone_with_strategy(strategy))
-            .unwrap_or_else(|| MissionControlSettings::from(strategy)),
+            .unwrap_or_else(|| MissionControlSettings::from_strategy(strategy)),
+    );
+}
+
+fn set_mission_control_config_impl(config: &Option<MonitoringConfig>, state: &mut HeapState) {
+    state.settings = Some(
+        state
+            .settings
+            .as_ref()
+            .map(|settings| settings.clone_with_config(config))
+            .unwrap_or_else(|| MissionControlSettings::from_config(config)),
     );
 }
 

--- a/src/mission_control/src/types.rs
+++ b/src/mission_control/src/types.rs
@@ -59,9 +59,22 @@ pub mod state {
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct MissionControlSettings {
+        // The monitoring rules to observe the mission control itself
         pub monitoring: Option<Monitoring>,
+        pub monitoring_config: Option<MonitoringConfig>,
         pub created_at: Timestamp,
         pub updated_at: Timestamp,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct MonitoringConfig {
+        pub cycles: Option<CyclesMonitoringConfig>,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct CyclesMonitoringConfig {
+        pub notification: Option<DepositedCyclesEmailNotification>,
+        pub default_strategy: Option<CyclesMonitoringStrategy>,
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
@@ -116,6 +129,12 @@ pub mod state {
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct Monitoring {
         pub cycles: Option<CyclesMonitoring>,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct DepositedCyclesEmailNotification {
+        pub to: Option<String>,
+        pub enabled: bool,
     }
 
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
# Motivation

We want an option to enable or disable notification. We also want (in the future) to be able to use a particular email for the notification. Finally, we also want to save a default strategy which can be use to register monitoring when a new Satellite or Orbiter is created.

That's why this PR provides such configuration.