### PR TITLE
feat: monitoring and wallet on launchpad

### DIFF
--- a/src/frontend/src/lib/components/icons/IconAnalytics.svelte
+++ b/src/frontend/src/lib/components/icons/IconAnalytics.svelte
@@ -64,6 +64,6 @@
 	}
 
 	.uuid-6ee6014c-dbb3-4770-b018-42da8f70ae29 {
-		fill: var(--color-background-contrast);
+		fill: currentColor;
 	}
 </style>

--- a/src/frontend/src/lib/components/icons/IconMissionControl.svelte
+++ b/src/frontend/src/lib/components/icons/IconMissionControl.svelte
@@ -39,6 +39,6 @@
 
 	path,
 	circle {
-		fill: var(--color-background-contrast);
+		fill: currentColor;
 	}
 </style>

--- a/src/frontend/src/lib/components/icons/IconTelescope.svelte
+++ b/src/frontend/src/lib/components/icons/IconTelescope.svelte
@@ -27,6 +27,6 @@
 	}
 
 	.icon-telescope-3 {
-		fill: var(--color-background-contrast);
+		fill: currentColor;
 	}
 </style>

--- a/src/frontend/src/lib/components/icons/IconWallet.svelte
+++ b/src/frontend/src/lib/components/icons/IconWallet.svelte
@@ -24,12 +24,12 @@
 		style="fill: var(--color-background);"
 	/><path
 		d="M464,192l0,192c0,26.492 -21.508,48 -48,48l-320,0c-26.492,0 -48,-21.508 -48,-48l0,-192c0,-26.492 21.508,-48 48,-48l320,0c26.492,0 48,21.508 48,48Z"
-		style="fill:none;stroke:var(--color-background-contrast);stroke-width:32px;"
+		style="fill:none;stroke:currentColor;stroke-width:32px;"
 	/><path
 		d="M411.36,144l0,-30c-0.009,-27.423 -22.577,-49.984 -50,-49.984c-3.141,0 -6.275,0.296 -9.36,0.884l-263.36,44.95c-23.5,4.478 -40.656,25.227 -40.64,49.15l0,49"
-		style="fill:none;fill-rule:nonzero;stroke:var(--color-background-contrast);stroke-width:32px;"
+		style="fill:none;fill-rule:nonzero;stroke:currentColor;stroke-width:32px;"
 	/><path
 		d="M368,320c-17.555,0 -32,-14.445 -32,-32c0,-17.555 14.445,-32 32,-32c17.555,0 32,14.445 32,32c0,17.555 -14.445,32 -32,32Z"
-		style="fill-rule:nonzero;fill: var(--color-background-contrast);"
+		style="fill-rule:nonzero;fill: currentColor;"
 	/></svg
 >

--- a/src/frontend/src/lib/components/launchpad/Cockpit.svelte
+++ b/src/frontend/src/lib/components/launchpad/Cockpit.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { fade } from 'svelte/transition';
 	import { run } from 'svelte/legacy';
+	import { fade } from 'svelte/transition';
 	import Canister from '$lib/components/canister/Canister.svelte';
 	import CanisterIndicator from '$lib/components/canister/CanisterIndicator.svelte';
+	import CanisterTCycles from '$lib/components/canister/CanisterTCycles.svelte';
 	import IconAnalytics from '$lib/components/icons/IconAnalytics.svelte';
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
 	import IconTelescope from '$lib/components/icons/IconTelescope.svelte';
@@ -11,6 +12,8 @@
 	import LaunchpadLink from '$lib/components/launchpad/LaunchpadLink.svelte';
 	import MissionControlDataLoader from '$lib/components/mission-control/MissionControlDataLoader.svelte';
 	import MissionControlVersion from '$lib/components/mission-control/MissionControlVersion.svelte';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import {
 		missionControlIdDerived,
 		missionControlNotMonitored,
@@ -21,9 +24,6 @@
 	import { loadOrbiters } from '$lib/services/orbiters.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CanisterData } from '$lib/types/canister';
-	import CanisterTCycles from '$lib/components/canister/CanisterTCycles.svelte';
-	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
-	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { formatE8sICP } from '$lib/utils/icp.utils';
 
 	run(() => {

--- a/src/frontend/src/lib/components/launchpad/Cockpit.svelte
+++ b/src/frontend/src/lib/components/launchpad/Cockpit.svelte
@@ -1,17 +1,25 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { run } from 'svelte/legacy';
-	import { fade } from 'svelte/transition';
 	import Canister from '$lib/components/canister/Canister.svelte';
 	import CanisterIndicator from '$lib/components/canister/CanisterIndicator.svelte';
 	import IconAnalytics from '$lib/components/icons/IconAnalytics.svelte';
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
 	import LaunchpadLink from '$lib/components/launchpad/LaunchpadLink.svelte';
-	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
+	import {
+		missionControlIdDerived,
+		missionControlNotMonitored,
+		missionControlSettingsLoaded
+	} from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { loadOrbiters } from '$lib/services/orbiters.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CanisterData } from '$lib/types/canister';
+	import IconTelescope from '$lib/components/icons/IconTelescope.svelte';
+	import IconWallet from '$lib/components/icons/IconWallet.svelte';
+	import MissionControlDataLoader from '$lib/components/mission-control/MissionControlDataLoader.svelte';
+	import { missionControlVersion } from '$lib/derived/version.derived';
+	import MissionControlVersion from '$lib/components/mission-control/MissionControlVersion.svelte';
 
 	run(() => {
 		// @ts-expect-error TODO: to be migrated to Svelte v5
@@ -32,6 +40,52 @@
 	/>
 {/if}
 
+{#if nonNullish($orbiterStore)}
+	<Canister
+		canisterId={$orbiterStore.orbiter_id}
+		segment="orbiter"
+		display={false}
+		bind:data={orbiterData}
+	/>
+{/if}
+
+<div class="analytics">
+	<LaunchpadLink
+		size="small"
+		href="/analytics"
+		ariaLabel={`${$i18n.satellites.open}: ${$i18n.analytics.title}`}
+		highlight={isNullish($orbiterStore)}
+	>
+		<p>
+			<IconAnalytics size="24px" />
+			<span
+				>{$i18n.analytics.title}
+				{#if nonNullish($orbiterStore)}<CanisterIndicator data={orbiterData} />{/if}</span
+			>
+		</p>
+	</LaunchpadLink>
+</div>
+
+<MissionControlVersion />
+
+{#if nonNullish($missionControlIdDerived) && nonNullish($missionControlVersion)}
+	<MissionControlDataLoader missionControlId={$missionControlIdDerived} />
+{/if}
+
+<div class="monitoring">
+	<LaunchpadLink
+		size="small"
+		href="/monitoring"
+		ariaLabel={`${$i18n.satellites.open}: ${$i18n.monitoring.title}`}
+		highlight={$missionControlSettingsLoaded && $missionControlNotMonitored}
+	>
+		<p>
+			<IconTelescope />
+			<span>{$i18n.monitoring.title}</span>
+		</p>
+	</LaunchpadLink>
+</div>
+
 <div class="mission-control">
 	<LaunchpadLink
 		size="small"
@@ -45,27 +99,18 @@
 	</LaunchpadLink>
 </div>
 
-{#if nonNullish($orbiterStore)}
-	<Canister
-		canisterId={$orbiterStore.orbiter_id}
-		segment="orbiter"
-		display={false}
-		bind:data={orbiterData}
-	/>
-
-	<div in:fade class="analytics">
-		<LaunchpadLink
-			size="small"
-			href="/analytics"
-			ariaLabel={`${$i18n.satellites.open}: ${$i18n.analytics.title}`}
-		>
-			<p>
-				<IconAnalytics size="24px" />
-				<span>{$i18n.analytics.title} <CanisterIndicator data={orbiterData} /></span>
-			</p>
-		</LaunchpadLink>
-	</div>
-{/if}
+<div class="wallet">
+	<LaunchpadLink
+		size="small"
+		href="/mission-control"
+		ariaLabel={`${$i18n.satellites.open}: ${$i18n.mission_control.title}`}
+	>
+		<p>
+			<IconWallet />
+			<span>{$i18n.wallet.title}</span>
+		</p>
+	</LaunchpadLink>
+</div>
 
 <style lang="scss">
 	@use '../../../lib/styles/mixins/grid';
@@ -83,24 +128,37 @@
 	}
 
 	span {
-		display: inline-flex;
+		display: none;
+
 		align-items: center;
 		gap: var(--padding);
+
+		@include media.min-width(large) {
+			display: inline-flex;
+		}
 	}
 
 	.mission-control {
-		grid-column: 1 / 13;
-
-		@include media.min-width(medium) {
-			grid-column: 1 / 7;
+		@include media.min-width(large) {
+			grid-column: 7 / 10;
 		}
 	}
 
 	.analytics {
-		grid-column: 1 / 13;
+		@include media.min-width(large) {
+			grid-column: 1 / 4;
+		}
+	}
 
-		@include media.min-width(medium) {
-			grid-column: 7 / 13;
+	.monitoring {
+		@include media.min-width(large) {
+			grid-column: 4 / 7;
+		}
+	}
+
+	.wallet {
+		@include media.min-width(large) {
+			grid-column: 10 / 13;
 		}
 	}
 </style>

--- a/src/frontend/src/lib/components/launchpad/Cockpit.svelte
+++ b/src/frontend/src/lib/components/launchpad/Cockpit.svelte
@@ -5,21 +5,21 @@
 	import CanisterIndicator from '$lib/components/canister/CanisterIndicator.svelte';
 	import IconAnalytics from '$lib/components/icons/IconAnalytics.svelte';
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
+	import IconTelescope from '$lib/components/icons/IconTelescope.svelte';
+	import IconWallet from '$lib/components/icons/IconWallet.svelte';
 	import LaunchpadLink from '$lib/components/launchpad/LaunchpadLink.svelte';
+	import MissionControlDataLoader from '$lib/components/mission-control/MissionControlDataLoader.svelte';
+	import MissionControlVersion from '$lib/components/mission-control/MissionControlVersion.svelte';
 	import {
 		missionControlIdDerived,
 		missionControlNotMonitored,
 		missionControlSettingsLoaded
 	} from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
+	import { missionControlVersion } from '$lib/derived/version.derived';
 	import { loadOrbiters } from '$lib/services/orbiters.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CanisterData } from '$lib/types/canister';
-	import IconTelescope from '$lib/components/icons/IconTelescope.svelte';
-	import IconWallet from '$lib/components/icons/IconWallet.svelte';
-	import MissionControlDataLoader from '$lib/components/mission-control/MissionControlDataLoader.svelte';
-	import { missionControlVersion } from '$lib/derived/version.derived';
-	import MissionControlVersion from '$lib/components/mission-control/MissionControlVersion.svelte';
 
 	run(() => {
 		// @ts-expect-error TODO: to be migrated to Svelte v5

--- a/src/frontend/src/lib/components/launchpad/Launchpad.svelte
+++ b/src/frontend/src/lib/components/launchpad/Launchpad.svelte
@@ -38,7 +38,7 @@
 	{/if}
 {:else if ($satellitesStore?.length ?? 0) >= 1}
 	<div in:fade use:onIntersection onjunoIntersecting={onLayoutTitleIntersection}>
-		<section>
+		<section class="cockpit">
 			<Cockpit />
 		</section>
 
@@ -54,6 +54,7 @@
 
 <style lang="scss">
 	@use '../../../lib/styles/mixins/grid';
+	@use '../../../lib/styles/mixins/media';
 
 	section {
 		@include grid.twelve-columns;
@@ -62,6 +63,15 @@
 
 		&:first-of-type {
 			margin-top: var(--padding-4x);
+		}
+
+		&.cockpit {
+			display: flex;
+			justify-content: center;
+
+			@include media.min-width(large) {
+				@include grid.twelve-columns;
+			}
 		}
 	}
 

--- a/src/frontend/src/lib/components/launchpad/LaunchpadLink.svelte
+++ b/src/frontend/src/lib/components/launchpad/LaunchpadLink.svelte
@@ -9,12 +9,28 @@
 		ariaLabel: string;
 		size?: 'small' | 'default';
 		row?: boolean;
+		highlight?: boolean;
 	}
 
-	let { children, summary, href, ariaLabel, size = 'default', row = false }: Props = $props();
+	let {
+		children,
+		summary,
+		href,
+		ariaLabel,
+		size = 'default',
+		row = false,
+		highlight = false
+	}: Props = $props();
 </script>
 
-<a class="article" {href} aria-label={ariaLabel} class:small={size === 'small'} class:row>
+<a
+	class="article"
+	{href}
+	aria-label={ariaLabel}
+	class:small={size === 'small'}
+	class:row
+	class:highlight
+>
 	{#if nonNullish(summary)}
 		<div class="summary">
 			{@render summary()}
@@ -84,6 +100,23 @@
 			padding: var(--padding-2x) var(--padding-4x);
 			min-height: auto;
 			height: 100%;
+		}
+	}
+
+	a.article {
+		height: 100%;
+		justify-content: center;
+	}
+
+	a.highlight {
+		color: var(--color-primary);
+
+		border: 2px solid var(--color-primary);
+		box-shadow: 1px 1px var(--color-primary);
+
+		&:hover:not(:disabled),
+		&:focus:not(:disabled) {
+			color: var(--color-primary);
 		}
 	}
 </style>

--- a/src/frontend/src/lib/components/mission-control/MissionControlDataLoader.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlDataLoader.svelte
@@ -8,7 +8,7 @@
 
 	interface Props {
 		missionControlId: Principal;
-		children: Snippet;
+		children?: Snippet;
 	}
 
 	let { missionControlId, children }: Props = $props();
@@ -41,4 +41,4 @@
 	});
 </script>
 
-{@render children()}
+{@render children?.()}

--- a/src/frontend/src/lib/components/mission-control/MissionControlVersion.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlVersion.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { loadVersion } from '$lib/services/console.services';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
+	import { type Snippet, untrack } from 'svelte';
+
+	interface Props {
+		children?: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	const load = async () =>
+		await loadVersion({
+			satelliteId: undefined,
+			missionControlId: $missionControlIdDerived,
+			skipReload: true
+		});
+
+	$effect(() => {
+		$missionControlIdDerived;
+
+		untrack(load);
+	});
+</script>
+
+{@render children?.()}

--- a/src/frontend/src/lib/components/mission-control/MissionControlVersion.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlVersion.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { loadVersion } from '$lib/services/console.services';
-	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { type Snippet, untrack } from 'svelte';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
+	import { loadVersion } from '$lib/services/console.services';
 
 	interface Props {
 		children?: Snippet;

--- a/src/frontend/src/lib/components/wallet/WalletLoader.svelte
+++ b/src/frontend/src/lib/components/wallet/WalletLoader.svelte
@@ -12,7 +12,7 @@
 		missionControlId: Principal;
 		balance?: bigint | undefined;
 		transactions?: TransactionWithId[];
-		children: Snippet;
+		children?: Snippet;
 	}
 
 	let {
@@ -63,4 +63,4 @@
 	onDestroy(() => worker?.stop());
 </script>
 
-{@render children()}
+{@render children?.()}

--- a/src/frontend/src/lib/derived/mission-control.derived.ts
+++ b/src/frontend/src/lib/derived/mission-control.derived.ts
@@ -58,6 +58,11 @@ export const missionControlMonitored = derived(
 		fromNullable($missionControlMonitoring?.cycles ?? [])?.enabled === true
 );
 
+export const missionControlNotMonitored = derived(
+	[missionControlMonitored],
+	([$missionControlMonitored]) => !$missionControlMonitored
+);
+
 export const missionControlUserDataLoaded = derived(
 	[missionControlUserDataStore],
 	([$missionControlUserDataStore]) => $missionControlUserDataStore !== undefined


### PR DESCRIPTION
# Motivation

On one hand we want a quick access to the monitoring and wallet, on the other we also want to make more obvious when the analytics or monitoring are not yet used.

<img width="1536" alt="Capture d’écran 2025-01-07 à 22 00 57" src="https://github.com/user-attachments/assets/7d9e2b45-5f19-41c0-8579-c35afb69c15c" />

