### PR TITLE
test: adapt max heap memory

### DIFF
--- a/src/tests/satellite.datastore.spec.ts
+++ b/src/tests/satellite.datastore.spec.ts
@@ -763,7 +763,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 			describe.each([
 				{
 					memory: { Heap: null },
-					expectMemory: 3_932_160n
+					expectMemory: 3_997_696n
 				},
 				{
 					memory: { Stable: null },
@@ -790,7 +790,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				});
 
 				it('should not allow to set a document', async () => {
-					await expect(createDoc()).rejects.toThrow(errorMsg);
+					await expect(createDoc()).rejects.toThrowError(new RegExp(errorMsg, 'i'));
 				});
 
 				it('should not allow to set many documents', async () => {

--- a/src/tests/satellite.storage.spec.ts
+++ b/src/tests/satellite.storage.spec.ts
@@ -1168,7 +1168,7 @@ describe('Satellite storage', () => {
 	});
 
 	describe('More configuration', () => {
-		const maxHeapMemorySize = 3_932_160n;
+		const maxHeapMemorySize = 4_063_231n;
 		const maxStableMemorySize = 2_000_000n;
 
 		beforeAll(() => {
@@ -1178,7 +1178,7 @@ describe('Satellite storage', () => {
 		describe.each([
 			{
 				memory: { Heap: null },
-				expectMemory: 3_997_696n,
+				expectMemory: 4_063_232n,
 				allowedMemory: maxHeapMemorySize,
 				preUploadCount: 13
 			},


### PR DESCRIPTION
# Motivation

The newest version of Rust #1037 seems to use just a bit more memory on heap.
