### PR TITLE
test: await rejects.toThrow

### DIFF
--- a/src/tests/satellite.datastore.spec.ts
+++ b/src/tests/satellite.datastore.spec.ts
@@ -789,14 +789,14 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 					});
 				});
 
-				it('should not allow to set a document', () => {
-					expect(createDoc()).rejects.toThrow(errorMsg);
+				it('should not allow to set a document', async () => {
+					await expect(createDoc()).rejects.toThrow(errorMsg);
 				});
 
-				it('should not allow to set many documents', () => {
+				it('should not allow to set many documents', async () => {
 					const { set_many_docs } = actor;
 
-					expect(
+					await expect(
 						set_many_docs(
 							Array.from({ length: 4 }).map((_, i) => [
 								collection,


### PR DESCRIPTION
```
Promise returned by `expect(actual).rejects.toThrow(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at /home/runner/work/juno/juno/src/tests/satellite.datastore.spec.ts:793:24
```