### PR TITLE
feat: derive satellites and orbiters with canister sync data and load on table segments

### DIFF
--- a/src/frontend/src/lib/components/cli/CliAdd.svelte
+++ b/src/frontend/src/lib/components/cli/CliAdd.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { fade } from 'svelte/transition';
 	import type { Satellite, Orbiter } from '$declarations/mission_control/mission_control.did';
 	import { setOrbitersController } from '$lib/api/mission-control.api';
 	import SegmentsTable from '$lib/components/segments/SegmentsTable.svelte';
@@ -148,6 +149,8 @@
 	};
 
 	let disabled = $state(true);
+
+	let loadingSegments = $state<'loading' | 'ready' | 'error'>('loading');
 </script>
 
 <form onsubmit={onSubmit}>
@@ -161,35 +164,40 @@
 		bind:selectedSatellites
 		bind:selectedOrbiters
 		bind:selectedDisabled={disabled}
+		bind:loadingSegments
 	>
 		<div class="terminal">{$i18n.cli.terminal}:&nbsp;{principal}</div>
 	</SegmentsTable>
 
-	<div class="options">
-		<Collapsible>
-			<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
+	{#if loadingSegments === 'ready'}
+		<div class="options">
+			<Collapsible>
+				<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
 
-			<div>
-				<p class="profile-info">{$i18n.cli.profile_info}</p>
+				<div>
+					<p class="profile-info">{$i18n.cli.profile_info}</p>
 
-				<input
-					id="profile"
-					type="text"
-					placeholder={$i18n.cli.profile_placeholder}
-					name="profile"
-					bind:value={profile}
-					autocomplete="off"
-					data-1p-ignore
-				/>
-			</div>
-		</Collapsible>
-	</div>
+					<input
+						id="profile"
+						type="text"
+						placeholder={$i18n.cli.profile_placeholder}
+						name="profile"
+						bind:value={profile}
+						autocomplete="off"
+						data-1p-ignore
+					/>
+				</div>
+			</Collapsible>
+		</div>
 
-	<Warning>
-		<Html text={$i18n.cli.confirm} />
-	</Warning>
+		<div in:fade>
+			<Warning>
+				<Html text={$i18n.cli.confirm} />
+			</Warning>
 
-	<button {disabled}>{$i18n.cli.authorize}</button>
+			<button {disabled}>{$i18n.cli.authorize}</button>
+		</div>
+	{/if}
 </form>
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/monitoring/MonitoringSelectSegments.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringSelectSegments.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
 	import type { Snippet } from 'svelte';
+	import { fade } from 'svelte/transition';
 	import type { Orbiter, Satellite } from '$declarations/mission_control/mission_control.did';
 	import SegmentsTable from '$lib/components/segments/SegmentsTable.svelte';
 	import { isBusy } from '$lib/stores/busy.store';
@@ -24,6 +25,8 @@
 	}: Props = $props();
 
 	let selectedDisabled = $state(true);
+
+	let loadingSegments = $state<'loading' | 'ready' | 'error'>('loading');
 </script>
 
 {@render children()}
@@ -35,8 +38,11 @@
 	bind:selectedDisabled
 	withMissionControl={false}
 	reloadSegments={false}
+	bind:loadingSegments
 ></SegmentsTable>
 
-<button disabled={$isBusy || selectedDisabled} onclick={oncontinue}>
-	{$i18n.core.continue}
-</button>
+{#if loadingSegments === 'ready'}
+	<button disabled={$isBusy || selectedDisabled} onclick={oncontinue} in:fade>
+		{$i18n.core.continue}
+	</button>
+{/if}

--- a/src/frontend/src/lib/components/segments/SegmentsTable.svelte
+++ b/src/frontend/src/lib/components/segments/SegmentsTable.svelte
@@ -5,17 +5,17 @@
 	import type { Orbiter, Satellite } from '$declarations/mission_control/mission_control.did';
 	import Segment from '$lib/components/segments/Segment.svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
+	import { canisterSyncDataUncertifiedLoaded } from '$lib/derived/canisters.derived';
+	import { orbiterWithSyncData } from '$lib/derived/orbiter-merged.derived';
+	import { orbiterLoaded } from '$lib/derived/orbiter.derived';
+	import { satellitesWithSyncData } from '$lib/derived/satellites-merged.derived';
+	import { satellitesLoaded } from '$lib/derived/satellites.derived';
 	import { loadOrbiters } from '$lib/services/orbiters.services';
 	import { loadSatellites } from '$lib/services/satellites.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import { orbiterName } from '$lib/utils/orbiter.utils';
 	import { satelliteName } from '$lib/utils/satellite.utils';
-	import { satellitesWithSyncData } from '$lib/derived/satellites-merged.derived';
-	import { orbiterWithSyncData } from '$lib/derived/orbiter-merged.derived';
-	import { canisterSyncDataUncertifiedLoaded } from '$lib/derived/canisters.derived';
-	import { satellitesLoaded } from '$lib/derived/satellites.derived';
-	import { orbiterLoaded } from '$lib/derived/orbiter.derived';
 
 	interface Props {
 		missionControlId: MissionControlId;

--- a/src/frontend/src/lib/components/segments/SegmentsTable.svelte
+++ b/src/frontend/src/lib/components/segments/SegmentsTable.svelte
@@ -6,7 +6,7 @@
 	import type { Orbiter, Satellite } from '$declarations/mission_control/mission_control.did';
 	import Segment from '$lib/components/segments/Segment.svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
-	import SkeletonTableRow from '$lib/components/ui/SkeletonTableRow.svelte';
+	import SpinnerParagraph from '$lib/components/ui/SpinnerParagraph.svelte';
 	import {
 		canistersSyncDataUncertifiedCount,
 		canistersSyncDataUncertifiedNotSynced
@@ -205,7 +205,11 @@
 					</tr>
 				{/each}
 			{:else}
-				<SkeletonTableRow colspan={2} />
+				<tr
+					><td colspan="2" class="loading"
+						><SpinnerParagraph>{$i18n.canisters.loading_segments}</SpinnerParagraph></td
+					>
+				</tr>
 			{/if}
 		</tbody>
 	</table>
@@ -254,5 +258,9 @@
 	.actions {
 		display: flex;
 		padding: var(--padding-1_5x) var(--padding-2x);
+	}
+
+	.loading {
+		--spinner-paragraph-margin: 0;
 	}
 </style>

--- a/src/frontend/src/lib/components/snapshot/Snapshots.svelte
+++ b/src/frontend/src/lib/components/snapshot/Snapshots.svelte
@@ -9,7 +9,7 @@
 	import SnapshotsLoader from '$lib/components/snapshot/SnapshotsLoader.svelte';
 	import SnapshotsRefresh from '$lib/components/snapshot/SnapshotsRefresh.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
-	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import SkeletonTableRow from '$lib/components/ui/SkeletonTableRow.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { snapshotStore } from '$lib/stores/snapshot.store';
 	import { toasts } from '$lib/stores/toasts.store';
@@ -130,13 +130,7 @@
 						>
 					{/if}
 				{:else}
-					<tr
-						><td colspan="4">
-							<div class="skeleton">
-								&ZeroWidthSpace;<SkeletonText />
-							</div>
-						</td></tr
-					>
+					<SkeletonTableRow colspan={4} />
 				{/if}
 			</tbody>
 		</table>
@@ -175,12 +169,6 @@
 
 	.table-container {
 		margin: var(--padding-8x) 0 var(--padding-2x);
-	}
-
-	.skeleton {
-		display: flex;
-		max-width: 200px;
-		--skeleton-text-padding: var(--padding-0_25x) 0;
 	}
 
 	.actions {

--- a/src/frontend/src/lib/components/ui/SkeletonTableRow.svelte
+++ b/src/frontend/src/lib/components/ui/SkeletonTableRow.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+
+	interface Props {
+		colspan: number;
+	}
+
+	let { colspan }: Props = $props();
+</script>
+
+<tr
+	><td {colspan}>
+		<div class="skeleton">
+			&ZeroWidthSpace;<SkeletonText />
+		</div>
+	</td></tr
+>
+
+<style lang="scss">
+	.skeleton {
+		display: flex;
+		max-width: 200px;
+		--skeleton-text-padding: var(--padding-0_25x) 0;
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/SpinnerParagraph.svelte
+++ b/src/frontend/src/lib/components/ui/SpinnerParagraph.svelte
@@ -12,6 +12,8 @@
 <p class="label loading"><Spinner inline /> <span>{@render children()}</span></p>
 
 <style lang="scss">
+	@use '../../styles/mixins/text';
+
 	.loading {
 		display: flex;
 		gap: var(--padding);
@@ -27,6 +29,8 @@
 	span {
 		font-size: var(--font-size-small);
 		animation: pulse 1s linear infinite;
+
+		@include text.truncate;
 	}
 
 	/* -global- */

--- a/src/frontend/src/lib/derived/canisters.derived.ts
+++ b/src/frontend/src/lib/derived/canisters.derived.ts
@@ -1,7 +1,21 @@
-import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
+import { canistersSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
 import { derived } from 'svelte/store';
 
-export const canisterSyncDataUncertifiedLoaded = derived(
-	[canisterSyncDataUncertifiedStore],
-	([$canisterSyncDataUncertifiedStore]) => $canisterSyncDataUncertifiedStore !== undefined
+export const canistersSyncDataUncertifiedSynced = derived(
+	[canistersSyncDataUncertifiedStore],
+	([$canistersSyncDataUncertifiedStore]) =>
+		Object.values($canistersSyncDataUncertifiedStore ?? {}).find(
+			(canister) => !['synced', 'error'].includes(canister?.data.sync ?? 'loading')
+		) === undefined
+);
+
+export const canistersSyncDataUncertifiedNotSynced = derived(
+	[canistersSyncDataUncertifiedSynced],
+	([$canistersSyncDataUncertifiedSynced]) => !$canistersSyncDataUncertifiedSynced
+);
+
+export const canistersSyncDataUncertifiedCount = derived(
+	[canistersSyncDataUncertifiedStore],
+	([$canistersSyncDataUncertifiedStore]) =>
+		Object.values($canistersSyncDataUncertifiedStore ?? {}).length
 );

--- a/src/frontend/src/lib/derived/canisters.derived.ts
+++ b/src/frontend/src/lib/derived/canisters.derived.ts
@@ -1,0 +1,7 @@
+import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
+import { derived } from 'svelte/store';
+
+export const canisterSyncDataUncertifiedLoaded = derived(
+	[canisterSyncDataUncertifiedStore],
+	([$canisterSyncDataUncertifiedStore]) => $canisterSyncDataUncertifiedStore !== undefined
+);

--- a/src/frontend/src/lib/derived/orbiter-merged.derived.ts
+++ b/src/frontend/src/lib/derived/orbiter-merged.derived.ts
@@ -1,0 +1,28 @@
+import type { Orbiter } from '$declarations/mission_control/mission_control.did';
+import { orbiterStore } from '$lib/derived/orbiter.derived';
+import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
+import type { SegmentWithSyncData } from '$lib/types/satellite';
+import { isNullish } from '@dfinity/utils';
+import { derived } from 'svelte/store';
+
+export const orbiterWithSyncData = derived(
+	[orbiterStore, canisterSyncDataUncertifiedStore],
+	([$orbiterStore, $canisterSyncDataUncertifiedStore]) => {
+		if (isNullish($orbiterStore)) {
+			return undefined;
+		}
+
+		const { orbiter_id, ...rest } = $orbiterStore;
+
+		const canister = $canisterSyncDataUncertifiedStore?.[orbiter_id.toText()]?.data;
+
+		if (isNullish(canister)) {
+			return undefined;
+		}
+
+		return <SegmentWithSyncData<Orbiter>>{
+			segment: { orbiter_id, ...rest },
+			canister
+		};
+	}
+);

--- a/src/frontend/src/lib/derived/orbiter-merged.derived.ts
+++ b/src/frontend/src/lib/derived/orbiter-merged.derived.ts
@@ -1,12 +1,12 @@
 import type { Orbiter } from '$declarations/mission_control/mission_control.did';
 import { orbiterStore } from '$lib/derived/orbiter.derived';
-import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
+import { canistersSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
 import type { SegmentWithSyncData } from '$lib/types/satellite';
 import { isNullish } from '@dfinity/utils';
 import { derived } from 'svelte/store';
 
 export const orbiterWithSyncData = derived(
-	[orbiterStore, canisterSyncDataUncertifiedStore],
+	[orbiterStore, canistersSyncDataUncertifiedStore],
 	([$orbiterStore, $canisterSyncDataUncertifiedStore]) => {
 		if (isNullish($orbiterStore)) {
 			return undefined;

--- a/src/frontend/src/lib/derived/satellites-merged.derived.ts
+++ b/src/frontend/src/lib/derived/satellites-merged.derived.ts
@@ -1,15 +1,15 @@
 import type { Satellite } from '$declarations/mission_control/mission_control.did';
 import { sortedSatellites } from '$lib/derived/satellites.derived';
-import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
+import { canistersSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
 import type { SegmentWithSyncData } from '$lib/types/satellite';
 import { nonNullish } from '@dfinity/utils';
 import { derived } from 'svelte/store';
 
 export const satellitesWithSyncData = derived(
-	[sortedSatellites, canisterSyncDataUncertifiedStore],
-	([$sortedSatellites, $canisterSyncDataUncertifiedStore]) =>
+	[sortedSatellites, canistersSyncDataUncertifiedStore],
+	([$sortedSatellites, $canistersSyncDataUncertifiedStore]) =>
 		$sortedSatellites.reduce<SegmentWithSyncData<Satellite>[]>((acc, { satellite_id, ...rest }) => {
-			const canister = $canisterSyncDataUncertifiedStore?.[satellite_id.toText()]?.data;
+			const canister = $canistersSyncDataUncertifiedStore?.[satellite_id.toText()]?.data;
 
 			return [
 				...acc,

--- a/src/frontend/src/lib/derived/satellites-merged.derived.ts
+++ b/src/frontend/src/lib/derived/satellites-merged.derived.ts
@@ -1,0 +1,26 @@
+import type { Satellite } from '$declarations/mission_control/mission_control.did';
+import { sortedSatellites } from '$lib/derived/satellites.derived';
+import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
+import type { SegmentWithSyncData } from '$lib/types/satellite';
+import { nonNullish } from '@dfinity/utils';
+import { derived } from 'svelte/store';
+
+export const satellitesWithSyncData = derived(
+	[sortedSatellites, canisterSyncDataUncertifiedStore],
+	([$sortedSatellites, $canisterSyncDataUncertifiedStore]) =>
+		$sortedSatellites.reduce<SegmentWithSyncData<Satellite>[]>((acc, { satellite_id, ...rest }) => {
+			const canister = $canisterSyncDataUncertifiedStore?.[satellite_id.toText()]?.data;
+
+			return [
+				...acc,
+				...(nonNullish(canister)
+					? [
+							{
+								segment: { satellite_id, ...rest },
+								canister
+							}
+						]
+					: [])
+			];
+		}, [])
+);

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -208,7 +208,8 @@
 		"upgrade_snapshot": "Creating a backup...",
 		"edit_snapshot": "Edit backup",
 		"delete_snapshot": "Delete backup",
-		"delete_snapshot_confirm": "Are you sure you want to delete the backup {0} of your {1}?"
+		"delete_snapshot_confirm": "Are you sure you want to delete the backup {0} of your {1}?",
+		"loading_segments": "Loading your modules"
 	},
 	"sign_in": {
 		"quote_1": "Stars can't shine without darkness.",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -457,6 +457,7 @@
 		"canister_delete": "Unexpected error(s) while trying to delete the smart contract.",
 		"canister_settings_not_loaded": "The settings of the smart contract are not yet loaded.",
 		"canister_update_error": "Unexpected error(s) while updating the settings.",
+		"canister_status": "Unexpected error(s) while loading the status of your modules.",
 		"segment_detach": "Unexpected error(s) while trying to detach the module.",
 		"load_credits": "Cannot load your current credits status.",
 		"load_documents": "Unexpected error(s) while loading the documents.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -457,6 +457,7 @@
 		"canister_delete": "删除智能合约时出现异常错误.",
 		"canister_settings_not_loaded": "智能合约设置没有加载.",
 		"canister_update_error": "更新设置出现异常错误.",
+		"canister_status": "Unexpected error(s) while loading the status of your modules.",
 		"segment_detach": "解绑module时出现异常错误.",
 		"load_credits": "无法加载你当前credit状态.",
 		"load_documents": "Unexpected error(s) while loading the documents.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -208,7 +208,8 @@
 		"upgrade_snapshot": "创建备份...",
 		"edit_snapshot": "编辑备份",
 		"delete_snapshot": "删除备份",
-		"delete_snapshot_confirm": "你确定要删除你的 {1} 备份  {0}  ?"
+		"delete_snapshot_confirm": "你确定要删除你的 {1} 备份  {0}  ?",
+		"loading_segments": "Loading your modules"
 	},
 	"sign_in": {
 		"quote_1": "Stars can't shine without darkness.",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -473,6 +473,7 @@ interface I18nErrors {
 	canister_delete: string;
 	canister_settings_not_loaded: string;
 	canister_update_error: string;
+	canister_status: string;
 	segment_detach: string;
 	load_credits: string;
 	load_documents: string;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -213,6 +213,7 @@ interface I18nCanisters {
 	edit_snapshot: string;
 	delete_snapshot: string;
 	delete_snapshot_confirm: string;
+	loading_segments: string;
 }
 
 interface I18nSign_in {

--- a/src/frontend/src/lib/types/satellite.ts
+++ b/src/frontend/src/lib/types/satellite.ts
@@ -1,1 +1,9 @@
+import type { Orbiter, Satellite } from '$declarations/mission_control/mission_control.did';
+import type { CanisterSyncData } from '$lib/types/canister';
+
 export type SatelliteIdText = string;
+
+export interface SegmentWithSyncData<T extends Satellite | Orbiter> {
+	segment: T;
+	canister: CanisterSyncData;
+}

--- a/src/frontend/src/lib/utils/timeout.utils.ts
+++ b/src/frontend/src/lib/utils/timeout.utils.ts
@@ -2,3 +2,30 @@ export const waitForMilliseconds = (milliseconds: number): Promise<void> =>
 	new Promise((resolve) => {
 		setTimeout(resolve, milliseconds);
 	});
+
+export const waitReady = async ({
+	// 30 tries with a delay of 500ms each = max 15 seconds
+	retries = 30,
+	isDisabled,
+	intervalInMs = 500
+}: {
+	retries?: number;
+	isDisabled: () => boolean;
+	intervalInMs?: number;
+}): Promise<'ready' | 'timeout'> => {
+	const disabled = isDisabled();
+
+	if (!disabled) {
+		return 'ready';
+	}
+
+	const remainingRetries = retries - 1;
+
+	if (remainingRetries === 0) {
+		return 'timeout';
+	}
+
+	await waitForMilliseconds(intervalInMs);
+
+	return waitReady({ retries: remainingRetries, isDisabled });
+};

--- a/src/frontend/src/routes/(standalone)/cli/+page.svelte
+++ b/src/frontend/src/routes/(standalone)/cli/+page.svelte
@@ -3,8 +3,10 @@
 	import { fade } from 'svelte/transition';
 	import CliAdd from '$lib/components/cli/CliAdd.svelte';
 	import MissionControlGuard from '$lib/components/guards/MissionControlGuard.svelte';
+	import CanistersLoader from '$lib/components/loaders/CanistersLoader.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
+	import { sortedSatellites } from '$lib/derived/satellites.derived';
 	import { signIn } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Option } from '$lib/types/utils';
@@ -25,11 +27,13 @@
 {#if nonNullish(redirect_uri) && nonNullish(principal) && notEmptyString(redirect_uri) && notEmptyString(principal)}
 	{#if $authSignedIn}
 		<MissionControlGuard>
-			{#if nonNullish($missionControlIdDerived)}
-				<div in:fade>
-					<CliAdd {principal} {redirect_uri} missionControlId={$missionControlIdDerived} />
-				</div>
-			{/if}
+			<CanistersLoader satellites={$sortedSatellites}>
+				{#if nonNullish($missionControlIdDerived)}
+					<div in:fade>
+						<CliAdd {principal} {redirect_uri} missionControlId={$missionControlIdDerived} />
+					</div>
+				{/if}
+			</CanistersLoader>
 		</MissionControlGuard>
 	{:else}
 		<p>


### PR DESCRIPTION
# Motivation

We want to display only the running modules on the segments table for the monitoring or CLI. This implies that we have to wait for all the canister statuses to be loaded and when that's ready, we will be able to filter those active or not.
