### PR TITLE
feat: set default strategy in monitoring wizard

### DIFF
--- a/src/frontend/src/lib/api/mission-control.api.ts
+++ b/src/frontend/src/lib/api/mission-control.api.ts
@@ -1,6 +1,7 @@
 import type {
 	Controller,
 	MissionControlSettings,
+	MonitoringConfig,
 	MonitoringStartConfig,
 	MonitoringStopConfig,
 	Orbiter,
@@ -480,4 +481,21 @@ export const getMonitoringHistory = async ({
 		from: toNullable(from),
 		to: toNullable(to)
 	});
+};
+
+export const setMonitoringConfig = async ({
+	missionControlId,
+	identity,
+	config
+}: {
+	missionControlId: Principal;
+	identity: OptionIdentity;
+	config: MonitoringConfig | undefined;
+}): Promise<void> => {
+	const { set_monitoring_config } = await getMissionControlActor({
+		missionControlId,
+		identity
+	});
+
+	return await set_monitoring_config(toNullable(config));
 };

--- a/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
+++ b/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
-	import {fromNullable, isNullish} from '@dfinity/utils';
+	import { fromNullable, isNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
 	import type {
 		CyclesMonitoringStrategy,
 		Orbiter,
@@ -9,6 +10,7 @@
 	import MonitoringCreateStrategy from '$lib/components/monitoring/MonitoringCreateStrategy.svelte';
 	import MonitoringCreateStrategyMissionControl from '$lib/components/monitoring/MonitoringCreateStrategyMissionControl.svelte';
 	import MonitoringCreateStrategyReview from '$lib/components/monitoring/MonitoringCreateStrategyReview.svelte';
+	import MonitoringCreateStrategyWithDefault from '$lib/components/monitoring/MonitoringCreateStrategyWithDefault.svelte';
 	import MonitoringSelectSegments from '$lib/components/monitoring/MonitoringSelectSegments.svelte';
 	import ProgressMonitoring from '$lib/components/monitoring/ProgressMonitoring.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
@@ -18,8 +20,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalDetail, JunoModalMonitoringStrategyDetail } from '$lib/types/modal';
 	import type { MonitoringStrategyProgress } from '$lib/types/strategy';
-	import MonitoringCreateStrategyWithDefault from '$lib/components/monitoring/MonitoringCreateStrategyWithDefault.svelte';
-	import {onMount} from "svelte";
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -99,6 +99,7 @@
 			missionControlMonitored: missionControl.monitored,
 			missionControlMinCycles,
 			missionControlFundCycles,
+			useAsDefaultStrategy,
 			onProgress
 		});
 
@@ -122,7 +123,7 @@
 			<button onclick={onclose}>{$i18n.core.close}</button>
 		</div>
 	{:else if steps === 'in_progress'}
-		<ProgressMonitoring {progress} action="create" />
+		<ProgressMonitoring {progress} action="create" withOptions={useAsDefaultStrategy} />
 	{:else if steps === 'review'}
 		<MonitoringCreateStrategyReview
 			{selectedSatellites}

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategy.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategy.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
+	import {type Snippet, untrack} from 'svelte';
 	import Input from '$lib/components/ui/Input.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { isBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { tCyclesToCycles } from '$lib/utils/cycles.utils';
+	import Checkbox from "$lib/components/ui/Checkbox.svelte";
 
 	interface Props {
 		minCycles: bigint | undefined;
 		fundCycles: bigint | undefined;
 		strategy: 'modules' | 'mission-control';
+		children?: Snippet;
 		onback: () => void;
 		oncontinue: () => void;
 	}
@@ -18,6 +20,7 @@
 		minCycles = $bindable(undefined),
 		fundCycles = $bindable(undefined),
 		strategy,
+			children,
 		oncontinue,
 		onback
 	}: Props = $props();
@@ -79,6 +82,8 @@
 		placeholder={$i18n.canisters.amount_cycles}
 	/>
 </Value>
+
+{@render children?.()}
 
 <div class="toolbar">
 	<button disabled={$isBusy} onclick={onback}>{$i18n.core.back}</button>

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategy.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategy.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { type Snippet, untrack } from 'svelte';
-	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import Input from '$lib/components/ui/Input.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { isBusy } from '$lib/stores/busy.store';

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategy.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategy.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import {type Snippet, untrack} from 'svelte';
+	import { type Snippet, untrack } from 'svelte';
+	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import Input from '$lib/components/ui/Input.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { isBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { tCyclesToCycles } from '$lib/utils/cycles.utils';
-	import Checkbox from "$lib/components/ui/Checkbox.svelte";
 
 	interface Props {
 		minCycles: bigint | undefined;
@@ -20,7 +20,7 @@
 		minCycles = $bindable(undefined),
 		fundCycles = $bindable(undefined),
 		strategy,
-			children,
+		children,
 		oncontinue,
 		onback
 	}: Props = $props();

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyReview.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyReview.svelte
@@ -17,6 +17,7 @@
 		selectedOrbiters: [Principal, Orbiter][];
 		minCycles: bigint | undefined;
 		fundCycles: bigint | undefined;
+		useAsDefaultStrategy: boolean,
 		missionControlMinCycles: bigint | undefined;
 		missionControlFundCycles: bigint | undefined;
 		missionControl: { monitored: boolean; strategy: CyclesMonitoringStrategy | undefined };
@@ -29,6 +30,7 @@
 		selectedOrbiters,
 		minCycles,
 		fundCycles,
+		useAsDefaultStrategy,
 		missionControlMinCycles,
 		missionControlFundCycles,
 		missionControl,
@@ -87,6 +89,17 @@
 
 				<p>{formatTCycles(fundCycles ?? 0n)}</p>
 			</Value>
+
+			{#if useAsDefaultStrategy}
+
+				<Value>
+					{#snippet label()}
+						{$i18n.monitoring.default_strategy}
+					{/snippet}
+
+					<p>{$i18n.monitoring.configuration_for_modules}</p>
+				</Value>
+			{/if}
 		</div>
 	</div>
 </MonitoringStepReview>

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyReview.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyReview.svelte
@@ -17,7 +17,7 @@
 		selectedOrbiters: [Principal, Orbiter][];
 		minCycles: bigint | undefined;
 		fundCycles: bigint | undefined;
-		useAsDefaultStrategy: boolean,
+		useAsDefaultStrategy: boolean;
 		missionControlMinCycles: bigint | undefined;
 		missionControlFundCycles: bigint | undefined;
 		missionControl: { monitored: boolean; strategy: CyclesMonitoringStrategy | undefined };
@@ -91,7 +91,6 @@
 			</Value>
 
 			{#if useAsDefaultStrategy}
-
 				<Value>
 					{#snippet label()}
 						{$i18n.monitoring.default_strategy}

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyWithDefault.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyWithDefault.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { fromNullable, isNullish } from '@dfinity/utils';
 	import MonitoringCreateStrategy from '$lib/components/monitoring/MonitoringCreateStrategy.svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -37,10 +36,6 @@
 </MonitoringCreateStrategy>
 
 <style lang="scss">
-	.toolbar {
-		padding: var(--padding) 0 0 0;
-	}
-
 	.default-strategy {
 		margin: var(--padding) 0 var(--padding-2x);
 	}

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyWithDefault.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyWithDefault.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { fromNullable, isNullish } from '@dfinity/utils';
+	import Checkbox from '$lib/components/ui/Checkbox.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import MonitoringCreateStrategy from '$lib/components/monitoring/MonitoringCreateStrategy.svelte';
+
+	type Props = {
+		minCycles: bigint | undefined;
+		fundCycles: bigint | undefined;
+		useAsDefaultStrategy: boolean;
+		strategy: 'modules' | 'mission-control';
+		onback: () => void;
+		oncontinue: () => void;
+	};
+
+	let {
+		minCycles = $bindable(undefined),
+		fundCycles = $bindable(undefined),
+		useAsDefaultStrategy = $bindable(true),
+		strategy,
+		oncontinue,
+		onback
+	}: Props = $props();
+</script>
+
+<MonitoringCreateStrategy bind:minCycles bind:fundCycles {strategy} {oncontinue} {onback}>
+	<Checkbox>
+		<label class="default-strategy">
+			<input
+				type="checkbox"
+				checked={useAsDefaultStrategy}
+				onchange={() => (useAsDefaultStrategy = !useAsDefaultStrategy)}
+			/>
+			<span>{$i18n.monitoring.set_as_default_configuration}</span>
+		</label>
+	</Checkbox>
+</MonitoringCreateStrategy>
+
+<style lang="scss">
+	.toolbar {
+		padding: var(--padding) 0 0 0;
+	}
+
+	.default-strategy {
+		margin: var(--padding) 0 var(--padding-2x);
+	}
+</style>

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyWithDefault.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyWithDefault.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
 	import { fromNullable, isNullish } from '@dfinity/utils';
+	import MonitoringCreateStrategy from '$lib/components/monitoring/MonitoringCreateStrategy.svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import MonitoringCreateStrategy from '$lib/components/monitoring/MonitoringCreateStrategy.svelte';
 
-	type Props = {
+	interface Props {
 		minCycles: bigint | undefined;
 		fundCycles: bigint | undefined;
 		useAsDefaultStrategy: boolean;
 		strategy: 'modules' | 'mission-control';
 		onback: () => void;
 		oncontinue: () => void;
-	};
+	}
 
 	let {
 		minCycles = $bindable(undefined),

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -686,6 +686,7 @@
 		"stopping_monitoring": "Stopping monitoring...",
 		"remaining_threshold": "Remaining T Cycles Threshold",
 		"top_up_amount": "Top-Up Amount",
+		"set_as_default_configuration": "Set as default configuration",
 		"modules": "Modules",
 		"selected_modules": "Selected",
 		"monitored": "Monitored",
@@ -705,7 +706,9 @@
 		"last_status_check": "Last status check",
 		"last_top_up": "Last top-up",
 		"usage": "Usage",
-		"weekly_cycles_deposit": "Weekly cycles deposit"
+		"weekly_cycles_deposit": "Weekly cycles deposit",
+		"default_strategy": "Default Strategy",
+		"configuration_for_modules": "This configuration will be used as the default for monitoring newly created modules."
 	},
 	"preferences": {
 		"title": "Preferences",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -701,6 +701,7 @@
 		"warning_advice": "Go to the Monitoring section to enable it and ensure sufficient cycles for your modules.",
 		"strategy_preparing": "Preparing...",
 		"reload_settings": "Reloading settings...",
+		"saving_options": "Saving options...",
 		"stop_monitoring_question": "Do you want to stop monitoring your Mission Control as well?",
 		"stop_monitoring_note": "<strong>Important Note</strong>: it can only be stopped if all your modules are about to stop being monitored or if none are still monitored.",
 		"last_status_check": "Last status check",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -686,6 +686,7 @@
 		"stopping_monitoring": "Stopping monitoring...",
 		"remaining_threshold": "Remaining T Cycles Threshold",
 		"top_up_amount": "Top-Up Amount",
+		"set_as_default_configuration": "Set as default configuration",
 		"modules": "Modules",
 		"selected_modules": "Selected",
 		"monitored": "Monitored",
@@ -705,7 +706,9 @@
 		"last_status_check": "Last status check",
 		"last_top_up": "Last top-up",
 		"usage": "Usage",
-		"weekly_cycles_deposit": "Weekly cycles deposit"
+		"weekly_cycles_deposit": "Weekly cycles deposit",
+		"default_strategy": "Default Strategy",
+		"configuration_for_modules": "This configuration will be used as the default for monitoring newly created modules."
 	},
 	"preferences": {
 		"title": "偏好设置",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -701,6 +701,7 @@
 		"warning_advice": "Go to the Monitoring section to enable it and ensure sufficient cycles for your modules.",
 		"strategy_preparing": "Preparing...",
 		"reload_settings": "Reloading settings...",
+		"saving_options": "Saving options...",
 		"stop_monitoring_question": "Do you want to stop monitoring your Mission Control as well?",
 		"stop_monitoring_note": "<strong>Important Note</strong>: it can only be stopped if all your modules are about to stop being monitored or if none are still monitored.",
 		"last_status_check": "Last status check",

--- a/src/frontend/src/lib/services/monitoring.services.ts
+++ b/src/frontend/src/lib/services/monitoring.services.ts
@@ -14,7 +14,7 @@ import { loadSettings, loadUserMetadata } from '$lib/services/mission-control.se
 import { loadOrbiters } from '$lib/services/orbiters.services';
 import { loadSatellites } from '$lib/services/satellites.services';
 import { i18n } from '$lib/stores/i18n.store';
-import { missionControlSettingsDataStore } from '$lib/stores/mission-control.store';
+import {missionControlMetadataDataStore, missionControlSettingsDataStore} from '$lib/stores/mission-control.store';
 import { toasts } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/itentity';
 import {
@@ -429,7 +429,7 @@ export const openMonitoringModal = ({
 		detail: {
 			type,
 			detail: {
-				settings: undefined,
+				settings: $missionControlSettingsDataStore.data,
 				missionControlId
 			}
 		}

--- a/src/frontend/src/lib/services/monitoring.services.ts
+++ b/src/frontend/src/lib/services/monitoring.services.ts
@@ -14,7 +14,7 @@ import { loadSettings, loadUserMetadata } from '$lib/services/mission-control.se
 import { loadOrbiters } from '$lib/services/orbiters.services';
 import { loadSatellites } from '$lib/services/satellites.services';
 import { i18n } from '$lib/stores/i18n.store';
-import {missionControlMetadataDataStore, missionControlSettingsDataStore} from '$lib/stores/mission-control.store';
+import { missionControlSettingsDataStore } from '$lib/stores/mission-control.store';
 import { toasts } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/itentity';
 import {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -726,6 +726,7 @@ interface I18nMonitoring {
 	warning_advice: string;
 	strategy_preparing: string;
 	reload_settings: string;
+	saving_options: string;
 	stop_monitoring_question: string;
 	stop_monitoring_note: string;
 	last_status_check: string;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -711,6 +711,7 @@ interface I18nMonitoring {
 	stopping_monitoring: string;
 	remaining_threshold: string;
 	top_up_amount: string;
+	set_as_default_configuration: string;
 	modules: string;
 	selected_modules: string;
 	monitored: string;
@@ -731,6 +732,8 @@ interface I18nMonitoring {
 	last_top_up: string;
 	usage: string;
 	weekly_cycles_deposit: string;
+	default_strategy: string;
+	configuration_for_modules: string;
 }
 
 interface I18nPreferences {

--- a/src/frontend/src/lib/types/strategy.ts
+++ b/src/frontend/src/lib/types/strategy.ts
@@ -1,8 +1,9 @@
 import type { UpgradeCodeProgressState } from '@junobuild/admin';
 
 export enum MonitoringStrategyProgressStep {
+	Options = 0,
 	CreateOrStopMonitoring = 1,
-	ReloadSettings = 2
+	Reload = 2
 }
 
 export type MonitoringStrategyProgressState = UpgradeCodeProgressState;


### PR DESCRIPTION
# Motivation

With this option a developer can set a strategy as being the default which in turn can be used in the future to start monitoring new modules.
