### PR TITLE
chore: vitest reporters classic deprecated

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,14 @@ export default defineConfig({
 		globals: true,
 		watch: false,
 		silent: false,
-		reporters: ['basic'],
+		reporters: [
+			[
+				'default',
+				{
+					summary: false
+				}
+			]
+		],
 		environment: 'node',
 		poolOptions: {
 			threads: {


### PR DESCRIPTION
# Motivation

```
 DEPRECATED  'basic' reporter is deprecated and will be removed in Vitest v3.
Remove 'basic' from 'reporters' option. To match 'basic' reporter 100%, use configuration:
{
  "test": {
    "reporters": [
      [
        "default",
        {
          "summary": false
        }
      ]
    ]
  }
}
```

