### PR TITLE
style: adapt confetti colors to theme

### DIFF
--- a/src/frontend/src/lib/components/ui/Confetti.svelte
+++ b/src/frontend/src/lib/components/ui/Confetti.svelte
@@ -17,6 +17,7 @@
 		duration={5000}
 		amount={200}
 		fallDistance="300px"
+		colorArray={['var(--color-primary)', 'var(--color-secondary)', 'var(--color-tertiary)']}
 	/>
 </div>
 


### PR DESCRIPTION
<img width="1536" alt="Capture d’écran 2025-01-14 à 21 37 58" src="https://github.com/user-attachments/assets/77f6260c-dd79-41cc-8f1e-6c3f9fcf9077" />
