### PR TITLE
feat: no derived global page cleanup

### DIFF
--- a/src/frontend/src/lib/derived/page.derived.svelte.ts
+++ b/src/frontend/src/lib/derived/page.derived.svelte.ts
@@ -9,21 +9,14 @@ export type PageSatelliteIdStore = Readable<PageSatelliteIdStoreData>;
 const initPageSatelliteIdStore = (): PageSatelliteIdStore => {
 	const { subscribe, set } = writable<PageSatelliteIdStoreData>(undefined);
 
+	$effect.root(() => {
+		$effect(() => {
+			set(page.data?.satellite);
+		});
+	});
+
 	return {
-		subscribe: (run) => {
-			const cleanup = $effect.root(() => {
-				$effect(() => {
-					set(page.data?.satellite);
-				});
-			});
-
-			const unsubscribe = subscribe(run);
-
-			return () => {
-				cleanup();
-				unsubscribe();
-			};
-		}
+		subscribe
 	};
 };
 


### PR DESCRIPTION
# Motivation

Follow-up of #1128.

For performance reason, it's actually better to not cleanup given that the derived store is declared globally anyway and we do not really have a use case in which we would not like to subscribe anymore. This has an advantages: the store is set once on navigation and not twice.
