### PR TITLE
feat: per and bulk canisters monitoring and statuses

### DIFF
--- a/src/frontend/src/lib/components/loaders/CanistersMonitoringLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/CanistersMonitoringLoader.svelte
@@ -12,11 +12,9 @@
 		initMonitoringWorker,
 		type MonitoringWorker
 	} from '$lib/services/worker.monitoring.services';
-	import { canisterMonitoringUncertifiedStore } from '$lib/stores/canister-monitoring.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toasts } from '$lib/stores/toasts.store';
 	import type { CanisterSegment } from '$lib/types/canister';
-	import type { PostMessageDataResponseCanisterMonitoring } from '$lib/types/post-message';
 
 	interface Props {
 		children: Snippet;
@@ -28,20 +26,6 @@
 	let worker: MonitoringWorker | undefined = $state();
 
 	onMount(async () => (worker = await initMonitoringWorker()));
-
-	const syncCanister = ({ canister }: PostMessageDataResponseCanisterMonitoring) => {
-		if (isNullish(canister)) {
-			return;
-		}
-
-		canisterMonitoringUncertifiedStore.set({
-			canisterId: canister.id,
-			data: {
-				data: canister,
-				certified: false
-			}
-		});
-	};
 
 	const debounceStart = debounce(() => {
 		if (isNullish($missionControlIdDerived)) {
@@ -56,8 +40,7 @@
 			segments,
 			missionControlId: $missionControlIdDerived,
 			withMonitoringHistory:
-				compare($missionControlVersion.current ?? '0.0.0', MISSION_CONTROL_v0_0_14) >= 0,
-			callback: syncCanister
+				compare($missionControlVersion.current ?? '0.0.0', MISSION_CONTROL_v0_0_14) >= 0
 		});
 	});
 

--- a/src/frontend/src/lib/components/loaders/CanistersSyncDataLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/CanistersSyncDataLoader.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
-	import { debounce, isNullish } from '@dfinity/utils';
+	import { debounce } from '@dfinity/utils';
 	import { onDestroy, onMount, type Snippet } from 'svelte';
 	import type { Satellite } from '$declarations/mission_control/mission_control.did';
 	import { orbiterNotLoaded } from '$lib/derived/orbiter.derived';
 	import { satellitesNotLoaded } from '$lib/derived/satellites.derived';
 	import { type CyclesWorker, initCyclesWorker } from '$lib/services/worker.cycles.services';
-	import { canisterSyncDataUncertifiedStore } from '$lib/stores/canister-sync-data.store';
 	import type { CanisterSegment } from '$lib/types/canister';
-	import type { PostMessageDataResponseCanisterSyncData } from '$lib/types/post-message';
 
 	interface Props {
 		children: Snippet;
@@ -22,24 +20,9 @@
 
 	onMount(async () => (worker = await initCyclesWorker()));
 
-	const syncCanister = ({ canister }: PostMessageDataResponseCanisterSyncData) => {
-		if (isNullish(canister)) {
-			return;
-		}
-
-		canisterSyncDataUncertifiedStore.set({
-			canisterId: canister.id,
-			data: {
-				data: canister,
-				certified: false
-			}
-		});
-	};
-
 	const debounceStart = debounce(() =>
 		worker?.startCyclesTimer({
-			segments,
-			callback: syncCanister
+			segments
 		})
 	);
 

--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -48,9 +48,17 @@ export const PostMessageDataResponseCanisterMonitoringSchema = z.object({
 	canister: z.custom<CanisterSyncMonitoring>().optional()
 });
 
+export const PostMessageDataResponseCanistersSyncDataSchema = z.object({
+	canisters: z.array(z.custom<CanisterSyncData>()).optional()
+});
+
+export const PostMessageDataResponseCanistersMonitoringSchema = z.object({
+	canisters: z.array(z.custom<CanisterSyncMonitoring>()).optional()
+});
+
 export const PostMessageDataResponseCanisterSchema = z.union([
-	PostMessageDataResponseCanisterSyncDataSchema,
-	PostMessageDataResponseCanisterMonitoringSchema
+	PostMessageDataResponseCanistersSyncDataSchema,
+	PostMessageDataResponseCanistersMonitoringSchema
 ]);
 
 export const PostMessageDataResponseHostingSchema = z.object({
@@ -84,6 +92,7 @@ export const PostMessageRequestMsgSchema = z.enum([
 
 export const PostMessageResponseMsgSchema = z.enum([
 	'syncCanister',
+	'syncCanisters',
 	'signOutIdleTimer',
 	'delegationRemainingTime',
 	'customDomainRegistrationState',

--- a/src/frontend/src/lib/services/canisters.loader.services.ts
+++ b/src/frontend/src/lib/services/canisters.loader.services.ts
@@ -1,0 +1,86 @@
+import type { CanisterStoreData } from '$lib/stores/_canister.store';
+import {
+	canisterMonitoringUncertifiedStore,
+	canistersMonitoringUncertifiedStore,
+	type UncertifiedCanisterSyncMonitoring
+} from '$lib/stores/canister-monitoring.store';
+import {
+	canistersSyncDataUncertifiedStore,
+	canisterSyncDataUncertifiedStore,
+	type UncertifiedCanisterSyncData
+} from '$lib/stores/canister-sync-data.store';
+import type {
+	PostMessageDataResponseCanisterMonitoring,
+	PostMessageDataResponseCanistersMonitoring,
+	PostMessageDataResponseCanistersSyncData,
+	PostMessageDataResponseCanisterSyncData
+} from '$lib/types/post-message';
+import { isNullish } from '@dfinity/utils';
+
+export const syncCanisterMonitoring = ({ canister }: PostMessageDataResponseCanisterMonitoring) => {
+	if (isNullish(canister)) {
+		return;
+	}
+
+	canisterMonitoringUncertifiedStore.set({
+		canisterId: canister.id,
+		data: {
+			data: canister,
+			certified: false
+		}
+	});
+};
+
+export const syncCanistersMonitoring = ({
+	canisters
+}: PostMessageDataResponseCanistersMonitoring) => {
+	if (isNullish(canisters)) {
+		return;
+	}
+
+	const state = canisters.reduce<CanisterStoreData<UncertifiedCanisterSyncMonitoring>>(
+		(acc, canister) => ({
+			...acc,
+			[canister.id]: {
+				data: canister,
+				certified: false
+			}
+		}),
+		{}
+	);
+
+	canistersMonitoringUncertifiedStore.setAll(state);
+};
+
+export const syncCanisterSyncData = ({ canister }: PostMessageDataResponseCanisterSyncData) => {
+	if (isNullish(canister)) {
+		return;
+	}
+
+	canisterSyncDataUncertifiedStore.set({
+		canisterId: canister.id,
+		data: {
+			data: canister,
+			certified: false
+		}
+	});
+};
+
+export const syncCanistersSyncData = ({ canisters }: PostMessageDataResponseCanistersSyncData) => {
+	if (isNullish(canisters)) {
+		return;
+	}
+
+	const state = canisters.reduce<CanisterStoreData<UncertifiedCanisterSyncData>>(
+		(acc, canister) => ({
+			...acc,
+			[canister.id]: {
+				data: canister,
+				certified: false
+			}
+		}),
+		{}
+	);
+
+	canistersSyncDataUncertifiedStore.setAll(state);
+};

--- a/src/frontend/src/lib/services/worker.monitoring.services.ts
+++ b/src/frontend/src/lib/services/worker.monitoring.services.ts
@@ -1,19 +1,21 @@
+import {
+	syncCanisterMonitoring,
+	syncCanistersMonitoring
+} from '$lib/services/canisters.loader.services';
 import type { CanisterSegment } from '$lib/types/canister';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type {
 	PostMessage,
 	PostMessageDataResponseCanister,
-	PostMessageDataResponseCanisterMonitoring
+	PostMessageDataResponseCanisterMonitoring,
+	PostMessageDataResponseCanistersMonitoring
 } from '$lib/types/post-message';
-
-export type MonitoringCallback = (data: PostMessageDataResponseCanisterMonitoring) => void;
 
 export interface MonitoringWorker {
 	startMonitoringTimer: (params: {
 		segments: CanisterSegment[];
 		missionControlId: MissionControlId;
 		withMonitoringHistory: boolean;
-		callback: MonitoringCallback;
 	}) => void;
 	stopMonitoringTimer: () => void;
 	restartMonitoringTimer: (params: {
@@ -26,8 +28,6 @@ export const initMonitoringWorker = async (): Promise<MonitoringWorker> => {
 	const MonitoringWorker = await import('$lib/workers/workers?worker');
 	const monitoringWorker: Worker = new MonitoringWorker.default();
 
-	let monitoringCallback: MonitoringCallback | undefined;
-
 	monitoringWorker.onmessage = ({
 		data
 	}: MessageEvent<PostMessage<PostMessageDataResponseCanister>>) => {
@@ -35,15 +35,16 @@ export const initMonitoringWorker = async (): Promise<MonitoringWorker> => {
 
 		switch (msg) {
 			case 'syncCanister':
-				monitoringCallback?.(data.data as PostMessageDataResponseCanisterMonitoring);
+				syncCanisterMonitoring(data.data as PostMessageDataResponseCanisterMonitoring);
+				return;
+			case 'syncCanisters':
+				syncCanistersMonitoring(data.data as PostMessageDataResponseCanistersMonitoring);
 				return;
 		}
 	};
 
 	return {
-		startMonitoringTimer: ({ callback, segments, missionControlId, withMonitoringHistory }) => {
-			monitoringCallback = callback;
-
+		startMonitoringTimer: ({ segments, missionControlId, withMonitoringHistory }) => {
 			monitoringWorker.postMessage({
 				msg: 'startMonitoringTimer',
 				data: { segments, missionControlId: missionControlId.toText(), withMonitoringHistory }

--- a/src/frontend/src/lib/stores/_canister.store.ts
+++ b/src/frontend/src/lib/stores/_canister.store.ts
@@ -34,3 +34,13 @@ export const initCanisterStore = <T>(): CanisterStore<T> => {
 		resetAll: () => set(null)
 	};
 };
+
+// Each canister is set independently. This way the subscriber is triggered each time a canister changes.
+// Useful to update the UI without waiting all canisters data to be loaded.
+export const initPerCanisterStore = <T>(): Omit<CanisterStore<T>, 'setAll' | 'resetAll'> =>
+	initCanisterStore();
+
+// Only bulk independently. This way the subscribers is triggered only when all canisters are loaded.
+// Useful to reduce the amount of repaint.
+export const initBulkCanistersStore = <T>(): Omit<CanisterStore<T>, 'set' | 'reset'> =>
+	initCanisterStore();

--- a/src/frontend/src/lib/stores/canister-monitoring.store.ts
+++ b/src/frontend/src/lib/stores/canister-monitoring.store.ts
@@ -1,7 +1,13 @@
-import { initCanisterStore } from '$lib/stores/_canister.store';
+import { initBulkCanistersStore, initPerCanisterStore } from '$lib/stores/_canister.store';
 import type { CanisterSyncMonitoring } from '$lib/types/canister';
 import type { CertifiedData } from '$lib/types/store';
 
+export type UncertifiedCanisterSyncMonitoring = CertifiedData<CanisterSyncMonitoring>;
+
 // TODO: Uncertified because memory is not yet called with an update
 export const canisterMonitoringUncertifiedStore =
-	initCanisterStore<CertifiedData<CanisterSyncMonitoring>>();
+	initPerCanisterStore<UncertifiedCanisterSyncMonitoring>();
+
+// TODO: Uncertified because memory is not yet called with an update
+export const canistersMonitoringUncertifiedStore =
+	initBulkCanistersStore<UncertifiedCanisterSyncMonitoring>();

--- a/src/frontend/src/lib/stores/canister-sync-data.store.ts
+++ b/src/frontend/src/lib/stores/canister-sync-data.store.ts
@@ -1,7 +1,12 @@
-import { initCanisterStore } from '$lib/stores/_canister.store';
+import { initBulkCanistersStore, initPerCanisterStore } from '$lib/stores/_canister.store';
 import type { CanisterSyncData } from '$lib/types/canister';
 import type { CertifiedData } from '$lib/types/store';
 
+export type UncertifiedCanisterSyncData = CertifiedData<CanisterSyncData>;
+
 // TODO: Uncertified because memory is not yet called with an update
-export const canisterSyncDataUncertifiedStore =
-	initCanisterStore<CertifiedData<CanisterSyncData>>();
+export const canisterSyncDataUncertifiedStore = initPerCanisterStore<UncertifiedCanisterSyncData>();
+
+// TODO: Uncertified because memory is not yet called with an update
+export const canistersSyncDataUncertifiedStore =
+	initBulkCanistersStore<UncertifiedCanisterSyncData>();

--- a/src/frontend/src/lib/types/post-message.ts
+++ b/src/frontend/src/lib/types/post-message.ts
@@ -4,6 +4,8 @@ import {
 	PostMessageDataResponseAuthSchema,
 	PostMessageDataResponseCanisterMonitoringSchema,
 	PostMessageDataResponseCanisterSchema,
+	PostMessageDataResponseCanistersMonitoringSchema,
+	PostMessageDataResponseCanistersSyncDataSchema,
 	PostMessageDataResponseCanisterSyncDataSchema,
 	PostMessageDataResponseErrorSchema,
 	PostMessageDataResponseExchangeSchema,
@@ -34,6 +36,14 @@ export type PostMessageDataResponseCanisterSyncData = z.infer<
 
 export type PostMessageDataResponseCanisterMonitoring = z.infer<
 	typeof PostMessageDataResponseCanisterMonitoringSchema
+>;
+
+export type PostMessageDataResponseCanistersSyncData = z.infer<
+	typeof PostMessageDataResponseCanistersSyncDataSchema
+>;
+
+export type PostMessageDataResponseCanistersMonitoring = z.infer<
+	typeof PostMessageDataResponseCanistersMonitoringSchema
 >;
 
 export type PostMessageDataResponseCanister = z.infer<typeof PostMessageDataResponseCanisterSchema>;

--- a/src/frontend/src/lib/utils/worker.utils.ts
+++ b/src/frontend/src/lib/utils/worker.utils.ts
@@ -47,16 +47,29 @@ export const emitSavedCanisters = async <T extends Canister<T>>({
 				}) as Canister<T>
 		);
 
-	await Promise.all(canistersNeverSynced.map(emitCanister));
+	const syncedCanisters = [...canistersNeverSynced, ...canisters];
 
-	await Promise.all(canisters.map(emitCanister));
+	for (const canister of syncedCanisters) {
+		emitCanister(canister);
+	}
+
+	emitCanisters(syncedCanisters);
 };
 
-// Update ui with one canister information
+// Update ui with one canister information at a time
 export const emitCanister = <T>(canister: Canister<T>) =>
 	postMessage({
 		msg: 'syncCanister',
 		data: {
 			canister
+		}
+	});
+
+// Update ui with multiple canisters information
+export const emitCanisters = <T>(canisters: Canister<T>[]) =>
+	postMessage({
+		msg: 'syncCanisters',
+		data: {
+			canisters
 		}
 	});


### PR DESCRIPTION
# Motivation

There are scenario, as currently on production, where we want to get the status and monitoring of each canister separatly. This is useful to update the UI in an asynchronous way. This way that canister gets rendered or that canister information etc.

There are other scenario, such as in #1145 where we want to update the UI as few times as possible. Like getting all canisters in bulk, all statuses fetched.

Given that the store are not memoized, we do so by splitting the stores in two. One that is updated per canister and one that is updated with all canisters.
