### PR TITLE
fix: do no use default strategy if monitoring disabled

### DIFF
--- a/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterMonitoringDefaultStrategy.svelte
@@ -23,9 +23,10 @@
 
 	onMount(() => {
 		// If user as a default strategy, we use this strategy else, if monitored is already enabled, we use the basic suggested strategy
-		useMonitoringStrategy =
-			fromNullishNullable(fromNullishNullable(monitoringConfig?.cycles)?.default_strategy) ??
-			(monitoringEnabled ? BASIC_STRATEGY : undefined);
+		useMonitoringStrategy = monitoringEnabled
+			? (fromNullishNullable(fromNullishNullable(monitoringConfig?.cycles)?.default_strategy) ??
+				BASIC_STRATEGY)
+			: undefined;
 
 		monitoringStrategy = useMonitoringStrategy;
 		useDefaultStrategy = nonNullish(monitoringStrategy);


### PR DESCRIPTION
# Motivation

In the create module wizard the flag to detect if monitoring is enabled was solely use for the basic strategy so if a user had a default disable strategy, this one was use and per extension after the creation of the module, the process failed because monitoring could not be enabled with the mission control not being monitored.
