### PR TITLE
feat: remove canister status sync indicator

### DIFF
--- a/src/frontend/src/lib/components/canister/CanisterIndicator.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterIndicator.svelte
@@ -19,8 +19,6 @@
 
 {#if isNullish(status)}
 	<div in:fade></div>
-{:else if sync === 'syncing'}
-	<span class="spinner" in:blur><IconSync size="16px" /> </span>
 {:else if warning || status === 'stopping'}
 	<div class="warning" in:fade aria-label={$i18n.canisters.warning_indicator}></div>
 {:else if status === 'stopped'}
@@ -52,9 +50,5 @@
 
 	.stopped {
 		background: var(--color-error);
-	}
-
-	.spinner {
-		height: 16px;
 	}
 </style>


### PR DESCRIPTION
# Motivation

After all, this spinner does not add much value and it's also a bit unfortunate now to not be able to know the status indicator (greed, red etc) while it's spinning. Also we do not display spinners for other information being reloaded such as the wallet balance.
