### PR TITLE
feat: display monitoring disabled as "Auto-Refill"

### DIFF
--- a/src/frontend/src/lib/components/canister/CanisterMonitoring.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoring.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
+	import type { Snippet } from 'svelte';
 	import CanisterMonitoringChart from '$lib/components/canister/CanisterMonitoringChart.svelte';
 	import CanisterMonitoringLoader from '$lib/components/loaders/CanisterMonitoringLoader.svelte';
 	import type { CanisterMonitoringData, Segment } from '$lib/types/canister';
-	import type { Snippet } from 'svelte';
 
 	interface Props {
 		canisterId: Principal;

--- a/src/frontend/src/lib/components/canister/CanisterMonitoring.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoring.svelte
@@ -3,13 +3,15 @@
 	import CanisterMonitoringChart from '$lib/components/canister/CanisterMonitoringChart.svelte';
 	import CanisterMonitoringLoader from '$lib/components/loaders/CanisterMonitoringLoader.svelte';
 	import type { CanisterMonitoringData, Segment } from '$lib/types/canister';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		canisterId: Principal;
 		segment: Segment;
+		children: Snippet;
 	}
 
-	let props: Props = $props();
+	let { children, ...props }: Props = $props();
 
 	let monitoringData = $state<CanisterMonitoringData | undefined>(undefined);
 
@@ -19,5 +21,7 @@
 <CanisterMonitoringLoader {...props} bind:data={monitoringData}>
 	<div>
 		<CanisterMonitoringChart {chartsData} />
+
+		{@render children()}
 	</div>
 </CanisterMonitoringLoader>

--- a/src/frontend/src/lib/components/mission-control/MissionControl.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControl.svelte
@@ -6,7 +6,6 @@
 	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
 	import MissionControlActions from '$lib/components/mission-control/MissionControlActions.svelte';
 	import MissionControlDataLoader from '$lib/components/mission-control/MissionControlDataLoader.svelte';
-	import Monitoring from '$lib/components/monitoring/Monitoring.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
@@ -16,6 +15,7 @@
 	} from '$lib/derived/mission-control.derived';
 	import { missionControlVersion } from '$lib/derived/version.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 
 	interface Props {
 		missionControlId: Principal;
@@ -51,15 +51,6 @@
 						<p>v{$missionControlVersion?.current ?? '...'}</p>
 					</Value>
 				</div>
-
-				<div>
-					<MissionControlDataLoader {missionControlId}>
-						<Monitoring
-							monitoring={$missionControlMonitoring}
-							loading={$missionControlSettingsNotLoaded}
-						/>
-					</MissionControlDataLoader>
-				</div>
 			</div>
 		</div>
 
@@ -72,7 +63,14 @@
 		<div class="columns-3">
 			<CanisterOverview canisterId={missionControlId} segment="mission_control" />
 
-			<CanisterMonitoring canisterId={missionControlId} segment="mission_control" />
+			<CanisterMonitoring canisterId={missionControlId} segment="mission_control">
+				<MissionControlDataLoader {missionControlId}>
+					<MonitoringDisabled
+						monitoring={$missionControlMonitoring}
+						loading={$missionControlSettingsNotLoaded}
+					/>
+				</MissionControlDataLoader>
+			</CanisterMonitoring>
 		</div>
 	</div>
 {/if}

--- a/src/frontend/src/lib/components/mission-control/MissionControl.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControl.svelte
@@ -6,6 +6,7 @@
 	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
 	import MissionControlActions from '$lib/components/mission-control/MissionControlActions.svelte';
 	import MissionControlDataLoader from '$lib/components/mission-control/MissionControlDataLoader.svelte';
+	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
@@ -15,7 +16,6 @@
 	} from '$lib/derived/mission-control.derived';
 	import { missionControlVersion } from '$lib/derived/version.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 
 	interface Props {
 		missionControlId: Principal;

--- a/src/frontend/src/lib/components/monitoring/MonitoringArticle.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringArticle.svelte
@@ -90,7 +90,7 @@
 				{/if}
 			</span>
 		{:else}
-			<span class="info">Monitoring disabled.</span>
+			<span class="info">{$i18n.monitoring.auto_refill_disabled}</span>
 		{/if}
 	</button>
 </CanisterMonitoringLoader>

--- a/src/frontend/src/lib/components/monitoring/MonitoringDisabled.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringDisabled.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { fromNullable } from '@dfinity/utils';
 	import type { Monitoring } from '$declarations/mission_control/mission_control.did';
-	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import { fade } from 'svelte/transition';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
@@ -17,18 +17,14 @@
 	let enabled = $derived(cycles?.enabled === true);
 </script>
 
-<div>
-	<Value>
-		{#snippet label()}
-			{$i18n.monitoring.title}
-		{/snippet}
+{#if !enabled && !loading}
+	<div in:fade>
+		<Value>
+			{#snippet label()}
+				{$i18n.monitoring.auto_refill}
+			{/snippet}
 
-		{#if loading}
-			<SkeletonText />
-		{:else if enabled}
-			{$i18n.core.enabled}
-		{:else}
 			{$i18n.core.disabled}
-		{/if}
-	</Value>
-</div>
+		</Value>
+	</div>
+{/if}

--- a/src/frontend/src/lib/components/monitoring/MonitoringDisabled.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringDisabled.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { fromNullable } from '@dfinity/utils';
-	import type { Monitoring } from '$declarations/mission_control/mission_control.did';
 	import { fade } from 'svelte/transition';
+	import type { Monitoring } from '$declarations/mission_control/mission_control.did';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 

--- a/src/frontend/src/lib/components/orbiter/Orbiter.svelte
+++ b/src/frontend/src/lib/components/orbiter/Orbiter.svelte
@@ -4,13 +4,13 @@
 	import CanisterMonitoring from '$lib/components/canister/CanisterMonitoring.svelte';
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
 	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
-	import Monitoring from '$lib/components/monitoring/Monitoring.svelte';
 	import OrbiterActions from '$lib/components/orbiter/OrbiterActions.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { orbiterNotLoaded } from '$lib/derived/orbiter.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { versionStore } from '$lib/stores/version.store';
+	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 
 	interface Props {
 		orbiter: Orbiter;
@@ -47,10 +47,6 @@
 					<p>v{$versionStore?.orbiter?.current ?? '...'}</p>
 				</Value>
 			</div>
-
-			<div>
-				<Monitoring {monitoring} loading={$orbiterNotLoaded} />
-			</div>
 		</div>
 	</div>
 
@@ -67,7 +63,9 @@
 			heapWarningLabel={$i18n.canisters.warning_orbiter_heap_memory}
 		/>
 
-		<CanisterMonitoring segment="orbiter" canisterId={orbiter.orbiter_id} />
+		<CanisterMonitoring segment="orbiter" canisterId={orbiter.orbiter_id}>
+			<MonitoringDisabled {monitoring} loading={$orbiterNotLoaded} />
+		</CanisterMonitoring>
 	</div>
 </div>
 

--- a/src/frontend/src/lib/components/orbiter/Orbiter.svelte
+++ b/src/frontend/src/lib/components/orbiter/Orbiter.svelte
@@ -4,13 +4,13 @@
 	import CanisterMonitoring from '$lib/components/canister/CanisterMonitoring.svelte';
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
 	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
+	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 	import OrbiterActions from '$lib/components/orbiter/OrbiterActions.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { orbiterNotLoaded } from '$lib/derived/orbiter.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { versionStore } from '$lib/stores/version.store';
-	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 
 	interface Props {
 		orbiter: Orbiter;

--- a/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
@@ -4,7 +4,6 @@
 	import CanisterMonitoring from '$lib/components/canister/CanisterMonitoring.svelte';
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
 	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
-	import Monitoring from '$lib/components/monitoring/Monitoring.svelte';
 	import SatelliteActions from '$lib/components/satellites/SatelliteActions.svelte';
 	import SatelliteName from '$lib/components/satellites/SatelliteName.svelte';
 	import SatelliteOverviewCustomDomain from '$lib/components/satellites/SatelliteOverviewCustomDomain.svelte';
@@ -14,6 +13,7 @@
 	import { satellitesNotLoaded } from '$lib/derived/satellite.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { SatelliteIdText } from '$lib/types/satellite';
+	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 
 	interface Props {
 		satellite: Satellite;
@@ -47,10 +47,6 @@
 
 		<div>
 			<SatelliteOverviewVersion {satelliteId} />
-
-			<div>
-				<Monitoring {monitoring} loading={$satellitesNotLoaded} />
-			</div>
 		</div>
 	</div>
 
@@ -67,7 +63,9 @@
 			heapWarningLabel={$i18n.canisters.warning_satellite_heap_memory}
 		/>
 
-		<CanisterMonitoring segment="satellite" canisterId={satellite.satellite_id} />
+		<CanisterMonitoring segment="satellite" canisterId={satellite.satellite_id}>
+			<MonitoringDisabled {monitoring} loading={$satellitesNotLoaded} />
+		</CanisterMonitoring>
 	</div>
 </div>
 

--- a/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
@@ -4,6 +4,7 @@
 	import CanisterMonitoring from '$lib/components/canister/CanisterMonitoring.svelte';
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
 	import CanisterSubnet from '$lib/components/canister/CanisterSubnet.svelte';
+	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 	import SatelliteActions from '$lib/components/satellites/SatelliteActions.svelte';
 	import SatelliteName from '$lib/components/satellites/SatelliteName.svelte';
 	import SatelliteOverviewCustomDomain from '$lib/components/satellites/SatelliteOverviewCustomDomain.svelte';
@@ -13,7 +14,6 @@
 	import { satellitesNotLoaded } from '$lib/derived/satellite.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { SatelliteIdText } from '$lib/types/satellite';
-	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 
 	interface Props {
 		satellite: Satellite;

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -709,7 +709,9 @@
 		"usage": "Usage",
 		"weekly_cycles_deposit": "Weekly cycles deposit",
 		"default_strategy": "Default Strategy",
-		"configuration_for_modules": "This configuration will be used as the default for monitoring newly created modules."
+		"configuration_for_modules": "This configuration will be used as the default for monitoring newly created modules.",
+		"auto_refill": "Auto-refill",
+		"auto_refill_disabled": "Auto-refill disabled"
 	},
 	"preferences": {
 		"title": "Preferences",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -709,7 +709,9 @@
 		"usage": "Usage",
 		"weekly_cycles_deposit": "Weekly cycles deposit",
 		"default_strategy": "Default Strategy",
-		"configuration_for_modules": "This configuration will be used as the default for monitoring newly created modules."
+		"configuration_for_modules": "This configuration will be used as the default for monitoring newly created modules.",
+		"auto_refill": "Auto-refill",
+		"auto_refill_disabled": "Auto-refill disabled"
 	},
 	"preferences": {
 		"title": "偏好设置",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -735,6 +735,8 @@ interface I18nMonitoring {
 	weekly_cycles_deposit: string;
 	default_strategy: string;
 	configuration_for_modules: string;
+	auto_refill: string;
+	auto_refill_disabled: string;
 }
 
 interface I18nPreferences {


### PR DESCRIPTION
# Motivation

Using "Monitoring: disabled" is a bit misleading since the title of the section is "Monitoring". Therefore using "Auto-refill" instead.
