### PR TITLE
feat: format ICP decimals up to 8

### DIFF
--- a/src/frontend/src/lib/utils/icp.utils.ts
+++ b/src/frontend/src/lib/utils/icp.utils.ts
@@ -11,7 +11,7 @@ import { formatNumber, formatUsd } from './number.utils';
 export const formatICP = (icp: bigint): string =>
 	formatNumber(Number(icp) / Number(E8S_PER_ICP), {
 		minFraction: 4,
-		maxFraction: 4
+		maxFraction: 8
 	});
 
 /**


### PR DESCRIPTION
# Motivation

ICP is 8 decimals so we want to display as many if required.
