### PR TITLE
feat: display auto-refill strategy in modal detail

### DIFF
--- a/src/frontend/src/lib/components/modals/MonitoringDetailsModal.svelte
+++ b/src/frontend/src/lib/components/modals/MonitoringDetailsModal.svelte
@@ -6,6 +6,7 @@
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
 	import CanisterMonitoringLoader from '$lib/components/loaders/CanisterMonitoringLoader.svelte';
 	import MonitoringDepositCyclesChart from '$lib/components/monitoring/MonitoringDepositCyclesChart.svelte';
+	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -18,7 +19,6 @@
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { formatToRelativeTime } from '$lib/utils/date.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
-	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 
 	interface Props {
 		detail: JunoModalDetail;

--- a/src/frontend/src/lib/components/modals/MonitoringDetailsModal.svelte
+++ b/src/frontend/src/lib/components/modals/MonitoringDetailsModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Principal } from '@dfinity/principal';
-	import { nonNullish } from '@dfinity/utils';
+	import { fromNullable, nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import CanisterMonitoringChart from '$lib/components/canister/CanisterMonitoringChart.svelte';
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
@@ -10,9 +10,15 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CanisterMonitoringData } from '$lib/types/canister';
-	import type { JunoModalDetail, JunoModalSegmentDetail } from '$lib/types/modal';
+	import type {
+		JunoModalDetail,
+		JunoModalSegmentDetail,
+		JunoModalShowMonitoringDetail
+	} from '$lib/types/modal';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { formatToRelativeTime } from '$lib/utils/date.utils';
+	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -21,7 +27,7 @@
 
 	let { detail, onclose }: Props = $props();
 
-	let { segment } = $derived(detail as JunoModalSegmentDetail);
+	let { segment, monitoring } = $derived(detail as JunoModalShowMonitoringDetail);
 
 	let canisterId = $derived(Principal.fromText(segment?.canisterId));
 
@@ -34,6 +40,10 @@
 	let chartsData = $derived(monitoringData?.chartsData ?? []);
 
 	let depositedCyclesChartData = $derived(monitoringData?.charts.depositedCycles ?? []);
+
+	let monitoringStrategy = $derived(
+		fromNullable(fromNullable(monitoring?.cycles ?? [])?.strategy ?? [])
+	);
 </script>
 
 <Modal on:junoClose={onclose}>
@@ -44,6 +54,31 @@
 
 		<CanisterMonitoringLoader segment={segment.segment} {canisterId} bind:data={monitoringData}>
 			<div>
+				<div>
+					{#if nonNullish(monitoringStrategy)}
+						<Value>
+							{#snippet label()}
+								{$i18n.monitoring.auto_refill}
+							{/snippet}
+
+							<p>
+								{i18nFormat($i18n.monitoring.auto_refill_strategy, [
+									{
+										placeholder: '{0}',
+										value: formatTCycles(monitoringStrategy.BelowThreshold.min_cycles)
+									},
+									{
+										placeholder: '{1}',
+										value: formatTCycles(monitoringStrategy.BelowThreshold.fund_cycles)
+									}
+								])}
+							</p>
+						</Value>
+					{:else}
+						<MonitoringDisabled {monitoring} loading={false} />
+					{/if}
+				</div>
+
 				{#if nonNullish(lastExecutionTime)}
 					<div in:fade>
 						<Value>

--- a/src/frontend/src/lib/components/monitoring/MonitoringArticle.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringArticle.svelte
@@ -46,7 +46,8 @@
 						canisterId: canisterId.toText(),
 						segment,
 						segmentLabel
-					}
+					},
+					monitoring
 				}
 			}
 		});

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -711,7 +711,8 @@
 		"default_strategy": "Default Strategy",
 		"configuration_for_modules": "This configuration will be used as the default for monitoring newly created modules.",
 		"auto_refill": "Auto-refill",
-		"auto_refill_disabled": "Auto-refill disabled"
+		"auto_refill_disabled": "Auto-refill disabled",
+		"auto_refill_strategy": "Top-up {0}T Cycles if the remaining threshold falls below {1}"
 	},
 	"preferences": {
 		"title": "Preferences",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -711,7 +711,8 @@
 		"default_strategy": "Default Strategy",
 		"configuration_for_modules": "This configuration will be used as the default for monitoring newly created modules.",
 		"auto_refill": "Auto-refill",
-		"auto_refill_disabled": "Auto-refill disabled"
+		"auto_refill_disabled": "Auto-refill disabled",
+		"auto_refill_strategy": "Top-up {0} T Cycles if the remaining threshold falls below {1}"
 	},
 	"preferences": {
 		"title": "偏好设置",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -737,6 +737,7 @@ interface I18nMonitoring {
 	configuration_for_modules: string;
 	auto_refill: string;
 	auto_refill_disabled: string;
+	auto_refill_strategy: string;
 }
 
 interface I18nPreferences {

--- a/src/frontend/src/lib/types/modal.ts
+++ b/src/frontend/src/lib/types/modal.ts
@@ -1,6 +1,7 @@
 import type { snapshot } from '$declarations/ic/ic.did';
 import type {
 	MissionControlSettings,
+	Monitoring,
 	Satellite
 } from '$declarations/mission_control/mission_control.did';
 import type { OrbiterSatelliteFeatures } from '$declarations/orbiter/orbiter.did';
@@ -101,6 +102,10 @@ export interface JunoModalEditAuthConfigDetail extends JunoModalSatelliteDetail 
 export interface JunoModalMonitoringStrategyDetail {
 	missionControlId: Principal;
 	settings: MissionControlSettings | undefined;
+}
+
+export interface JunoModalShowMonitoringDetail extends JunoModalSegmentDetail {
+	monitoring: Monitoring | undefined;
 }
 
 export type JunoModalDetail =


### PR DESCRIPTION
# Motivation

It can probably be handy to retrieve the auto-refill strategy rules somewhere. So let's add that to the monitoring modal for now at least.

<img width="1536" alt="Capture d’écran 2025-01-03 à 18 39 21" src="https://github.com/user-attachments/assets/74c9c601-8a41-4111-b304-72a5a0dbf09f" />

