### PR TITLE
fix: pin ic-certification v2.4.0

### DIFF
--- a/src/libs/storage/Cargo.toml
+++ b/src/libs/storage/Cargo.toml
@@ -22,8 +22,8 @@ ic-stable-structures.workspace = true
 sha2.workspace = true
 hex.workspace = true
 serde_bytes = "0.11.12"
-ic-certification = "2.4.0"
-ic-representation-independent-hash = "2.4.0"
+ic-certification = {version = "= 2.4.0"}
+ic-representation-independent-hash = {version = "= 2.4.0"}
 regex.workspace = true
 base64 = "0.13.1"
 url = "2.4.0"

--- a/src/tests/orbiter.upgrade-configuration.spec.ts
+++ b/src/tests/orbiter.upgrade-configuration.spec.ts
@@ -104,76 +104,84 @@ describe('Orbiter upgrade- Configuration', () => {
 			expect(fromNullable(configs[0][1].features)).toBeUndefined();
 		});
 
-		it('should migrate configuration enabled to the new features', async () => {
-			const { set_satellite_configs } = actor;
+		it(
+			'should migrate configuration enabled to the new features',
+			async () => {
+				const { set_satellite_configs } = actor;
 
-			await expect(
-				set_satellite_configs([
-					[
-						satelliteIdMock,
-						{
-							version: [],
-							enabled: true
-						}
-					]
-				])
-			).resolves.not.toThrowError();
+				await expect(
+					set_satellite_configs([
+						[
+							satelliteIdMock,
+							{
+								version: [],
+								enabled: true
+							}
+						]
+					])
+				).resolves.not.toThrowError();
 
-			await upgradeVersion();
+				await upgradeVersion();
 
-			const newActor = pic.createActor<OrbiterActor>(idlFactorOrbiter, canisterId);
-			newActor.setIdentity(controller);
+				const newActor = pic.createActor<OrbiterActor>(idlFactorOrbiter, canisterId);
+				newActor.setIdentity(controller);
 
-			const { list_satellite_configs } = newActor;
+				const { list_satellite_configs } = newActor;
 
-			const configs = await list_satellite_configs();
-			expect(configs.length).toBe(1);
+				const configs = await list_satellite_configs();
+				expect(configs.length).toBe(1);
 
-			expect(configs[0][0].toText()).toEqual(satelliteIdMock.toText());
-			expect(fromNullable(configs[0][1].version)).toBe(1n);
-			expect(fromNullable(configs[0][1].features)).toEqual({
-				page_views: true,
-				performance_metrics: true,
-				track_events: true
-			});
-		});
+				expect(configs[0][0].toText()).toEqual(satelliteIdMock.toText());
+				expect(fromNullable(configs[0][1].version)).toBe(1n);
+				expect(fromNullable(configs[0][1].features)).toEqual({
+					page_views: true,
+					performance_metrics: true,
+					track_events: true
+				});
+			},
+			{ timeout: 60000 }
+		);
 	});
 
 	describe('v0.0.7 -> v0.0.8 -> current', () => {
-		it('should migrate configuration enabled to the new features', async () => {
-			const { set_satellite_configs } = actor;
+		it(
+			'should migrate configuration enabled to the new features',
+			async () => {
+				const { set_satellite_configs } = actor;
 
-			await expect(
-				set_satellite_configs([
-					[
-						satelliteIdMock,
-						{
-							version: [],
-							enabled: true
-						}
-					]
-				])
-			).resolves.not.toThrowError();
+				await expect(
+					set_satellite_configs([
+						[
+							satelliteIdMock,
+							{
+								version: [],
+								enabled: true
+							}
+						]
+					])
+				).resolves.not.toThrowError();
 
-			await upgradeVersion();
+				await upgradeVersion();
 
-			await upgradeCurrent();
+				await upgradeCurrent();
 
-			const newActor = pic.createActor<OrbiterActor>(idlFactorOrbiter, canisterId);
-			newActor.setIdentity(controller);
+				const newActor = pic.createActor<OrbiterActor>(idlFactorOrbiter, canisterId);
+				newActor.setIdentity(controller);
 
-			const { list_satellite_configs } = newActor;
+				const { list_satellite_configs } = newActor;
 
-			const configs = await list_satellite_configs();
-			expect(configs.length).toBe(1);
+				const configs = await list_satellite_configs();
+				expect(configs.length).toBe(1);
 
-			expect(configs[0][0].toText()).toEqual(satelliteIdMock.toText());
-			expect(fromNullable(configs[0][1].version)).toBe(1n);
-			expect(fromNullable(configs[0][1].features)).toEqual({
-				page_views: true,
-				performance_metrics: true,
-				track_events: true
-			});
-		});
+				expect(configs[0][0].toText()).toEqual(satelliteIdMock.toText());
+				expect(fromNullable(configs[0][1].version)).toBe(1n);
+				expect(fromNullable(configs[0][1].features)).toEqual({
+					page_views: true,
+					performance_metrics: true,
+					track_events: true
+				});
+			},
+			{ timeout: 60000 }
+		);
 	});
 });

--- a/src/tests/orbiter.upgrade.spec.ts
+++ b/src/tests/orbiter.upgrade.spec.ts
@@ -322,7 +322,7 @@ describe('Orbiter upgrade', () => {
 					expect('Err' in results).toBeFalsy();
 				});
 			},
-			{ timeout: 600000 }
+			{ timeout: 1200000 }
 		);
 
 		describe(
@@ -394,7 +394,7 @@ describe('Orbiter upgrade', () => {
 					expect('Err' in results).toBeFalsy();
 				});
 			},
-			{ timeout: 600000 }
+			{ timeout: 1200000 }
 		);
 	});
 });


### PR DESCRIPTION
# Motivation

After releasing the crates, the test starts failing.

The root cause is a change in the `ic-certification` shipped in `v2.6.0`

To prevent the issue, I pin `v2.4.0`.
