### PR TITLE
refactor: uncertified store

### DIFF
--- a/src/frontend/src/lib/stores/_uncertified.store.ts
+++ b/src/frontend/src/lib/stores/_uncertified.store.ts
@@ -1,0 +1,21 @@
+import { type CertifiedStore, initCertifiedStore } from '$lib/stores/_certified.store';
+
+export interface UncertifiedStore<T> extends Omit<CertifiedStore<T>, 'set'> {
+	set: (data: T) => void;
+}
+
+// Just a shorthand. That way we can find easily which store uses the pattern but, not yet query+update.
+export const initUncertifiedStore = <T>(): UncertifiedStore<T> => {
+	const { set, ...rest } = initCertifiedStore<T>();
+
+	return {
+		...rest,
+
+		set(data) {
+			set({
+				data,
+				certified: false
+			});
+		}
+	};
+};

--- a/src/frontend/src/lib/stores/mission-control.store.ts
+++ b/src/frontend/src/lib/stores/mission-control.store.ts
@@ -2,11 +2,13 @@ import type {
 	MissionControlSettings,
 	User
 } from '$declarations/mission_control/mission_control.did';
-import { initDataStore } from '$lib/stores/_data.store';
+import { initUncertifiedStore } from '$lib/stores/_uncertified.store';
 import type { Principal } from '@dfinity/principal';
 
-export const missionControlIdDataStore = initDataStore<Principal>();
+export const missionControlIdDataStore = initUncertifiedStore<Principal>();
 
-export const missionControlUserDataStore = initDataStore<User>();
+export const missionControlUserDataStore = initUncertifiedStore<User>();
 
-export const missionControlSettingsDataStore = initDataStore<MissionControlSettings | undefined>();
+export const missionControlSettingsDataStore = initUncertifiedStore<
+	MissionControlSettings | undefined
+>();

--- a/src/frontend/src/lib/stores/orbiter.store.ts
+++ b/src/frontend/src/lib/stores/orbiter.store.ts
@@ -1,4 +1,4 @@
 import type { Orbiter } from '$declarations/mission_control/mission_control.did';
-import { initDataStore } from '$lib/stores/_data.store';
+import { initUncertifiedStore } from '$lib/stores/_uncertified.store';
 
-export const orbitersDataStore = initDataStore<Orbiter[]>();
+export const orbitersDataStore = initUncertifiedStore<Orbiter[]>();

--- a/src/frontend/src/lib/stores/satellite.store.ts
+++ b/src/frontend/src/lib/stores/satellite.store.ts
@@ -1,4 +1,4 @@
 import type { Satellite } from '$declarations/mission_control/mission_control.did';
-import { initDataStore } from '$lib/stores/_data.store';
+import { initUncertifiedStore } from '$lib/stores/_uncertified.store';
 
-export const satellitesDataStore = initDataStore<Satellite[]>();
+export const satellitesDataStore = initUncertifiedStore<Satellite[]>();


### PR DESCRIPTION
# Motivation

I want to reuse the same certified store for those stores I recently moved to a data (not loaded/loaded) store pattern. That way if someday we start certifying those information, it will be easy to retrieve those.
