### PR TITLE
chore: generate certified idl

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"format-imports": "eslint --fix --rule 'import/no-duplicates: [error, { prefer-inline: true }]' ./src/frontend/src/**/*.svelte",
 		"format": "prettier --write './**/*.{ts,js,mjs,json,scss,css,svelte,html,md}' && npm run format-imports",
 		"prebuild": "npm run generate",
-		"generate": "scripts/did.sh && scripts/did.idl.sh && node scripts/did.update.types.mjs && npm run copy:mjs && npm run format",
+		"generate": "scripts/did.sh && scripts/did.idl.sh && node scripts/did.update.types.mjs && scripts/did.idl.certified.sh && npm run copy:mjs && npm run format",
 		"copy:mjs": "cp src/declarations/console/console.factory.did.js src/declarations/console/console.factory.did.mjs && cp src/declarations/satellite/satellite.factory.did.js src/declarations/satellite/satellite.factory.did.mjs && cp src/declarations/observatory/observatory.factory.did.js src/declarations/observatory/observatory.factory.did.mjs && cp src/declarations/satellite/satellite.factory.did.js src/declarations/satellite/satellite.factory.did.mjs && cp src/declarations/orbiter/orbiter.factory.did.js src/declarations/orbiter/orbiter.factory.did.mjs && cp src/declarations/ic/ic.factory.did.js src/declarations/ic/ic.factory.did.mjs",
 		"console:invitation": "node scripts/console.invitation.mjs",
 		"console:credits": "node scripts/console.credits.mjs",

--- a/scripts/did.idl.certified.sh
+++ b/scripts/did.idl.certified.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+function generate_certified_did_idl() {
+  local canister=$1
+
+  sed "s/\['query'\]/\[\]/g" src/declarations/"$canister"/"$canister".factory.did.js > src/declarations/"$canister"/"$canister".factory.certified.did.js
+}
+
+CANISTERS=console,observatory,mission_control,orbiter,satellite
+
+for canister in $(echo $CANISTERS | sed "s/,/ /g")
+do
+    generate_certified_did_idl "$canister"
+done
+

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -1,0 +1,285 @@
+// @ts-ignore
+export const idlFactory = ({ IDL }) => {
+	const Tokens = IDL.Record({ e8s: IDL.Nat64 });
+	const AssertMissionControlCenterArgs = IDL.Record({
+		mission_control_id: IDL.Principal,
+		user: IDL.Principal
+	});
+	const CommitBatch = IDL.Record({
+		batch_id: IDL.Nat,
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		chunk_ids: IDL.Vec(IDL.Nat)
+	});
+	const CommitProposal = IDL.Record({
+		sha256: IDL.Vec(IDL.Nat8),
+		proposal_id: IDL.Nat
+	});
+	const CreateCanisterArgs = IDL.Record({
+		block_index: IDL.Opt(IDL.Nat64),
+		subnet_id: IDL.Opt(IDL.Principal),
+		user: IDL.Principal
+	});
+	const DeleteControllersArgs = IDL.Record({
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const DeleteProposalAssets = IDL.Record({
+		proposal_ids: IDL.Vec(IDL.Nat)
+	});
+	const StorageConfigIFrame = IDL.Variant({
+		Deny: IDL.Null,
+		AllowAny: IDL.Null,
+		SameOrigin: IDL.Null
+	});
+	const ConfigMaxMemorySize = IDL.Record({
+		stable: IDL.Opt(IDL.Nat64),
+		heap: IDL.Opt(IDL.Nat64)
+	});
+	const StorageConfigRawAccess = IDL.Variant({
+		Deny: IDL.Null,
+		Allow: IDL.Null
+	});
+	const StorageConfigRedirect = IDL.Record({
+		status_code: IDL.Nat16,
+		location: IDL.Text
+	});
+	const StorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
+	const Config = IDL.Record({ storage: StorageConfig });
+	const GetCreateCanisterFeeArgs = IDL.Record({ user: IDL.Principal });
+	const ProposalStatus = IDL.Variant({
+		Initialized: IDL.Null,
+		Failed: IDL.Null,
+		Open: IDL.Null,
+		Rejected: IDL.Null,
+		Executed: IDL.Null,
+		Accepted: IDL.Null
+	});
+	const AssetsUpgradeOptions = IDL.Record({
+		clear_existing_assets: IDL.Opt(IDL.Bool)
+	});
+	const SegmentsDeploymentOptions = IDL.Record({
+		orbiter: IDL.Opt(IDL.Text),
+		mission_control_version: IDL.Opt(IDL.Text),
+		satellite_version: IDL.Opt(IDL.Text)
+	});
+	const ProposalType = IDL.Variant({
+		AssetsUpgrade: AssetsUpgradeOptions,
+		SegmentsDeployment: SegmentsDeploymentOptions
+	});
+	const Proposal = IDL.Record({
+		status: ProposalStatus,
+		updated_at: IDL.Nat64,
+		sha256: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		executed_at: IDL.Opt(IDL.Nat64),
+		owner: IDL.Principal,
+		created_at: IDL.Nat64,
+		version: IDL.Opt(IDL.Nat64),
+		proposal_type: ProposalType
+	});
+	const MissionControl = IDL.Record({
+		updated_at: IDL.Nat64,
+		credits: Tokens,
+		mission_control_id: IDL.Opt(IDL.Principal),
+		owner: IDL.Principal,
+		created_at: IDL.Nat64
+	});
+	const HttpRequest = IDL.Record({
+		url: IDL.Text,
+		method: IDL.Text,
+		body: IDL.Vec(IDL.Nat8),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		certificate_version: IDL.Opt(IDL.Nat16)
+	});
+	const Memory = IDL.Variant({ Heap: IDL.Null, Stable: IDL.Null });
+	const StreamingCallbackToken = IDL.Record({
+		memory: Memory,
+		token: IDL.Opt(IDL.Text),
+		sha256: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		index: IDL.Nat64,
+		encoding_type: IDL.Text,
+		full_path: IDL.Text
+	});
+	const StreamingStrategy = IDL.Variant({
+		Callback: IDL.Record({
+			token: StreamingCallbackToken,
+			callback: IDL.Func([], [], [])
+		})
+	});
+	const HttpResponse = IDL.Record({
+		body: IDL.Vec(IDL.Nat8),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		streaming_strategy: IDL.Opt(StreamingStrategy),
+		status_code: IDL.Nat16
+	});
+	const StreamingCallbackHttpResponse = IDL.Record({
+		token: IDL.Opt(StreamingCallbackToken),
+		body: IDL.Vec(IDL.Nat8)
+	});
+	const InitAssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		encoding_type: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const InitUploadResult = IDL.Record({ batch_id: IDL.Nat });
+	const ListOrderField = IDL.Variant({
+		UpdatedAt: IDL.Null,
+		Keys: IDL.Null,
+		CreatedAt: IDL.Null
+	});
+	const ListOrder = IDL.Record({ field: ListOrderField, desc: IDL.Bool });
+	const TimestampMatcher = IDL.Variant({
+		Equal: IDL.Nat64,
+		Between: IDL.Tuple(IDL.Nat64, IDL.Nat64),
+		GreaterThan: IDL.Nat64,
+		LessThan: IDL.Nat64
+	});
+	const ListMatcher = IDL.Record({
+		key: IDL.Opt(IDL.Text),
+		updated_at: IDL.Opt(TimestampMatcher),
+		description: IDL.Opt(IDL.Text),
+		created_at: IDL.Opt(TimestampMatcher)
+	});
+	const ListPaginate = IDL.Record({
+		start_after: IDL.Opt(IDL.Text),
+		limit: IDL.Opt(IDL.Nat64)
+	});
+	const ListParams = IDL.Record({
+		order: IDL.Opt(ListOrder),
+		owner: IDL.Opt(IDL.Principal),
+		matcher: IDL.Opt(ListMatcher),
+		paginate: IDL.Opt(ListPaginate)
+	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const AssetEncodingNoContent = IDL.Record({
+		modified: IDL.Nat64,
+		sha256: IDL.Vec(IDL.Nat8),
+		total_length: IDL.Nat
+	});
+	const AssetNoContent = IDL.Record({
+		key: AssetKey,
+		updated_at: IDL.Nat64,
+		encodings: IDL.Vec(IDL.Tuple(IDL.Text, AssetEncodingNoContent)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		version: IDL.Opt(IDL.Nat64)
+	});
+	const ListResults = IDL.Record({
+		matches_pages: IDL.Opt(IDL.Nat64),
+		matches_length: IDL.Nat64,
+		items_page: IDL.Opt(IDL.Nat64),
+		items: IDL.Vec(IDL.Tuple(IDL.Text, AssetNoContent)),
+		items_length: IDL.Nat64
+	});
+	const CustomDomain = IDL.Record({
+		updated_at: IDL.Nat64,
+		created_at: IDL.Nat64,
+		version: IDL.Opt(IDL.Nat64),
+		bn_id: IDL.Opt(IDL.Text)
+	});
+	const PaymentStatus = IDL.Variant({
+		Refunded: IDL.Null,
+		Acknowledged: IDL.Null,
+		Completed: IDL.Null
+	});
+	const Payment = IDL.Record({
+		status: PaymentStatus,
+		updated_at: IDL.Nat64,
+		block_index_payment: IDL.Nat64,
+		mission_control_id: IDL.Opt(IDL.Principal),
+		created_at: IDL.Nat64,
+		block_index_refunded: IDL.Opt(IDL.Nat64)
+	});
+	const ControllerScope = IDL.Variant({
+		Write: IDL.Null,
+		Admin: IDL.Null
+	});
+	const SetController = IDL.Record({
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const SetControllersArgs = IDL.Record({
+		controller: SetController,
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const SegmentKind = IDL.Variant({
+		Orbiter: IDL.Null,
+		MissionControl: IDL.Null,
+		Satellite: IDL.Null
+	});
+	const RateConfig = IDL.Record({
+		max_tokens: IDL.Nat64,
+		time_per_token_ns: IDL.Nat64
+	});
+	const UploadChunk = IDL.Record({
+		content: IDL.Vec(IDL.Nat8),
+		batch_id: IDL.Nat,
+		order_id: IDL.Opt(IDL.Nat)
+	});
+	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
+	return IDL.Service({
+		add_credits: IDL.Func([IDL.Principal, Tokens], [], []),
+		add_invitation_code: IDL.Func([IDL.Text], [], []),
+		assert_mission_control_center: IDL.Func([AssertMissionControlCenterArgs], [], []),
+		commit_asset_upload: IDL.Func([CommitBatch], [], []),
+		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		create_orbiter: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
+		create_satellite: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
+		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
+		del_custom_domain: IDL.Func([IDL.Text], [], []),
+		delete_proposal_assets: IDL.Func([DeleteProposalAssets], [], []),
+		get_config: IDL.Func([], [Config], []),
+		get_create_orbiter_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], []),
+		get_create_satellite_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], []),
+		get_credits: IDL.Func([], [Tokens], []),
+		get_proposal: IDL.Func([IDL.Nat], [IDL.Opt(Proposal)], []),
+		get_storage_config: IDL.Func([], [StorageConfig], []),
+		get_user_mission_control_center: IDL.Func([], [IDL.Opt(MissionControl)], []),
+		http_request: IDL.Func([HttpRequest], [HttpResponse], []),
+		http_request_streaming_callback: IDL.Func(
+			[StreamingCallbackToken],
+			[StreamingCallbackHttpResponse],
+			[]
+		),
+		init_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
+		init_proposal: IDL.Func([ProposalType], [IDL.Nat, Proposal], []),
+		init_user_mission_control_center: IDL.Func([], [MissionControl], []),
+		list_assets: IDL.Func([IDL.Text, ListParams], [ListResults], []),
+		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
+		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], []),
+		list_user_mission_control_centers: IDL.Func(
+			[],
+			[IDL.Vec(IDL.Tuple(IDL.Principal, MissionControl))],
+			[]
+		),
+		set_controllers: IDL.Func([SetControllersArgs], [], []),
+		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
+		set_fee: IDL.Func([SegmentKind, Tokens], [], []),
+		set_storage_config: IDL.Func([StorageConfig], [], []),
+		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
+		update_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
+		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
+		version: IDL.Func([], [IDL.Text], [])
+	});
+};
+// @ts-ignore
+export const init = ({ IDL }) => {
+	return [];
+};

--- a/src/declarations/mission_control/mission_control.factory.certified.did.js
+++ b/src/declarations/mission_control/mission_control.factory.certified.did.js
@@ -1,0 +1,247 @@
+// @ts-ignore
+export const idlFactory = ({ IDL }) => {
+	const CyclesThreshold = IDL.Record({
+		fund_cycles: IDL.Nat,
+		min_cycles: IDL.Nat
+	});
+	const CyclesMonitoringStrategy = IDL.Variant({
+		BelowThreshold: CyclesThreshold
+	});
+	const CyclesMonitoring = IDL.Record({
+		strategy: IDL.Opt(CyclesMonitoringStrategy),
+		enabled: IDL.Bool
+	});
+	const Monitoring = IDL.Record({ cycles: IDL.Opt(CyclesMonitoring) });
+	const Settings = IDL.Record({ monitoring: IDL.Opt(Monitoring) });
+	const Orbiter = IDL.Record({
+		updated_at: IDL.Nat64,
+		orbiter_id: IDL.Principal,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		settings: IDL.Opt(Settings)
+	});
+	const CreateCanisterConfig = IDL.Record({
+		subnet_id: IDL.Opt(IDL.Principal),
+		name: IDL.Opt(IDL.Text)
+	});
+	const Satellite = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		satellite_id: IDL.Principal,
+		settings: IDL.Opt(Settings)
+	});
+	const DepositCyclesArgs = IDL.Record({
+		cycles: IDL.Nat,
+		destination_id: IDL.Principal
+	});
+	const DepositedCyclesEmailNotification = IDL.Record({
+		to: IDL.Opt(IDL.Text),
+		enabled: IDL.Bool
+	});
+	const CyclesMonitoringConfig = IDL.Record({
+		notification: IDL.Opt(DepositedCyclesEmailNotification),
+		default_strategy: IDL.Opt(CyclesMonitoringStrategy)
+	});
+	const MonitoringConfig = IDL.Record({
+		cycles: IDL.Opt(CyclesMonitoringConfig)
+	});
+	const Config = IDL.Record({ monitoring: IDL.Opt(MonitoringConfig) });
+	const GetMonitoringHistory = IDL.Record({
+		to: IDL.Opt(IDL.Nat64),
+		from: IDL.Opt(IDL.Nat64),
+		segment_id: IDL.Principal
+	});
+	const MonitoringHistoryKey = IDL.Record({
+		segment_id: IDL.Principal,
+		created_at: IDL.Nat64,
+		nonce: IDL.Int32
+	});
+	const CyclesBalance = IDL.Record({
+		timestamp: IDL.Nat64,
+		amount: IDL.Nat
+	});
+	const MonitoringHistoryCycles = IDL.Record({
+		deposited_cycles: IDL.Opt(CyclesBalance),
+		cycles: CyclesBalance
+	});
+	const MonitoringHistory = IDL.Record({
+		cycles: IDL.Opt(MonitoringHistoryCycles)
+	});
+	const CyclesMonitoringStatus = IDL.Record({
+		monitored_ids: IDL.Vec(IDL.Principal),
+		running: IDL.Bool
+	});
+	const MonitoringStatus = IDL.Record({
+		cycles: IDL.Opt(CyclesMonitoringStatus)
+	});
+	const MissionControlSettings = IDL.Record({
+		updated_at: IDL.Nat64,
+		created_at: IDL.Nat64,
+		monitoring: IDL.Opt(Monitoring)
+	});
+	const User = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		user: IDL.Opt(IDL.Principal),
+		created_at: IDL.Nat64,
+		config: IDL.Opt(Config)
+	});
+	const Tokens = IDL.Record({ e8s: IDL.Nat64 });
+	const Timestamp = IDL.Record({ timestamp_nanos: IDL.Nat64 });
+	const TransferArgs = IDL.Record({
+		to: IDL.Vec(IDL.Nat8),
+		fee: Tokens,
+		memo: IDL.Nat64,
+		from_subaccount: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		created_at_time: IDL.Opt(Timestamp),
+		amount: Tokens
+	});
+	const TransferError = IDL.Variant({
+		TxTooOld: IDL.Record({ allowed_window_nanos: IDL.Nat64 }),
+		BadFee: IDL.Record({ expected_fee: Tokens }),
+		TxDuplicate: IDL.Record({ duplicate_of: IDL.Nat64 }),
+		TxCreatedInFuture: IDL.Null,
+		InsufficientFunds: IDL.Record({ balance: Tokens })
+	});
+	const Result = IDL.Variant({ Ok: IDL.Nat64, Err: TransferError });
+	const Account = IDL.Record({
+		owner: IDL.Principal,
+		subaccount: IDL.Opt(IDL.Vec(IDL.Nat8))
+	});
+	const TransferArg = IDL.Record({
+		to: Account,
+		fee: IDL.Opt(IDL.Nat),
+		memo: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		from_subaccount: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		created_at_time: IDL.Opt(IDL.Nat64),
+		amount: IDL.Nat
+	});
+	const TransferError_1 = IDL.Variant({
+		GenericError: IDL.Record({
+			message: IDL.Text,
+			error_code: IDL.Nat
+		}),
+		TemporarilyUnavailable: IDL.Null,
+		BadBurn: IDL.Record({ min_burn_amount: IDL.Nat }),
+		Duplicate: IDL.Record({ duplicate_of: IDL.Nat }),
+		BadFee: IDL.Record({ expected_fee: IDL.Nat }),
+		CreatedInFuture: IDL.Record({ ledger_time: IDL.Nat64 }),
+		TooOld: IDL.Null,
+		InsufficientFunds: IDL.Record({ balance: IDL.Nat })
+	});
+	const Result_1 = IDL.Variant({ Ok: IDL.Nat, Err: TransferError_1 });
+	const ControllerScope = IDL.Variant({
+		Write: IDL.Null,
+		Admin: IDL.Null
+	});
+	const Controller = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const SetController = IDL.Record({
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const SegmentsMonitoringStrategy = IDL.Record({
+		ids: IDL.Vec(IDL.Principal),
+		strategy: CyclesMonitoringStrategy
+	});
+	const CyclesMonitoringStartConfig = IDL.Record({
+		orbiters_strategy: IDL.Opt(SegmentsMonitoringStrategy),
+		mission_control_strategy: IDL.Opt(CyclesMonitoringStrategy),
+		satellites_strategy: IDL.Opt(SegmentsMonitoringStrategy)
+	});
+	const MonitoringStartConfig = IDL.Record({
+		cycles_config: IDL.Opt(CyclesMonitoringStartConfig)
+	});
+	const CyclesMonitoringStopConfig = IDL.Record({
+		satellite_ids: IDL.Opt(IDL.Vec(IDL.Principal)),
+		try_mission_control: IDL.Opt(IDL.Bool),
+		orbiter_ids: IDL.Opt(IDL.Vec(IDL.Principal))
+	});
+	const MonitoringStopConfig = IDL.Record({
+		cycles_config: IDL.Opt(CyclesMonitoringStopConfig)
+	});
+	return IDL.Service({
+		add_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal)], [], []),
+		add_satellites_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),
+		create_orbiter: IDL.Func([IDL.Opt(IDL.Text)], [Orbiter], []),
+		create_orbiter_with_config: IDL.Func([CreateCanisterConfig], [Orbiter], []),
+		create_satellite: IDL.Func([IDL.Text], [Satellite], []),
+		create_satellite_with_config: IDL.Func([CreateCanisterConfig], [Satellite], []),
+		del_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal)], [], []),
+		del_orbiter: IDL.Func([IDL.Principal, IDL.Nat], [], []),
+		del_orbiters_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),
+		del_satellite: IDL.Func([IDL.Principal, IDL.Nat], [], []),
+		del_satellites_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),
+		deposit_cycles: IDL.Func([DepositCyclesArgs], [], []),
+		get_config: IDL.Func([], [IDL.Opt(Config)], []),
+		get_metadata: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], []),
+		get_monitoring_history: IDL.Func(
+			[GetMonitoringHistory],
+			[IDL.Vec(IDL.Tuple(MonitoringHistoryKey, MonitoringHistory))],
+			[]
+		),
+		get_monitoring_status: IDL.Func([], [MonitoringStatus], []),
+		get_settings: IDL.Func([], [IDL.Opt(MissionControlSettings)], []),
+		get_user: IDL.Func([], [IDL.Principal], []),
+		get_user_data: IDL.Func([], [User], []),
+		icp_transfer: IDL.Func([TransferArgs], [Result], []),
+		icrc_transfer: IDL.Func([IDL.Principal, TransferArg], [Result_1], []),
+		list_mission_control_controllers: IDL.Func(
+			[],
+			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],
+			[]
+		),
+		list_orbiters: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Orbiter))], []),
+		list_satellites: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Satellite))], []),
+		remove_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal)], [], []),
+		remove_satellites_controllers: IDL.Func(
+			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)],
+			[],
+			[]
+		),
+		set_config: IDL.Func([IDL.Opt(Config)], [], []),
+		set_metadata: IDL.Func([IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], [], []),
+		set_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal), SetController], [], []),
+		set_orbiter: IDL.Func([IDL.Principal, IDL.Opt(IDL.Text)], [Orbiter], []),
+		set_orbiter_metadata: IDL.Func(
+			[IDL.Principal, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],
+			[Orbiter],
+			[]
+		),
+		set_orbiters_controllers: IDL.Func(
+			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetController],
+			[],
+			[]
+		),
+		set_satellite: IDL.Func([IDL.Principal, IDL.Opt(IDL.Text)], [Satellite], []),
+		set_satellite_metadata: IDL.Func(
+			[IDL.Principal, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],
+			[Satellite],
+			[]
+		),
+		set_satellites_controllers: IDL.Func(
+			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetController],
+			[],
+			[]
+		),
+		start_monitoring: IDL.Func([], [], []),
+		stop_monitoring: IDL.Func([], [], []),
+		top_up: IDL.Func([IDL.Principal, Tokens], [], []),
+		unset_orbiter: IDL.Func([IDL.Principal], [], []),
+		unset_satellite: IDL.Func([IDL.Principal], [], []),
+		update_and_start_monitoring: IDL.Func([MonitoringStartConfig], [], []),
+		update_and_stop_monitoring: IDL.Func([MonitoringStopConfig], [], []),
+		version: IDL.Func([], [IDL.Text], [])
+	});
+};
+// @ts-ignore
+export const init = ({ IDL }) => {
+	return [];
+};

--- a/src/declarations/observatory/observatory.factory.certified.did.js
+++ b/src/declarations/observatory/observatory.factory.certified.did.js
@@ -1,0 +1,77 @@
+// @ts-ignore
+export const idlFactory = ({ IDL }) => {
+	const DeleteControllersArgs = IDL.Record({
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const GetNotifications = IDL.Record({
+		to: IDL.Opt(IDL.Nat64),
+		from: IDL.Opt(IDL.Nat64),
+		segment_id: IDL.Opt(IDL.Principal)
+	});
+	const NotifyStatus = IDL.Record({
+		pending: IDL.Nat64,
+		sent: IDL.Nat64,
+		failed: IDL.Nat64
+	});
+	const ControllerScope = IDL.Variant({
+		Write: IDL.Null,
+		Admin: IDL.Null
+	});
+	const Controller = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const CyclesBalance = IDL.Record({
+		timestamp: IDL.Nat64,
+		amount: IDL.Nat
+	});
+	const DepositedCyclesEmailNotification = IDL.Record({
+		to: IDL.Text,
+		deposited_cycles: CyclesBalance
+	});
+	const NotificationKind = IDL.Variant({
+		DepositedCyclesEmail: DepositedCyclesEmailNotification
+	});
+	const SegmentKind = IDL.Variant({
+		Orbiter: IDL.Null,
+		MissionControl: IDL.Null,
+		Satellite: IDL.Null
+	});
+	const Segment = IDL.Record({
+		id: IDL.Principal,
+		metadata: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
+		kind: SegmentKind
+	});
+	const NotifyArgs = IDL.Record({
+		kind: NotificationKind,
+		user: IDL.Principal,
+		segment: Segment
+	});
+	const SetController = IDL.Record({
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const SetControllersArgs = IDL.Record({
+		controller: SetController,
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const Env = IDL.Record({ email_api_key: IDL.Opt(IDL.Text) });
+	return IDL.Service({
+		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
+		get_notify_status: IDL.Func([GetNotifications], [NotifyStatus], []),
+		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], []),
+		notify: IDL.Func([NotifyArgs], [], []),
+		ping: IDL.Func([NotifyArgs], [], []),
+		set_controllers: IDL.Func([SetControllersArgs], [], []),
+		set_env: IDL.Func([Env], [], []),
+		version: IDL.Func([], [IDL.Text], [])
+	});
+};
+// @ts-ignore
+export const init = ({ IDL }) => {
+	return [];
+};

--- a/src/declarations/orbiter/orbiter.factory.certified.did.js
+++ b/src/declarations/orbiter/orbiter.factory.certified.did.js
@@ -1,0 +1,255 @@
+// @ts-ignore
+export const idlFactory = ({ IDL }) => {
+	const DeleteControllersArgs = IDL.Record({
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const ControllerScope = IDL.Variant({
+		Write: IDL.Null,
+		Admin: IDL.Null
+	});
+	const Controller = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const DelSatelliteConfig = IDL.Record({ version: IDL.Opt(IDL.Nat64) });
+	const DepositCyclesArgs = IDL.Record({
+		cycles: IDL.Nat,
+		destination_id: IDL.Principal
+	});
+	const GetAnalytics = IDL.Record({
+		to: IDL.Opt(IDL.Nat64),
+		from: IDL.Opt(IDL.Nat64),
+		satellite_id: IDL.Opt(IDL.Principal)
+	});
+	const AnalyticKey = IDL.Record({
+		key: IDL.Text,
+		collected_at: IDL.Nat64
+	});
+	const PageViewDevice = IDL.Record({
+		inner_height: IDL.Nat16,
+		inner_width: IDL.Nat16
+	});
+	const PageView = IDL.Record({
+		title: IDL.Text,
+		updated_at: IDL.Nat64,
+		referrer: IDL.Opt(IDL.Text),
+		time_zone: IDL.Text,
+		session_id: IDL.Text,
+		href: IDL.Text,
+		created_at: IDL.Nat64,
+		satellite_id: IDL.Principal,
+		device: PageViewDevice,
+		version: IDL.Opt(IDL.Nat64),
+		user_agent: IDL.Opt(IDL.Text)
+	});
+	const AnalyticsBrowsersPageViews = IDL.Record({
+		safari: IDL.Float64,
+		opera: IDL.Float64,
+		others: IDL.Float64,
+		firefox: IDL.Float64,
+		chrome: IDL.Float64
+	});
+	const AnalyticsDevicesPageViews = IDL.Record({
+		desktop: IDL.Float64,
+		others: IDL.Float64,
+		mobile: IDL.Float64
+	});
+	const AnalyticsClientsPageViews = IDL.Record({
+		browsers: AnalyticsBrowsersPageViews,
+		devices: AnalyticsDevicesPageViews
+	});
+	const CalendarDate = IDL.Record({
+		day: IDL.Nat8,
+		month: IDL.Nat8,
+		year: IDL.Int32
+	});
+	const AnalyticsMetricsPageViews = IDL.Record({
+		bounce_rate: IDL.Float64,
+		average_page_views_per_session: IDL.Float64,
+		daily_total_page_views: IDL.Vec(IDL.Tuple(CalendarDate, IDL.Nat32)),
+		total_page_views: IDL.Nat32,
+		unique_page_views: IDL.Nat64,
+		unique_sessions: IDL.Nat64
+	});
+	const AnalyticsTop10PageViews = IDL.Record({
+		referrers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
+		pages: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))
+	});
+	const NavigationType = IDL.Variant({
+		Navigate: IDL.Null,
+		Restore: IDL.Null,
+		Reload: IDL.Null,
+		BackForward: IDL.Null,
+		BackForwardCache: IDL.Null,
+		Prerender: IDL.Null
+	});
+	const WebVitalsMetric = IDL.Record({
+		id: IDL.Text,
+		value: IDL.Float64,
+		navigation_type: IDL.Opt(NavigationType),
+		delta: IDL.Float64
+	});
+	const PerformanceData = IDL.Variant({ WebVitalsMetric: WebVitalsMetric });
+	const PerformanceMetricName = IDL.Variant({
+		CLS: IDL.Null,
+		FCP: IDL.Null,
+		INP: IDL.Null,
+		LCP: IDL.Null,
+		TTFB: IDL.Null
+	});
+	const PerformanceMetric = IDL.Record({
+		updated_at: IDL.Nat64,
+		session_id: IDL.Text,
+		data: PerformanceData,
+		href: IDL.Text,
+		metric_name: PerformanceMetricName,
+		created_at: IDL.Nat64,
+		satellite_id: IDL.Principal,
+		version: IDL.Opt(IDL.Nat64)
+	});
+	const AnalyticsWebVitalsPageMetrics = IDL.Record({
+		cls: IDL.Opt(IDL.Float64),
+		fcp: IDL.Opt(IDL.Float64),
+		inp: IDL.Opt(IDL.Float64),
+		lcp: IDL.Opt(IDL.Float64),
+		ttfb: IDL.Opt(IDL.Float64)
+	});
+	const AnalyticsWebVitalsPerformanceMetrics = IDL.Record({
+		overall: AnalyticsWebVitalsPageMetrics,
+		pages: IDL.Vec(IDL.Tuple(IDL.Text, AnalyticsWebVitalsPageMetrics))
+	});
+	const TrackEvent = IDL.Record({
+		updated_at: IDL.Nat64,
+		session_id: IDL.Text,
+		metadata: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
+		name: IDL.Text,
+		created_at: IDL.Nat64,
+		satellite_id: IDL.Principal,
+		version: IDL.Opt(IDL.Nat64)
+	});
+	const AnalyticsTrackEvents = IDL.Record({
+		total: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))
+	});
+	const OrbiterSatelliteFeatures = IDL.Record({
+		performance_metrics: IDL.Bool,
+		track_events: IDL.Bool,
+		page_views: IDL.Bool
+	});
+	const OrbiterSatelliteConfig = IDL.Record({
+		updated_at: IDL.Nat64,
+		features: IDL.Opt(OrbiterSatelliteFeatures),
+		created_at: IDL.Nat64,
+		version: IDL.Opt(IDL.Nat64)
+	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
+	const SetController = IDL.Record({
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const SetControllersArgs = IDL.Record({
+		controller: SetController,
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const SetPageView = IDL.Record({
+		title: IDL.Text,
+		updated_at: IDL.Opt(IDL.Nat64),
+		referrer: IDL.Opt(IDL.Text),
+		time_zone: IDL.Text,
+		session_id: IDL.Text,
+		href: IDL.Text,
+		satellite_id: IDL.Principal,
+		device: PageViewDevice,
+		version: IDL.Opt(IDL.Nat64),
+		user_agent: IDL.Opt(IDL.Text)
+	});
+	const Result = IDL.Variant({ Ok: PageView, Err: IDL.Text });
+	const Result_1 = IDL.Variant({
+		Ok: IDL.Null,
+		Err: IDL.Vec(IDL.Tuple(AnalyticKey, IDL.Text))
+	});
+	const SetPerformanceMetric = IDL.Record({
+		session_id: IDL.Text,
+		data: PerformanceData,
+		href: IDL.Text,
+		metric_name: PerformanceMetricName,
+		satellite_id: IDL.Principal,
+		version: IDL.Opt(IDL.Nat64),
+		user_agent: IDL.Opt(IDL.Text)
+	});
+	const Result_2 = IDL.Variant({ Ok: PerformanceMetric, Err: IDL.Text });
+	const SetSatelliteConfig = IDL.Record({
+		features: IDL.Opt(OrbiterSatelliteFeatures),
+		version: IDL.Opt(IDL.Nat64)
+	});
+	const SetTrackEvent = IDL.Record({
+		updated_at: IDL.Opt(IDL.Nat64),
+		session_id: IDL.Text,
+		metadata: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
+		name: IDL.Text,
+		satellite_id: IDL.Principal,
+		version: IDL.Opt(IDL.Nat64),
+		user_agent: IDL.Opt(IDL.Text)
+	});
+	const Result_3 = IDL.Variant({ Ok: TrackEvent, Err: IDL.Text });
+	return IDL.Service({
+		del_controllers: IDL.Func(
+			[DeleteControllersArgs],
+			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],
+			[]
+		),
+		del_satellite_config: IDL.Func([IDL.Principal, DelSatelliteConfig], [], []),
+		deposit_cycles: IDL.Func([DepositCyclesArgs], [], []),
+		get_page_views: IDL.Func([GetAnalytics], [IDL.Vec(IDL.Tuple(AnalyticKey, PageView))], []),
+		get_page_views_analytics_clients: IDL.Func([GetAnalytics], [AnalyticsClientsPageViews], []),
+		get_page_views_analytics_metrics: IDL.Func([GetAnalytics], [AnalyticsMetricsPageViews], []),
+		get_page_views_analytics_top_10: IDL.Func([GetAnalytics], [AnalyticsTop10PageViews], []),
+		get_performance_metrics: IDL.Func(
+			[GetAnalytics],
+			[IDL.Vec(IDL.Tuple(AnalyticKey, PerformanceMetric))],
+			[]
+		),
+		get_performance_metrics_analytics_web_vitals: IDL.Func(
+			[GetAnalytics],
+			[AnalyticsWebVitalsPerformanceMetrics],
+			[]
+		),
+		get_track_events: IDL.Func([GetAnalytics], [IDL.Vec(IDL.Tuple(AnalyticKey, TrackEvent))], []),
+		get_track_events_analytics: IDL.Func([GetAnalytics], [AnalyticsTrackEvents], []),
+		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], []),
+		list_satellite_configs: IDL.Func(
+			[],
+			[IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
+			[]
+		),
+		memory_size: IDL.Func([], [MemorySize], []),
+		set_controllers: IDL.Func(
+			[SetControllersArgs],
+			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],
+			[]
+		),
+		set_page_view: IDL.Func([AnalyticKey, SetPageView], [Result], []),
+		set_page_views: IDL.Func([IDL.Vec(IDL.Tuple(AnalyticKey, SetPageView))], [Result_1], []),
+		set_performance_metric: IDL.Func([AnalyticKey, SetPerformanceMetric], [Result_2], []),
+		set_performance_metrics: IDL.Func(
+			[IDL.Vec(IDL.Tuple(AnalyticKey, SetPerformanceMetric))],
+			[Result_1],
+			[]
+		),
+		set_satellite_configs: IDL.Func(
+			[IDL.Vec(IDL.Tuple(IDL.Principal, SetSatelliteConfig))],
+			[IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
+			[]
+		),
+		set_track_event: IDL.Func([AnalyticKey, SetTrackEvent], [Result_3], []),
+		set_track_events: IDL.Func([IDL.Vec(IDL.Tuple(AnalyticKey, SetTrackEvent))], [Result_1], []),
+		version: IDL.Func([], [IDL.Text], [])
+	});
+};
+// @ts-ignore
+export const init = ({ IDL }) => {
+	return [];
+};

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -1,0 +1,316 @@
+// @ts-ignore
+export const idlFactory = ({ IDL }) => {
+	const CommitBatch = IDL.Record({
+		batch_id: IDL.Nat,
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		chunk_ids: IDL.Vec(IDL.Nat)
+	});
+	const ListOrderField = IDL.Variant({
+		UpdatedAt: IDL.Null,
+		Keys: IDL.Null,
+		CreatedAt: IDL.Null
+	});
+	const ListOrder = IDL.Record({ field: ListOrderField, desc: IDL.Bool });
+	const TimestampMatcher = IDL.Variant({
+		Equal: IDL.Nat64,
+		Between: IDL.Tuple(IDL.Nat64, IDL.Nat64),
+		GreaterThan: IDL.Nat64,
+		LessThan: IDL.Nat64
+	});
+	const ListMatcher = IDL.Record({
+		key: IDL.Opt(IDL.Text),
+		updated_at: IDL.Opt(TimestampMatcher),
+		description: IDL.Opt(IDL.Text),
+		created_at: IDL.Opt(TimestampMatcher)
+	});
+	const ListPaginate = IDL.Record({
+		start_after: IDL.Opt(IDL.Text),
+		limit: IDL.Opt(IDL.Nat64)
+	});
+	const ListParams = IDL.Record({
+		order: IDL.Opt(ListOrder),
+		owner: IDL.Opt(IDL.Principal),
+		matcher: IDL.Opt(ListMatcher),
+		paginate: IDL.Opt(ListPaginate)
+	});
+	const DeleteControllersArgs = IDL.Record({
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const ControllerScope = IDL.Variant({
+		Write: IDL.Null,
+		Admin: IDL.Null
+	});
+	const Controller = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const DelDoc = IDL.Record({ version: IDL.Opt(IDL.Nat64) });
+	const RulesType = IDL.Variant({ Db: IDL.Null, Storage: IDL.Null });
+	const DelRule = IDL.Record({ version: IDL.Opt(IDL.Nat64) });
+	const DepositCyclesArgs = IDL.Record({
+		cycles: IDL.Nat,
+		destination_id: IDL.Principal
+	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const AssetEncodingNoContent = IDL.Record({
+		modified: IDL.Nat64,
+		sha256: IDL.Vec(IDL.Nat8),
+		total_length: IDL.Nat
+	});
+	const AssetNoContent = IDL.Record({
+		key: AssetKey,
+		updated_at: IDL.Nat64,
+		encodings: IDL.Vec(IDL.Tuple(IDL.Text, AssetEncodingNoContent)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		version: IDL.Opt(IDL.Nat64)
+	});
+	const AuthenticationConfigInternetIdentity = IDL.Record({
+		derivation_origin: IDL.Opt(IDL.Text)
+	});
+	const AuthenticationConfig = IDL.Record({
+		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity)
+	});
+	const ConfigMaxMemorySize = IDL.Record({
+		stable: IDL.Opt(IDL.Nat64),
+		heap: IDL.Opt(IDL.Nat64)
+	});
+	const DbConfig = IDL.Record({
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize)
+	});
+	const StorageConfigIFrame = IDL.Variant({
+		Deny: IDL.Null,
+		AllowAny: IDL.Null,
+		SameOrigin: IDL.Null
+	});
+	const StorageConfigRawAccess = IDL.Variant({
+		Deny: IDL.Null,
+		Allow: IDL.Null
+	});
+	const StorageConfigRedirect = IDL.Record({
+		status_code: IDL.Nat16,
+		location: IDL.Text
+	});
+	const StorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
+	const Config = IDL.Record({
+		db: IDL.Opt(DbConfig),
+		authentication: IDL.Opt(AuthenticationConfig),
+		storage: StorageConfig
+	});
+	const Doc = IDL.Record({
+		updated_at: IDL.Nat64,
+		owner: IDL.Principal,
+		data: IDL.Vec(IDL.Nat8),
+		description: IDL.Opt(IDL.Text),
+		created_at: IDL.Nat64,
+		version: IDL.Opt(IDL.Nat64)
+	});
+	const Memory = IDL.Variant({ Heap: IDL.Null, Stable: IDL.Null });
+	const Permission = IDL.Variant({
+		Controllers: IDL.Null,
+		Private: IDL.Null,
+		Public: IDL.Null,
+		Managed: IDL.Null
+	});
+	const RateConfig = IDL.Record({
+		max_tokens: IDL.Nat64,
+		time_per_token_ns: IDL.Nat64
+	});
+	const Rule = IDL.Record({
+		max_capacity: IDL.Opt(IDL.Nat32),
+		memory: IDL.Opt(Memory),
+		updated_at: IDL.Nat64,
+		max_size: IDL.Opt(IDL.Nat),
+		read: Permission,
+		created_at: IDL.Nat64,
+		version: IDL.Opt(IDL.Nat64),
+		mutable_permissions: IDL.Opt(IDL.Bool),
+		rate_config: IDL.Opt(RateConfig),
+		write: Permission
+	});
+	const HttpRequest = IDL.Record({
+		url: IDL.Text,
+		method: IDL.Text,
+		body: IDL.Vec(IDL.Nat8),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		certificate_version: IDL.Opt(IDL.Nat16)
+	});
+	const StreamingCallbackToken = IDL.Record({
+		memory: Memory,
+		token: IDL.Opt(IDL.Text),
+		sha256: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		index: IDL.Nat64,
+		encoding_type: IDL.Text,
+		full_path: IDL.Text
+	});
+	const StreamingStrategy = IDL.Variant({
+		Callback: IDL.Record({
+			token: StreamingCallbackToken,
+			callback: IDL.Func([], [], [])
+		})
+	});
+	const HttpResponse = IDL.Record({
+		body: IDL.Vec(IDL.Nat8),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		streaming_strategy: IDL.Opt(StreamingStrategy),
+		status_code: IDL.Nat16
+	});
+	const StreamingCallbackHttpResponse = IDL.Record({
+		token: IDL.Opt(StreamingCallbackToken),
+		body: IDL.Vec(IDL.Nat8)
+	});
+	const InitAssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		encoding_type: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const InitUploadResult = IDL.Record({ batch_id: IDL.Nat });
+	const ListResults = IDL.Record({
+		matches_pages: IDL.Opt(IDL.Nat64),
+		matches_length: IDL.Nat64,
+		items_page: IDL.Opt(IDL.Nat64),
+		items: IDL.Vec(IDL.Tuple(IDL.Text, AssetNoContent)),
+		items_length: IDL.Nat64
+	});
+	const CustomDomain = IDL.Record({
+		updated_at: IDL.Nat64,
+		created_at: IDL.Nat64,
+		version: IDL.Opt(IDL.Nat64),
+		bn_id: IDL.Opt(IDL.Text)
+	});
+	const ListResults_1 = IDL.Record({
+		matches_pages: IDL.Opt(IDL.Nat64),
+		matches_length: IDL.Nat64,
+		items_page: IDL.Opt(IDL.Nat64),
+		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
+		items_length: IDL.Nat64
+	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
+	const SetController = IDL.Record({
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const SetControllersArgs = IDL.Record({
+		controller: SetController,
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const SetDoc = IDL.Record({
+		data: IDL.Vec(IDL.Nat8),
+		description: IDL.Opt(IDL.Text),
+		version: IDL.Opt(IDL.Nat64)
+	});
+	const SetRule = IDL.Record({
+		max_capacity: IDL.Opt(IDL.Nat32),
+		memory: IDL.Opt(Memory),
+		max_size: IDL.Opt(IDL.Nat),
+		read: Permission,
+		version: IDL.Opt(IDL.Nat64),
+		mutable_permissions: IDL.Opt(IDL.Bool),
+		rate_config: IDL.Opt(RateConfig),
+		write: Permission
+	});
+	const UploadChunk = IDL.Record({
+		content: IDL.Vec(IDL.Nat8),
+		batch_id: IDL.Nat,
+		order_id: IDL.Opt(IDL.Nat)
+	});
+	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
+	return IDL.Service({
+		build_version: IDL.Func([], [IDL.Text], []),
+		commit_asset_upload: IDL.Func([CommitBatch], [], []),
+		count_assets: IDL.Func([IDL.Text, ListParams], [IDL.Nat64], []),
+		count_collection_assets: IDL.Func([IDL.Text], [IDL.Nat64], []),
+		count_collection_docs: IDL.Func([IDL.Text], [IDL.Nat64], []),
+		count_docs: IDL.Func([IDL.Text, ListParams], [IDL.Nat64], []),
+		del_asset: IDL.Func([IDL.Text, IDL.Text], [], []),
+		del_assets: IDL.Func([IDL.Text], [], []),
+		del_controllers: IDL.Func(
+			[DeleteControllersArgs],
+			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],
+			[]
+		),
+		del_custom_domain: IDL.Func([IDL.Text], [], []),
+		del_doc: IDL.Func([IDL.Text, IDL.Text, DelDoc], [], []),
+		del_docs: IDL.Func([IDL.Text], [], []),
+		del_filtered_assets: IDL.Func([IDL.Text, ListParams], [], []),
+		del_filtered_docs: IDL.Func([IDL.Text, ListParams], [], []),
+		del_many_assets: IDL.Func([IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], [], []),
+		del_many_docs: IDL.Func([IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text, DelDoc))], [], []),
+		del_rule: IDL.Func([RulesType, IDL.Text, DelRule], [], []),
+		deposit_cycles: IDL.Func([DepositCyclesArgs], [], []),
+		get_asset: IDL.Func([IDL.Text, IDL.Text], [IDL.Opt(AssetNoContent)], []),
+		get_auth_config: IDL.Func([], [IDL.Opt(AuthenticationConfig)], []),
+		get_config: IDL.Func([], [Config], []),
+		get_db_config: IDL.Func([], [IDL.Opt(DbConfig)], []),
+		get_doc: IDL.Func([IDL.Text, IDL.Text], [IDL.Opt(Doc)], []),
+		get_many_assets: IDL.Func(
+			[IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],
+			[IDL.Vec(IDL.Tuple(IDL.Text, IDL.Opt(AssetNoContent)))],
+			[]
+		),
+		get_many_docs: IDL.Func(
+			[IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],
+			[IDL.Vec(IDL.Tuple(IDL.Text, IDL.Opt(Doc)))],
+			[]
+		),
+		get_rule: IDL.Func([RulesType, IDL.Text], [IDL.Opt(Rule)], []),
+		get_storage_config: IDL.Func([], [StorageConfig], []),
+		http_request: IDL.Func([HttpRequest], [HttpResponse], []),
+		http_request_streaming_callback: IDL.Func(
+			[StreamingCallbackToken],
+			[StreamingCallbackHttpResponse],
+			[]
+		),
+		init_asset_upload: IDL.Func([InitAssetKey], [InitUploadResult], []),
+		list_assets: IDL.Func([IDL.Text, ListParams], [ListResults], []),
+		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], []),
+		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
+		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
+		list_rules: IDL.Func([RulesType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
+		memory_size: IDL.Func([], [MemorySize], []),
+		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
+		set_controllers: IDL.Func(
+			[SetControllersArgs],
+			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],
+			[]
+		),
+		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
+		set_db_config: IDL.Func([DbConfig], [], []),
+		set_doc: IDL.Func([IDL.Text, IDL.Text, SetDoc], [Doc], []),
+		set_many_docs: IDL.Func(
+			[IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text, SetDoc))],
+			[IDL.Vec(IDL.Tuple(IDL.Text, Doc))],
+			[]
+		),
+		set_rule: IDL.Func([RulesType, IDL.Text, SetRule], [Rule], []),
+		set_storage_config: IDL.Func([StorageConfig], [], []),
+		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
+		version: IDL.Func([], [IDL.Text], [])
+	});
+};
+// @ts-ignore
+export const init = ({ IDL }) => {
+	return [];
+};


### PR DESCRIPTION
# Motivation

Generate certified did files by removing keyword `query` otherwise one cannot make an update call to a query endpoint in javascript.

I can't believe those kind of sh** are still necessary.
