### PR TITLE
refactor: create a generic execute function

### DIFF
--- a/src/frontend/src/lib/services/monitoring.services.ts
+++ b/src/frontend/src/lib/services/monitoring.services.ts
@@ -15,6 +15,7 @@ import { orbiterNotLoaded, orbiterStore } from '$lib/derived/orbiter.derived';
 import { satellitesNotLoaded, satellitesStore } from '$lib/derived/satellite.derived';
 import { loadSettings, loadUserMetadata } from '$lib/services/mission-control.services';
 import { loadOrbiters } from '$lib/services/orbiters.services';
+import { execute } from '$lib/services/progress.services';
 import { loadSatellites } from '$lib/services/satellites.services';
 import { i18n } from '$lib/stores/i18n.store';
 import {
@@ -443,37 +444,6 @@ const buildMissionControlStrategy = ({
 	return {
 		BelowThreshold
 	};
-};
-
-const execute = async ({
-	fn,
-	step,
-	onProgress
-}: {
-	fn: () => Promise<void>;
-	step: MonitoringStrategyProgressStep;
-	onProgress: MonitoringStrategyOnProgress;
-}) => {
-	onProgress({
-		step,
-		state: 'in_progress'
-	});
-
-	try {
-		await fn();
-
-		onProgress({
-			step,
-			state: 'success'
-		});
-	} catch (err: unknown) {
-		onProgress({
-			step,
-			state: 'error'
-		});
-
-		throw err;
-	}
 };
 
 export const openMonitoringModal = ({

--- a/src/frontend/src/lib/services/progress.services.ts
+++ b/src/frontend/src/lib/services/progress.services.ts
@@ -1,0 +1,39 @@
+import type { UpgradeCodeProgressState } from '@junobuild/admin';
+
+export type ProgressState = UpgradeCodeProgressState;
+
+export interface Progress<Step> {
+	step: Step;
+	state: ProgressState;
+}
+
+export const execute = async <Step>({
+	fn,
+	step,
+	onProgress
+}: {
+	fn: () => Promise<void>;
+	step: Step;
+	onProgress: (progress: Progress<Step> | undefined) => void;
+}) => {
+	onProgress({
+		step,
+		state: 'in_progress'
+	});
+
+	try {
+		await fn();
+
+		onProgress({
+			step,
+			state: 'success'
+		});
+	} catch (err: unknown) {
+		onProgress({
+			step,
+			state: 'error'
+		});
+
+		throw err;
+	}
+};

--- a/src/frontend/src/lib/services/snapshots.services.ts
+++ b/src/frontend/src/lib/services/snapshots.services.ts
@@ -14,6 +14,7 @@ import {
 	setIdbStore,
 	syncIdbStore
 } from '$lib/services/idb-store.services';
+import { execute } from '$lib/services/progress.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { snapshotsIdbStore } from '$lib/stores/idb.store';
 import { snapshotStore } from '$lib/stores/snapshot.store';
@@ -246,37 +247,6 @@ const updateStore = async ({
 		canisterId: canisterId.toText(),
 		data: [snapshot]
 	});
-};
-
-const execute = async ({
-	fn,
-	step,
-	onProgress
-}: {
-	fn: () => Promise<void>;
-	step: SnapshotProgressStep;
-	onProgress: SnapshotOnProgress;
-}) => {
-	onProgress({
-		step,
-		state: 'in_progress'
-	});
-
-	try {
-		await fn();
-
-		onProgress({
-			step,
-			state: 'success'
-		});
-	} catch (err: unknown) {
-		onProgress({
-			step,
-			state: 'error'
-		});
-
-		throw err;
-	}
 };
 
 export const loadSnapshots = async ({


### PR DESCRIPTION
# Motivation

The `execute` function that execute steps with progression can be extracted instead of being duplicated. 
