### PR TITLE
feat: send notification when enabled

### DIFF
--- a/src/mission_control/src/monitoring/store/heap.rs
+++ b/src/mission_control/src/monitoring/store/heap.rs
@@ -5,6 +5,10 @@ use crate::types::state::{
 };
 use junobuild_shared::types::state::{OrbiterId, SatelliteId};
 
+pub fn get_monitoring_config() -> Option<MonitoringConfig> {
+    STATE.with(|state| state.borrow().heap.settings.as_ref().and_then(|settings| settings.monitoring_config.clone()))
+}
+
 pub fn set_monitoring_config(config: &Option<MonitoringConfig>) {
     STATE.with(|state| set_monitoring_config_impl(config, &mut state.borrow_mut().heap))
 }

--- a/src/tests/mission-control.monitoring.notifications.spec.ts
+++ b/src/tests/mission-control.monitoring.notifications.spec.ts
@@ -63,6 +63,7 @@ describe('Mission Control - Notifications', () => {
 	it(
 		'should notify observatory',
 		async () => {
+			// Init a mission control
 			const [user] = await initMissionControls({ actor, pic, length: 1 });
 
 			actor.setIdentity(user);
@@ -74,6 +75,7 @@ describe('Mission Control - Notifications', () => {
 
 			assertNonNullish(missionControlId);
 
+			// Assert no notification have been submitted to the Observatory yet
 			const observatoryActor = pic.createActor<ObservatoryActor>(
 				idlFactorObservatory,
 				observatoryId
@@ -95,6 +97,7 @@ describe('Mission Control - Notifications', () => {
 				sent: 0n
 			});
 
+			// Spin some modules to monitor
 			const missionControlActor = pic.createActor<MissionControlActor>(
 				idlFactorMissionControl,
 				missionControlId
@@ -110,9 +113,23 @@ describe('Mission Control - Notifications', () => {
 				missionControlId
 			});
 
-			const { update_and_start_monitoring, set_metadata, set_satellite } = missionControlActor;
+			// Set an email, enable notification, attach the module that was created and start monitoring
+			const { update_and_start_monitoring, set_metadata, set_monitoring_config, set_satellite } =
+				missionControlActor;
 
 			await set_metadata([['email', 'test@test.com']]);
+
+			await set_monitoring_config(
+				toNullable({
+					cycles: toNullable({
+						default_strategy: toNullable(),
+						notification: toNullable({
+							enabled: true,
+							to: toNullable() // We are only using the global email currently but, have foreseen an option
+						})
+					})
+				})
+			);
 
 			await set_satellite(satelliteId, []);
 


### PR DESCRIPTION
# Motivation

We added a flag to send notification or not. That way we don't rely of having an email or not - i.e. it needs an email and the flag enabled to send the notification.
