### PR TITLE
style: fix launchpad cockpit overflow on mobile

### DIFF
--- a/src/frontend/src/lib/components/launchpad/Cockpit.svelte
+++ b/src/frontend/src/lib/components/launchpad/Cockpit.svelte
@@ -149,6 +149,8 @@
 
 		display: flex;
 		align-items: center;
+		justify-content: center;
+
 		gap: var(--padding-3x);
 
 		margin: 0 0 var(--padding);

--- a/src/frontend/src/lib/components/launchpad/Launchpad.svelte
+++ b/src/frontend/src/lib/components/launchpad/Launchpad.svelte
@@ -66,8 +66,16 @@
 		}
 
 		&.cockpit {
-			display: flex;
-			justify-content: center;
+			padding: 0 var(--padding-12x);
+
+			@include grid.two-columns;
+
+			@include media.min-width(small) {
+				display: flex;
+				justify-content: center;
+
+				padding: 0;
+			}
 
 			@include media.min-width(large) {
 				@include grid.twelve-columns;


### PR DESCRIPTION
# Motivation

<img width="1536" alt="Capture d’écran 2025-01-25 à 13 16 02" src="https://github.com/user-attachments/assets/114e7e92-55ee-4ce2-8e77-1b7e619fa08b" />

