### PR TITLE
test: vitest third argument is deprecated

### DIFF
--- a/src/tests/console.upgrade.spec.ts
+++ b/src/tests/console.upgrade.spec.ts
@@ -87,6 +87,9 @@ describe('Console upgrade', () => {
 		describe('Heap state', () => {
 			it(
 				'should still list mission controls',
+				{
+					timeout: 120000
+				},
 				async () => {
 					// We need to advance time for the rate limiter
 					await pic.advanceTime(1000);
@@ -115,9 +118,6 @@ describe('Console upgrade', () => {
 						actor,
 						pic
 					});
-				},
-				{
-					timeout: 120000
 				}
 			);
 		});

--- a/src/tests/mission-control.monitoring.notifications.spec.ts
+++ b/src/tests/mission-control.monitoring.notifications.spec.ts
@@ -60,149 +60,142 @@ describe('Mission Control - Notifications', () => {
 		await pic?.tearDown();
 	});
 
-	it(
-		'should notify observatory',
-		async () => {
-			// Init a mission control
-			const [user] = await initMissionControls({ actor, pic, length: 1 });
+	it('should notify observatory', { timeout: 600000 }, async () => {
+		// Init a mission control
+		const [user] = await initMissionControls({ actor, pic, length: 1 });
 
-			actor.setIdentity(user);
+		actor.setIdentity(user);
 
-			const { get_user_mission_control_center } = actor;
-			const missionControl = await get_user_mission_control_center();
+		const { get_user_mission_control_center } = actor;
+		const missionControl = await get_user_mission_control_center();
 
-			const missionControlId = fromNullable(fromNullable(missionControl)?.mission_control_id ?? []);
+		const missionControlId = fromNullable(fromNullable(missionControl)?.mission_control_id ?? []);
 
-			assertNonNullish(missionControlId);
+		assertNonNullish(missionControlId);
 
-			// Assert no notification have been submitted to the Observatory yet
-			const observatoryActor = pic.createActor<ObservatoryActor>(
-				idlFactorObservatory,
-				observatoryId
-			);
+		// Assert no notification have been submitted to the Observatory yet
+		const observatoryActor = pic.createActor<ObservatoryActor>(idlFactorObservatory, observatoryId);
 
-			observatoryActor.setIdentity(controller);
+		observatoryActor.setIdentity(controller);
 
-			const { get_notify_status } = observatoryActor;
+		const { get_notify_status } = observatoryActor;
 
-			const status = await get_notify_status({
+		const status = await get_notify_status({
+			segment_id: toNullable(),
+			from: toNullable(),
+			to: toNullable()
+		});
+
+		expect(status).toEqual({
+			failed: 0n,
+			pending: 0n,
+			sent: 0n
+		});
+
+		// Spin some modules to monitor
+		const missionControlActor = pic.createActor<MissionControlActor>(
+			idlFactorMissionControl,
+			missionControlId
+		);
+
+		missionControlActor.setIdentity(user);
+
+		// We set up a satellite to consumes the cycles from the mission control to top-up the satellite.
+		// That way we can write a test without the need of spinning a ledger.
+		const { satelliteId } = await setupMissionControlModules({
+			pic,
+			controller,
+			missionControlId
+		});
+
+		// Set an email, enable notification, attach the module that was created and start monitoring
+		const { update_and_start_monitoring, set_metadata, set_config, set_satellite } =
+			missionControlActor;
+
+		await set_metadata([['email', 'test@test.com']]);
+
+		await set_config(
+			toNullable({
+				monitoring: toNullable({
+					cycles: toNullable({
+						default_strategy: toNullable(),
+						notification: toNullable({
+							enabled: true,
+							to: toNullable() // We are only using the global email currently but, have foreseen an option
+						})
+					})
+				})
+			})
+		);
+
+		await set_satellite(satelliteId, []);
+
+		const missionControlCurrentCycles = await pic.getCyclesBalance(missionControlId);
+		const satelliteCurrentCycles = await pic.getCyclesBalance(satelliteId);
+
+		const satelliteStrategy: CyclesMonitoringStrategy = {
+			BelowThreshold: {
+				// This way the satellite already requires cycles
+				min_cycles: BigInt(satelliteCurrentCycles) + 100_000_000_000n,
+				fund_cycles: 100_000n
+			}
+		};
+
+		const missionControlStrategy: CyclesMonitoringStrategy = {
+			BelowThreshold: {
+				// This way the mission control can consume some of its cycles already requires cycles
+				min_cycles: BigInt(Math.min(missionControlCurrentCycles - 100_000_000_000, 100_000)),
+				fund_cycles: 100_000n
+			}
+		};
+
+		const config: MonitoringStartConfig = {
+			cycles_config: [
+				{
+					satellites_strategy: toNullable({
+						ids: [satelliteId],
+						strategy: satelliteStrategy
+					}),
+					orbiters_strategy: toNullable(),
+					mission_control_strategy: toNullable(missionControlStrategy)
+				}
+			]
+		};
+
+		await update_and_start_monitoring(config);
+
+		// One pending notification should be registered in the Observatory
+		await vi.waitFor(async () => {
+			await pic.tick();
+
+			const statusPending = await get_notify_status({
 				segment_id: toNullable(),
 				from: toNullable(),
 				to: toNullable()
 			});
 
-			expect(status).toEqual({
+			expect(statusPending).toEqual({
 				failed: 0n,
+				pending: 1n,
+				sent: 0n
+			});
+		});
+
+		// The notification should fail because no api key for the proxy is registered
+		await vi.waitFor(async () => {
+			await pic.tick();
+
+			const statusFailed = await get_notify_status({
+				segment_id: toNullable(),
+				from: toNullable(),
+				to: toNullable()
+			});
+
+			expect(statusFailed).toEqual({
+				failed: 1n,
 				pending: 0n,
 				sent: 0n
 			});
-
-			// Spin some modules to monitor
-			const missionControlActor = pic.createActor<MissionControlActor>(
-				idlFactorMissionControl,
-				missionControlId
-			);
-
-			missionControlActor.setIdentity(user);
-
-			// We set up a satellite to consumes the cycles from the mission control to top-up the satellite.
-			// That way we can write a test without the need of spinning a ledger.
-			const { satelliteId } = await setupMissionControlModules({
-				pic,
-				controller,
-				missionControlId
-			});
-
-			// Set an email, enable notification, attach the module that was created and start monitoring
-			const { update_and_start_monitoring, set_metadata, set_config, set_satellite } =
-				missionControlActor;
-
-			await set_metadata([['email', 'test@test.com']]);
-
-			await set_config(
-				toNullable({
-					monitoring: toNullable({
-						cycles: toNullable({
-							default_strategy: toNullable(),
-							notification: toNullable({
-								enabled: true,
-								to: toNullable() // We are only using the global email currently but, have foreseen an option
-							})
-						})
-					})
-				})
-			);
-
-			await set_satellite(satelliteId, []);
-
-			const missionControlCurrentCycles = await pic.getCyclesBalance(missionControlId);
-			const satelliteCurrentCycles = await pic.getCyclesBalance(satelliteId);
-
-			const satelliteStrategy: CyclesMonitoringStrategy = {
-				BelowThreshold: {
-					// This way the satellite already requires cycles
-					min_cycles: BigInt(satelliteCurrentCycles) + 100_000_000_000n,
-					fund_cycles: 100_000n
-				}
-			};
-
-			const missionControlStrategy: CyclesMonitoringStrategy = {
-				BelowThreshold: {
-					// This way the mission control can consume some of its cycles already requires cycles
-					min_cycles: BigInt(Math.min(missionControlCurrentCycles - 100_000_000_000, 100_000)),
-					fund_cycles: 100_000n
-				}
-			};
-
-			const config: MonitoringStartConfig = {
-				cycles_config: [
-					{
-						satellites_strategy: toNullable({
-							ids: [satelliteId],
-							strategy: satelliteStrategy
-						}),
-						orbiters_strategy: toNullable(),
-						mission_control_strategy: toNullable(missionControlStrategy)
-					}
-				]
-			};
-
-			await update_and_start_monitoring(config);
-
-			// One pending notification should be registered in the Observatory
-			await vi.waitFor(async () => {
-				await pic.tick();
-
-				const statusPending = await get_notify_status({
-					segment_id: toNullable(),
-					from: toNullable(),
-					to: toNullable()
-				});
-
-				expect(statusPending).toEqual({
-					failed: 0n,
-					pending: 1n,
-					sent: 0n
-				});
-			});
-
-			// The notification should fail because no api key for the proxy is registered
-			await vi.waitFor(async () => {
-				await pic.tick();
-
-				const statusFailed = await get_notify_status({
-					segment_id: toNullable(),
-					from: toNullable(),
-					to: toNullable()
-				});
-
-				expect(statusFailed).toEqual({
-					failed: 1n,
-					pending: 0n,
-					sent: 0n
-				});
-			});
-		},
-		{ timeout: 600000 }
-	);
+		});
+	});
 });

--- a/src/tests/mission-control.upgrade.spec.ts
+++ b/src/tests/mission-control.upgrade.spec.ts
@@ -113,6 +113,7 @@ describe('Mission control upgrade', () => {
 
 		it(
 			'should still contains data after upgrade even if the internal state variable is renamed from state to heap',
+			{ timeout: 60000 },
 			async () => {
 				await setModules();
 
@@ -126,8 +127,7 @@ describe('Mission control upgrade', () => {
 
 				await testModules();
 				await testUser();
-			},
-			{ timeout: 60000 }
+			}
 		);
 
 		it('should migrate with no settings', async () => {

--- a/src/tests/satellite.upgrade.spec.ts
+++ b/src/tests/satellite.upgrade.spec.ts
@@ -122,6 +122,9 @@ describe('Satellite upgrade', () => {
 
 		it(
 			'should add users after upgrade and still list all users from heap',
+			{
+				timeout: 120000
+			},
 			async () => {
 				await initUsers();
 
@@ -134,9 +137,6 @@ describe('Satellite upgrade', () => {
 				const moreUsers = await initUsers();
 
 				await testUsers([...users, ...moreUsers]);
-			},
-			{
-				timeout: 120000
 			}
 		);
 
@@ -188,45 +188,41 @@ describe('Satellite upgrade', () => {
 			actor.setIdentity(controller);
 		});
 
-		it(
-			'should still list users from heap',
-			async () => {
-				await initUsers();
+		it('should still list users from heap', { timeout: 600000 }, async () => {
+			await initUsers();
 
-				const users = await initUsers();
+			const users = await initUsers();
 
-				await testUsers(users);
+			await testUsers(users);
 
-				await upgradeVersion('0.0.12');
+			await upgradeVersion('0.0.12');
 
-				await testUsers(users);
+			await testUsers(users);
 
-				await upgradeVersion('0.0.13');
+			await upgradeVersion('0.0.13');
 
-				await testUsers(users);
+			await testUsers(users);
 
-				await upgradeVersion('0.0.14');
+			await upgradeVersion('0.0.14');
 
-				await testUsers(users);
+			await testUsers(users);
 
-				await upgradeVersion('0.0.15');
+			await upgradeVersion('0.0.15');
 
-				await testUsers(users);
+			await testUsers(users);
 
-				await upgradeVersion('0.0.16');
+			await upgradeVersion('0.0.16');
 
-				await testUsers(users);
+			await testUsers(users);
 
-				await upgradeVersion('0.0.17');
+			await upgradeVersion('0.0.17');
 
-				await testUsers(users);
+			await testUsers(users);
 
-				await upgrade();
+			await upgrade();
 
-				await testUsers(users);
-			},
-			{ timeout: 600000 }
-		);
+			await testUsers(users);
+		});
 	});
 
 	describe('v0.0.16 -> v0.0.16', () => {
@@ -453,6 +449,7 @@ describe('Satellite upgrade', () => {
 
 				it(
 					'should be able to update after upgrade and has version set',
+					{ timeout: 60000 },
 					async () => {
 						const { set_custom_domain: set_custom_domain_deprecated } = actor;
 
@@ -473,8 +470,7 @@ describe('Satellite upgrade', () => {
 						const [[_, { version }]] = await list_custom_domains();
 
 						expect(fromNullable(version)).toEqual(1n);
-					},
-					{ timeout: 60000 }
+					}
 				);
 			});
 
@@ -544,6 +540,7 @@ describe('Satellite upgrade', () => {
 
 				it(
 					'should be able to update after upgrade and has version set',
+					{ timeout: 60000 },
 					async () => {
 						const full_path = `/${collection}/ugprade.html`;
 
@@ -565,8 +562,7 @@ describe('Satellite upgrade', () => {
 
 						expect(asset).not.toBeUndefined();
 						expect(fromNullable(asset!.version)).toEqual(1n);
-					},
-					{ timeout: 60000 }
+					}
 				);
 			});
 		});


### PR DESCRIPTION
# Motivation

Resolve warning:

> Using an object as a third argument is deprecated. Vitest 4 will throw an error if the third argument is not a timeout number. Please use the second argument for options. See more at https://vitest.dev/guide/migration
