### PR TITLE
fix: token amount assertion

### DIFF
--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -53,7 +53,7 @@ export const assertAndConvertAmountToICPToken = ({
 		return { valid: false };
 	}
 
-	if (balance + fee < tokenAmount.toE8s()) {
+	if (balance - fee < tokenAmount.toE8s()) {
 		toasts.error({
 			text: labels.errors.invalid_amount
 		});


### PR DESCRIPTION
# Motivation

That's a dumb mistake. It's the balance minus the fee that should be greater or equals to the amount, not balance + fee.
