### PR TITLE
feat: prevent stop, detach and delete if monitoring is enabled

### DIFF
--- a/src/frontend/src/lib/components/canister/CanisterStop.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterStop.svelte
@@ -15,11 +15,12 @@
 
 	interface Props {
 		canister: CanisterSyncData;
+		monitoringEnabled: boolean;
 		segment: 'satellite' | 'orbiter';
 		onstop: () => void;
 	}
 
-	let { canister, segment, onstop }: Props = $props();
+	let { canister, monitoringEnabled, segment, onstop }: Props = $props();
 
 	let visible = $state(false);
 
@@ -30,6 +31,11 @@
 			toasts.error({
 				text: $i18n.errors.no_identity
 			});
+			return;
+		}
+
+		if (monitoringEnabled) {
+			toasts.warn($i18n.monitoring.warn_monitoring_enabled);
 			return;
 		}
 

--- a/src/frontend/src/lib/components/canister/CanisterStopStart.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterStopStart.svelte
@@ -7,12 +7,13 @@
 
 	interface Props {
 		canister?: CanisterSyncData | undefined;
+		monitoringEnabled: boolean;
 		segment: 'satellite' | 'orbiter';
 		onstart: () => void;
 		onstop: () => void;
 	}
 
-	let { canister = undefined, segment, onstart, onstop }: Props = $props();
+	let { canister = undefined, monitoringEnabled, segment, onstart, onstop }: Props = $props();
 
 	let status = $derived<CanisterStatus | undefined>(canister?.data?.canister.status);
 	let sync = $derived<CanisterSyncStatus | undefined>(canister?.sync);
@@ -21,7 +22,7 @@
 {#if nonNullish(canister) && status === 'stopped' && sync === 'synced'}
 	<div in:fade><CanisterStart {canister} {segment} {onstart} /></div>
 {:else if nonNullish(canister) && status === 'running' && sync === 'synced'}
-	<div in:fade><CanisterStop {canister} {segment} {onstop} /></div>
+	<div in:fade><CanisterStop {canister} {monitoringEnabled} {segment} {onstop} /></div>
 {/if}
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/canister/SegmentDetach.svelte
+++ b/src/frontend/src/lib/components/canister/SegmentDetach.svelte
@@ -15,11 +15,12 @@
 
 	interface Props {
 		segment: 'satellite' | 'orbiter';
+		monitoringEnabled: boolean;
 		segmentId: Principal;
 		ondetach: () => void;
 	}
 
-	let { segment, segmentId, ondetach }: Props = $props();
+	let { segment, monitoringEnabled, segmentId, ondetach }: Props = $props();
 
 	let visible = $state(false);
 
@@ -37,6 +38,12 @@
 			toasts.error({
 				text: $i18n.errors.no_mission_control
 			});
+			return;
+		}
+
+		// TODO: can be removed once the mission control is patched to disable monitoring on detach
+		if (monitoringEnabled) {
+			toasts.warn($i18n.monitoring.warn_monitoring_enabled);
 			return;
 		}
 

--- a/src/frontend/src/lib/components/orbiter/OrbiterActions.svelte
+++ b/src/frontend/src/lib/components/orbiter/OrbiterActions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { fromNullishNullable } from '@dfinity/utils';
 	import type { Orbiter } from '$declarations/mission_control/mission_control.did';
 	import CanisterBuyCycleExpress from '$lib/components/canister/CanisterBuyCycleExpress.svelte';
 	import CanisterDelete from '$lib/components/canister/CanisterDelete.svelte';
@@ -8,11 +9,10 @@
 	import SegmentDetach from '$lib/components/canister/SegmentDetach.svelte';
 	import TopUp from '$lib/components/canister/TopUp.svelte';
 	import SegmentActions from '$lib/components/segments/SegmentActions.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { toasts } from '$lib/stores/toasts.store';
 	import type { CanisterSyncData as CanisterSyncDataType } from '$lib/types/canister';
 	import { emit } from '$lib/utils/events.utils';
-	import { fromNullishNullable } from '@dfinity/utils';
-	import { toasts } from '$lib/stores/toasts.store';
-	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
 		orbiter: Orbiter;

--- a/src/frontend/src/lib/components/satellites/SatelliteActions.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteActions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { fromNullishNullable } from '@dfinity/utils';
 	import type { Satellite } from '$declarations/mission_control/mission_control.did';
 	import CanisterBuyCycleExpress from '$lib/components/canister/CanisterBuyCycleExpress.svelte';
 	import CanisterDelete from '$lib/components/canister/CanisterDelete.svelte';
@@ -10,11 +11,10 @@
 	import SegmentActions from '$lib/components/segments/SegmentActions.svelte';
 	import { listCustomDomains } from '$lib/services/hosting.services';
 	import { busy } from '$lib/stores/busy.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { toasts } from '$lib/stores/toasts.store';
 	import type { CanisterSyncData as CanisterSyncDataType } from '$lib/types/canister';
 	import { emit } from '$lib/utils/events.utils';
-	import { fromNullishNullable } from '@dfinity/utils';
-	import { toasts } from '$lib/stores/toasts.store';
-	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
 		satellite: Satellite;

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -740,7 +740,8 @@
 		"custom": "Custom",
 		"custom_description": "Define your own thresholds and top-up amounts.",
 		"default": "Your strategy",
-		"default_description": "Use your previously saved default strategy."
+		"default_description": "Use your previously saved default strategy.",
+		"warn_monitoring_enabled": "Please disable monitoring before proceeding."
 	},
 	"preferences": {
 		"title": "Preferences",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -740,7 +740,8 @@
 		"custom": "Custom",
 		"custom_description": "Define your own thresholds and top-up amounts.",
 		"default": "Your strategy",
-		"default_description": "Use your previously saved default strategy."
+		"default_description": "Use your previously saved default strategy.",
+		"warn_monitoring_enabled": "Please disable monitoring before proceeding."
 	},
 	"preferences": {
 		"title": "偏好设置",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -766,6 +766,7 @@ interface I18nMonitoring {
 	custom_description: string;
 	default: string;
 	default_description: string;
+	warn_monitoring_enabled: string;
 }
 
 interface I18nPreferences {


### PR DESCRIPTION
# Motivation

Technically it's possible to keep the monitoring active while the canister is stopped but, if it ain't stop, then the cronjob will hit an error on every run which is annoying.

For delete and detach, we need a patch for #1137.
