### PR TITLE
feat: launchpad link in user menu

### DIFF
--- a/src/frontend/src/lib/components/core/Navmenu.svelte
+++ b/src/frontend/src/lib/components/core/Navmenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isEmptyString } from '@dfinity/utils';
+	import { notEmptyString } from '@dfinity/utils';
 	import { circOut, quintOut } from 'svelte/easing';
 	import { slide } from 'svelte/transition';
 	import { page } from '$app/state';
@@ -10,7 +10,6 @@
 	import IconFunctions from '$lib/components/icons/IconFunctions.svelte';
 	import IconHosting from '$lib/components/icons/IconHosting.svelte';
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
-	import IconRocket from '$lib/components/icons/IconRocket.svelte';
 	import IconSatellite from '$lib/components/icons/IconSatellite.svelte';
 	import IconStorage from '$lib/components/icons/IconStorage.svelte';
 	import IconTelescope from '$lib/components/icons/IconTelescope.svelte';
@@ -42,12 +41,7 @@
 
 <Menu>
 	<nav>
-		{#if isEmptyString(satelliteId)}
-			<a class="link" href="/">
-				<IconRocket size="24px" />
-				<span>{$i18n.satellites.launchpad}</span>
-			</a>
-		{:else}
+		{#if notEmptyString(satelliteId)}
 			<a
 				class="link"
 				href={`/satellite/?s=${satelliteId}`}

--- a/src/frontend/src/lib/components/core/User.svelte
+++ b/src/frontend/src/lib/components/core/User.svelte
@@ -3,6 +3,7 @@
 	import IconAnalytics from '$lib/components/icons/IconAnalytics.svelte';
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
 	import IconRaygun from '$lib/components/icons/IconRaygun.svelte';
+	import IconRocket from '$lib/components/icons/IconRocket.svelte';
 	import IconSignIn from '$lib/components/icons/IconSignIn.svelte';
 	import IconSignOut from '$lib/components/icons/IconSignOut.svelte';
 	import IconTelescope from '$lib/components/icons/IconTelescope.svelte';
@@ -45,10 +46,12 @@
 		visible = true;
 	};
 
+	let home = $derived(page.route.id === '/(home)');
+	let preferences = $derived(page.route.id === '/(single)/preferences');
+
 	// If there is no satellites, we consider the user has a new developer and want to show all links in the user popover that way the user can navigate anyway on the home screen.
 	let newDeveloper = $derived($satellitesNotLoaded || ($satellitesStore?.length ?? 0) === 0);
-	let routeId: string | null = $derived(page.route.id);
-	let showNavigation = $derived(newDeveloper && routeId === '/(home)');
+	let showNavigation = $derived(newDeveloper && home);
 </script>
 
 {#if $authSignedIn}
@@ -69,6 +72,13 @@
 
 <Popover bind:visible anchor={button} direction="rtl">
 	<div class="container">
+		{#if !home && !preferences}
+			<a href="/" class="menu" role="menuitem" aria-haspopup="menu" onclick={close}>
+				<IconRocket />
+				<span>{$i18n.satellites.launchpad}</span>
+			</a>
+		{/if}
+
 		{#if showNavigation}
 			<a href="/mission-control" class="menu" role="menuitem" aria-haspopup="menu" onclick={close}>
 				<IconMissionControl />
@@ -97,10 +107,12 @@
 			</a>
 		{/if}
 
-		<a href="/preferences" class="menu" role="menuitem" aria-haspopup="menu" onclick={close}>
-			<IconRaygun />
-			<span>{$i18n.preferences.title}</span>
-		</a>
+		{#if !preferences}
+			<a href="/preferences" class="menu" role="menuitem" aria-haspopup="menu" onclick={close}>
+				<IconRaygun />
+				<span>{$i18n.preferences.title}</span>
+			</a>
+		{/if}
 
 		<button type="button" role="menuitem" aria-haspopup="menu" onclick={signOutClose} class="menu">
 			<IconSignOut />


### PR DESCRIPTION
# Motivation

I'm not sure how to handle gracefully accessing the app without selecting a satellite in terms of navigation. So this is another try to embed the launchpad link in the ux.
