### PR TITLE
feat: replace on:junoSyncCanister with store derived

### DIFF
--- a/src/frontend/src/app.d.ts
+++ b/src/frontend/src/app.d.ts
@@ -17,7 +17,6 @@ declare namespace svelteHTML {
 		onjunoIntersecting?: (event: CustomEvent<any>) => void;
 		onjunoModal?: (event: CustomEvent<any>) => void;
 		onjunoSyncCustomDomains?: (event: CustomEvent<any>) => void;
-		onjunoSyncCanister?: (event: CustomEvent<any>) => void;
 		onjunoRestartCycles?: (event: CustomEvent<any>) => void;
 		onjunoReloadVersions?: (event: CustomEvent<any>) => void;
 		onjunoCloseActions?: (event: CustomEvent<any>) => void;

--- a/src/frontend/src/lib/components/canister/Canister.svelte
+++ b/src/frontend/src/lib/components/canister/Canister.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
 	import CanisterIndicator from '$lib/components/canister/CanisterIndicator.svelte';
+	import CanisterSyncData from '$lib/components/canister/CanisterSyncData.svelte';
 	import CanisterTCycles from '$lib/components/canister/CanisterTCycles.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { CanisterSyncData, CanisterData, CanisterSyncStatus } from '$lib/types/canister';
+	import type {
+		CanisterSyncData as CanisterSyncDataType,
+		CanisterData,
+		CanisterSyncStatus
+	} from '$lib/types/canister';
 	import { formatBytes } from '$lib/utils/number.utils';
-	import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
 
 	interface Props {
 		canisterId: Principal;
@@ -24,9 +28,7 @@
 		sync = $bindable(undefined)
 	}: Props = $props();
 
-	let canister: CanisterSyncData | undefined = $derived(
-		$canisterSyncDataUncertifiedStore?.[canisterId.toText()]?.data
-	);
+	let canister = $state<CanisterSyncDataType | undefined>(undefined);
 
 	$effect(() => {
 		const c = canister ?? { data: undefined, sync: undefined };
@@ -44,6 +46,8 @@
 		}
 	);
 </script>
+
+<CanisterSyncData {canisterId} bind:canister />
 
 {#if display}
 	<div class:row>

--- a/src/frontend/src/lib/components/canister/CanisterSyncData.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterSyncData.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { Principal } from '@dfinity/principal';
+	import type { Snippet } from 'svelte';
+	import { canisterMonitoringUncertifiedStore } from '$lib/stores/canister-monitoring.store';
+	import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
+	import type { CanisterMonitoringData, CanisterSyncData } from '$lib/types/canister';
+
+	interface Props {
+		canisterId: Principal;
+		children?: Snippet;
+		canister: CanisterSyncData | undefined;
+	}
+
+	let { children, canisterId, canister = $bindable(undefined) }: Props = $props();
+
+	$effect(() => {
+		canister = $canisterSyncDataUncertifiedStore?.[canisterId.toText()]?.data;
+	});
+</script>
+
+{@render children?.()}

--- a/src/frontend/src/lib/components/canister/CanisterWarnings.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterWarnings.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
 	import type { Snippet } from 'svelte';
+	import CanisterSyncData from '$lib/components/canister/CanisterSyncData.svelte';
 	import Warning from '$lib/components/ui/Warning.svelte';
-	import type { CanisterSyncData } from '$lib/types/canister';
+	import type { CanisterSyncData as CanisterSyncDataType } from '$lib/types/canister';
 
 	interface Props {
 		canisterId: Principal;
@@ -12,22 +13,16 @@
 
 	let { canisterId, cycles, heap }: Props = $props();
 
-	let cyclesWarning = $state(false);
+	let canister = $state<CanisterSyncDataType | undefined>(undefined);
+
+	let cyclesWarning = $derived(canister?.data?.warning?.cycles === true);
+
+	// Disabled for now, a bit too much in your face given that wasm memory cannot be shrink. We can always activate this warning if necessary, therefore I don't remove the code.
+	// heapWarning = data?.warning?.heap === true ?? false;
 	let heapWarning = false;
-
-	const syncCanister = ({ id, data }: CanisterSyncData) => {
-		if (id !== canisterId.toText()) {
-			return;
-		}
-
-		cyclesWarning = data?.warning?.cycles === true;
-
-		// Disabled for now, a bit too much in your face given that wasm memory cannot be shrink. We can always activate this warning if necessary, therefore I don't remove the code.
-		// heapWarning = data?.warning?.heap === true ?? false;
-	};
 </script>
 
-<svelte:window onjunoSyncCanister={({ detail: { canister } }) => syncCanister(canister)} />
+<CanisterSyncData {canisterId} bind:canister />
 
 {#if cyclesWarning}
 	<Warning>

--- a/src/frontend/src/lib/components/loaders/CanistersSyncDataLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/CanistersSyncDataLoader.svelte
@@ -9,7 +9,6 @@
 	import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
 	import type { CanisterSegment } from '$lib/types/canister';
 	import type { PostMessageDataResponseCanisterSyncData } from '$lib/types/post-message';
-	import { emit } from '$lib/utils/events.utils';
 
 	interface Props {
 		children: Snippet;
@@ -35,9 +34,6 @@
 				certified: false
 			}
 		});
-
-		// TODO: use store
-		emit({ message: 'junoSyncCanister', detail: { canister } });
 	};
 
 	const debounceStart = debounce(() =>

--- a/src/frontend/src/lib/components/mission-control/MissionControlActions.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlActions.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import CanisterBuyCycleExpress from '$lib/components/canister/CanisterBuyCycleExpress.svelte';
+	import CanisterSyncData from '$lib/components/canister/CanisterSyncData.svelte';
 	import CanisterTransferCycles from '$lib/components/canister/CanisterTransferCycles.svelte';
 	import TopUp from '$lib/components/canister/TopUp.svelte';
 	import MissionControlAttachOrbiter from '$lib/components/mission-control/MissionControlAttachOrbiter.svelte';
 	import MissionControlAttachSatellite from '$lib/components/mission-control/MissionControlAttachSatellite.svelte';
 	import SegmentActions from '$lib/components/segments/SegmentActions.svelte';
-	import type { CanisterSyncData } from '$lib/types/canister';
+	import type { CanisterSyncData as CanisterSyncDataType } from '$lib/types/canister';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import { emit } from '$lib/utils/events.utils';
 
@@ -15,18 +16,10 @@
 
 	let { missionControlId }: Props = $props();
 
-	let canister: CanisterSyncData | undefined = $state(undefined);
+	let canister = $state<CanisterSyncDataType | undefined>(undefined);
 
 	let visible: boolean = $state(false);
 	const close = () => (visible = false);
-
-	const onSyncCanister = (syncCanister: CanisterSyncData) => {
-		if (syncCanister.id !== missionControlId.toText()) {
-			return;
-		}
-
-		canister = syncCanister;
-	};
 
 	// eslint-disable-next-line require-await
 	const onTransferCycles = async () => {
@@ -44,10 +37,7 @@
 	};
 </script>
 
-<svelte:window
-	onjunoSyncCanister={({ detail: { canister } }: CustomEvent<{ canister: CanisterSyncData }>) =>
-		onSyncCanister(canister)}
-/>
+<CanisterSyncData canisterId={missionControlId} bind:canister />
 
 <SegmentActions bind:visible segment="mission_control">
 	{#snippet cycleActions()}

--- a/src/frontend/src/lib/components/orbiter/OrbiterActions.svelte
+++ b/src/frontend/src/lib/components/orbiter/OrbiterActions.svelte
@@ -3,11 +3,12 @@
 	import CanisterBuyCycleExpress from '$lib/components/canister/CanisterBuyCycleExpress.svelte';
 	import CanisterDelete from '$lib/components/canister/CanisterDelete.svelte';
 	import CanisterStopStart from '$lib/components/canister/CanisterStopStart.svelte';
+	import CanisterSyncData from '$lib/components/canister/CanisterSyncData.svelte';
 	import CanisterTransferCycles from '$lib/components/canister/CanisterTransferCycles.svelte';
 	import SegmentDetach from '$lib/components/canister/SegmentDetach.svelte';
 	import TopUp from '$lib/components/canister/TopUp.svelte';
 	import SegmentActions from '$lib/components/segments/SegmentActions.svelte';
-	import type { CanisterSyncData } from '$lib/types/canister';
+	import type { CanisterSyncData as CanisterSyncDataType } from '$lib/types/canister';
 	import { emit } from '$lib/utils/events.utils';
 
 	interface Props {
@@ -16,15 +17,7 @@
 
 	let { orbiter }: Props = $props();
 
-	let canister: CanisterSyncData | undefined = $state(undefined);
-
-	const onSyncCanister = (syncCanister: CanisterSyncData) => {
-		if (syncCanister.id !== orbiter.orbiter_id.toText()) {
-			return;
-		}
-
-		canister = syncCanister;
-	};
+	let canister = $state<CanisterSyncDataType | undefined>(undefined);
 
 	let visible: boolean = $state(false);
 	const close = () => (visible = false);
@@ -45,10 +38,7 @@
 	};
 </script>
 
-<svelte:window
-	onjunoSyncCanister={({ detail: { canister } }: CustomEvent<{ canister: CanisterSyncData }>) =>
-		onSyncCanister(canister)}
-/>
+<CanisterSyncData canisterId={orbiter.orbiter_id} bind:canister />
 
 <SegmentActions bind:visible segment="orbiter">
 	{#snippet cycleActions()}

--- a/src/frontend/src/lib/components/satellites/SatelliteActions.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteActions.svelte
@@ -3,13 +3,14 @@
 	import CanisterBuyCycleExpress from '$lib/components/canister/CanisterBuyCycleExpress.svelte';
 	import CanisterDelete from '$lib/components/canister/CanisterDelete.svelte';
 	import CanisterStopStart from '$lib/components/canister/CanisterStopStart.svelte';
+	import CanisterSyncData from '$lib/components/canister/CanisterSyncData.svelte';
 	import CanisterTransferCycles from '$lib/components/canister/CanisterTransferCycles.svelte';
 	import SegmentDetach from '$lib/components/canister/SegmentDetach.svelte';
 	import TopUp from '$lib/components/canister/TopUp.svelte';
 	import SegmentActions from '$lib/components/segments/SegmentActions.svelte';
 	import { listCustomDomains } from '$lib/services/hosting.services';
 	import { busy } from '$lib/stores/busy.store';
-	import type { CanisterSyncData } from '$lib/types/canister';
+	import type { CanisterSyncData as CanisterSyncDataType } from '$lib/types/canister';
 	import { emit } from '$lib/utils/events.utils';
 
 	interface Props {
@@ -20,15 +21,7 @@
 
 	let detail = { satellite };
 
-	let canister: CanisterSyncData | undefined = $state(undefined);
-
-	const onSyncCanister = (syncCanister: CanisterSyncData) => {
-		if (syncCanister.id !== satellite.satellite_id.toText()) {
-			return;
-		}
-
-		canister = syncCanister;
-	};
+	let canister = $state<CanisterSyncDataType | undefined>(undefined);
 
 	let visible: boolean = $state(false);
 	const close = () => (visible = false);
@@ -78,10 +71,7 @@
 	};
 </script>
 
-<svelte:window
-	onjunoSyncCanister={({ detail: { canister } }: CustomEvent<{ canister: CanisterSyncData }>) =>
-		onSyncCanister(canister)}
-/>
+<CanisterSyncData canisterId={satellite.satellite_id} bind:canister />
 
 <SegmentActions bind:visible segment="satellite">
 	{#snippet cycleActions()}


### PR DESCRIPTION
# Motivation

We have a global store now for synced canister data therefore we can avoid the use of an emitter.
