### PR TITLE
feat: wrap view with wallet loader

### DIFF
--- a/src/frontend/src/lib/components/core/NavbarCockpit.svelte
+++ b/src/frontend/src/lib/components/core/NavbarCockpit.svelte
@@ -10,7 +10,6 @@
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
 	import IconWallet from '$lib/components/icons/IconWallet.svelte';
 	import WalletInlineBalance from '$lib/components/wallet/WalletInlineBalance.svelte';
-	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { balance, balanceLoaded } from '$lib/derived/balance.derived';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
@@ -70,16 +69,14 @@
 {/if}
 
 {#if nonNullish($missionControlIdDerived)}
-	<WalletLoader missionControlId={$missionControlIdDerived}>
-		{#if $balanceLoaded}
-			<div in:slide={{ axis: 'x' }} class="container wallet">
-				<NavbarLink href="/wallet" ariaLabel={`${$i18n.core.open}: ${$i18n.wallet.title}`}>
-					<IconWallet />
-					<WalletInlineBalance balance={$balance} />
-				</NavbarLink>
-			</div>
-		{/if}
-	</WalletLoader>
+	{#if $balanceLoaded}
+		<div in:slide={{ axis: 'x' }} class="container wallet">
+			<NavbarLink href="/wallet" ariaLabel={`${$i18n.core.open}: ${$i18n.wallet.title}`}>
+				<IconWallet />
+				<WalletInlineBalance balance={$balance} />
+			</NavbarLink>
+		</div>
+	{/if}
 {/if}
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/launchpad/Cockpit.svelte
+++ b/src/frontend/src/lib/components/launchpad/Cockpit.svelte
@@ -14,7 +14,6 @@
 	import MissionControlVersion from '$lib/components/mission-control/MissionControlVersion.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import WalletInlineBalance from '$lib/components/wallet/WalletInlineBalance.svelte';
-	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { balance } from '$lib/derived/balance.derived';
 	import {
 		missionControlNotMonitored,
@@ -128,10 +127,6 @@
 		</p>
 	</LaunchpadLink>
 </div>
-
-{#if nonNullish($missionControlIdDerived)}
-	<WalletLoader missionControlId={$missionControlIdDerived} />
-{/if}
 
 <div class="wallet">
 	<LaunchpadLink

--- a/src/frontend/src/lib/components/wallet/Wallet.svelte
+++ b/src/frontend/src/lib/components/wallet/Wallet.svelte
@@ -8,7 +8,6 @@
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import WalletBalance from '$lib/components/wallet/WalletBalance.svelte';
-	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { PAGINATION } from '$lib/constants/constants';
 	import { MISSION_CONTROL_v0_0_12 } from '$lib/constants/version.constants';
 	import { authSignedIn, authSignedOut } from '$lib/derived/auth.derived';
@@ -95,48 +94,46 @@
 </script>
 
 {#if $authSignedIn}
-	<WalletLoader {missionControlId}>
-		<div class="card-container with-title">
-			<span class="title">{$i18n.wallet.overview}</span>
+	<div class="card-container with-title">
+		<span class="title">{$i18n.wallet.overview}</span>
 
-			<div class="columns-3 fit-column-1">
-				<div>
-					<Value>
-						{#snippet label()}
-							{$i18n.wallet.wallet_id}
-						{/snippet}
-						<Identifier shorten={false} small={false} identifier={missionControlId.toText()} />
-					</Value>
+		<div class="columns-3 fit-column-1">
+			<div>
+				<Value>
+					{#snippet label()}
+						{$i18n.wallet.wallet_id}
+					{/snippet}
+					<Identifier shorten={false} small={false} identifier={missionControlId.toText()} />
+				</Value>
 
-					<Value>
-						{#snippet label()}
-							{$i18n.wallet.account_identifier}
-						{/snippet}
-						<Identifier identifier={accountIdentifier?.toHex() ?? ''} small={false} />
-					</Value>
-				</div>
+				<Value>
+					{#snippet label()}
+						{$i18n.wallet.account_identifier}
+					{/snippet}
+					<Identifier identifier={accountIdentifier?.toHex() ?? ''} small={false} />
+				</Value>
+			</div>
 
-				<div>
-					<WalletBalance balance={$balance} />
-				</div>
+			<div>
+				<WalletBalance balance={$balance} />
 			</div>
 		</div>
+	</div>
 
-		<div class="toolbar">
-			<button onclick={openReceive}>{$i18n.wallet.receive}</button>
+	<div class="toolbar">
+		<button onclick={openReceive}>{$i18n.wallet.receive}</button>
 
-			<button onclick={openSend}>{$i18n.wallet.send}</button>
-		</div>
+		<button onclick={openSend}>{$i18n.wallet.send}</button>
+	</div>
 
-		<Transactions
-			transactions={$transactions}
-			{disableInfiniteScroll}
-			{missionControlId}
-			{onintersect}
-		/>
+	<Transactions
+		transactions={$transactions}
+		{disableInfiniteScroll}
+		{missionControlId}
+		{onintersect}
+	/>
 
-		<TransactionsExport transactions={$transactions} {missionControlId} />
-	</WalletLoader>
+	<TransactionsExport transactions={$transactions} {missionControlId} />
 {/if}
 
 <ReceiveTokens bind:visible={receiveVisible} {missionControlId} />

--- a/src/frontend/src/lib/components/wallet/WalletLoader.svelte
+++ b/src/frontend/src/lib/components/wallet/WalletLoader.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { onDestroy, onMount, type Snippet } from 'svelte';
+	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { type WalletWorker, initWalletWorker } from '$lib/services/worker.wallet.services';
-	import type { MissionControlId } from '$lib/types/mission-control';
 
 	interface Props {
-		missionControlId: MissionControlId;
 		children?: Snippet;
 	}
 
-	let { missionControlId, children }: Props = $props();
+	let { children }: Props = $props();
 
 	let worker: WalletWorker | undefined = $state();
 
@@ -18,22 +17,22 @@
 	};
 
 	$effect(() => {
-		if (isNullish(missionControlId)) {
+		if (isNullish($missionControlIdDerived)) {
 			worker?.stop();
 			return;
 		}
 
 		worker?.start({
-			missionControlId
+			missionControlId: $missionControlIdDerived
 		});
 	});
 
 	const onRestartWallet = () => {
-		if (isNullish(missionControlId)) {
+		if (isNullish($missionControlIdDerived)) {
 			return;
 		}
 
-		worker?.restart({ missionControlId });
+		worker?.restart({ missionControlId: $missionControlIdDerived });
 	};
 
 	onMount(async () => await initWorker());

--- a/src/frontend/src/routes/(home)/+page.svelte
+++ b/src/frontend/src/routes/(home)/+page.svelte
@@ -4,14 +4,17 @@
 	import Launchpad from '$lib/components/launchpad/Launchpad.svelte';
 
 	import SatellitesLoader from '$lib/components/loaders/SatellitesLoader.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 </script>
 
 {#if $authSignedIn}
 	<div in:fade>
-		<SatellitesLoader>
-			<Launchpad />
-		</SatellitesLoader>
+		<WalletLoader>
+			<SatellitesLoader>
+				<Launchpad />
+			</SatellitesLoader>
+		</WalletLoader>
 	</div>
 {:else}
 	<SignIn />

--- a/src/frontend/src/routes/(split)/analytics/+page.svelte
+++ b/src/frontend/src/routes/(split)/analytics/+page.svelte
@@ -12,6 +12,7 @@
 	import Orbiter from '$lib/components/orbiter/Orbiter.svelte';
 	import OrbiterConfig from '$lib/components/orbiter/OrbiterConfig.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import Warnings from '$lib/components/warning/Warnings.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
@@ -73,20 +74,22 @@
 			{/if}
 		{/snippet}
 
-		<SatellitesLoader>
-			<OrbitersLoader withVersion>
-				<MissionControlGuard>
-					{#if $store.tabId === $store.tabs[0].id}
-						<Analytics />
-					{:else if $store.tabId === $store.tabs[1].id && nonNullish($orbiterStore)}
-						<Orbiter orbiter={$orbiterStore} />
-					{:else if $store.tabId === $store.tabs[2].id && nonNullish($orbiterStore)}
-						<OrbiterConfig orbiterId={$orbiterStore.orbiter_id} />
+		<WalletLoader>
+			<SatellitesLoader>
+				<OrbitersLoader withVersion>
+					<MissionControlGuard>
+						{#if $store.tabId === $store.tabs[0].id}
+							<Analytics />
+						{:else if $store.tabId === $store.tabs[1].id && nonNullish($orbiterStore)}
+							<Orbiter orbiter={$orbiterStore} />
+						{:else if $store.tabId === $store.tabs[2].id && nonNullish($orbiterStore)}
+							<OrbiterConfig orbiterId={$orbiterStore.orbiter_id} />
 
-						<AnalyticsSettings orbiterId={$orbiterStore.orbiter_id} />
-					{/if}
-				</MissionControlGuard>
-			</OrbitersLoader>
-		</SatellitesLoader>
+							<AnalyticsSettings orbiterId={$orbiterStore.orbiter_id} />
+						{/if}
+					</MissionControlGuard>
+				</OrbitersLoader>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/authentication/+page.svelte
+++ b/src/frontend/src/routes/(split)/authentication/+page.svelte
@@ -8,6 +8,7 @@
 	import SatelliteGuard from '$lib/components/guards/SatelliteGuard.svelte';
 	import SatellitesLoader from '$lib/components/loaders/SatellitesLoader.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { satelliteStore } from '$lib/derived/satellite.derived';
 	import {
 		type Tab,
@@ -40,16 +41,18 @@
 
 <IdentityGuard>
 	<Tabs help="https://juno.build/docs/build/authentication">
-		<SatellitesLoader>
-			<SatelliteGuard>
-				{#if nonNullish($satelliteStore)}
-					{#if $store.tabId === $store.tabs[0].id}
-						<Users satelliteId={$satelliteStore.satellite_id} />
-					{:else if $store.tabId === $store.tabs[1].id}
-						<AuthSettings satellite={$satelliteStore} />
+		<WalletLoader>
+			<SatellitesLoader>
+				<SatelliteGuard>
+					{#if nonNullish($satelliteStore)}
+						{#if $store.tabId === $store.tabs[0].id}
+							<Users satelliteId={$satelliteStore.satellite_id} />
+						{:else if $store.tabId === $store.tabs[1].id}
+							<AuthSettings satellite={$satelliteStore} />
+						{/if}
 					{/if}
-				{/if}
-			</SatelliteGuard>
-		</SatellitesLoader>
+				</SatelliteGuard>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/datastore/+page.svelte
+++ b/src/frontend/src/routes/(split)/datastore/+page.svelte
@@ -7,6 +7,7 @@
 	import SatelliteGuard from '$lib/components/guards/SatelliteGuard.svelte';
 	import SatellitesLoader from '$lib/components/loaders/SatellitesLoader.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { satelliteStore } from '$lib/derived/satellite.derived';
 	import {
 		type Tab,
@@ -39,12 +40,14 @@
 
 <IdentityGuard>
 	<Tabs help="https://juno.build/docs/build/datastore">
-		<SatellitesLoader>
-			<SatelliteGuard>
-				{#if nonNullish($satelliteStore)}
-					<Db satelliteId={$satelliteStore.satellite_id} />
-				{/if}
-			</SatelliteGuard>
-		</SatellitesLoader>
+		<WalletLoader>
+			<SatellitesLoader>
+				<SatelliteGuard>
+					{#if nonNullish($satelliteStore)}
+						<Db satelliteId={$satelliteStore.satellite_id} />
+					{/if}
+				</SatelliteGuard>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/functions/+page.svelte
+++ b/src/frontend/src/routes/(split)/functions/+page.svelte
@@ -7,6 +7,7 @@
 	import SatellitesLoader from '$lib/components/loaders/SatellitesLoader.svelte';
 	import Logs from '$lib/components/logs/Logs.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { satelliteStore } from '$lib/derived/satellite.derived';
 	import {
 		type Tab,
@@ -35,12 +36,14 @@
 
 <IdentityGuard>
 	<Tabs help="https://juno.build/docs/build/functions">
-		<SatellitesLoader>
-			<SatelliteGuard>
-				{#if nonNullish($satelliteStore)}
-					<Logs satelliteId={$satelliteStore.satellite_id} />
-				{/if}
-			</SatelliteGuard>
-		</SatellitesLoader>
+		<WalletLoader>
+			<SatellitesLoader>
+				<SatelliteGuard>
+					{#if nonNullish($satelliteStore)}
+						<Logs satelliteId={$satelliteStore.satellite_id} />
+					{/if}
+				</SatelliteGuard>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/hosting/+page.svelte
+++ b/src/frontend/src/routes/(split)/hosting/+page.svelte
@@ -8,6 +8,7 @@
 	import Hosting from '$lib/components/hosting/Hosting.svelte';
 	import SatellitesLoader from '$lib/components/loaders/SatellitesLoader.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { satelliteStore } from '$lib/derived/satellite.derived';
 	import {
 		type Tab,
@@ -36,16 +37,18 @@
 
 <IdentityGuard>
 	<Tabs help="https://juno.build/docs/build/hosting">
-		<SatellitesLoader>
-			<SatelliteGuard>
-				<MissionControlGuard>
-					{#if nonNullish($satelliteStore)}
-						{#if $store.tabId === $store.tabs[0].id}
-							<Hosting satellite={$satelliteStore} />
+		<WalletLoader>
+			<SatellitesLoader>
+				<SatelliteGuard>
+					<MissionControlGuard>
+						{#if nonNullish($satelliteStore)}
+							{#if $store.tabId === $store.tabs[0].id}
+								<Hosting satellite={$satelliteStore} />
+							{/if}
 						{/if}
-					{/if}
-				</MissionControlGuard>
-			</SatelliteGuard>
-		</SatellitesLoader>
+					</MissionControlGuard>
+				</SatelliteGuard>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/mission-control/+page.svelte
+++ b/src/frontend/src/routes/(split)/mission-control/+page.svelte
@@ -8,6 +8,7 @@
 	import MissionControl from '$lib/components/mission-control/MissionControl.svelte';
 	import MissionControlSettings from '$lib/components/mission-control/MissionControlSettings.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import Warnings from '$lib/components/warning/Warnings.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
@@ -52,16 +53,18 @@
 			{/if}
 		{/snippet}
 
-		<SatellitesLoader>
-			<MissionControlGuard>
-				{#if nonNullish($missionControlIdDerived)}
-					{#if $store.tabId === $store.tabs[0].id}
-						<MissionControl missionControlId={$missionControlIdDerived} />
-					{:else if $store.tabId === $store.tabs[1].id}
-						<MissionControlSettings missionControlId={$missionControlIdDerived} />
+		<WalletLoader>
+			<SatellitesLoader>
+				<MissionControlGuard>
+					{#if nonNullish($missionControlIdDerived)}
+						{#if $store.tabId === $store.tabs[0].id}
+							<MissionControl missionControlId={$missionControlIdDerived} />
+						{:else if $store.tabId === $store.tabs[1].id}
+							<MissionControlSettings missionControlId={$missionControlIdDerived} />
+						{/if}
 					{/if}
-				{/if}
-			</MissionControlGuard>
-		</SatellitesLoader>
+				</MissionControlGuard>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/monitoring/+page.svelte
+++ b/src/frontend/src/routes/(split)/monitoring/+page.svelte
@@ -10,6 +10,7 @@
 	import MonitoringDashboard from '$lib/components/monitoring/MonitoringDashboard.svelte';
 	import MonitoringSettings from '$lib/components/monitoring/MonitoringSettings.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import Warnings from '$lib/components/warning/Warnings.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import { hasMissionControlSettings } from '$lib/derived/mission-control-settings.derived';
@@ -64,20 +65,22 @@
 			{/if}
 		{/snippet}
 
-		<SatellitesLoader>
-			<OrbitersLoader>
-				<MissionControlGuard>
-					{#if nonNullish($missionControlIdDerived)}
-						<MissionControlDataLoader missionControlId={$missionControlIdDerived} reload>
-							{#if $store.tabId === $store.tabs[0].id}
-								<MonitoringDashboard missionControlId={$missionControlIdDerived} />
-							{:else if $store.tabId === $store.tabs[1].id && $hasMissionControlSettings}
-								<MonitoringSettings missionControlId={$missionControlIdDerived} />
-							{/if}
-						</MissionControlDataLoader>
-					{/if}
-				</MissionControlGuard>
-			</OrbitersLoader>
-		</SatellitesLoader>
+		<WalletLoader>
+			<SatellitesLoader>
+				<OrbitersLoader>
+					<MissionControlGuard>
+						{#if nonNullish($missionControlIdDerived)}
+							<MissionControlDataLoader missionControlId={$missionControlIdDerived} reload>
+								{#if $store.tabId === $store.tabs[0].id}
+									<MonitoringDashboard missionControlId={$missionControlIdDerived} />
+								{:else if $store.tabId === $store.tabs[1].id && $hasMissionControlSettings}
+									<MonitoringSettings missionControlId={$missionControlIdDerived} />
+								{/if}
+							</MissionControlDataLoader>
+						{/if}
+					</MissionControlGuard>
+				</OrbitersLoader>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/satellite/+page.svelte
+++ b/src/frontend/src/routes/(split)/satellite/+page.svelte
@@ -11,6 +11,7 @@
 	import SatelliteOverview from '$lib/components/satellites/SatelliteOverview.svelte';
 	import SatelliteSettings from '$lib/components/satellites/SatelliteSettings.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import Warnings from '$lib/components/warning/Warnings.svelte';
 	import { satelliteStore } from '$lib/derived/satellite.derived';
 	import {
@@ -54,22 +55,24 @@
 			{/if}
 		{/snippet}
 
-		<SatellitesLoader>
-			<OrbitersLoader>
-				<SatelliteGuard>
-					<MissionControlGuard>
-						{#if nonNullish($satelliteStore)}
-							{#if $store.tabId === $store.tabs[0].id}
-								<SatelliteOverview satellite={$satelliteStore} />
+		<WalletLoader>
+			<SatellitesLoader>
+				<OrbitersLoader>
+					<SatelliteGuard>
+						<MissionControlGuard>
+							{#if nonNullish($satelliteStore)}
+								{#if $store.tabId === $store.tabs[0].id}
+									<SatelliteOverview satellite={$satelliteStore} />
 
-								<Guides />
-							{:else if $store.tabId === $store.tabs[1].id}
-								<SatelliteSettings satellite={$satelliteStore} />
+									<Guides />
+								{:else if $store.tabId === $store.tabs[1].id}
+									<SatelliteSettings satellite={$satelliteStore} />
+								{/if}
 							{/if}
-						{/if}
-					</MissionControlGuard>
-				</SatelliteGuard>
-			</OrbitersLoader>
-		</SatellitesLoader>
+						</MissionControlGuard>
+					</SatelliteGuard>
+				</OrbitersLoader>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/storage/+page.svelte
+++ b/src/frontend/src/routes/(split)/storage/+page.svelte
@@ -7,6 +7,7 @@
 	import SatellitesLoader from '$lib/components/loaders/SatellitesLoader.svelte';
 	import Storage from '$lib/components/storage/Storage.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import { satelliteStore } from '$lib/derived/satellite.derived';
 	import {
 		type Tab,
@@ -39,12 +40,14 @@
 
 <IdentityGuard>
 	<Tabs help="https://juno.build/docs/build/storage">
-		<SatellitesLoader>
-			<SatelliteGuard>
-				{#if nonNullish($satelliteStore)}
-					<Storage satelliteId={$satelliteStore?.satellite_id} />
-				{/if}
-			</SatelliteGuard>
-		</SatellitesLoader>
+		<WalletLoader>
+			<SatellitesLoader>
+				<SatelliteGuard>
+					{#if nonNullish($satelliteStore)}
+						<Storage satelliteId={$satelliteStore?.satellite_id} />
+					{/if}
+				</SatelliteGuard>
+			</SatellitesLoader>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/wallet/+page.svelte
+++ b/src/frontend/src/routes/(split)/wallet/+page.svelte
@@ -6,6 +6,7 @@
 	import MissionControlGuard from '$lib/components/guards/MissionControlGuard.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import Wallet from '$lib/components/wallet/Wallet.svelte';
+	import WalletLoader from '$lib/components/wallet/WalletLoader.svelte';
 	import Warnings from '$lib/components/warning/Warnings.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
@@ -42,12 +43,14 @@
 			{/if}
 		{/snippet}
 
-		<MissionControlGuard>
-			{#if nonNullish($missionControlIdDerived)}
-				{#if $store.tabId === $store.tabs[0].id}
-					<Wallet missionControlId={$missionControlIdDerived} />
+		<WalletLoader>
+			<MissionControlGuard>
+				{#if nonNullish($missionControlIdDerived)}
+					{#if $store.tabId === $store.tabs[0].id}
+						<Wallet missionControlId={$missionControlIdDerived} />
+					{/if}
 				{/if}
-			{/if}
-		</MissionControlGuard>
+			</MissionControlGuard>
+		</WalletLoader>
 	</Tabs>
 </IdentityGuard>


### PR DESCRIPTION
# Motivation

We do not want to load the wallet worker 20 times. Given that it is now used in any views and the balance is used from the store - i.e. with the value loaded by the worker - we can wrap the entire view with the `WalletLoader`. It's also cleaner.
