### PR TITLE
feat: set monitoring to run every hour

### DIFF
--- a/src/mission_control/src/constants.rs
+++ b/src/mission_control/src/constants.rs
@@ -1,2 +1,5 @@
 // We archive statuses in memory up to 30 days (1h * 24 * 30).
 pub const RETAIN_ARCHIVE_STATUSES_NS: u64 = 3_600_000_000_000 * 24 * 30;
+
+// We run the monitoring one per hour.
+pub const MONITORING_INTERVAL_SECONDS: u64 = 60 * 60;

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -37,7 +37,10 @@ use crate::types::interface::{
     CreateCanisterConfig, GetMonitoringHistory, MonitoringStartConfig, MonitoringStatus,
     MonitoringStopConfig,
 };
-use crate::types::state::{Config, HeapState, MissionControlSettings, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters, Satellite, Satellites, State, User};
+use crate::types::state::{
+    Config, HeapState, MissionControlSettings, MonitoringHistory, MonitoringHistoryKey, Orbiter,
+    Orbiters, Satellite, Satellites, State, User,
+};
 use candid::Principal;
 use ciborium::into_writer;
 use ic_cdk::api::call::{arg_data, ArgDecoderConfig};
@@ -70,8 +73,9 @@ use segments::store::{
 use std::collections::HashMap;
 use user::store::{
     get_config as get_config_store, get_metadata as get_metadata_store,
-    get_settings as get_settings_store, get_user as get_user_store, set_config as set_config_store,
-    set_metadata as set_metadata_store, get_user_data as get_user_data_store,
+    get_settings as get_settings_store, get_user as get_user_store,
+    get_user_data as get_user_data_store, set_config as set_config_store,
+    set_metadata as set_metadata_store,
 };
 
 #[init]

--- a/src/mission_control/src/monitoring/cycles/funding.rs
+++ b/src/mission_control/src/monitoring/cycles/funding.rs
@@ -1,3 +1,4 @@
+use crate::constants::MONITORING_INTERVAL_SECONDS;
 use crate::monitoring::cycles::history::save_monitoring_history;
 use crate::monitoring::cycles::notification::defer_notify;
 use crate::types::state::CyclesMonitoringStrategy;
@@ -33,8 +34,7 @@ pub fn init_register_options(
 
 fn init_funding_config() -> FundManagerOptions {
     FundManagerOptions::new()
-        // TODO: Integrate in mission control config
-        .with_interval_secs(30)
+        .with_interval_secs(MONITORING_INTERVAL_SECONDS)
         .with_obtain_cycles_options(Some(obtain_cycles_options()))
         .with_funding_callback(funding_callback())
 }

--- a/src/tests/mission-control.monitoring.history.spec.ts
+++ b/src/tests/mission-control.monitoring.history.spec.ts
@@ -30,6 +30,8 @@ describe('Mission Control - History', () => {
 
 	const controller = Ed25519KeyIdentity.generate();
 
+	const MONITORING_INTERVAL_IN_MILLISECONDS = 60 * 60 * 1000;
+
 	beforeAll(async () => {
 		pic = await PocketIc.create(inject('PIC_URL'));
 
@@ -193,7 +195,7 @@ describe('Mission Control - History', () => {
 		describe('collect entries over time', () => {
 			describe('first round', () => {
 				beforeAll(async () => {
-					await pic.advanceTime(30000);
+					await pic.advanceTime(MONITORING_INTERVAL_IN_MILLISECONDS);
 
 					await tick(pic);
 				});
@@ -215,7 +217,7 @@ describe('Mission Control - History', () => {
 				beforeAll(async () => {
 					await tick(pic);
 
-					await pic.advanceTime(30000);
+					await pic.advanceTime(MONITORING_INTERVAL_IN_MILLISECONDS);
 
 					await tick(pic);
 				});
@@ -274,7 +276,7 @@ describe('Mission Control - History', () => {
 				const thirtyDays = 1000 * 60 * 60 * 24 * 30;
 
 				// We want to keep the history for the first round and second round but, clean up the start
-				await pic.advanceTime(thirtyDays - 2 * 30000);
+				await pic.advanceTime(thirtyDays - 2 * MONITORING_INTERVAL_IN_MILLISECONDS);
 
 				await tick(pic);
 			});


### PR DESCRIPTION
# Motivation

Until #1024 is implemented, we set the periodicity of the monitory auto-refill to one hour.
