### PR TITLE
refactor: rename missionControl param

### DIFF
--- a/src/frontend/src/lib/components/canister/CanisterDeleteWizard.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterDeleteWizard.svelte
@@ -85,7 +85,7 @@
 			});
 
 			await loadSatellites({
-				missionControl: $missionControlIdDerived,
+				missionControlId: $missionControlIdDerived,
 				reload: true
 			});
 

--- a/src/frontend/src/lib/components/canister/CanistersPicker.svelte
+++ b/src/frontend/src/lib/components/canister/CanistersPicker.svelte
@@ -29,8 +29,8 @@
 	onMount(
 		async () =>
 			await Promise.all([
-				loadOrbiters({ missionControl: $missionControlIdDerived }),
-				loadSatellites({ missionControl: $missionControlIdDerived })
+				loadOrbiters({ missionControlId: $missionControlIdDerived }),
+				loadSatellites({ missionControlId: $missionControlIdDerived })
 			])
 	);
 </script>

--- a/src/frontend/src/lib/components/core/NavbarCockpit.svelte
+++ b/src/frontend/src/lib/components/core/NavbarCockpit.svelte
@@ -24,7 +24,7 @@
 	run(() => {
 		// @ts-expect-error TODO: to be migrated to Svelte v5
 		$missionControlIdDerived,
-			(async () => await loadOrbiters({ missionControl: $missionControlIdDerived }))();
+			(async () => await loadOrbiters({ missionControlId: $missionControlIdDerived }))();
 	});
 </script>
 

--- a/src/frontend/src/lib/components/launchpad/Cockpit.svelte
+++ b/src/frontend/src/lib/components/launchpad/Cockpit.svelte
@@ -16,7 +16,7 @@
 	run(() => {
 		// @ts-expect-error TODO: to be migrated to Svelte v5
 		$missionControlIdDerived,
-			(async () => await loadOrbiters({ missionControl: $missionControlIdDerived }))();
+			(async () => await loadOrbiters({ missionControlId: $missionControlIdDerived }))();
 	});
 
 	let missionControlData: CanisterData | undefined = $state(undefined);

--- a/src/frontend/src/lib/components/loaders/OrbitersLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/OrbitersLoader.svelte
@@ -15,8 +15,8 @@
 
 	let { children, withVersion = false }: Props = $props();
 
-	const load = async (missionControl: Option<Principal>) => {
-		await loadOrbiters({ missionControl });
+	const load = async (missionControlId: Option<Principal>) => {
+		await loadOrbiters({ missionControlId });
 	};
 
 	const loadVersion = async ({

--- a/src/frontend/src/lib/components/loaders/SatellitesLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/SatellitesLoader.svelte
@@ -11,8 +11,8 @@
 
 	let { children }: Props = $props();
 
-	const load = async (missionControl: Option<Principal>) => {
-		await loadSatellites({ missionControl });
+	const load = async (missionControlId: Option<Principal>) => {
+		await loadSatellites({ missionControlId });
 	};
 
 	$effect(() => {

--- a/src/frontend/src/lib/components/mission-control/MissionControlDataLoader.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlDataLoader.svelte
@@ -20,11 +20,11 @@
 
 		await Promise.all([
 			loadSettings({
-				missionControl: missionControlId,
+				missionControlId,
 				identity: $authStore.identity
 			}),
 			loadUserMetadata({
-				missionControl: missionControlId,
+				missionControlId,
 				identity: $authStore.identity
 			})
 		]);

--- a/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
@@ -40,14 +40,14 @@
 			const fn = nonNullish(subnetId) ? createOrbiterWithConfig : createOrbiter;
 
 			await fn({
-				missionControl: $missionControlIdDerived,
+				missionControlId: $missionControlIdDerived,
 				config: {
 					...(nonNullish(subnetId) && { subnetId: Principal.fromText(subnetId) })
 				}
 			});
 
 			// Reload list of orbiters before navigation
-			await loadOrbiters({ missionControl: $missionControlIdDerived, reload: true });
+			await loadOrbiters({ missionControlId: $missionControlIdDerived, reload: true });
 
 			step = 'ready';
 		} catch (err) {

--- a/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
@@ -51,7 +51,7 @@
 			const fn = nonNullish(subnetId) ? createSatelliteWithConfig : createSatellite;
 
 			satellite = await fn({
-				missionControl: $missionControlIdDerived,
+				missionControlId: $missionControlIdDerived,
 				config: {
 					name: satelliteName,
 					...(nonNullish(subnetId) && { subnetId: Principal.fromText(subnetId) })
@@ -59,7 +59,7 @@
 			});
 
 			// Reload list of satellites before navigation
-			await loadSatellites({ missionControl: $missionControlIdDerived, reload: true });
+			await loadSatellites({ missionControlId: $missionControlIdDerived, reload: true });
 
 			step = 'ready';
 		} catch (err) {

--- a/src/frontend/src/lib/components/monitoring/MonitoringSettings.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringSettings.svelte
@@ -31,7 +31,7 @@
 	const openCreateModal = () => openModal('create_monitoring_strategy');
 	const openStopModal = () => openModal('stop_monitoring_strategy');
 
-	onMount(async () => await loadOrbiters({ missionControl: missionControlId }));
+	onMount(async () => await loadOrbiters({ missionControlId }));
 
 	let orbiterMonitored = $state(false);
 	let hasSatellitesMonitored = $state(false);

--- a/src/frontend/src/lib/components/segments/SegmentsTable.svelte
+++ b/src/frontend/src/lib/components/segments/SegmentsTable.svelte
@@ -40,8 +40,8 @@
 
 	const loadSegments = async () => {
 		const [{ result: resultSatellites }, { result: resultOrbiters }] = await Promise.all([
-			loadSatellites({ missionControl: missionControlId, reload: reloadSegments }),
-			loadOrbiters({ missionControl: missionControlId, reload: reloadSegments })
+			loadSatellites({ missionControlId, reload: reloadSegments }),
+			loadOrbiters({ missionControlId, reload: reloadSegments })
 		]);
 
 		if (

--- a/src/frontend/src/lib/services/mission-control.services.ts
+++ b/src/frontend/src/lib/services/mission-control.services.ts
@@ -191,7 +191,7 @@ export const attachSatellite = async ({
 
 	// We reload all satellites because if the developer accesses the mission control page directly, the satellites may not be loaded. Adding just one satellite could give the user the impression that there is an issue.
 	await loadSatellites({
-		missionControl: missionControlId,
+		missionControlId,
 		reload: true
 	});
 };
@@ -208,7 +208,7 @@ export const detachSatellite = async ({
 	await unsetSatellite({ missionControlId, satelliteId: canisterId, identity });
 
 	await loadSatellites({
-		missionControl: missionControlId,
+		missionControlId,
 		reload: true
 	});
 };
@@ -239,11 +239,11 @@ export const detachOrbiter = async ({
 };
 
 export const loadSettings = async ({
-	missionControl: missionControlId,
+	missionControlId,
 	identity,
 	reload = false
 }: {
-	missionControl: Principal;
+	missionControlId: Principal;
 	identity: OptionIdentity;
 	reload?: boolean;
 }): Promise<{ success: boolean }> => {
@@ -275,11 +275,11 @@ export const loadSettings = async ({
 };
 
 export const loadUserMetadata = async ({
-	missionControl: missionControlId,
+	missionControlId,
 	identity,
 	reload = false
 }: {
-	missionControl: Principal;
+	missionControlId: Principal;
 	identity: OptionIdentity;
 	reload?: boolean;
 }): Promise<{ success: boolean }> => {

--- a/src/frontend/src/lib/services/orbiters.services.ts
+++ b/src/frontend/src/lib/services/orbiters.services.ts
@@ -52,36 +52,36 @@ interface CreateOrbiterConfig {
 }
 
 export const createOrbiter = async ({
-	missionControl,
+	missionControlId,
 	config: { name }
 }: {
-	missionControl: Option<Principal>;
+	missionControlId: Option<Principal>;
 	config: CreateOrbiterConfig;
 }): Promise<Orbiter | undefined> => {
-	assertNonNullish(missionControl);
+	assertNonNullish(missionControlId);
 
 	const identity = get(authStore).identity;
 
 	const { create_orbiter } = await getMissionControlActor({
-		missionControlId: missionControl,
+		missionControlId,
 		identity
 	});
 	return create_orbiter(toNullable(name));
 };
 
 export const createOrbiterWithConfig = async ({
-	missionControl,
+	missionControlId,
 	config: { name, subnetId }
 }: {
-	missionControl: Option<Principal>;
+	missionControlId: Option<Principal>;
 	config: CreateOrbiterConfig;
 }): Promise<Orbiter | undefined> => {
-	assertNonNullish(missionControl);
+	assertNonNullish(missionControlId);
 
 	const identity = get(authStore).identity;
 
 	const { create_orbiter_with_config } = await getMissionControlActor({
-		missionControlId: missionControl,
+		missionControlId,
 		identity
 	});
 	return create_orbiter_with_config({
@@ -91,19 +91,19 @@ export const createOrbiterWithConfig = async ({
 };
 
 export const loadOrbiters = async ({
-	missionControl,
+	missionControlId,
 	reload = false
 }: {
-	missionControl: Option<Principal>;
+	missionControlId: Option<Principal>;
 	reload?: boolean;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
-	if (isNullish(missionControl)) {
+	if (isNullish(missionControlId)) {
 		return { result: 'skip' };
 	}
 
 	const load = async (identity: Identity): Promise<Orbiter[]> => {
 		const { list_orbiters } = await getMissionControlActor({
-			missionControlId: missionControl,
+			missionControlId,
 			identity
 		});
 

--- a/src/frontend/src/lib/services/satellites.services.ts
+++ b/src/frontend/src/lib/services/satellites.services.ts
@@ -15,36 +15,36 @@ interface CreateSatelliteConfig {
 }
 
 export const createSatellite = async ({
-	missionControl,
+	missionControlId,
 	config: { name }
 }: {
-	missionControl: Option<Principal>;
+	missionControlId: Option<Principal>;
 	config: CreateSatelliteConfig;
 }): Promise<Satellite | undefined> => {
-	assertNonNullish(missionControl);
+	assertNonNullish(missionControlId);
 
 	const identity = get(authStore).identity;
 
 	const { create_satellite } = await getMissionControlActor({
-		missionControlId: missionControl,
+		missionControlId,
 		identity
 	});
 	return create_satellite(name);
 };
 
 export const createSatelliteWithConfig = async ({
-	missionControl,
+	missionControlId,
 	config: { name, subnetId }
 }: {
-	missionControl: Option<Principal>;
+	missionControlId: Option<Principal>;
 	config: CreateSatelliteConfig;
 }): Promise<Satellite | undefined> => {
-	assertNonNullish(missionControl);
+	assertNonNullish(missionControlId);
 
 	const identity = get(authStore).identity;
 
 	const { create_satellite_with_config } = await getMissionControlActor({
-		missionControlId: missionControl,
+		missionControlId,
 		identity
 	});
 	return create_satellite_with_config({
@@ -54,19 +54,19 @@ export const createSatelliteWithConfig = async ({
 };
 
 export const loadSatellites = async ({
-	missionControl,
+	missionControlId,
 	reload = false
 }: {
-	missionControl: Option<Principal>;
+	missionControlId: Option<Principal>;
 	reload?: boolean;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
-	if (isNullish(missionControl)) {
+	if (isNullish(missionControlId)) {
 		return { result: 'skip' };
 	}
 
 	const load = async (identity: Identity): Promise<Satellite[]> => {
 		const { list_satellites } = await getMissionControlActor({
-			missionControlId: missionControl,
+			missionControlId,
 			identity
 		});
 


### PR DESCRIPTION
# Motivation

Over time I was using both `missionControl` and `missionControlId` as parameter name for IDs, so let's use solely `missionControlId`. 
