### PR TITLE
feat: use store function to get_controllers in guards

### DIFF
--- a/src/libs/satellite/src/guards.rs
+++ b/src/libs/satellite/src/guards.rs
@@ -1,11 +1,11 @@
-use crate::memory::STATE;
+use crate::controllers::store::get_controllers;
 use ic_cdk::caller;
 use junobuild_shared::controllers::{is_admin_controller, is_controller};
 use junobuild_shared::types::state::Controllers;
 
 pub fn caller_is_admin_controller() -> Result<(), String> {
     let caller = caller();
-    let controllers: Controllers = STATE.with(|state| state.borrow().heap.controllers.clone());
+    let controllers: Controllers = get_controllers();
 
     if is_admin_controller(caller, &controllers) {
         Ok(())
@@ -16,7 +16,7 @@ pub fn caller_is_admin_controller() -> Result<(), String> {
 
 pub fn caller_is_controller() -> Result<(), String> {
     let caller = caller();
-    let controllers: Controllers = STATE.with(|state| state.borrow().heap.controllers.clone());
+    let controllers: Controllers = get_controllers();
 
     if is_controller(caller, &controllers) {
         Ok(())


### PR DESCRIPTION
# Motivation

A bit more elegant than accessing the STATE directly.
