### PR TITLE
feat: use a single web worker

### DIFF
--- a/src/frontend/src/lib/services/worker.auth.services.ts
+++ b/src/frontend/src/lib/services/worker.auth.services.ts
@@ -3,7 +3,7 @@ import { authRemainingTimeStore, type AuthStoreData } from '$lib/stores/auth.sto
 import type { PostMessage, PostMessageDataResponseAuth } from '$lib/types/post-message';
 
 export const initAuthWorker = async () => {
-	const AuthWorker = await import('$lib/workers/auth.worker?worker');
+	const AuthWorker = await import('$lib/workers/workers?worker');
 	const authWorker: Worker = new AuthWorker.default();
 
 	authWorker.onmessage = async ({

--- a/src/frontend/src/lib/services/worker.cycles.services.ts
+++ b/src/frontend/src/lib/services/worker.cycles.services.ts
@@ -10,7 +10,7 @@ export interface CyclesWorker {
 }
 
 export const initCyclesWorker = async (): Promise<CyclesWorker> => {
-	const CyclesWorker = await import('$lib/workers/cycles.worker?worker');
+	const CyclesWorker = await import('$lib/workers/workers?worker');
 	const cyclesWorker: Worker = new CyclesWorker.default();
 
 	let cyclesCallback: CyclesCallback | undefined;

--- a/src/frontend/src/lib/services/worker.hosting.services.ts
+++ b/src/frontend/src/lib/services/worker.hosting.services.ts
@@ -4,7 +4,7 @@ import type { PostMessage, PostMessageDataResponse } from '$lib/types/post-messa
 export type HostingCallback = (data: PostMessageDataResponse) => void;
 
 export const initHostingWorker = async () => {
-	const HostingWorker = await import('$lib/workers/hosting.worker?worker');
+	const HostingWorker = await import('$lib/workers/workers?worker');
 	const hostingWorker: Worker = new HostingWorker.default();
 
 	let hostingCallback: HostingCallback | undefined;

--- a/src/frontend/src/lib/services/worker.monitoring.services.ts
+++ b/src/frontend/src/lib/services/worker.monitoring.services.ts
@@ -19,7 +19,7 @@ export interface MonitoringWorker {
 }
 
 export const initStatusesWorker = async (): Promise<MonitoringWorker> => {
-	const MonitoringWorker = await import('$lib/workers/monitoring.worker?worker');
+	const MonitoringWorker = await import('$lib/workers/workers?worker');
 	const monitoringWorker: Worker = new MonitoringWorker.default();
 
 	let monitoringCallback: MonitoringCallback | undefined;

--- a/src/frontend/src/lib/services/worker.wallet.services.ts
+++ b/src/frontend/src/lib/services/worker.wallet.services.ts
@@ -9,7 +9,7 @@ export interface WalletWorker {
 }
 
 export const initWalletWorker = async (): Promise<WalletWorker> => {
-	const WalletWorker = await import('$lib/workers/wallet.worker?worker');
+	const WalletWorker = await import('$lib/workers/workers?worker');
 	const worker: Worker = new WalletWorker.default();
 
 	let walletCallback: WalletCallback | undefined;

--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -4,9 +4,9 @@ import { createAuthClient } from '$lib/utils/auth.utils';
 import { IdbStorage, KEY_STORAGE_DELEGATION, type AuthClient } from '@dfinity/auth-client';
 import { DelegationChain, isDelegationValid } from '@dfinity/identity';
 
-// eslint-disable-next-line require-await
 export const onAuthMessage = async ({
 	data
+	// eslint-disable-next-line require-await
 }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg } = data;
 

--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -4,7 +4,9 @@ import { createAuthClient } from '$lib/utils/auth.utils';
 import { IdbStorage, KEY_STORAGE_DELEGATION, type AuthClient } from '@dfinity/auth-client';
 import { DelegationChain, isDelegationValid } from '@dfinity/identity';
 
-onmessage = ({ data }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+export const onAuthMessage = async ({
+	data
+}: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg } = data;
 
 	switch (msg) {

--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -4,6 +4,7 @@ import { createAuthClient } from '$lib/utils/auth.utils';
 import { IdbStorage, KEY_STORAGE_DELEGATION, type AuthClient } from '@dfinity/auth-client';
 import { DelegationChain, isDelegationValid } from '@dfinity/identity';
 
+// eslint-disable-next-line require-await
 export const onAuthMessage = async ({
 	data
 }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {

--- a/src/frontend/src/lib/workers/cycles.worker.ts
+++ b/src/frontend/src/lib/workers/cycles.worker.ts
@@ -17,7 +17,9 @@ import type { Identity } from '@dfinity/agent';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { set } from 'idb-keyval';
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+export const onCyclesMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/lib/workers/hosting.worker.ts
+++ b/src/frontend/src/lib/workers/hosting.worker.ts
@@ -5,7 +5,9 @@ import type { CustomDomainRegistrationState } from '$lib/types/custom-domain';
 import type { PostMessage, PostMessageDataRequest } from '$lib/types/post-message';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+export const onHostingMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/lib/workers/monitoring.worker.ts
+++ b/src/frontend/src/lib/workers/monitoring.worker.ts
@@ -23,7 +23,9 @@ import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 import { addDays, endOfDay, format, startOfDay } from 'date-fns';
 import { get, set } from 'idb-keyval';
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+export const onMonitoringMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/lib/workers/wallet.worker.ts
+++ b/src/frontend/src/lib/workers/wallet.worker.ts
@@ -11,7 +11,9 @@ import type {
 import { Principal } from '@dfinity/principal';
 import { isNullish, jsonReplacer } from '@dfinity/utils';
 
-onmessage = async ({ data: dataMsg }: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+export const onWalletMessage = async ({
+	data: dataMsg
+}: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
 	const { msg, data } = dataMsg;
 
 	switch (msg) {

--- a/src/frontend/src/lib/workers/workers.ts
+++ b/src/frontend/src/lib/workers/workers.ts
@@ -1,0 +1,16 @@
+import type { PostMessage, PostMessageDataRequest } from '$lib/types/post-message';
+import { onAuthMessage } from '$lib/workers/auth.worker';
+import { onCyclesMessage } from '$lib/workers/cycles.worker';
+import { onHostingMessage } from '$lib/workers/hosting.worker';
+import { onMonitoringMessage } from '$lib/workers/monitoring.worker';
+import { onWalletMessage } from '$lib/workers/wallet.worker';
+
+onmessage = async (msg: MessageEvent<PostMessage<PostMessageDataRequest>>) => {
+	await Promise.allSettled([
+		onAuthMessage(msg),
+		onCyclesMessage(msg),
+		onHostingMessage(msg),
+		onMonitoringMessage(msg),
+		onWalletMessage(msg)
+	]);
+};


### PR DESCRIPTION
# Motivation

I don't know why I didn't realize this earlier, but each worker in our setup is bundled by vite and rollup into a standalone chunk without reusing chunks across workers. As a result, we are shipping quite a bit of redundant code since almost every worker includes both Buffer, agent-js and other inherited stuffs.

I couldn't find any non-hacky bundling option to improve this. However, I did come up with a potential solution: **using a single worker entry point**.

Since we are already splitting each worker into different modules, we can easily integrate a single worker entry point that dispatches messages to the appropriate modules. Furthermore, because the context is created at usage, even with a single entry point, we still maintain separate contexts for each worker.

Here's what I observed when testing this approach in Juno.

Before:

```
/_app/immutable/workers/hosting.worker-DJ0sxOzi.js                   114.96 kB
/_app/immutable/workers/auth.worker-LXN6paDJ.js                      172.25 kB
/_app/immutable/workers/cycles.worker-OP7SV1jr.js                    312.98 kB
/_app/immutable/workers/monitoring.worker-DexfhUsd.js                321.21 kB
/_app/immutable/workers/wallet.worker-DzZ6Mwhs.js                    326.69 kB
```

After:

```
_app/immutable/workers/workers-DwpSKPp4.js                          394.36 kB
```

Again, these are not gzipped numbers, and fundamentally, it would be great if agent-js+deps could become slimmer someday, but, still quite a different to download on the wire for the client.

<img width="1536" alt="Capture d’écran 2025-01-09 à 18 34 01" src="https://github.com/user-attachments/assets/0f611960-b248-405a-8e88-815dedd16cc7" />
<img width="1536" alt="Capture d’écran 2025-01-09 à 18 33 37" src="https://github.com/user-attachments/assets/74818a38-32e8-441b-8891-0c2d65c11e0d" />

