### PR TITLE
fix: intersection observer after migration to Svelte v5

### DIFF
--- a/src/frontend/src/lib/components/transactions/Transactions.svelte
+++ b/src/frontend/src/lib/components/transactions/Transactions.svelte
@@ -9,13 +9,19 @@
 		missionControlId: Principal;
 		transactions: TransactionWithId[];
 		disableInfiniteScroll?: boolean;
+		onintersect: () => void;
 	}
 
-	let { missionControlId, transactions, disableInfiniteScroll = false }: Props = $props();
+	let {
+		missionControlId,
+		transactions,
+		onintersect,
+		disableInfiniteScroll = false
+	}: Props = $props();
 </script>
 
 {#if transactions.length > 0}
-	<InfiniteScroll on:junoIntersect disabled={disableInfiniteScroll}>
+	<InfiniteScroll {onintersect} disabled={disableInfiniteScroll}>
 		<div class="table-container">
 			<table>
 				<thead>

--- a/src/frontend/src/lib/components/ui/InfiniteScroll.svelte
+++ b/src/frontend/src/lib/components/ui/InfiniteScroll.svelte
@@ -1,31 +1,31 @@
-<!-- @migration-task Error while migrating Svelte code: Can't migrate code with afterUpdate and beforeUpdate. Please migrate by hand. -->
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
-	import { afterUpdate, beforeUpdate, createEventDispatcher, onDestroy } from 'svelte';
+	import { onDestroy, type Snippet } from 'svelte';
 
-	// TODO: migrate to Svelte v5
-	// e.g. afterUpdate cannot be used in runes mode
+	interface Props {
+		onintersect: () => void;
+		disabled?: boolean;
+		// IntersectionObserverInit is not recognized by the linter
+		// eslint-disable-next-line no-undef
+		options?: IntersectionObserverInit;
+		children: Snippet;
+	}
 
-	/**
-	 * Source: @dfinity/gix-components
-	 */
+	let {
+		onintersect,
+		disabled = false,
+		options = {
+			rootMargin: '300px',
+			threshold: 0
+		},
+		children
+	}: Props = $props();
 
-	export let disabled = false;
-
-	// IntersectionObserverInit is not recognized by the linter
-	// eslint-disable-next-line no-undef
-	export let options: IntersectionObserverInit = {
-		rootMargin: '300px',
-		threshold: 0
-	};
-
-	let container: HTMLDivElement | undefined;
-
-	const dispatch = createEventDispatcher();
+	let target: HTMLDivElement | undefined;
 
 	// eslint-disable-next-line local-rules/prefer-object-params
-	const onIntersection = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
-		const intersecting: IntersectionObserverEntry | undefined = entries.find(
+	const onIntersection = (entries: IntersectionObserverEntry[]) => {
+		const intersecting = entries.find(
 			({ isIntersecting }: IntersectionObserverEntry) => isIntersecting
 		);
 
@@ -33,10 +33,7 @@
 			return;
 		}
 
-		// We can disconnect the observer. We have detected an intersection and consumer is going to fetch new elements.
-		observer.disconnect();
-
-		dispatch('junoIntersect');
+		onintersect();
 	};
 
 	const observer: IntersectionObserver = new IntersectionObserver(onIntersection, options);
@@ -45,19 +42,19 @@
 	let skipContainerNextUpdate = false;
 
 	// We disconnect previous observer before any update. We do want to trigger an intersection in case of layout shifting.
-	beforeUpdate(() => {
+	$effect.pre(() => {
 		if (!skipContainerNextUpdate) {
 			observer.disconnect();
 		}
 
-		skipContainerNextUpdate = isNullish(container);
+		skipContainerNextUpdate = isNullish(target);
 	});
 
-	afterUpdate(() => {
+	$effect(() => {
 		// The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
 
-		// If not children, no element to observe
-		if (isNullish(container) || isNullish(container.lastElementChild)) {
+		// If no element to observe
+		if (isNullish(target)) {
 			return;
 		}
 
@@ -66,18 +63,21 @@
 			return;
 		}
 
-		observer.observe(container.lastElementChild);
+		observer.observe(target);
 	});
 
 	onDestroy(() => observer.disconnect());
 </script>
 
-<div bind:this={container}>
-	<slot />
-</div>
+{@render children()}
+
+<div bind:this={target} class="intersection-observer-target"></div>
 
 <style lang="scss">
-	div {
-		display: contents;
+	.intersection-observer-target {
+		width: 0;
+		height: 0;
+		opacity: 0;
+		visibility: hidden;
 	}
 </style>

--- a/src/frontend/src/lib/components/wallet/Wallet.svelte
+++ b/src/frontend/src/lib/components/wallet/Wallet.svelte
@@ -41,7 +41,7 @@
 
 	let disableInfiniteScroll = $state(false);
 
-	const onIntersect = async () => {
+	const onintersect = async () => {
 		if ($authSignedOut) {
 			toasts.error({
 				text: $i18n.errors.no_identity
@@ -154,7 +154,7 @@
 			{transactions}
 			{disableInfiniteScroll}
 			{missionControlId}
-			on:junoIntersect={onIntersect}
+			{onintersect}
 		/>
 
 		<TransactionsExport {transactions} {missionControlId} />

--- a/src/frontend/src/lib/components/wallet/Wallet.svelte
+++ b/src/frontend/src/lib/components/wallet/Wallet.svelte
@@ -150,12 +150,7 @@
 			<button onclick={openSend}>{$i18n.wallet.send}</button>
 		</div>
 
-		<Transactions
-			{transactions}
-			{disableInfiniteScroll}
-			{missionControlId}
-			{onintersect}
-		/>
+		<Transactions {transactions} {disableInfiniteScroll} {missionControlId} {onintersect} />
 
 		<TransactionsExport {transactions} {missionControlId} />
 	</WalletLoader>


### PR DESCRIPTION
# Motivation

After migration to Svelte v5, the `InfiniteScroll` was actually broken. The root cause of the issue is the following breaking change: 

> beforeUpdate/afterUpdate no longer run when the component contains a <slot> and its content is updated.

https://svelte.dev/docs/svelte/v5-migration-guide#Other-breaking-changes-beforeUpdate-afterUpdate-changes

As a result, the "next" wallet transactions were not loaded in the UI.

It took me a bit of time to figure out, but the solution was to move the observer after the container instead of keeping it inside.
