### PR TITLE
fix: Observatory http outcalls

### DIFF
--- a/src/observatory/src/http/constants.rs
+++ b/src/observatory/src/http/constants.rs
@@ -1,0 +1,3 @@
+// When we installed the feature on mainnet, the call was rejected because 20_888_358_400 cycles are required.
+// That is why, to have some margin, we set 30_000_000_000.
+pub const SEND_EMAIL_CYCLES: u128 = 30_000_000_000;

--- a/src/observatory/src/http/mod.rs
+++ b/src/observatory/src/http/mod.rs
@@ -1,3 +1,4 @@
+mod constants;
 mod request;
 pub mod response;
 pub mod send;

--- a/src/observatory/src/http/request.rs
+++ b/src/observatory/src/http/request.rs
@@ -1,9 +1,13 @@
+use crate::http::constants::SEND_EMAIL_CYCLES;
 use crate::http::types::EmailRequestBody;
 use crate::types::state::ApiKey;
-use ic_cdk::api::management_canister::http_request::http_request as http_request_outcall;
+use ic_cdk::api::management_canister::http_request::{
+    http_request as http_request_outcall, TransformContext, TransformFunc,
+};
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument, HttpHeader, HttpMethod,
 };
+use ic_cdk::id;
 use serde_json::json;
 
 pub async fn post_email(
@@ -13,7 +17,7 @@ pub async fn post_email(
 ) -> Result<(), String> {
     let request = get_email_request(idempotency_key, api_key, email)?;
 
-    match http_request_outcall(request, 5_000_000_000).await {
+    match http_request_outcall(request, SEND_EMAIL_CYCLES).await {
         Ok((_response,)) => Ok(()),
         Err((r, m)) => {
             let message = format!("HTTP request error. RejectionCode: {:?}, Error: {}", r, m);
@@ -54,7 +58,17 @@ fn get_email_request(
         method: HttpMethod::POST,
         body: Some(body_json.as_bytes().to_vec()),
         max_response_bytes: None,
-        transform: None,
+        transform: param_transform(),
         headers: request_headers,
+    })
+}
+
+fn param_transform() -> Option<TransformContext> {
+    Some(TransformContext {
+        function: TransformFunc(candid::Func {
+            principal: id(),
+            method: "transform".to_string(),
+        }),
+        context: vec![],
     })
 }

--- a/src/observatory/src/http/response.rs
+++ b/src/observatory/src/http/response.rs
@@ -1,47 +1,9 @@
-use ic_cdk::api::management_canister::http_request::{
-    HttpHeader, HttpResponse as HttpResponseCdk, TransformArgs as TransformArgsCdk,
-};
+use ic_cdk::api::management_canister::http_request::{HttpResponse, TransformArgs};
 
-// Strips all data that is not needed from the original response.
-pub fn transform_response(raw: TransformArgsCdk) -> HttpResponseCdk {
-    let headers = vec![
-        HttpHeader {
-            name: "Content-Security-Policy".to_string(),
-            value: "default-src 'self'".to_string(),
-        },
-        HttpHeader {
-            name: "Referrer-Policy".to_string(),
-            value: "strict-origin".to_string(),
-        },
-        HttpHeader {
-            name: "Permissions-Policy".to_string(),
-            value: "geolocation=(self)".to_string(),
-        },
-        HttpHeader {
-            name: "Strict-Transport-Security".to_string(),
-            value: "max-age=63072000".to_string(),
-        },
-        HttpHeader {
-            name: "X-Frame-Options".to_string(),
-            value: "DENY".to_string(),
-        },
-        HttpHeader {
-            name: "X-Content-Type-Options".to_string(),
-            value: "nosniff".to_string(),
-        },
-    ];
-
-    let mut res = HttpResponseCdk {
+pub fn transform_response(raw: TransformArgs) -> HttpResponse {
+    HttpResponse {
         status: raw.response.status.clone(),
         body: raw.response.body.clone(),
-        headers,
-    };
-
-    if i32::try_from(res.status.clone().0).unwrap() == 200 {
-        res.body = raw.response.body;
-    } else {
-        ic_cdk::api::print(format!("Received an error from proxy: err = {:?}", raw));
+        headers: vec![],
     }
-
-    res
 }

--- a/src/observatory/src/lib.rs
+++ b/src/observatory/src/lib.rs
@@ -130,7 +130,7 @@ fn ping(notify_args: NotifyArgs) {
 // HTTP Outcalls
 // ---------------------------------------------------------
 
-#[query]
+#[query(hidden = true)]
 fn transform(raw: TransformArgs) -> HttpResponse {
     transform_response(raw)
 }


### PR DESCRIPTION
# Motivation

- Proper cycles
- Use transform function
- nitpick: hide endpoint
