### PR TITLE
test: assert certificate with response-verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 			},
 			"devDependencies": {
 				"@dfinity/eslint-config-oisy-wallet": "^0.0.6",
+				"@dfinity/response-verification": "^3.0.2",
 				"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 				"@hadronous/pic": "^0.10.0",
 				"@junobuild/cli-tools": "^0.0.16",
@@ -816,6 +817,13 @@
 			"dependencies": {
 				"@noble/hashes": "^1.3.1"
 			}
+		},
+		"node_modules/@dfinity/response-verification": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/response-verification/-/response-verification-3.0.2.tgz",
+			"integrity": "sha512-6ASX//lux2f8XE4PyH2h/2QQvHoZWlWx7XFB++Mmv3VQCLtvPAXp0dxAoo7OUq3NsMwVHLgALmccbYSeZtSYlA==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/@dfinity/utils": {
 			"version": "2.8.0",
@@ -11189,6 +11197,12 @@
 			"requires": {
 				"@noble/hashes": "^1.3.1"
 			}
+		},
+		"@dfinity/response-verification": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/response-verification/-/response-verification-3.0.2.tgz",
+			"integrity": "sha512-6ASX//lux2f8XE4PyH2h/2QQvHoZWlWx7XFB++Mmv3VQCLtvPAXp0dxAoo7OUq3NsMwVHLgALmccbYSeZtSYlA==",
+			"dev": true
 		},
 		"@dfinity/utils": {
 			"version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 	},
 	"devDependencies": {
 		"@dfinity/eslint-config-oisy-wallet": "^0.0.6",
+		"@dfinity/response-verification": "^3.0.2",
 		"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 		"@hadronous/pic": "^0.10.0",
 		"@junobuild/cli-tools": "^0.0.16",

--- a/src/tests/satellite.storage.spec.ts
+++ b/src/tests/satellite.storage.spec.ts
@@ -258,6 +258,7 @@ describe('Satellite storage', () => {
 
 			const rest = headers.filter(([header, _]) => header !== 'IC-Certificate');
 
+			/* eslint-disable no-useless-escape */
 			expect(rest).toEqual([
 				['accept-ranges', 'bytes'],
 				['etag', '"03ee66f1452916b4f91a504c1e9babfa201b6d64c26a82b2cf03c3ed49d91585"'],
@@ -266,12 +267,12 @@ describe('Satellite storage', () => {
 				['Referrer-Policy', 'same-origin'],
 				['X-Frame-Options', 'DENY'],
 				['Cache-Control', 'no-cache'],
-				// eslint-disable-next-line no-useless-escape
 				[
 					'IC-CertificateExpression',
 					'default_certification(ValidationArgs{certification:Certification{no_request_certification:Empty{},response_certification:ResponseCertification{certified_response_headers:ResponseHeaderList{headers:[\"accept-ranges\",\"etag\",\"X-Content-Type-Options\",\"Strict-Transport-Security\",\"Referrer-Policy\",\"X-Frame-Options\",\"Cache-Control\"]}}}})'
 				]
 			]);
+			/* eslint-enable no-useless-escape */
 
 			await assertCertification({
 				canisterId,
@@ -382,6 +383,7 @@ describe('Satellite storage', () => {
 
 					const rest = headers.filter(([header, _]) => header !== 'IC-Certificate');
 
+					/* eslint-disable no-useless-escape */
 					expect(rest).toEqual([
 						['accept-ranges', 'bytes'],
 						['etag', '"03ee66f1452916b4f91a504c1e9babfa201b6d64c26a82b2cf03c3ed49d91585"'],
@@ -390,12 +392,12 @@ describe('Satellite storage', () => {
 						['Referrer-Policy', 'same-origin'],
 						['X-Frame-Options', 'DENY'],
 						['Cache-Control', 'no-cache'],
-						// eslint-disable-next-line no-useless-escape
 						[
 							'IC-CertificateExpression',
 							'default_certification(ValidationArgs{certification:Certification{no_request_certification:Empty{},response_certification:ResponseCertification{certified_response_headers:ResponseHeaderList{headers:[\"accept-ranges\",\"etag\",\"X-Content-Type-Options\",\"Strict-Transport-Security\",\"Referrer-Policy\",\"X-Frame-Options\",\"Cache-Control\"]}}}})'
 						]
 					]);
+					/* eslint-enable no-useless-escape */
 
 					await assertCertification({
 						canisterId,

--- a/src/tests/utils/certification-test.utils.ts
+++ b/src/tests/utils/certification-test.utils.ts
@@ -1,0 +1,56 @@
+import type { HttpResponse } from '$declarations/satellite/satellite.did';
+import type { Principal } from '@dfinity/principal';
+import { verifyRequestResponsePair, type Request } from '@dfinity/response-verification';
+import type { PocketIc } from '@hadronous/pic';
+import { assertNonNullish } from '@junobuild/utils';
+
+const CERTIFICATE_VERSION = 2;
+
+const NS_PER_MS = 1e6;
+const MS_PER_S = 1e3;
+const S_PER_MIN = 60;
+
+const getRootKey = (pic: PocketIc): Promise<ArrayBufferLike> => {
+	const subnets = pic.getApplicationSubnets();
+	return pic.getPubKey(subnets[0].id);
+};
+
+/**
+ * @see https://github.com/dfinity/response-verification/blob/main/examples/http-certification/assets/src/tests/src/http.spec.ts
+ */
+export const assertCertification = async ({
+	pic,
+	currentDate,
+	canisterId,
+	request,
+	response
+}: {
+	pic: PocketIc;
+	currentDate: Date;
+	canisterId: Principal;
+	request: Request;
+	response: HttpResponse;
+}) => {
+	const rootKey = await getRootKey(pic);
+
+	const currentTimeNs = BigInt(currentDate.getTime() * NS_PER_MS);
+	const maxCertTimeOffsetNs = BigInt(5 * S_PER_MIN * MS_PER_S * NS_PER_MS);
+
+	const { verificationVersion, response: verificationResponse } = verifyRequestResponsePair(
+		request,
+		response,
+		canisterId.toUint8Array(),
+		currentTimeNs,
+		maxCertTimeOffsetNs,
+		new Uint8Array(rootKey),
+		CERTIFICATE_VERSION
+	);
+
+	expect(verificationVersion).toEqual(CERTIFICATE_VERSION);
+
+	assertNonNullish(verificationResponse);
+
+	const { statusCode } = verificationResponse;
+
+	expect(statusCode).toBe(200);
+};


### PR DESCRIPTION
# Motivation

According @nathanosdev the testing issue appearing while migrating the ic-certification crate to v2.6.0 (#1044) is kind of expected. Instead of hardcording some certification we should rather use the `@dfinity/response-verification` library to validate certife in the test suite.
