### PR TITLE
feat: use deposited cycles in monitoring graph

### DIFF
--- a/src/frontend/src/lib/workers/monitoring.worker.ts
+++ b/src/frontend/src/lib/workers/monitoring.worker.ts
@@ -188,9 +188,17 @@ const buildCycles = (history: MonitoringHistory): ChartsData[] =>
 				};
 			}
 
+			const {
+				cycles: { amount },
+				deposited_cycles
+			} = cycles;
+
+			// The cycles amount is collected before the round of monitoring. By adding the potential deposited cycles, we got the resulting value.
+			const cyclesAmount = amount + (fromNullable(deposited_cycles)?.amount ?? 0n);
+
 			return {
 				x: `${fromBigIntNanoSeconds(created_at).getTime()}`,
-				y: parseFloat(formatTCycles(cycles.cycles.amount))
+				y: parseFloat(formatTCycles(cyclesAmount))
 			};
 		})
 		.sort(sortChartsData);


### PR DESCRIPTION
# Motivation

> What I was suggesting is that you could always show get_cycles() + last_deposited_cycles if the last_deposited_cycles always showed the number for the current round. Which would make the graph accurate with funding
