### PR TITLE
feat: move monitoring config to user

### DIFF
--- a/src/declarations/mission_control/mission_control.did.d.ts
+++ b/src/declarations/mission_control/mission_control.did.d.ts
@@ -6,6 +6,9 @@ export interface Account {
 	owner: Principal;
 	subaccount: [] | [Uint8Array | number[]];
 }
+export interface Config {
+	monitoring: [] | [MonitoringConfig];
+}
 export interface Controller {
 	updated_at: bigint;
 	metadata: Array<[string, string]>;
@@ -64,7 +67,6 @@ export interface GetMonitoringHistory {
 }
 export interface MissionControlSettings {
 	updated_at: bigint;
-	monitoring_config: [] | [MonitoringConfig];
 	created_at: bigint;
 	monitoring: [] | [Monitoring];
 }
@@ -177,6 +179,7 @@ export interface _SERVICE {
 	del_satellite: ActorMethod<[Principal, bigint], undefined>;
 	del_satellites_controllers: ActorMethod<[Array<Principal>, Array<Principal>], undefined>;
 	deposit_cycles: ActorMethod<[DepositCyclesArgs], undefined>;
+	get_config: ActorMethod<[], [] | [Config]>;
 	get_metadata: ActorMethod<[], Array<[string, string]>>;
 	get_monitoring_history: ActorMethod<
 		[GetMonitoringHistory],
@@ -192,9 +195,9 @@ export interface _SERVICE {
 	list_satellites: ActorMethod<[], Array<[Principal, Satellite]>>;
 	remove_mission_control_controllers: ActorMethod<[Array<Principal>], undefined>;
 	remove_satellites_controllers: ActorMethod<[Array<Principal>, Array<Principal>], undefined>;
+	set_config: ActorMethod<[[] | [Config]], undefined>;
 	set_metadata: ActorMethod<[Array<[string, string]>], undefined>;
 	set_mission_control_controllers: ActorMethod<[Array<Principal>, SetController], undefined>;
-	set_monitoring_config: ActorMethod<[[] | [MonitoringConfig]], undefined>;
 	set_orbiter: ActorMethod<[Principal, [] | [string]], Orbiter>;
 	set_orbiter_metadata: ActorMethod<[Principal, Array<[string, string]>], Orbiter>;
 	set_orbiters_controllers: ActorMethod<

--- a/src/declarations/mission_control/mission_control.did.d.ts
+++ b/src/declarations/mission_control/mission_control.did.d.ts
@@ -166,6 +166,13 @@ export type TransferError_1 =
 	| { CreatedInFuture: { ledger_time: bigint } }
 	| { TooOld: null }
 	| { InsufficientFunds: { balance: bigint } };
+export interface User {
+	updated_at: bigint;
+	metadata: Array<[string, string]>;
+	user: [] | [Principal];
+	created_at: bigint;
+	config: [] | [Config];
+}
 export interface _SERVICE {
 	add_mission_control_controllers: ActorMethod<[Array<Principal>], undefined>;
 	add_satellites_controllers: ActorMethod<[Array<Principal>, Array<Principal>], undefined>;
@@ -188,6 +195,7 @@ export interface _SERVICE {
 	get_monitoring_status: ActorMethod<[], MonitoringStatus>;
 	get_settings: ActorMethod<[], [] | [MissionControlSettings]>;
 	get_user: ActorMethod<[], Principal>;
+	get_user_data: ActorMethod<[], User>;
 	icp_transfer: ActorMethod<[TransferArgs], Result>;
 	icrc_transfer: ActorMethod<[Principal, TransferArg], Result_1>;
 	list_mission_control_controllers: ActorMethod<[], Array<[Principal, Controller]>>;

--- a/src/declarations/mission_control/mission_control.factory.did.js
+++ b/src/declarations/mission_control/mission_control.factory.did.js
@@ -35,6 +35,18 @@ export const idlFactory = ({ IDL }) => {
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
 	});
+	const DepositedCyclesEmailNotification = IDL.Record({
+		to: IDL.Opt(IDL.Text),
+		enabled: IDL.Bool
+	});
+	const CyclesMonitoringConfig = IDL.Record({
+		notification: IDL.Opt(DepositedCyclesEmailNotification),
+		default_strategy: IDL.Opt(CyclesMonitoringStrategy)
+	});
+	const MonitoringConfig = IDL.Record({
+		cycles: IDL.Opt(CyclesMonitoringConfig)
+	});
+	const Config = IDL.Record({ monitoring: IDL.Opt(MonitoringConfig) });
 	const GetMonitoringHistory = IDL.Record({
 		to: IDL.Opt(IDL.Nat64),
 		from: IDL.Opt(IDL.Nat64),
@@ -63,20 +75,8 @@ export const idlFactory = ({ IDL }) => {
 	const MonitoringStatus = IDL.Record({
 		cycles: IDL.Opt(CyclesMonitoringStatus)
 	});
-	const DepositedCyclesEmailNotification = IDL.Record({
-		to: IDL.Opt(IDL.Text),
-		enabled: IDL.Bool
-	});
-	const CyclesMonitoringConfig = IDL.Record({
-		notification: IDL.Opt(DepositedCyclesEmailNotification),
-		default_strategy: IDL.Opt(CyclesMonitoringStrategy)
-	});
-	const MonitoringConfig = IDL.Record({
-		cycles: IDL.Opt(CyclesMonitoringConfig)
-	});
 	const MissionControlSettings = IDL.Record({
 		updated_at: IDL.Nat64,
-		monitoring_config: IDL.Opt(MonitoringConfig),
 		created_at: IDL.Nat64,
 		monitoring: IDL.Opt(Monitoring)
 	});
@@ -173,6 +173,7 @@ export const idlFactory = ({ IDL }) => {
 		del_satellite: IDL.Func([IDL.Principal, IDL.Nat], [], []),
 		del_satellites_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),
 		deposit_cycles: IDL.Func([DepositCyclesArgs], [], []),
+		get_config: IDL.Func([], [IDL.Opt(Config)], ['query']),
 		get_metadata: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], ['query']),
 		get_monitoring_history: IDL.Func(
 			[GetMonitoringHistory],
@@ -197,9 +198,9 @@ export const idlFactory = ({ IDL }) => {
 			[],
 			[]
 		),
+		set_config: IDL.Func([IDL.Opt(Config)], [], []),
 		set_metadata: IDL.Func([IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], [], []),
 		set_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal), SetController], [], []),
-		set_monitoring_config: IDL.Func([IDL.Opt(MonitoringConfig)], [], []),
 		set_orbiter: IDL.Func([IDL.Principal, IDL.Opt(IDL.Text)], [Orbiter], []),
 		set_orbiter_metadata: IDL.Func(
 			[IDL.Principal, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],

--- a/src/declarations/mission_control/mission_control.factory.did.js
+++ b/src/declarations/mission_control/mission_control.factory.did.js
@@ -80,6 +80,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		monitoring: IDL.Opt(Monitoring)
 	});
+	const User = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		user: IDL.Opt(IDL.Principal),
+		created_at: IDL.Nat64,
+		config: IDL.Opt(Config)
+	});
 	const Tokens = IDL.Record({ e8s: IDL.Nat64 });
 	const Timestamp = IDL.Record({ timestamp_nanos: IDL.Nat64 });
 	const TransferArgs = IDL.Record({
@@ -183,6 +190,7 @@ export const idlFactory = ({ IDL }) => {
 		get_monitoring_status: IDL.Func([], [MonitoringStatus], ['query']),
 		get_settings: IDL.Func([], [IDL.Opt(MissionControlSettings)], ['query']),
 		get_user: IDL.Func([], [IDL.Principal], ['query']),
+		get_user_data: IDL.Func([], [User], ['query']),
 		icp_transfer: IDL.Func([TransferArgs], [Result], []),
 		icrc_transfer: IDL.Func([IDL.Principal, TransferArg], [Result_1], []),
 		list_mission_control_controllers: IDL.Func(

--- a/src/frontend/src/lib/api/mission-control.api.ts
+++ b/src/frontend/src/lib/api/mission-control.api.ts
@@ -1,7 +1,7 @@
 import type {
+	Config,
 	Controller,
 	MissionControlSettings,
-	MonitoringConfig,
 	MonitoringStartConfig,
 	MonitoringStopConfig,
 	Orbiter,
@@ -9,7 +9,8 @@ import type {
 	Result_1,
 	Satellite,
 	TransferArg,
-	TransferArgs
+	TransferArgs,
+	User
 } from '$declarations/mission_control/mission_control.did';
 import { getMissionControlActor } from '$lib/api/actors/actor.juno.api';
 import type { SetControllerParams } from '$lib/types/controllers';
@@ -404,16 +405,15 @@ export const icrcTransfer = async ({
 	return icrc_transfer(ledgerId, args);
 };
 
-export const getMetadata = async ({
+export const getUserData = async ({
 	missionControlId,
-
 	identity
 }: {
 	missionControlId: Principal;
 	identity: OptionIdentity;
-}): Promise<[] | Metadata> => {
-	const { get_metadata } = await getMissionControlActor({ missionControlId, identity });
-	return get_metadata();
+}): Promise<User> => {
+	const { get_user_data } = await getMissionControlActor({ missionControlId, identity });
+	return get_user_data();
 };
 
 export const getSettings = async ({
@@ -483,21 +483,21 @@ export const getMonitoringHistory = async ({
 	});
 };
 
-export const setMonitoringConfig = async ({
+export const setConfig = async ({
 	missionControlId,
 	identity,
 	config
 }: {
 	missionControlId: Principal;
 	identity: OptionIdentity;
-	config: MonitoringConfig | undefined;
+	config: Config | undefined;
 }): Promise<void> => {
-	const { set_monitoring_config } = await getMissionControlActor({
+	const { set_config } = await getMissionControlActor({
 		missionControlId,
 		identity
 	});
 
-	return await set_monitoring_config(toNullable(config));
+	return await set_config(toNullable(config));
 };
 
 export const setMetadata = async ({

--- a/src/frontend/src/lib/components/mission-control/MissionControlDataLoader.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlDataLoader.svelte
@@ -3,7 +3,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import { onMount, type Snippet, untrack } from 'svelte';
 	import { missionControlVersion } from '$lib/derived/version.derived';
-	import { loadSettings, loadMetadata } from '$lib/services/mission-control.services';
+	import { loadSettings, loadUserData } from '$lib/services/mission-control.services';
 	import { authStore } from '$lib/stores/auth.store';
 
 	interface Props {
@@ -23,7 +23,7 @@
 				missionControlId,
 				identity: $authStore.identity
 			}),
-			loadMetadata({
+			loadUserData({
 				missionControlId,
 				identity: $authStore.identity
 			})

--- a/src/frontend/src/lib/components/mission-control/MissionControlEmail.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlEmail.svelte
@@ -10,7 +10,7 @@
 		missionControlEmail,
 		missionControlIdDerived,
 		missionControlMetadata,
-		missionControlMetadataLoaded
+		missionControlUserDataLoaded
 	} from '$lib/derived/mission-control.derived';
 	import { setMetadataEmail } from '$lib/services/mission-control.services';
 	import { authStore } from '$lib/stores/auth.store';
@@ -57,7 +57,7 @@
 		{$i18n.core.email_address}
 	{/snippet}
 
-	{#if $missionControlMetadataLoaded}
+	{#if $missionControlUserDataLoaded}
 		<p in:fade class="email">
 			<span>{$missionControlEmail ?? $i18n.core.none}</span>
 

--- a/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
+++ b/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
@@ -34,7 +34,9 @@
 
 	let { detail, onclose }: Props = $props();
 
-	let { settings, user, missionControlId } = $derived(detail as JunoModalCreateMonitoringStrategyDetail);
+	let { settings, user, missionControlId } = $derived(
+		detail as JunoModalCreateMonitoringStrategyDetail
+	);
 
 	// Wizard navigation
 

--- a/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
+++ b/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
@@ -22,7 +22,7 @@
 	import { authStore } from '$lib/stores/auth.store';
 	import { wizardBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { JunoModalDetail, JunoModalMonitoringStrategyDetail } from '$lib/types/modal';
+	import type { JunoModalDetail, JunoModalCreateMonitoringStrategyDetail } from '$lib/types/modal';
 	import type { MonitoringStrategyProgress } from '$lib/types/strategy';
 	import type { Option } from '$lib/types/utils';
 	import { metadataEmail } from '$lib/utils/metadata.utils';
@@ -34,7 +34,7 @@
 
 	let { detail, onclose }: Props = $props();
 
-	let { settings, user, missionControlId } = $derived(detail as JunoModalMonitoringStrategyDetail);
+	let { settings, user, missionControlId } = $derived(detail as JunoModalCreateMonitoringStrategyDetail);
 
 	// Wizard navigation
 

--- a/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
+++ b/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
@@ -34,9 +34,7 @@
 
 	let { detail, onclose }: Props = $props();
 
-	let { settings, metadata, missionControlId } = $derived(
-		detail as JunoModalMonitoringStrategyDetail
-	);
+	let { settings, user, missionControlId } = $derived(detail as JunoModalMonitoringStrategyDetail);
 
 	// Wizard navigation
 
@@ -93,13 +91,14 @@
 
 	// Monitoring email
 
+	let metadata = $derived(user.metadata);
 	let missionControlEmail = $derived(metadataEmail(metadata));
 	let hasMissionControlEmail = $derived(nonNullish(missionControlEmail));
 	let userEmail: Option<string> = $state(undefined);
 
 	// Monitoring config
 
-	let monitoringConfig = $derived(fromNullable(settings?.monitoring_config ?? []));
+	let monitoringConfig = $derived(fromNullable(fromNullable(user?.config ?? [])?.monitoring ?? []));
 
 	let defaultStrategy = $derived(
 		fromNullable(fromNullable(monitoringConfig?.cycles ?? [])?.default_strategy ?? [])

--- a/src/frontend/src/lib/components/modals/StopMonitoringStrategyModal.svelte
+++ b/src/frontend/src/lib/components/modals/StopMonitoringStrategyModal.svelte
@@ -15,7 +15,7 @@
 	import { authStore } from '$lib/stores/auth.store';
 	import { wizardBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { JunoModalDetail, JunoModalMonitoringStrategyDetail } from '$lib/types/modal';
+	import type { JunoModalDetail, JunoModalCreateMonitoringStrategyDetail } from '$lib/types/modal';
 	import type { MonitoringStrategyProgress } from '$lib/types/strategy';
 
 	interface Props {
@@ -25,7 +25,7 @@
 
 	let { detail, onclose }: Props = $props();
 
-	let { settings, missionControlId } = $derived(detail as JunoModalMonitoringStrategyDetail);
+	let { settings, missionControlId } = $derived(detail as JunoModalCreateMonitoringStrategyDetail);
 
 	let selectedSatellites: [Principal, Satellite][] = $state([]);
 	let selectedOrbiters: [Principal, Orbiter][] = $state([]);

--- a/src/frontend/src/lib/components/monitoring/MonitoringNotifications.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringNotifications.svelte
@@ -6,7 +6,7 @@
 	import Value from '$lib/components/ui/Value.svelte';
 	import {
 		missionControlIdDerived,
-		missionControlMonitoringConfig,
+		missionControlConfigMonitoring,
 		missionControlSettingsLoaded
 	} from '$lib/derived/mission-control.derived';
 	import { setMonitoringNotification } from '$lib/services/monitoring.services';
@@ -17,7 +17,7 @@
 	let enabled = $state(false);
 
 	let monitoringEnabled = $derived(
-		fromNullable(fromNullable($missionControlMonitoringConfig?.cycles ?? [])?.notification ?? [])
+		fromNullable(fromNullable($missionControlConfigMonitoring?.cycles ?? [])?.notification ?? [])
 			?.enabled === true
 	);
 
@@ -36,7 +36,7 @@
 		await setMonitoringNotification({
 			identity: $authStore.identity,
 			missionControlId: $missionControlIdDerived,
-			monitoringConfig: $missionControlMonitoringConfig,
+			monitoringConfig: $missionControlConfigMonitoring,
 			enabled
 		});
 

--- a/src/frontend/src/lib/components/monitoring/MonitoringNotifications.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringNotifications.svelte
@@ -59,7 +59,7 @@
 				{$i18n.monitoring.notifications}
 			{/snippet}
 
-			<Toggle toggle={!enabled} onclick={onToggle}
+			<Toggle {enabled} onclick={onToggle}
 				><span>{enabled ? $i18n.core.enabled : $i18n.core.disabled}</span></Toggle
 			>
 		</Value>

--- a/src/frontend/src/lib/components/monitoring/ProgressMonitoring.svelte
+++ b/src/frontend/src/lib/components/monitoring/ProgressMonitoring.svelte
@@ -49,7 +49,7 @@
 		reload: {
 			state: 'next',
 			step: 'reload',
-			text: $i18n.monitoring.reload_settings
+			text: $i18n.monitoring.reload_data
 		}
 	});
 

--- a/src/frontend/src/lib/components/ui/Theme.svelte
+++ b/src/frontend/src/lib/components/ui/Theme.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Toggle
-	toggle={dark}
+	enabled={!dark}
 	onclick={() => theme.select(dark ? Theme.LIGHT : Theme.DARK)}
 	nomargin={!inline}
 >

--- a/src/frontend/src/lib/components/ui/Toggle.svelte
+++ b/src/frontend/src/lib/components/ui/Toggle.svelte
@@ -5,14 +5,14 @@
 
 	interface Props {
 		children: Snippet;
-		toggle: boolean;
+		enabled: boolean;
 		onclick: () => void;
 		nomargin?: boolean;
 	}
 
-	let { children, onclick, toggle, nomargin = false }: Props = $props();
+	let { children, onclick, enabled, nomargin = false }: Props = $props();
 
-	let Icon = $derived(toggle ? IconLightOff : IconLightOn);
+	let Icon = $derived(enabled ? IconLightOn : IconLightOff);
 </script>
 
 <button class="text" class:nomargin {onclick}>

--- a/src/frontend/src/lib/derived/mission-control.derived.ts
+++ b/src/frontend/src/lib/derived/mission-control.derived.ts
@@ -1,7 +1,7 @@
 import {
 	missionControlIdDataStore,
-	missionControlMetadataDataStore,
-	missionControlSettingsDataStore
+	missionControlSettingsDataStore,
+	missionControlUserDataStore
 } from '$lib/stores/mission-control.store';
 import { metadataEmail } from '$lib/utils/metadata.utils';
 import { fromNullable, nonNullish } from '@dfinity/utils';
@@ -38,9 +38,18 @@ export const missionControlMonitoring = derived(
 	([$missionControlSettings]) => fromNullable($missionControlSettings?.monitoring ?? [])
 );
 
-export const missionControlMonitoringConfig = derived(
-	[missionControlSettings],
-	([$missionControlSettings]) => fromNullable($missionControlSettings?.monitoring_config ?? [])
+export const missionControlUserData = derived(
+	[missionControlUserDataStore],
+	([$missionControlUserDataStore]) => $missionControlUserDataStore?.data
+);
+
+export const missionControlConfig = derived([missionControlUserData], ([$missionControlUserData]) =>
+	fromNullable($missionControlUserData?.config ?? [])
+);
+
+export const missionControlConfigMonitoring = derived(
+	[missionControlConfig],
+	([$missionControlConfig]) => fromNullable($missionControlConfig?.monitoring ?? [])
 );
 
 export const missionControlMonitored = derived(
@@ -49,18 +58,16 @@ export const missionControlMonitored = derived(
 		fromNullable($missionControlMonitoring?.cycles ?? [])?.enabled === true
 );
 
-export const missionControlMetadataLoaded = derived(
-	[missionControlMetadataDataStore],
-	([$missionControlMetadataDataStore]) => $missionControlMetadataDataStore !== undefined
+export const missionControlUserDataLoaded = derived(
+	[missionControlUserDataStore],
+	([$missionControlUserDataStore]) => $missionControlUserDataStore !== undefined
 );
 
 export const missionControlMetadata = derived(
-	[missionControlMetadataDataStore],
-	([$missionControlMetadataDataStore]) => $missionControlMetadataDataStore?.data
+	[missionControlUserData],
+	([$missionControlUserData]) => $missionControlUserData?.metadata
 );
 
-export const missionControlEmail = derived(
-	[missionControlMetadataDataStore],
-	([$missionControlMetadataDataStore]) =>
-		metadataEmail($missionControlMetadataDataStore?.data ?? [])
+export const missionControlEmail = derived([missionControlUserData], ([$missionControlUserData]) =>
+	metadataEmail($missionControlUserData?.metadata ?? [])
 );

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -530,7 +530,7 @@
 		"auth_domain_config": "Unexpected error(s) while trying to update your authentication configuration",
 		"mission_control_not_loaded": "Your mission control is not yet loaded.",
 		"mission_control_settings_not_loaded": "The settings for the mission control are not yet loaded.",
-		"mission_control_metadata_not_loaded": "The metadata for the mission control are not yet loaded.",
+		"mission_control_user_data_not_loaded": "Your data (metadata, config, etc) for the mission control are not yet loaded.",
 		"monitoring_apply_strategy_error": "Unexpected error(s) while applying the strategy.",
 		"monitoring_stop_error": "Unexpected error(s) while stopping the monitoring.",
 		"monitoring_no_modules": "Monitoring requires at least one satellite or orbiter to be set up. Add a module to get started.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -708,7 +708,7 @@
 		"review_strategy": "Review Strategy",
 		"warning_advice": "Go to the Monitoring section to enable it and ensure sufficient cycles for your modules.",
 		"strategy_preparing": "Preparing...",
-		"reload_settings": "Reloading settings...",
+		"reload_data": "Reloading data...",
 		"saving_options": "Saving options...",
 		"stop_monitoring_question": "Do you want to stop monitoring your Mission Control as well?",
 		"stop_monitoring_note": "<strong>Important Note</strong>: it can only be stopped if all your modules are about to stop being monitored or if none are still monitored.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -454,7 +454,7 @@
 		"load_documents": "Unexpected error(s) while loading the documents.",
 		"load_users": "Unexpected error(s) while loading the users.",
 		"load_settings": "Unexpected error(s) while loading the settings.",
-		"load_metadata": "Unexpected error(s) while loading the metadata.",
+		"load_user_data": "Unexpected error(s) while loading your data (configuration, metadata, etc.).",
 		"hosting_missing_domain_name": "A domain name must be provided.",
 		"hosting_invalid_url": "Please provide a valid URL.",
 		"hosting_missing_dns_configuration": "A domain name configuration must be provided.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -708,7 +708,7 @@
 		"review_strategy": "Review Strategy",
 		"warning_advice": "Go to the Monitoring section to enable it and ensure sufficient cycles for your modules.",
 		"strategy_preparing": "Preparing...",
-		"reload_settings": "Reloading settings...",
+		"reload_data": "Reloading data...",
 		"saving_options": "Saving options...",
 		"stop_monitoring_question": "Do you want to stop monitoring your Mission Control as well?",
 		"stop_monitoring_note": "<strong>Important Note</strong>: it can only be stopped if all your modules are about to stop being monitored or if none are still monitored.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -530,7 +530,7 @@
 		"auth_domain_config": "更新认证配置是出现异常错误",
 		"mission_control_not_loaded": "Your mission control is not yet loaded.",
 		"mission_control_settings_not_loaded": "The settings for the mission control are not yet loaded.",
-		"mission_control_metadata_not_loaded": "The metadata for the mission control are not yet loaded.",
+		"mission_control_user_data_not_loaded": "Your data (metadata, config, etc) for the mission control are not yet loaded.",
 		"monitoring_apply_strategy_error": "Unexpected error(s) while applying the strategy.",
 		"monitoring_stop_error": "Unexpected error(s) while stopping the monitoring.",
 		"monitoring_no_modules": "Monitoring requires at least one satellite or orbiter to be set up. Add a module to get started.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -454,7 +454,7 @@
 		"load_documents": "Unexpected error(s) while loading the documents.",
 		"load_users": "Unexpected error(s) while loading the users.",
 		"load_settings": "Unexpected error(s) while loading the settings.",
-		"load_metadata": "Unexpected error(s) while loading the metadata.",
+		"load_user_data": "Unexpected error(s) while loading your data (configuration, metadata, etc.).",
 		"hosting_missing_domain_name": "必须提供一个域名.",
 		"hosting_invalid_url": "请提供一个有效的 URL.",
 		"hosting_missing_dns_configuration": "必须提供域名配置信息.",

--- a/src/frontend/src/lib/services/monitoring.services.ts
+++ b/src/frontend/src/lib/services/monitoring.services.ts
@@ -12,6 +12,7 @@ import {
 	updateAndStopMonitoring
 } from '$lib/api/mission-control.api';
 import { METADATA_KEY_EMAIL } from '$lib/constants/metadata.constants';
+import { missionControlUserData } from '$lib/derived/mission-control.derived';
 import { orbiterNotLoaded, orbiterStore } from '$lib/derived/orbiter.derived';
 import { satellitesNotLoaded, satellitesStore } from '$lib/derived/satellite.derived';
 import { loadSettings, loadUserData } from '$lib/services/mission-control.services';
@@ -19,13 +20,11 @@ import { loadOrbiters } from '$lib/services/orbiters.services';
 import { execute } from '$lib/services/progress.services';
 import { loadSatellites } from '$lib/services/satellites.services';
 import { i18n } from '$lib/stores/i18n.store';
-import {
-	missionControlSettingsDataStore,
-	missionControlUserDataStore
-} from '$lib/stores/mission-control.store';
+import { missionControlSettingsDataStore } from '$lib/stores/mission-control.store';
 import { toasts } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/itentity';
 import type { Metadata } from '$lib/types/metadata';
+import type { JunoModal, JunoModalCreateMonitoringStrategyDetail } from '$lib/types/modal';
 import {
 	type MonitoringStrategyProgress,
 	MonitoringStrategyProgressStep
@@ -43,8 +42,6 @@ import {
 	toNullable
 } from '@dfinity/utils';
 import { get } from 'svelte/store';
-import type {JunoModal, JunoModalCreateMonitoringStrategyDetail} from "$lib/types/modal";
-import {missionControlUserData} from "$lib/derived/mission-control.derived";
 
 type MonitoringStrategyOnProgress = (progress: MonitoringStrategyProgress | undefined) => void;
 

--- a/src/frontend/src/lib/services/monitoring.services.ts
+++ b/src/frontend/src/lib/services/monitoring.services.ts
@@ -43,6 +43,8 @@ import {
 	toNullable
 } from '@dfinity/utils';
 import { get } from 'svelte/store';
+import type {JunoModal, JunoModalCreateMonitoringStrategyDetail} from "$lib/types/modal";
+import {missionControlUserData} from "$lib/derived/mission-control.derived";
 
 type MonitoringStrategyOnProgress = (progress: MonitoringStrategyProgress | undefined) => void;
 
@@ -464,9 +466,9 @@ export const openMonitoringModal = ({
 		return;
 	}
 
-	const $missionControlMetadataDataStore = get(missionControlUserDataStore);
-	if (isNullish($missionControlMetadataDataStore)) {
-		toasts.warn(get(i18n).errors.mission_control_metadata_not_loaded);
+	const $missionControlUserData = get(missionControlUserData);
+	if (isNullish($missionControlUserData)) {
+		toasts.warn(get(i18n).errors.mission_control_user_data_not_loaded);
 		return;
 	}
 
@@ -489,13 +491,13 @@ export const openMonitoringModal = ({
 		return;
 	}
 
-	emit({
+	emit<JunoModal<JunoModalCreateMonitoringStrategyDetail>>({
 		message: 'junoModal',
 		detail: {
 			type,
 			detail: {
 				settings: $missionControlSettingsDataStore.data,
-				metadata: $missionControlMetadataDataStore.data,
+				user: $fmissionControlUserData,
 				missionControlId
 			}
 		}

--- a/src/frontend/src/lib/services/monitoring.services.ts
+++ b/src/frontend/src/lib/services/monitoring.services.ts
@@ -497,7 +497,7 @@ export const openMonitoringModal = ({
 			type,
 			detail: {
 				settings: $missionControlSettingsDataStore.data,
-				user: $fmissionControlUserData,
+				user: $missionControlUserData,
 				missionControlId
 			}
 		}

--- a/src/frontend/src/lib/services/monitoring.services.ts
+++ b/src/frontend/src/lib/services/monitoring.services.ts
@@ -541,7 +541,7 @@ export const setMonitoringNotification = async ({
 			config
 		});
 
-		await loadSettings({
+		await loadUserData({
 			identity,
 			missionControlId,
 			reload: true

--- a/src/frontend/src/lib/services/wizard.services.ts
+++ b/src/frontend/src/lib/services/wizard.services.ts
@@ -8,7 +8,7 @@ import { updateAndStartMonitoring } from '$lib/api/mission-control.api';
 import { missionControlConfigMonitoring } from '$lib/derived/mission-control.derived';
 import { getMissionControlBalance } from '$lib/services/balance.services';
 import { loadVersion } from '$lib/services/console.services';
-import { loadSettings } from '$lib/services/mission-control.services';
+import { loadUserData } from '$lib/services/mission-control.services';
 import {
 	createOrbiter,
 	createOrbiterWithConfig,
@@ -105,7 +105,7 @@ const initCreateWizard = async ({
 		skipReload: true
 	});
 
-	const { success } = await loadSettings({
+	const { success } = await loadUserData({
 		identity,
 		missionControlId
 	});

--- a/src/frontend/src/lib/services/wizard.services.ts
+++ b/src/frontend/src/lib/services/wizard.services.ts
@@ -5,7 +5,7 @@ import type {
 } from '$declarations/mission_control/mission_control.did';
 import { getOrbiterFee, getSatelliteFee } from '$lib/api/console.api';
 import { updateAndStartMonitoring } from '$lib/api/mission-control.api';
-import { missionControlMonitoringConfig } from '$lib/derived/mission-control.derived';
+import { missionControlConfigMonitoring } from '$lib/derived/mission-control.derived';
 import { getMissionControlBalance } from '$lib/services/balance.services';
 import { loadVersion } from '$lib/services/console.services';
 import { loadSettings } from '$lib/services/mission-control.services';
@@ -116,7 +116,7 @@ const initCreateWizard = async ({
 		return;
 	}
 
-	const monitoringConfig = get(missionControlMonitoringConfig);
+	const monitoringConfig = get(missionControlConfigMonitoring);
 
 	emit<JunoModal<JunoModalCreateSegmentDetail>>({
 		message: 'junoModal',

--- a/src/frontend/src/lib/stores/mission-control.store.ts
+++ b/src/frontend/src/lib/stores/mission-control.store.ts
@@ -1,10 +1,12 @@
-import type { MissionControlSettings } from '$declarations/mission_control/mission_control.did';
+import type {
+	MissionControlSettings,
+	User
+} from '$declarations/mission_control/mission_control.did';
 import { initDataStore } from '$lib/stores/data.store';
-import type { Metadata } from '$lib/types/metadata';
 import type { Principal } from '@dfinity/principal';
 
 export const missionControlIdDataStore = initDataStore<Principal>();
 
-export const missionControlMetadataDataStore = initDataStore<Metadata>();
+export const missionControlUserDataStore = initDataStore<User>();
 
 export const missionControlSettingsDataStore = initDataStore<MissionControlSettings | undefined>();

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -733,7 +733,7 @@ interface I18nMonitoring {
 	review_strategy: string;
 	warning_advice: string;
 	strategy_preparing: string;
-	reload_settings: string;
+	reload_data: string;
 	saving_options: string;
 	stop_monitoring_question: string;
 	stop_monitoring_note: string;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -470,7 +470,7 @@ interface I18nErrors {
 	load_documents: string;
 	load_users: string;
 	load_settings: string;
-	load_metadata: string;
+	load_user_data: string;
 	hosting_missing_domain_name: string;
 	hosting_invalid_url: string;
 	hosting_missing_dns_configuration: string;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -546,7 +546,7 @@ interface I18nErrors {
 	auth_domain_config: string;
 	mission_control_not_loaded: string;
 	mission_control_settings_not_loaded: string;
-	mission_control_metadata_not_loaded: string;
+	mission_control_user_data_not_loaded: string;
 	monitoring_apply_strategy_error: string;
 	monitoring_stop_error: string;
 	monitoring_no_modules: string;

--- a/src/frontend/src/lib/types/modal.ts
+++ b/src/frontend/src/lib/types/modal.ts
@@ -3,7 +3,8 @@ import type {
 	MissionControlSettings,
 	Monitoring,
 	MonitoringConfig,
-	Satellite
+	Satellite,
+	User
 } from '$declarations/mission_control/mission_control.did';
 import type { OrbiterSatelliteFeatures } from '$declarations/orbiter/orbiter.did';
 import type { AuthenticationConfig, Rule } from '$declarations/satellite/satellite.did';
@@ -11,7 +12,6 @@ import type { MissionControlBalance } from '$lib/types/balance';
 import type { CanisterSegmentWithLabel, CanisterSettings } from '$lib/types/canister';
 import type { SetControllerParams } from '$lib/types/controllers';
 import type { CustomDomains } from '$lib/types/custom-domain';
-import type { Metadata } from '$lib/types/metadata';
 import type { OrbiterSatelliteConfigEntry } from '$lib/types/ortbiter';
 import type { SatelliteIdText } from '$lib/types/satellite';
 import type { Option } from '$lib/types/utils';
@@ -106,7 +106,7 @@ export interface JunoModalEditAuthConfigDetail extends JunoModalSatelliteDetail 
 export interface JunoModalMonitoringStrategyDetail {
 	missionControlId: Principal;
 	settings: MissionControlSettings | undefined;
-	metadata: Metadata;
+	user: User;
 }
 
 export interface JunoModalShowMonitoringDetail extends JunoModalSegmentDetail {

--- a/src/frontend/src/lib/types/modal.ts
+++ b/src/frontend/src/lib/types/modal.ts
@@ -103,7 +103,7 @@ export interface JunoModalEditAuthConfigDetail extends JunoModalSatelliteDetail 
 	config: AuthenticationConfig | undefined;
 }
 
-export interface JunoModalMonitoringStrategyDetail {
+export interface JunoModalCreateMonitoringStrategyDetail {
 	missionControlId: Principal;
 	settings: MissionControlSettings | undefined;
 	user: User;
@@ -125,7 +125,7 @@ export type JunoModalDetail =
 	| JunoModalDeleteSatelliteDetail
 	| JunoModalSendTokensDetail
 	| JunoModalEditOrbiterConfigDetail
-	| JunoModalMonitoringStrategyDetail;
+	| JunoModalCreateMonitoringStrategyDetail;
 
 export interface JunoModal<T extends JunoModalDetail> {
 	type:

--- a/src/mission_control/mission_control.did
+++ b/src/mission_control/mission_control.did
@@ -132,6 +132,13 @@ type TransferError_1 = variant {
   TooOld;
   InsufficientFunds : record { balance : nat };
 };
+type User = record {
+  updated_at : nat64;
+  metadata : vec record { text; text };
+  user : opt principal;
+  created_at : nat64;
+  config : opt Config;
+};
 service : () -> {
   add_mission_control_controllers : (vec principal) -> ();
   add_satellites_controllers : (vec principal, vec principal) -> ();
@@ -153,6 +160,7 @@ service : () -> {
   get_monitoring_status : () -> (MonitoringStatus) query;
   get_settings : () -> (opt MissionControlSettings) query;
   get_user : () -> (principal) query;
+  get_user_data : () -> (User) query;
   icp_transfer : (TransferArgs) -> (Result);
   icrc_transfer : (principal, TransferArg) -> (Result_1);
   list_mission_control_controllers : () -> (

--- a/src/mission_control/mission_control.did
+++ b/src/mission_control/mission_control.did
@@ -1,4 +1,5 @@
 type Account = record { owner : principal; subaccount : opt blob };
+type Config = record { monitoring : opt MonitoringConfig };
 type Controller = record {
   updated_at : nat64;
   metadata : vec record { text; text };
@@ -48,7 +49,6 @@ type GetMonitoringHistory = record {
 };
 type MissionControlSettings = record {
   updated_at : nat64;
-  monitoring_config : opt MonitoringConfig;
   created_at : nat64;
   monitoring : opt Monitoring;
 };
@@ -145,6 +145,7 @@ service : () -> {
   del_satellite : (principal, nat) -> ();
   del_satellites_controllers : (vec principal, vec principal) -> ();
   deposit_cycles : (DepositCyclesArgs) -> ();
+  get_config : () -> (opt Config) query;
   get_metadata : () -> (vec record { text; text }) query;
   get_monitoring_history : (GetMonitoringHistory) -> (
       vec record { MonitoringHistoryKey; MonitoringHistory },
@@ -161,9 +162,9 @@ service : () -> {
   list_satellites : () -> (vec record { principal; Satellite }) query;
   remove_mission_control_controllers : (vec principal) -> ();
   remove_satellites_controllers : (vec principal, vec principal) -> ();
+  set_config : (opt Config) -> ();
   set_metadata : (vec record { text; text }) -> ();
   set_mission_control_controllers : (vec principal, SetController) -> ();
-  set_monitoring_config : (opt MonitoringConfig) -> ();
   set_orbiter : (principal, opt text) -> (Orbiter);
   set_orbiter_metadata : (principal, vec record { text; text }) -> (Orbiter);
   set_orbiters_controllers : (

--- a/src/mission_control/src/controllers/mission_control.rs
+++ b/src/mission_control/src/controllers/mission_control.rs
@@ -1,5 +1,5 @@
 use crate::controllers::store::{delete_controllers, get_admin_controllers, set_controllers};
-use crate::store::get_user;
+use crate::user::store::get_user;
 use ic_cdk::id;
 use junobuild_shared::constants::MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS;
 use junobuild_shared::controllers::{

--- a/src/mission_control/src/guards.rs
+++ b/src/mission_control/src/guards.rs
@@ -1,5 +1,5 @@
 use crate::memory::STATE;
-use crate::store::get_user;
+use crate::user::store::get_user;
 use ic_cdk::api::is_controller as ic_canister_controller;
 use ic_cdk::caller;
 use junobuild_shared::controllers::is_admin_controller;

--- a/src/mission_control/src/impls.rs
+++ b/src/mission_control/src/impls.rs
@@ -2,7 +2,7 @@ use crate::memory::init_stable_state;
 use crate::types::core::{Segment, SettingsMonitoring};
 use crate::types::state::CyclesMonitoringStrategy::BelowThreshold;
 use crate::types::state::{
-    Archive, ArchiveStatuses, CyclesMonitoring, CyclesMonitoringStrategy, HeapState,
+    Archive, ArchiveStatuses, Config, CyclesMonitoring, CyclesMonitoringStrategy, HeapState,
     MissionControlSettings, Monitoring, MonitoringConfig, MonitoringHistory, MonitoringHistoryKey,
     Orbiter, Orbiters, Satellite, Settings, State, User,
 };
@@ -44,6 +44,7 @@ impl From<&UserId> for User {
         User {
             user: Some(*user),
             metadata: HashMap::new(),
+            config: None,
             created_at: now,
             updated_at: now,
         }
@@ -238,24 +239,34 @@ impl CyclesMonitoringStrategy {
     }
 }
 
+impl User {
+    pub fn clone_with_metadata(&self, metadata: &Metadata) -> Self {
+        let now = time();
+
+        User {
+            metadata: metadata.clone(),
+            updated_at: now,
+            ..self.clone()
+        }
+    }
+
+    pub fn clone_with_config(&self, config: &Option<Config>) -> Self {
+        let now = time();
+
+        User {
+            config: config.clone(),
+            updated_at: now,
+            ..self.clone()
+        }
+    }
+}
+
 impl MissionControlSettings {
     pub fn from_strategy(strategy: &CyclesMonitoringStrategy) -> Self {
         let now = time();
 
         MissionControlSettings {
             monitoring: Some(Monitoring::from(strategy)),
-            monitoring_config: None,
-            updated_at: now,
-            created_at: now,
-        }
-    }
-
-    pub fn from_config(config: &Option<MonitoringConfig>) -> Self {
-        let now = time();
-
-        MissionControlSettings {
-            monitoring: None,
-            monitoring_config: config.clone(),
             updated_at: now,
             created_at: now,
         }
@@ -266,16 +277,6 @@ impl MissionControlSettings {
 
         MissionControlSettings {
             monitoring: Some(Monitoring::from(strategy)),
-            updated_at: now,
-            ..self.clone()
-        }
-    }
-
-    pub fn clone_with_config(&self, config: &Option<MonitoringConfig>) -> Self {
-        let now = time();
-
-        MissionControlSettings {
-            monitoring_config: config.clone(),
             updated_at: now,
             ..self.clone()
         }

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -37,10 +37,7 @@ use crate::types::interface::{
     CreateCanisterConfig, GetMonitoringHistory, MonitoringStartConfig, MonitoringStatus,
     MonitoringStopConfig,
 };
-use crate::types::state::{
-    Config, HeapState, MissionControlSettings, MonitoringConfig, MonitoringHistory,
-    MonitoringHistoryKey, Orbiter, Orbiters, Satellite, Satellites, State,
-};
+use crate::types::state::{Config, HeapState, MissionControlSettings, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters, Satellite, Satellites, State, User};
 use candid::Principal;
 use ciborium::into_writer;
 use ic_cdk::api::call::{arg_data, ArgDecoderConfig};
@@ -74,7 +71,7 @@ use std::collections::HashMap;
 use user::store::{
     get_config as get_config_store, get_metadata as get_metadata_store,
     get_settings as get_settings_store, get_user as get_user_store, set_config as set_config_store,
-    set_metadata as set_metadata_store,
+    set_metadata as set_metadata_store, get_user_data as get_user_data_store,
 };
 
 #[init]
@@ -367,6 +364,11 @@ fn list_mission_control_controllers() -> Controllers {
 #[query(guard = "caller_is_user_or_admin_controller")]
 fn get_user() -> UserId {
     get_user_store()
+}
+
+#[query(guard = "caller_is_user_or_admin_controller")]
+fn get_user_data() -> User {
+    get_user_data_store()
 }
 
 #[query(guard = "caller_is_user_or_admin_controller")]

--- a/src/mission_control/src/monitoring/cycles/notification.rs
+++ b/src/mission_control/src/monitoring/cycles/notification.rs
@@ -1,7 +1,7 @@
 use crate::monitoring::cycles::utils::get_deposited_cycles;
 use crate::monitoring::observatory::notify_observatory;
 use crate::segments::store::{get_orbiter, get_satellite};
-use crate::store::{get_metadata, get_user};
+use crate::user::store::{get_config, get_metadata, get_user};
 use canfund::manager::record::CanisterRecord;
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_cdk::{id, print, spawn};
@@ -14,7 +14,6 @@ use junobuild_shared::types::state::{
 use junobuild_shared::utils::principal_equal;
 use std::collections::HashMap;
 use std::time::Duration;
-use crate::monitoring::store::heap::get_monitoring_config;
 
 pub fn defer_notify(records: HashMap<CanisterId, CanisterRecord>) {
     set_timer(Duration::ZERO, || spawn(notify(records)));
@@ -38,7 +37,7 @@ async fn notify(records: HashMap<CanisterId, CanisterRecord>) {
 }
 
 fn prepare_args(canister_id: &CanisterId, deposited_cycles: &CyclesBalance) -> Option<NotifyArgs> {
-    let config = get_monitoring_config()?.cycles?.notification?;
+    let config = get_config()?.monitoring?.cycles?.notification?;
 
     if !config.enabled {
         return None;

--- a/src/mission_control/src/monitoring/cycles/start.rs
+++ b/src/mission_control/src/monitoring/cycles/start.rs
@@ -8,10 +8,10 @@ use crate::monitoring::store::heap::{
     enable_mission_control_monitoring, enable_orbiter_monitoring, enable_satellite_monitoring,
 };
 use crate::segments::store::{get_orbiters, get_satellites};
-use crate::store::get_settings;
 use crate::types::core::SettingsMonitoring;
 use crate::types::runtime::RuntimeState;
 use crate::types::state::CyclesMonitoringStrategy;
+use crate::user::store::get_settings;
 use ic_cdk::id;
 use junobuild_shared::types::state::SegmentId;
 

--- a/src/mission_control/src/monitoring/monitor.rs
+++ b/src/mission_control/src/monitoring/monitor.rs
@@ -4,7 +4,6 @@ use crate::monitoring::cycles::config::{
 use crate::monitoring::cycles::start::start_cycles_monitoring;
 use crate::monitoring::cycles::status::get_cycles_monitoring_status;
 use crate::monitoring::cycles::stop::stop_cycles_monitoring;
-use crate::monitoring::store::heap::set_monitoring_config;
 use crate::monitoring::store::stable::get_monitoring_history as get_monitoring_history_store;
 use crate::types::interface::{
     GetMonitoringHistory, MonitoringStartConfig, MonitoringStatus, MonitoringStopConfig,
@@ -59,8 +58,4 @@ pub fn get_monitoring_history(
     filter: &GetMonitoringHistory,
 ) -> Vec<(MonitoringHistoryKey, MonitoringHistory)> {
     get_monitoring_history_store(filter)
-}
-
-pub fn update_monitoring_config(config: &Option<MonitoringConfig>) {
-    set_monitoring_config(config);
 }

--- a/src/mission_control/src/monitoring/store/heap.rs
+++ b/src/mission_control/src/monitoring/store/heap.rs
@@ -5,14 +5,6 @@ use crate::types::state::{
 };
 use junobuild_shared::types::state::{OrbiterId, SatelliteId};
 
-pub fn get_monitoring_config() -> Option<MonitoringConfig> {
-    STATE.with(|state| state.borrow().heap.settings.as_ref().and_then(|settings| settings.monitoring_config.clone()))
-}
-
-pub fn set_monitoring_config(config: &Option<MonitoringConfig>) {
-    STATE.with(|state| set_monitoring_config_impl(config, &mut state.borrow_mut().heap))
-}
-
 pub fn set_mission_control_strategy(strategy: &CyclesMonitoringStrategy) {
     STATE.with(|state| set_mission_control_strategy_impl(strategy, &mut state.borrow_mut().heap))
 }
@@ -86,16 +78,6 @@ fn set_mission_control_strategy_impl(strategy: &CyclesMonitoringStrategy, state:
             .as_ref()
             .map(|settings| settings.clone_with_strategy(strategy))
             .unwrap_or_else(|| MissionControlSettings::from_strategy(strategy)),
-    );
-}
-
-fn set_monitoring_config_impl(config: &Option<MonitoringConfig>, state: &mut HeapState) {
-    state.settings = Some(
-        state
-            .settings
-            .as_ref()
-            .map(|settings| settings.clone_with_config(config))
-            .unwrap_or_else(|| MissionControlSettings::from_config(config)),
     );
 }
 

--- a/src/mission_control/src/segments/canister.rs
+++ b/src/mission_control/src/segments/canister.rs
@@ -1,5 +1,5 @@
-use crate::store::get_user;
 use crate::types::interface::CreateCanisterConfig;
+use crate::user::store::get_user;
 use candid::Principal;
 use ic_cdk::api::call::CallResult;
 use ic_cdk::{call, id};

--- a/src/mission_control/src/types.rs
+++ b/src/mission_control/src/types.rs
@@ -63,8 +63,8 @@ pub mod state {
         pub monitoring: Option<MonitoringConfig>,
     }
 
-    // The settings of the mission control itself, similar to those contained in Satellite or Orbiter.
-    // This way we can have a specific timestamp.
+    // The configuration of Mission Control, similar to the settings found in a Satellite or Orbiter.
+    // This approach allows us to include a specific timestamp.
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct MissionControlSettings {
         pub monitoring: Option<Monitoring>,

--- a/src/mission_control/src/types.rs
+++ b/src/mission_control/src/types.rs
@@ -55,13 +55,19 @@ pub mod state {
         pub created_at: Timestamp,
         pub updated_at: Timestamp,
         pub metadata: Metadata,
+        pub config: Option<Config>,
     }
 
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
+    pub struct Config {
+        pub monitoring: Option<MonitoringConfig>,
+    }
+
+    // The settings of the mission control itself, similar to those contained in Satellite or Orbiter.
+    // This way we can have a specific timestamp.
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct MissionControlSettings {
-        // The monitoring rules to observe the mission control itself
         pub monitoring: Option<Monitoring>,
-        pub monitoring_config: Option<MonitoringConfig>,
         pub created_at: Timestamp,
         pub updated_at: Timestamp,
     }

--- a/src/mission_control/src/user/mod.rs
+++ b/src/mission_control/src/user/mod.rs
@@ -1,0 +1,1 @@
+pub mod store;

--- a/src/mission_control/src/user/store.rs
+++ b/src/mission_control/src/user/store.rs
@@ -1,6 +1,5 @@
 use crate::memory::STATE;
-use crate::types::state::{HeapState, MissionControlSettings, User};
-use ic_cdk::api::time;
+use crate::types::state::{Config, HeapState, MissionControlSettings};
 use junobuild_shared::types::state::{Metadata, UserId};
 
 pub fn get_user() -> UserId {
@@ -19,15 +18,20 @@ pub fn set_metadata(metadata: &Metadata) {
     STATE.with(|state| set_metadata_impl(metadata, &mut state.borrow_mut().heap))
 }
 
+pub fn get_config() -> Option<Config> {
+    STATE.with(|state| state.borrow().heap.user.config.clone())
+}
+
+pub fn set_config(config: &Option<Config>) {
+    STATE.with(|state| set_config_impl(config, &mut state.borrow_mut().heap))
+}
+
 fn set_metadata_impl(metadata: &Metadata, state: &mut HeapState) {
-    let now = time();
+    let updated_user = state.user.clone_with_metadata(metadata);
+    state.user = updated_user;
+}
 
-    let updated_user = User {
-        user: state.user.user,
-        metadata: metadata.clone(),
-        created_at: state.user.created_at,
-        updated_at: now,
-    };
-
+fn set_config_impl(config: &Option<Config>, state: &mut HeapState) {
+    let updated_user = state.user.clone_with_config(config);
     state.user = updated_user;
 }

--- a/src/mission_control/src/user/store.rs
+++ b/src/mission_control/src/user/store.rs
@@ -1,9 +1,13 @@
 use crate::memory::STATE;
-use crate::types::state::{Config, HeapState, MissionControlSettings};
+use crate::types::state::{Config, HeapState, MissionControlSettings, User};
 use junobuild_shared::types::state::{Metadata, UserId};
 
 pub fn get_user() -> UserId {
     STATE.with(|state| state.borrow().heap.user.user).unwrap()
+}
+
+pub fn get_user_data() -> User {
+    STATE.with(|state| state.borrow().heap.user.clone())
 }
 
 pub fn get_settings() -> Option<MissionControlSettings> {

--- a/src/tests/mission-control.monitoring.notifications.spec.ts
+++ b/src/tests/mission-control.monitoring.notifications.spec.ts
@@ -114,18 +114,20 @@ describe('Mission Control - Notifications', () => {
 			});
 
 			// Set an email, enable notification, attach the module that was created and start monitoring
-			const { update_and_start_monitoring, set_metadata, set_monitoring_config, set_satellite } =
+			const { update_and_start_monitoring, set_metadata, set_config, set_satellite } =
 				missionControlActor;
 
 			await set_metadata([['email', 'test@test.com']]);
 
-			await set_monitoring_config(
+			await set_config(
 				toNullable({
-					cycles: toNullable({
-						default_strategy: toNullable(),
-						notification: toNullable({
-							enabled: true,
-							to: toNullable() // We are only using the global email currently but, have foreseen an option
+					monitoring: toNullable({
+						cycles: toNullable({
+							default_strategy: toNullable(),
+							notification: toNullable({
+								enabled: true,
+								to: toNullable() // We are only using the global email currently but, have foreseen an option
+							})
 						})
 					})
 				})

--- a/src/tests/mission-control.monitoring.spec.ts
+++ b/src/tests/mission-control.monitoring.spec.ts
@@ -1,10 +1,10 @@
 import type {
+	Config,
 	CyclesMonitoringStrategy,
 	_SERVICE as MissionControlActor,
 	Monitoring,
-	MonitoringConfig,
 	MonitoringStartConfig,
-	MonitoringStopConfig, Config
+	MonitoringStopConfig
 } from '$declarations/mission_control/mission_control.did';
 import { idlFactory as idlFactorMissionControl } from '$declarations/mission_control/mission_control.factory.did';
 import { AnonymousIdentity } from '@dfinity/agent';
@@ -622,11 +622,9 @@ describe('Mission Control - Monitoring', () => {
 			await testOrbiterMonitoring({ expectedEnabled: true, expectedStrategy: updateStrategy });
 		});
 
-		it('should set monitoring config', async () => {
-			const { set_config, get_config } = actor;
-
-			const config: Config = {
-				monitoring: [{
+		const config: Config = {
+			monitoring: [
+				{
 					cycles: [
 						{
 							default_strategy: [strategy],
@@ -638,8 +636,12 @@ describe('Mission Control - Monitoring', () => {
 							]
 						}
 					]
-				}]
-			};
+				}
+			]
+		};
+
+		it('should set monitoring config', async () => {
+			const { set_config, get_config } = actor;
 
 			await set_config(toNullable(config));
 
@@ -656,6 +658,24 @@ describe('Mission Control - Monitoring', () => {
 			const saved_config = await get_config();
 
 			expect(fromNullable(saved_config)).toBeUndefined();
+		});
+
+		it('should set monitoring config without overwriting metadata', async () => {
+			const { set_config, get_config, set_metadata, get_metadata } = actor;
+
+			const metadata: [string, string][] = [['email', 'test@test.com']];
+
+			await set_metadata(metadata);
+
+			await set_config(toNullable(config));
+
+			const saved_config = await get_config();
+
+			expect(fromNullable(saved_config)).toEqual(config);
+
+			const saved_metadata = await get_metadata();
+
+			expect(saved_metadata).toEqual(metadata);
 		});
 	});
 });

--- a/src/tests/mission-control.monitoring.spec.ts
+++ b/src/tests/mission-control.monitoring.spec.ts
@@ -4,7 +4,7 @@ import type {
 	Monitoring,
 	MonitoringConfig,
 	MonitoringStartConfig,
-	MonitoringStopConfig
+	MonitoringStopConfig, Config
 } from '$declarations/mission_control/mission_control.did';
 import { idlFactory as idlFactorMissionControl } from '$declarations/mission_control/mission_control.factory.did';
 import { AnonymousIdentity } from '@dfinity/agent';
@@ -117,10 +117,16 @@ describe('Mission Control - Monitoring', () => {
 			).rejects.toThrow(CONTROLLER_ERROR_MSG);
 		});
 
-		it('should throw errors on set monitoring config', async () => {
-			const { set_monitoring_config } = actor;
+		it('should throw errors on get config', async () => {
+			const { get_config } = actor;
 
-			await expect(set_monitoring_config([])).rejects.toThrow(CONTROLLER_ERROR_MSG);
+			await expect(get_config()).rejects.toThrow(CONTROLLER_ERROR_MSG);
+		});
+
+		it('should throw errors on set config', async () => {
+			const { set_config } = actor;
+
+			await expect(set_config([])).rejects.toThrow(CONTROLLER_ERROR_MSG);
 		});
 	};
 
@@ -617,37 +623,39 @@ describe('Mission Control - Monitoring', () => {
 		});
 
 		it('should set monitoring config', async () => {
-			const { set_monitoring_config, get_settings } = actor;
+			const { set_config, get_config } = actor;
 
-			const config: MonitoringConfig = {
-				cycles: [
-					{
-						default_strategy: [strategy],
-						notification: [
-							{
-								enabled: true,
-								to: toNullable()
-							}
-						]
-					}
-				]
+			const config: Config = {
+				monitoring: [{
+					cycles: [
+						{
+							default_strategy: [strategy],
+							notification: [
+								{
+									enabled: true,
+									to: toNullable()
+								}
+							]
+						}
+					]
+				}]
 			};
 
-			await set_monitoring_config(toNullable(config));
+			await set_config(toNullable(config));
 
-			const settings = await get_settings();
+			const saved_config = await get_config();
 
-			expect(fromNullable(fromNullable(settings)?.monitoring_config ?? [])).toEqual(config);
+			expect(fromNullable(saved_config)).toEqual(config);
 		});
 
 		it('should set monitoring config to none', async () => {
-			const { set_monitoring_config, get_settings } = actor;
+			const { set_config, get_config } = actor;
 
-			await set_monitoring_config(toNullable());
+			await set_config(toNullable());
 
-			const settings = await get_settings();
+			const saved_config = await get_config();
 
-			expect(fromNullable(fromNullable(settings)?.monitoring_config ?? [])).toBeUndefined();
+			expect(fromNullable(saved_config)).toBeUndefined();
 		});
 	});
 });

--- a/src/tests/mission-control.spec.ts
+++ b/src/tests/mission-control.spec.ts
@@ -1,6 +1,7 @@
 import type {
 	Config,
-	_SERVICE as MissionControlActor, CyclesMonitoringStrategy
+	CyclesMonitoringStrategy,
+	_SERVICE as MissionControlActor
 } from '$declarations/mission_control/mission_control.did';
 import { idlFactory as idlFactorMissionControl } from '$declarations/mission_control/mission_control.factory.did';
 import { AnonymousIdentity } from '@dfinity/agent';


### PR DESCRIPTION
# Motivation

I'm not happy with the structure of the data regarding the monitoring configuration (global parameters like "default strategy"). This is my attempt to have something cleaner, which makes sense while being at least a bit future prone.
