### PR TITLE
fix: monitoring sentence

### DIFF
--- a/src/frontend/src/lib/components/modals/MonitoringSentence.svelte
+++ b/src/frontend/src/lib/components/modals/MonitoringSentence.svelte
@@ -14,10 +14,10 @@
 {i18nFormat($i18n.monitoring.auto_refill_strategy, [
 	{
 		placeholder: '{0}',
-		value: formatTCycles(monitoringStrategy.BelowThreshold.min_cycles)
+		value: formatTCycles(monitoringStrategy.BelowThreshold.fund_cycles)
 	},
 	{
 		placeholder: '{1}',
-		value: formatTCycles(monitoringStrategy.BelowThreshold.fund_cycles)
+		value: formatTCycles(monitoringStrategy.BelowThreshold.min_cycles)
 	}
 ])}


### PR DESCRIPTION
# Motivation

"Top-up 0.800T Cycles if the remaining threshold falls below 0.100"

0.8 and 0.1 are inverted
