### PR TITLE
feat: integrate monitoring in create Satellite and Orbiter wizard

### DIFF
--- a/src/frontend/src/lib/components/analytics/AnalyticsNew.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsNew.svelte
@@ -1,27 +1,14 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
-	import { getCreateOrbiterFeeBalance } from '$lib/services/wizard.services';
+	import { initOrbiterWizard } from '$lib/services/wizard.services';
 	import { authStore } from '$lib/stores/auth.store';
-	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { emit } from '$lib/utils/events.utils';
 
 	const createOrbiter = async () => {
-		busy.start();
-
-		const { result, error } = await getCreateOrbiterFeeBalance({
+		await initOrbiterWizard({
 			identity: $authStore.identity,
 			missionControlId: $missionControlIdDerived
 		});
-
-		busy.stop();
-
-		if (nonNullish(error) || isNullish(result)) {
-			return;
-		}
-
-		emit({ message: 'junoModal', detail: { type: 'create_orbiter', detail: result } });
 	};
 </script>
 

--- a/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
@@ -1,18 +1,26 @@
 <script lang="ts">
+	import type { MonitoringConfig } from '$declarations/mission_control/mission_control.did';
+	import CanisterMonitoringDefaultStrategy from '$lib/components/canister/CanisterMonitoringDefaultStrategy.svelte';
 	import CanisterSubnets from '$lib/components/canister/CanisterSubnets.svelte';
 	import Collapsible from '$lib/components/ui/Collapsible.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { PrincipalText } from '$lib/types/itentity';
+	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
+	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		subnetId: PrincipalText | undefined;
+		useDefaultStrategy: boolean | undefined;
+		detail: JunoModalDetail;
 	}
 
-	let { subnetId = $bindable() }: Props = $props();
+	let { subnetId = $bindable(), useDefaultStrategy = $bindable(), detail }: Props = $props();
 </script>
 
 <Collapsible>
 	<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
 
 	<CanisterSubnets bind:subnetId />
+
+	<CanisterMonitoringDefaultStrategy bind:useDefaultStrategy {detail} />
 </Collapsible>

--- a/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
-	import type { MonitoringConfig } from '$declarations/mission_control/mission_control.did';
 	import CanisterMonitoringDefaultStrategy from '$lib/components/canister/CanisterMonitoringDefaultStrategy.svelte';
 	import CanisterSubnets from '$lib/components/canister/CanisterSubnets.svelte';
 	import Collapsible from '$lib/components/ui/Collapsible.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { PrincipalText } from '$lib/types/itentity';
-	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
-	import type { Option } from '$lib/types/utils';
+	import type { JunoModalDetail } from '$lib/types/modal';
+	import type {CyclesMonitoringStrategy} from "$declarations/mission_control/mission_control.did";
 
 	interface Props {
 		subnetId: PrincipalText | undefined;
-		useDefaultStrategy: boolean | undefined;
+		monitoringStrategy: CyclesMonitoringStrategy | undefined;
 		detail: JunoModalDetail;
 	}
 
-	let { subnetId = $bindable(), useDefaultStrategy = $bindable(), detail }: Props = $props();
+	let { subnetId = $bindable(), monitoringStrategy = $bindable(), detail }: Props = $props();
 </script>
 
 <Collapsible>
@@ -22,5 +21,5 @@
 
 	<CanisterSubnets bind:subnetId />
 
-	<CanisterMonitoringDefaultStrategy bind:useDefaultStrategy {detail} />
+	<CanisterMonitoringDefaultStrategy bind:monitoringStrategy {detail} />
 </Collapsible>

--- a/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 	import CanisterMonitoringDefaultStrategy from '$lib/components/canister/CanisterMonitoringDefaultStrategy.svelte';
 	import CanisterSubnets from '$lib/components/canister/CanisterSubnets.svelte';
 	import Collapsible from '$lib/components/ui/Collapsible.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { PrincipalText } from '$lib/types/itentity';
 	import type { JunoModalDetail } from '$lib/types/modal';
-	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 
 	interface Props {
 		subnetId: PrincipalText | undefined;

--- a/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
@@ -5,7 +5,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { PrincipalText } from '$lib/types/itentity';
 	import type { JunoModalDetail } from '$lib/types/modal';
-	import type {CyclesMonitoringStrategy} from "$declarations/mission_control/mission_control.did";
+	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 
 	interface Props {
 		subnetId: PrincipalText | undefined;

--- a/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
@@ -2,11 +2,11 @@
 	import { fromNullable, nonNullish } from '@dfinity/utils';
 	import { onMount, untrack } from 'svelte';
 	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
+	import MonitoringSentence from '$lib/components/modals/MonitoringSentence.svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
-	import MonitoringSentence from '$lib/components/modals/MonitoringSentence.svelte';
 
 	interface Props {
 		detail: JunoModalDetail;

--- a/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
@@ -6,8 +6,6 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
-	import { formatTCycles } from '$lib/utils/cycles.utils';
-	import { i18nFormat } from '$lib/utils/i18n.utils';
 	import MonitoringSentence from '$lib/components/modals/MonitoringSentence.svelte';
 
 	interface Props {

--- a/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
@@ -8,6 +8,7 @@
 	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import MonitoringSentence from '$lib/components/modals/MonitoringSentence.svelte';
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -50,18 +51,7 @@
 						checked={useDefaultStrategy}
 						onchange={() => (useDefaultStrategy = !useDefaultStrategy)}
 					/>
-					<span
-						>{i18nFormat($i18n.monitoring.auto_refill_strategy, [
-							{
-								placeholder: '{0}',
-								value: formatTCycles(monitoringStrategy.BelowThreshold.min_cycles)
-							},
-							{
-								placeholder: '{1}',
-								value: formatTCycles(monitoringStrategy.BelowThreshold.fund_cycles)
-							}
-						])}</span
-					>
+					<span><MonitoringSentence monitoringStrategy={useMonitoringStrategy} /></span>
 				</Checkbox>
 			</div>
 		</Value>

--- a/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { fromNullable, nonNullish } from '@dfinity/utils';
 	import { onMount, untrack } from 'svelte';
+	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
-	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 
 	interface Props {
 		detail: JunoModalDetail;

--- a/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { fromNullable, nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
+	import Checkbox from '$lib/components/ui/Checkbox.svelte';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
+	import { formatTCycles } from '$lib/utils/cycles.utils';
+	import { i18nFormat } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		detail: JunoModalDetail;
+		useDefaultStrategy: boolean | undefined;
+	}
+
+	let { useDefaultStrategy = $bindable(), detail }: Props = $props();
+
+	let { monitoringConfig } = detail as JunoModalCreateSegmentDetail;
+
+	let monitoringStrategy = $derived(
+		fromNullable(fromNullable(monitoringConfig?.cycles ?? [])?.default_strategy ?? [])
+	);
+
+	onMount(() => {
+		useDefaultStrategy = nonNullish(monitoringStrategy);
+	});
+</script>
+
+{#if nonNullish(useDefaultStrategy) && nonNullish(monitoringStrategy)}
+	<div class="default-strategy">
+		<Value>
+			{#snippet label()}
+				{$i18n.monitoring.auto_refill}
+			{/snippet}
+
+			<div class="group">
+				<Checkbox>
+					<input
+						type="checkbox"
+						checked={useDefaultStrategy}
+						onchange={() => (useDefaultStrategy = !useDefaultStrategy)}
+					/>
+					<span
+						>{i18nFormat($i18n.monitoring.auto_refill_strategy, [
+							{
+								placeholder: '{0}',
+								value: formatTCycles(monitoringStrategy.BelowThreshold.min_cycles)
+							},
+							{
+								placeholder: '{1}',
+								value: formatTCycles(monitoringStrategy.BelowThreshold.fund_cycles)
+							}
+						])}</span
+					>
+				</Checkbox>
+			</div>
+		</Value>
+	</div>
+{/if}
+
+<style lang="scss">
+	.default-strategy {
+		margin: var(--padding-0_5x) 0 0;
+	}
+
+	.group {
+		padding: var(--padding) 0 0;
+	}
+</style>

--- a/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
@@ -7,21 +7,21 @@
 	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import type {CyclesMonitoringStrategy} from "$declarations/mission_control/mission_control.did";
 
 	interface Props {
 		detail: JunoModalDetail;
-		useDefaultStrategy: boolean | undefined;
+		monitoringStrategy: CyclesMonitoringStrategy | undefined;
 	}
 
-	let { useDefaultStrategy = $bindable(), detail }: Props = $props();
+	let { monitoringStrategy = $bindable(), detail }: Props = $props();
 
 	let { monitoringConfig } = detail as JunoModalCreateSegmentDetail;
 
-	let monitoringStrategy = $derived(
-		fromNullable(fromNullable(monitoringConfig?.cycles ?? [])?.default_strategy ?? [])
-	);
+	let useDefaultStrategy = $state(false);
 
 	onMount(() => {
+		monitoringStrategy = fromNullable(fromNullable(monitoringConfig?.cycles ?? [])?.default_strategy ?? []);
 		useDefaultStrategy = nonNullish(monitoringStrategy);
 	});
 </script>

--- a/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { fromNullable, nonNullish } from '@dfinity/utils';
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
-	import type {CyclesMonitoringStrategy} from "$declarations/mission_control/mission_control.did";
+	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -19,14 +19,24 @@
 	let { monitoringConfig } = detail as JunoModalCreateSegmentDetail;
 
 	let useDefaultStrategy = $state(false);
+	let useMonitoringStrategy: CyclesMonitoringStrategy | undefined = $state(undefined);
 
 	onMount(() => {
-		monitoringStrategy = fromNullable(fromNullable(monitoringConfig?.cycles ?? [])?.default_strategy ?? []);
+		useMonitoringStrategy = fromNullable(
+			fromNullable(monitoringConfig?.cycles ?? [])?.default_strategy ?? []
+		);
+		monitoringStrategy = useMonitoringStrategy;
 		useDefaultStrategy = nonNullish(monitoringStrategy);
+	});
+
+	$effect(() => {
+		useDefaultStrategy;
+
+		untrack(() => (monitoringStrategy = useDefaultStrategy ? useMonitoringStrategy : undefined));
 	});
 </script>
 
-{#if nonNullish(useDefaultStrategy) && nonNullish(monitoringStrategy)}
+{#if nonNullish(useDefaultStrategy) && nonNullish(useMonitoringStrategy)}
 	<div class="default-strategy">
 		<Value>
 			{#snippet label()}

--- a/src/frontend/src/lib/components/canister/ProgressCreate.svelte
+++ b/src/frontend/src/lib/components/canister/ProgressCreate.svelte
@@ -34,10 +34,10 @@
 			text: segment === 'orbiter' ? $i18n.analytics.initializing : $i18n.satellites.initializing
 		},
 		...(withMonitoring === true && {
-			options: {
+			monitoring: {
 				state: 'next',
 				step: 'monitoring',
-				text: $i18n.monitoring.applying_strategy
+				text: $i18n.monitoring.starting_monitoring
 			}
 		}),
 		reload: {
@@ -68,7 +68,7 @@
 							: create.state
 				},
 				...(nonNullish(monitoring) && {
-					options: {
+					monitoring: {
 						...monitoring,
 						state:
 							progress?.step === WizardCreateProgressStep.Monitoring

--- a/src/frontend/src/lib/components/modals/Modals.svelte
+++ b/src/frontend/src/lib/components/modals/Modals.svelte
@@ -24,9 +24,9 @@
 	import SatelliteUpgradeModal from '$lib/components/modals/SatelliteUpgradeModal.svelte';
 	import SendTokensModal from '$lib/components/modals/SendTokensModal.svelte';
 	import StopMonitoringStrategyModal from '$lib/components/modals/StopMonitoringStrategyModal.svelte';
-	import type { JunoModal } from '$lib/types/modal';
+	import type { JunoModal, JunoModalDetail } from '$lib/types/modal';
 
-	let modal: JunoModal | undefined = $state(undefined);
+	let modal: JunoModal<JunoModalDetail> | undefined = $state(undefined);
 
 	const close = () => (modal = undefined);
 </script>

--- a/src/frontend/src/lib/components/modals/MonitoringDetailsModal.svelte
+++ b/src/frontend/src/lib/components/modals/MonitoringDetailsModal.svelte
@@ -14,7 +14,7 @@
 	import type { JunoModalDetail, JunoModalShowMonitoringDetail } from '$lib/types/modal';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { formatToRelativeTime } from '$lib/utils/date.utils';
-	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import MonitoringSentence from '$lib/components/modals/MonitoringSentence.svelte';
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -57,18 +57,7 @@
 								{$i18n.monitoring.auto_refill}
 							{/snippet}
 
-							<p>
-								{i18nFormat($i18n.monitoring.auto_refill_strategy, [
-									{
-										placeholder: '{0}',
-										value: formatTCycles(monitoringStrategy.BelowThreshold.min_cycles)
-									},
-									{
-										placeholder: '{1}',
-										value: formatTCycles(monitoringStrategy.BelowThreshold.fund_cycles)
-									}
-								])}
-							</p>
+							<p><MonitoringSentence {monitoringStrategy} /></p>
 						</Value>
 					{:else}
 						<MonitoringDisabled {monitoring} loading={false} />

--- a/src/frontend/src/lib/components/modals/MonitoringDetailsModal.svelte
+++ b/src/frontend/src/lib/components/modals/MonitoringDetailsModal.svelte
@@ -5,6 +5,7 @@
 	import CanisterMonitoringChart from '$lib/components/canister/CanisterMonitoringChart.svelte';
 	import CanisterOverview from '$lib/components/canister/CanisterOverview.svelte';
 	import CanisterMonitoringLoader from '$lib/components/loaders/CanisterMonitoringLoader.svelte';
+	import MonitoringSentence from '$lib/components/modals/MonitoringSentence.svelte';
 	import MonitoringDepositCyclesChart from '$lib/components/monitoring/MonitoringDepositCyclesChart.svelte';
 	import MonitoringDisabled from '$lib/components/monitoring/MonitoringDisabled.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
@@ -14,7 +15,6 @@
 	import type { JunoModalDetail, JunoModalShowMonitoringDetail } from '$lib/types/modal';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { formatToRelativeTime } from '$lib/utils/date.utils';
-	import MonitoringSentence from '$lib/components/modals/MonitoringSentence.svelte';
 
 	interface Props {
 		detail: JunoModalDetail;

--- a/src/frontend/src/lib/components/modals/MonitoringSentence.svelte
+++ b/src/frontend/src/lib/components/modals/MonitoringSentence.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
-	import { i18n } from '$lib/stores/i18n.store';
-	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 
 	interface Props {
 		monitoringStrategy: CyclesMonitoringStrategy;

--- a/src/frontend/src/lib/components/modals/MonitoringSentence.svelte
+++ b/src/frontend/src/lib/components/modals/MonitoringSentence.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { formatTCycles } from '$lib/utils/cycles.utils';
+	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
+
+	interface Props {
+		monitoringStrategy: CyclesMonitoringStrategy;
+	}
+
+	let { monitoringStrategy }: Props = $props();
+</script>
+
+{i18nFormat($i18n.monitoring.auto_refill_strategy, [
+	{
+		placeholder: '{0}',
+		value: formatTCycles(monitoringStrategy.BelowThreshold.min_cycles)
+	},
+	{
+		placeholder: '{1}',
+		value: formatTCycles(monitoringStrategy.BelowThreshold.fund_cycles)
+	}
+])}

--- a/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 	import CanisterAdvancedOptions from '$lib/components/canister/CanisterAdvancedOptions.svelte';
 	import ProgressCreate from '$lib/components/canister/ProgressCreate.svelte';
 	import CreditsGuard from '$lib/components/guards/CreditsGuard.svelte';
@@ -14,7 +15,6 @@
 	import type { PrincipalText } from '$lib/types/itentity';
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { WizardCreateProgress } from '$lib/types/wizard';
-	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 
 	interface Props {
 		detail: JunoModalDetail;

--- a/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
+	import {isNullish, nonNullish} from '@dfinity/utils';
 	import CanisterAdvancedOptions from '$lib/components/canister/CanisterAdvancedOptions.svelte';
 	import ProgressCreate from '$lib/components/canister/ProgressCreate.svelte';
 	import CreditsGuard from '$lib/components/guards/CreditsGuard.svelte';
@@ -14,6 +14,7 @@
 	import type { PrincipalText } from '$lib/types/itentity';
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { WizardCreateProgress } from '$lib/types/wizard';
+	import type {CyclesMonitoringStrategy} from "$declarations/mission_control/mission_control.did";
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -44,6 +45,7 @@
 			identity: $authStore.identity,
 			missionControlId: $missionControlIdDerived,
 			subnetId,
+			monitoringStrategy,
 			onProgress
 		});
 
@@ -60,7 +62,7 @@
 	const close = () => onclose();
 
 	let subnetId: PrincipalText | undefined = $state();
-	let useDefaultStrategy: boolean | undefined = $state();
+	let monitoringStrategy: CyclesMonitoringStrategy | undefined = $state();
 </script>
 
 <Modal on:junoClose={close}>
@@ -72,7 +74,7 @@
 			<button onclick={close}>{$i18n.core.close}</button>
 		</div>
 	{:else if step === 'in_progress'}
-		<ProgressCreate segment="orbiter" {progress} />
+		<ProgressCreate segment="orbiter" {progress} withMonitoring={nonNullish(monitoringStrategy)} />
 	{:else}
 		<h2>{$i18n.analytics.start}</h2>
 
@@ -87,7 +89,7 @@
 			priceLabel={$i18n.analytics.create_orbiter_price}
 		>
 			<form onsubmit={onSubmit}>
-				<CanisterAdvancedOptions bind:subnetId bind:useDefaultStrategy {detail} />
+				<CanisterAdvancedOptions bind:subnetId bind:monitoringStrategy {detail} />
 
 				<button
 					type="submit"

--- a/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import {isNullish, nonNullish} from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import CanisterAdvancedOptions from '$lib/components/canister/CanisterAdvancedOptions.svelte';
 	import ProgressCreate from '$lib/components/canister/ProgressCreate.svelte';
 	import CreditsGuard from '$lib/components/guards/CreditsGuard.svelte';
@@ -14,7 +14,7 @@
 	import type { PrincipalText } from '$lib/types/itentity';
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { WizardCreateProgress } from '$lib/types/wizard';
-	import type {CyclesMonitoringStrategy} from "$declarations/mission_control/mission_control.did";
+	import type { CyclesMonitoringStrategy } from '$declarations/mission_control/mission_control.did';
 
 	interface Props {
 		detail: JunoModalDetail;

--- a/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterCreateModal.svelte
@@ -65,6 +65,7 @@
 	const close = () => onclose();
 
 	let subnetId: PrincipalText | undefined = $state();
+	let useDefaultStrategy: boolean | undefined = $state();
 </script>
 
 <Modal on:junoClose={close}>
@@ -93,7 +94,7 @@
 			priceLabel={$i18n.analytics.create_orbiter_price}
 		>
 			<form onsubmit={onSubmit}>
-				<CanisterAdvancedOptions bind:subnetId />
+				<CanisterAdvancedOptions bind:subnetId bind:useDefaultStrategy {detail} />
 
 				<button
 					type="submit"

--- a/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
@@ -81,6 +81,7 @@
 
 	let satelliteName: string | undefined = $state(undefined);
 	let subnetId: PrincipalText | undefined = $state();
+	let useDefaultStrategy: boolean | undefined = $state();
 </script>
 
 <Modal on:junoClose={onclose}>
@@ -123,7 +124,7 @@
 					/>
 				</Value>
 
-				<CanisterAdvancedOptions bind:subnetId />
+				<CanisterAdvancedOptions bind:subnetId bind:useDefaultStrategy {detail} />
 
 				<button
 					type="submit"

--- a/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-	import {isNullish, nonNullish} from '@dfinity/utils';
-	import type {CyclesMonitoringStrategy, Satellite} from '$declarations/mission_control/mission_control.did';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type {
+		CyclesMonitoringStrategy,
+		Satellite
+	} from '$declarations/mission_control/mission_control.did';
 	import CanisterAdvancedOptions from '$lib/components/canister/CanisterAdvancedOptions.svelte';
 	import ProgressCreate from '$lib/components/canister/ProgressCreate.svelte';
 	import CreditsGuard from '$lib/components/guards/CreditsGuard.svelte';
@@ -84,7 +87,11 @@
 			<button onclick={navigate}>{$i18n.core.continue}</button>
 		</div>
 	{:else if step === 'in_progress'}
-		<ProgressCreate segment="satellite" {progress} withMonitoring={nonNullish(monitoringStrategy)} />
+		<ProgressCreate
+			segment="satellite"
+			{progress}
+			withMonitoring={nonNullish(monitoringStrategy)}
+		/>
 	{:else}
 		<h2>{$i18n.satellites.start}</h2>
 

--- a/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteCreateModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
-	import type { Satellite } from '$declarations/mission_control/mission_control.did';
+	import {isNullish, nonNullish} from '@dfinity/utils';
+	import type {CyclesMonitoringStrategy, Satellite} from '$declarations/mission_control/mission_control.did';
 	import CanisterAdvancedOptions from '$lib/components/canister/CanisterAdvancedOptions.svelte';
 	import ProgressCreate from '$lib/components/canister/ProgressCreate.svelte';
 	import CreditsGuard from '$lib/components/guards/CreditsGuard.svelte';
@@ -48,6 +48,7 @@
 			identity: $authStore.identity,
 			missionControlId: $missionControlIdDerived,
 			subnetId,
+			monitoringStrategy,
 			satelliteName,
 			onProgress
 		});
@@ -71,7 +72,7 @@
 
 	let satelliteName: string | undefined = $state(undefined);
 	let subnetId: PrincipalText | undefined = $state();
-	let useDefaultStrategy: boolean | undefined = $state();
+	let monitoringStrategy: CyclesMonitoringStrategy | undefined = $state();
 </script>
 
 <Modal on:junoClose={onclose}>
@@ -83,7 +84,7 @@
 			<button onclick={navigate}>{$i18n.core.continue}</button>
 		</div>
 	{:else if step === 'in_progress'}
-		<ProgressCreate segment="satellite" {progress} />
+		<ProgressCreate segment="satellite" {progress} withMonitoring={nonNullish(monitoringStrategy)} />
 	{:else}
 		<h2>{$i18n.satellites.start}</h2>
 
@@ -112,7 +113,7 @@
 					/>
 				</Value>
 
-				<CanisterAdvancedOptions bind:subnetId bind:useDefaultStrategy {detail} />
+				<CanisterAdvancedOptions bind:subnetId bind:monitoringStrategy {detail} />
 
 				<button
 					type="submit"

--- a/src/frontend/src/lib/components/monitoring/ProgressMonitoring.svelte
+++ b/src/frontend/src/lib/components/monitoring/ProgressMonitoring.svelte
@@ -44,7 +44,7 @@
 			text:
 				action === 'stop'
 					? $i18n.monitoring.stopping_monitoring
-					: $i18n.monitoring.applying_strategy
+					: $i18n.monitoring.starting_monitoring
 		},
 		reload: {
 			state: 'next',

--- a/src/frontend/src/lib/components/satellites/SatelliteNew.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteNew.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { get } from 'svelte/store';
 	import IconNew from '$lib/components/icons/IconNew.svelte';
 	import LaunchpadButton from '$lib/components/launchpad/LaunchpadButton.svelte';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';

--- a/src/frontend/src/lib/components/satellites/SatelliteNew.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteNew.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { get } from 'svelte/store';
 	import IconNew from '$lib/components/icons/IconNew.svelte';
 	import LaunchpadButton from '$lib/components/launchpad/LaunchpadButton.svelte';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
-	import { getCreateSatelliteFeeBalance } from '$lib/services/wizard.services';
+	import { initSatelliteWizard } from '$lib/services/wizard.services';
 	import { authStore } from '$lib/stores/auth.store';
-	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { emit } from '$lib/utils/events.utils';
 
 	interface Props {
 		row?: boolean;
@@ -16,20 +15,10 @@
 	let { row = false }: Props = $props();
 
 	const createSatellite = async () => {
-		busy.start();
-
-		const { result, error } = await getCreateSatelliteFeeBalance({
+		await initSatelliteWizard({
 			identity: $authStore.identity,
 			missionControlId: $missionControlIdDerived
 		});
-
-		busy.stop();
-
-		if (nonNullish(error) || isNullish(result)) {
-			return;
-		}
-
-		emit({ message: 'junoModal', detail: { type: 'create_satellite', detail: result } });
 	};
 </script>
 

--- a/src/frontend/src/lib/derived/mission-control.derived.ts
+++ b/src/frontend/src/lib/derived/mission-control.derived.ts
@@ -36,6 +36,11 @@ export const missionControlMonitoring = derived(
 	([$missionControlSettings]) => fromNullable($missionControlSettings?.monitoring ?? [])
 );
 
+export const missionControlMonitoringConfig = derived(
+	[missionControlSettings],
+	([$missionControlSettings]) => fromNullable($missionControlSettings?.monitoring_config ?? [])
+);
+
 export const missionControlMonitored = derived(
 	[missionControlMonitoring],
 	([$missionControlMonitoring]) =>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -686,7 +686,7 @@
 		"stop_monitoring": "Stop monitoring",
 		"strategy_created": "Strategy successfully created and monitoring started.",
 		"monitoring_stopped": "Selected monitoring stopped.",
-		"applying_strategy": "Applying strategy and starting monitoring...",
+		"starting_monitoring": "Starting monitoring...",
 		"stopping_monitoring": "Stopping monitoring...",
 		"remaining_threshold": "Remaining T Cycles Threshold",
 		"top_up_amount": "Top-Up Amount",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -526,6 +526,7 @@
 		"auth_rate_config_max_tokens": "A maximal number of updates per minute is required.",
 		"auth_rate_config_update": "Unexpected error(s) while trying to update your authentication settings.",
 		"auth_domain_config": "Unexpected error(s) while trying to update your authentication configuration",
+		"mission_control_not_loaded": "Your mission control is not yet loaded.",
 		"mission_control_settings_not_loaded": "The settings for the mission control are not yet loaded.",
 		"mission_control_metadata_not_loaded": "The metadata for the mission control are not yet loaded.",
 		"monitoring_apply_strategy_error": "Unexpected error(s) while applying the strategy.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -686,7 +686,7 @@
 		"stop_monitoring": "Stop monitoring",
 		"strategy_created": "Strategy successfully created and monitoring started.",
 		"monitoring_stopped": "Selected monitoring stopped.",
-		"applying_strategy": "Applying strategy and starting monitoring...",
+		"starting_monitoring": "Starting monitoring...",
 		"stopping_monitoring": "Stopping monitoring...",
 		"remaining_threshold": "Remaining T Cycles Threshold",
 		"top_up_amount": "Top-Up Amount",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -526,6 +526,7 @@
 		"auth_rate_config_max_tokens": "每分钟最多更新操作数量是必须的.",
 		"auth_rate_config_update": "更改认证配置出现异常错误.",
 		"auth_domain_config": "更新认证配置是出现异常错误",
+		"mission_control_not_loaded": "Your mission control is not yet loaded.",
 		"mission_control_settings_not_loaded": "The settings for the mission control are not yet loaded.",
 		"mission_control_metadata_not_loaded": "The metadata for the mission control are not yet loaded.",
 		"monitoring_apply_strategy_error": "Unexpected error(s) while applying the strategy.",

--- a/src/frontend/src/lib/services/wizard.services.ts
+++ b/src/frontend/src/lib/services/wizard.services.ts
@@ -4,6 +4,7 @@ import type {
 	Satellite
 } from '$declarations/mission_control/mission_control.did';
 import { getOrbiterFee, getSatelliteFee } from '$lib/api/console.api';
+import { updateAndStartMonitoring } from '$lib/api/mission-control.api';
 import { missionControlMonitoringConfig } from '$lib/derived/mission-control.derived';
 import { getMissionControlBalance } from '$lib/services/balance.services';
 import { loadVersion } from '$lib/services/console.services';
@@ -29,9 +30,8 @@ import { type WizardCreateProgress, WizardCreateProgressStep } from '$lib/types/
 import { emit } from '$lib/utils/events.utils';
 import type { Identity } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
-import {assertNonNullish, isNullish, nonNullish, toNullable} from '@dfinity/utils';
+import { assertNonNullish, isNullish, nonNullish, toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
-import {updateAndStartMonitoring} from "$lib/api/mission-control.api";
 
 interface GetFeeBalance {
 	result?: Omit<JunoModalCreateSegmentDetail, 'monitoringConfig'>;
@@ -232,7 +232,13 @@ export const createSatelliteWizard = async ({
 			return undefined;
 		}
 
-		return async ({identity, segment}: {identity: Identity, segment: Satellite}): Promise<void> => {
+		return async ({
+			identity,
+			segment
+		}: {
+			identity: Identity;
+			segment: Satellite;
+		}): Promise<void> => {
 			assertNonNullish(missionControlId);
 
 			await updateAndStartMonitoring({
@@ -249,8 +255,8 @@ export const createSatelliteWizard = async ({
 					})
 				}
 			});
-		}
-	}
+		};
+	};
 
 	const monitoringFn = buildMonitoringFn();
 
@@ -295,7 +301,13 @@ export const createOrbiterWizard = async ({
 			return undefined;
 		}
 
-		return async ({identity, segment}: {identity: Identity, segment: Orbiter}): Promise<void> => {
+		return async ({
+			identity,
+			segment
+		}: {
+			identity: Identity;
+			segment: Orbiter;
+		}): Promise<void> => {
 			assertNonNullish(missionControlId);
 
 			await updateAndStartMonitoring({
@@ -312,8 +324,8 @@ export const createOrbiterWizard = async ({
 					})
 				}
 			});
-		}
-	}
+		};
+	};
 
 	const monitoringFn = buildMonitoringFn();
 
@@ -328,7 +340,7 @@ export const createOrbiterWizard = async ({
 	});
 };
 
-type MonitoringFn<T> = (params: { identity: Identity, segment: T }) => Promise<void>;
+type MonitoringFn<T> = (params: { identity: Identity; segment: T }) => Promise<void>;
 
 const createWizard = async <T>({
 	missionControlId,

--- a/src/frontend/src/lib/services/wizard.services.ts
+++ b/src/frontend/src/lib/services/wizard.services.ts
@@ -1,28 +1,122 @@
 import { getOrbiterFee, getSatelliteFee } from '$lib/api/console.api';
+import { missionControlMonitoringConfig } from '$lib/derived/mission-control.derived';
 import { getMissionControlBalance } from '$lib/services/balance.services';
+import { loadVersion } from '$lib/services/console.services';
+import { loadSettings } from '$lib/services/mission-control.services';
+import { busy } from '$lib/stores/busy.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toasts } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/itentity';
-import type { JunoModalCreateSegmentDetail } from '$lib/types/modal';
+import type { JunoModal, JunoModalCreateSegmentDetail } from '$lib/types/modal';
 import type { Option } from '$lib/types/utils';
+import { emit } from '$lib/utils/events.utils';
+import type { Identity } from '@dfinity/agent';
 import type { Principal } from '@dfinity/principal';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-export interface GetFeeBalance {
-	result?: JunoModalCreateSegmentDetail;
+interface GetFeeBalance {
+	result?: Omit<JunoModalCreateSegmentDetail, 'monitoringConfig'>;
 	error?: unknown;
 }
 
-export const getCreateSatelliteFeeBalance = async (params: {
-	identity: OptionIdentity;
-	missionControlId: Option<Principal>;
-}): Promise<GetFeeBalance> => await getCreateFeeBalance({ ...params, getFee: getSatelliteFee });
+type GetFeeBalanceFn = (params: {
+	missionControlId: Principal;
+	identity: Option<Identity>;
+}) => Promise<GetFeeBalance>;
 
-export const getCreateOrbiterFeeBalance = async (params: {
-	identity: OptionIdentity;
+export const initSatelliteWizard = async ({
+	missionControlId,
+	identity
+}: {
 	missionControlId: Option<Principal>;
-}): Promise<GetFeeBalance> => await getCreateFeeBalance({ ...params, getFee: getOrbiterFee });
+	identity: Option<Identity>;
+}) =>
+	initCreateWizard({
+		missionControlId,
+		identity,
+		feeFn: getCreateSatelliteFeeBalance,
+		modalType: 'create_satellite'
+	});
+
+export const initOrbiterWizard = async ({
+	missionControlId,
+	identity
+}: {
+	missionControlId: Option<Principal>;
+	identity: Option<Identity>;
+}) =>
+	initCreateWizard({
+		missionControlId,
+		identity,
+		feeFn: getCreateSatelliteFeeBalance,
+		modalType: 'create_satellite'
+	});
+
+const initCreateWizard = async ({
+	missionControlId,
+	identity,
+	feeFn,
+	modalType
+}: {
+	missionControlId: Option<Principal>;
+	identity: Option<Identity>;
+	feeFn: GetFeeBalanceFn;
+	modalType: 'create_satellite' | 'create_orbiter';
+}) => {
+	if (isNullish(missionControlId)) {
+		toasts.warn(get(i18n).errors.mission_control_not_loaded);
+		return;
+	}
+
+	busy.start();
+
+	const { result: feeBalance, error } = await feeFn({
+		identity,
+		missionControlId
+	});
+
+	if (nonNullish(error) || isNullish(feeBalance)) {
+		busy.stop();
+		return;
+	}
+
+	await loadVersion({
+		satelliteId: undefined,
+		missionControlId,
+		skipReload: true
+	});
+
+	const { success } = await loadSettings({
+		identity,
+		missionControlId
+	});
+
+	busy.stop();
+
+	if (!success) {
+		return;
+	}
+
+	const monitoringConfig = get(missionControlMonitoringConfig);
+
+	emit<JunoModal<JunoModalCreateSegmentDetail>>({
+		message: 'junoModal',
+		detail: {
+			type: modalType,
+			detail: {
+				...feeBalance,
+				monitoringConfig
+			}
+		}
+	});
+};
+
+const getCreateSatelliteFeeBalance: GetFeeBalanceFn = async (params): Promise<GetFeeBalance> =>
+	await getCreateFeeBalance({ ...params, getFee: getSatelliteFee });
+
+const getCreateOrbiterFeeBalance: GetFeeBalanceFn = async (params): Promise<GetFeeBalance> =>
+	await getCreateFeeBalance({ ...params, getFee: getOrbiterFee });
 
 const getCreateFeeBalance = async ({
 	identity,

--- a/src/frontend/src/lib/services/wizard.services.ts
+++ b/src/frontend/src/lib/services/wizard.services.ts
@@ -62,8 +62,8 @@ export const initOrbiterWizard = async ({
 	initCreateWizard({
 		missionControlId,
 		identity,
-		feeFn: getCreateSatelliteFeeBalance,
-		modalType: 'create_satellite'
+		feeFn: getCreateOrbiterFeeBalance,
+		modalType: 'create_orbiter'
 	});
 
 const initCreateWizard = async ({

--- a/src/frontend/src/lib/services/wizard.services.ts
+++ b/src/frontend/src/lib/services/wizard.services.ts
@@ -43,13 +43,13 @@ type GetFeeBalanceFn = (params: {
 	identity: Option<Identity>;
 }) => Promise<GetFeeBalance>;
 
-export const initSatelliteWizard = async ({
+export const initSatelliteWizard = ({
 	missionControlId,
 	identity
 }: {
 	missionControlId: Option<Principal>;
 	identity: Option<Identity>;
-}) =>
+}): Promise<void> =>
 	initCreateWizard({
 		missionControlId,
 		identity,
@@ -57,13 +57,13 @@ export const initSatelliteWizard = async ({
 		modalType: 'create_satellite'
 	});
 
-export const initOrbiterWizard = async ({
+export const initOrbiterWizard = ({
 	missionControlId,
 	identity
 }: {
 	missionControlId: Option<Principal>;
 	identity: Option<Identity>;
-}) =>
+}): Promise<void> =>
 	initCreateWizard({
 		missionControlId,
 		identity,

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -711,7 +711,7 @@ interface I18nMonitoring {
 	stop_monitoring: string;
 	strategy_created: string;
 	monitoring_stopped: string;
-	applying_strategy: string;
+	starting_monitoring: string;
 	stopping_monitoring: string;
 	remaining_threshold: string;
 	top_up_amount: string;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -542,6 +542,7 @@ interface I18nErrors {
 	auth_rate_config_max_tokens: string;
 	auth_rate_config_update: string;
 	auth_domain_config: string;
+	mission_control_not_loaded: string;
 	mission_control_settings_not_loaded: string;
 	mission_control_metadata_not_loaded: string;
 	monitoring_apply_strategy_error: string;

--- a/src/frontend/src/lib/types/modal.ts
+++ b/src/frontend/src/lib/types/modal.ts
@@ -2,6 +2,7 @@ import type { snapshot } from '$declarations/ic/ic.did';
 import type {
 	MissionControlSettings,
 	Monitoring,
+	MonitoringConfig,
 	Satellite
 } from '$declarations/mission_control/mission_control.did';
 import type { OrbiterSatelliteFeatures } from '$declarations/orbiter/orbiter.did';
@@ -13,6 +14,7 @@ import type { CustomDomains } from '$lib/types/custom-domain';
 import type { Metadata } from '$lib/types/metadata';
 import type { OrbiterSatelliteConfigEntry } from '$lib/types/ortbiter';
 import type { SatelliteIdText } from '$lib/types/satellite';
+import type { Option } from '$lib/types/utils';
 import type { Principal } from '@dfinity/principal';
 import type { BuildType } from '@junobuild/admin';
 
@@ -42,6 +44,7 @@ export type JunoModalUpgradeSatelliteDetail = JunoModalUpgradeDetail &
 
 export interface JunoModalCreateSegmentDetail extends JunoModalBalance {
 	fee: bigint;
+	monitoringConfig: Option<MonitoringConfig>;
 }
 
 export interface JunoModalCustomDomainDetail {
@@ -124,7 +127,7 @@ export type JunoModalDetail =
 	| JunoModalEditOrbiterConfigDetail
 	| JunoModalMonitoringStrategyDetail;
 
-export interface JunoModal {
+export interface JunoModal<T extends JunoModalDetail> {
 	type:
 		| 'create_satellite'
 		| 'create_orbiter'
@@ -150,5 +153,5 @@ export interface JunoModal {
 		| 'create_monitoring_strategy'
 		| 'stop_monitoring_strategy'
 		| 'show_monitoring_details';
-	detail?: JunoModalDetail;
+	detail?: T;
 }


### PR DESCRIPTION
# Motivation

If the developer has already setup a default strategy, it would be really handy if any new satellites or orbiters can automatically be setup with the monitoring strategy on creation. That's why we integrate the monitoring in the wizard.
