### PR TITLE
feat: user usage count changes

### DIFF
--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -192,7 +192,7 @@ export interface SetRule {
 	write: Permission;
 }
 export interface SetUserUsage {
-	items_count: number;
+	changes_count: number;
 }
 export interface StorageConfig {
 	iframe: [] | [StorageConfigIFrame];
@@ -244,7 +244,7 @@ export interface UserUsage {
 	updated_at: bigint;
 	created_at: bigint;
 	version: [] | [bigint];
-	items_count: number;
+	changes_count: number;
 }
 export interface _SERVICE {
 	build_version: ActorMethod<[], string>;

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -149,7 +149,7 @@ export const idlFactory = ({ IDL }) => {
 		updated_at: IDL.Nat64,
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64),
-		items_count: IDL.Nat32
+		changes_count: IDL.Nat32
 	});
 	const HttpRequest = IDL.Record({
 		url: IDL.Text,
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 		rate_config: IDL.Opt(RateConfig),
 		write: Permission
 	});
-	const SetUserUsage = IDL.Record({ items_count: IDL.Nat32 });
+	const SetUserUsage = IDL.Record({ changes_count: IDL.Nat32 });
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -149,7 +149,7 @@ export const idlFactory = ({ IDL }) => {
 		updated_at: IDL.Nat64,
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64),
-		items_count: IDL.Nat32
+		changes_count: IDL.Nat32
 	});
 	const HttpRequest = IDL.Record({
 		url: IDL.Text,
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 		rate_config: IDL.Opt(RateConfig),
 		write: Permission
 	});
-	const SetUserUsage = IDL.Record({ items_count: IDL.Nat32 });
+	const SetUserUsage = IDL.Record({ changes_count: IDL.Nat32 });
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -149,7 +149,7 @@ export const idlFactory = ({ IDL }) => {
 		updated_at: IDL.Nat64,
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64),
-		items_count: IDL.Nat32
+		changes_count: IDL.Nat32
 	});
 	const HttpRequest = IDL.Record({
 		url: IDL.Text,
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 		rate_config: IDL.Opt(RateConfig),
 		write: Permission
 	});
-	const SetUserUsage = IDL.Record({ items_count: IDL.Nat32 });
+	const SetUserUsage = IDL.Record({ changes_count: IDL.Nat32 });
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -155,7 +155,7 @@ type SetRule = record {
   rate_config : opt RateConfig;
   write : Permission;
 };
-type SetUserUsage = record { items_count : nat32 };
+type SetUserUsage = record { changes_count : nat32 };
 type StorageConfig = record {
   iframe : opt StorageConfigIFrame;
   rewrites : vec record { text; text };
@@ -202,7 +202,7 @@ type UserUsage = record {
   updated_at : nat64;
   created_at : nat64;
   version : opt nat64;
-  items_count : nat32;
+  changes_count : nat32;
 };
 service : () -> {
   commit_asset_upload : (CommitBatch) -> ();

--- a/src/libs/satellite/src/satellite.rs
+++ b/src/libs/satellite/src/satellite.rs
@@ -41,9 +41,8 @@ use crate::types::state::{CollectionType, HeapState, RuntimeState, State};
 use crate::usage::types::interface::SetUserUsage;
 use crate::usage::types::state::UserUsage;
 use crate::usage::user_usage::{
-    increase_db_usage_by, increase_storage_usage_by,
-    get_db_usage_by_id, get_storage_usage_by_id, increase_db_usage, increase_storage_usage,
-    set_db_usage, set_storage_usage,
+    get_db_usage_by_id, get_storage_usage_by_id, increase_db_usage, increase_db_usage_by,
+    increase_storage_usage, increase_storage_usage_by, set_db_usage, set_storage_usage,
 };
 use ciborium::{from_reader, into_writer};
 use ic_cdk::api::call::{arg_data, ArgDecoderConfig};

--- a/src/libs/satellite/src/satellite.rs
+++ b/src/libs/satellite/src/satellite.rs
@@ -41,7 +41,7 @@ use crate::types::state::{CollectionType, HeapState, RuntimeState, State};
 use crate::usage::types::interface::SetUserUsage;
 use crate::usage::types::state::UserUsage;
 use crate::usage::user_usage::{
-    decrease_db_usage, decrease_db_usage_by, decrease_storage_usage, decrease_storage_usage_by,
+    increase_db_usage_by, increase_storage_usage_by,
     get_db_usage_by_id, get_storage_usage_by_id, increase_db_usage, increase_storage_usage,
     set_db_usage, set_storage_usage,
 };
@@ -158,7 +158,7 @@ pub fn del_doc(collection: CollectionKey, key: Key, doc: DelDoc) {
     let deleted_doc =
         delete_doc_store(caller, collection.clone(), key, doc).unwrap_or_else(|e| trap(&e));
 
-    decrease_db_usage(&collection, &caller);
+    increase_db_usage(&collection, &caller);
 
     invoke_on_delete_doc(&caller, &deleted_doc);
 }
@@ -225,7 +225,7 @@ pub fn del_many_docs(docs: Vec<(CollectionKey, Key, DelDoc)>) {
         let deleted_doc = delete_doc_store(caller, collection.clone(), key.clone(), doc)
             .unwrap_or_else(|e| trap(&e));
 
-        decrease_db_usage(&collection, &caller);
+        increase_db_usage(&collection, &caller);
 
         results.push(deleted_doc);
     }
@@ -239,7 +239,7 @@ pub fn del_filtered_docs(collection: CollectionKey, filter: ListParams) {
     let results = delete_filtered_docs_store(caller, collection.clone(), &filter)
         .unwrap_or_else(|e| trap(&e));
 
-    decrease_db_usage_by(&collection, &caller, results.len() as u32);
+    increase_db_usage_by(&collection, &caller, results.len() as u32);
 
     invoke_on_delete_filtered_docs(&caller, &results);
 }
@@ -482,7 +482,7 @@ pub fn del_asset(collection: CollectionKey, full_path: FullPath) {
 
     match result {
         Ok(asset) => {
-            decrease_storage_usage(&collection, &caller);
+            increase_storage_usage(&collection, &caller);
 
             invoke_on_delete_asset(&caller, &asset)
         }
@@ -499,7 +499,7 @@ pub fn del_many_assets(assets: Vec<(CollectionKey, String)>) {
         let deleted_asset =
             delete_asset_store(caller, &collection, full_path).unwrap_or_else(|e| trap(&e));
 
-        decrease_storage_usage(&collection, &caller);
+        increase_storage_usage(&collection, &caller);
 
         results.push(deleted_asset);
     }
@@ -513,7 +513,7 @@ pub fn del_filtered_assets(collection: CollectionKey, filter: ListParams) {
     let results = delete_filtered_assets_store(caller, collection.clone(), &filter)
         .unwrap_or_else(|e| trap(&e));
 
-    decrease_storage_usage_by(&collection, &caller, results.len() as u32);
+    increase_storage_usage_by(&collection, &caller, results.len() as u32);
 
     invoke_on_delete_filtered_assets(&caller, &results);
 }
@@ -585,10 +585,10 @@ pub fn set_user_usage(
 ) -> UserUsage {
     match collection_type {
         CollectionType::Db => {
-            set_db_usage(collection, user_id, usage.items_count).unwrap_or_else(|e| trap(&e))
+            set_db_usage(collection, user_id, usage.changes_count).unwrap_or_else(|e| trap(&e))
         }
         CollectionType::Storage => {
-            set_storage_usage(collection, user_id, usage.items_count).unwrap_or_else(|e| trap(&e))
+            set_storage_usage(collection, user_id, usage.changes_count).unwrap_or_else(|e| trap(&e))
         }
     }
 }

--- a/src/libs/satellite/src/usage/impls.rs
+++ b/src/libs/satellite/src/usage/impls.rs
@@ -1,5 +1,4 @@
 use crate::types::state::CollectionType;
-use crate::usage::types::interface::ModificationType;
 use crate::usage::types::state::{UserUsage, UserUsageKey};
 use ic_cdk::api::time;
 use ic_stable_structures::storable::Bound;
@@ -39,9 +38,8 @@ impl UserUsage {
         UserUsage::apply_update(current_user_usage, count)
     }
 
-    pub fn increase_or_decrease(
+    pub fn increment(
         current_user_usage: &Option<UserUsage>,
-        modification: &ModificationType,
         count: Option<u32>,
     ) -> Self {
         let count = count.unwrap_or(1);
@@ -49,11 +47,8 @@ impl UserUsage {
         // User usage for the collection
 
         let items_count: u32 = match current_user_usage {
-            None => 1,
-            Some(current_user_usage) => match modification {
-                ModificationType::Set => current_user_usage.items_count.saturating_add(count),
-                ModificationType::Delete => current_user_usage.items_count.saturating_sub(count),
-            },
+            None => count,
+            Some(current_user_usage) => current_user_usage.changes_count.saturating_add(count),
         };
 
         UserUsage::apply_update(current_user_usage, items_count)
@@ -77,7 +72,7 @@ impl UserUsage {
         let updated_at: Timestamp = now;
 
         UserUsage {
-            items_count,
+            changes_count: items_count,
             created_at,
             updated_at,
             version: Some(version),

--- a/src/libs/satellite/src/usage/impls.rs
+++ b/src/libs/satellite/src/usage/impls.rs
@@ -38,10 +38,7 @@ impl UserUsage {
         UserUsage::apply_update(current_user_usage, count)
     }
 
-    pub fn increment(
-        current_user_usage: &Option<UserUsage>,
-        count: Option<u32>,
-    ) -> Self {
+    pub fn increment(current_user_usage: &Option<UserUsage>, count: Option<u32>) -> Self {
         let count = count.unwrap_or(1);
 
         // User usage for the collection

--- a/src/libs/satellite/src/usage/store.rs
+++ b/src/libs/satellite/src/usage/store.rs
@@ -1,6 +1,5 @@
 use crate::memory::STATE;
 use crate::types::state::CollectionType;
-use crate::usage::types::interface::ModificationType;
 use crate::usage::types::state::{UserUsage, UserUsageKey, UserUsageStable};
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_shared::types::state::UserId;
@@ -24,7 +23,6 @@ pub fn update_user_usage(
     collection_key: &CollectionKey,
     collection_type: &CollectionType,
     user_id: &UserId,
-    modification: &ModificationType,
     count: Option<u32>,
 ) {
     STATE.with(|state| {
@@ -32,7 +30,6 @@ pub fn update_user_usage(
             collection_key,
             collection_type,
             user_id,
-            modification,
             count,
             &mut state.borrow_mut().stable.user_usage,
         )
@@ -71,7 +68,6 @@ fn update_user_usage_impl(
     collection_key: &CollectionKey,
     collection_type: &CollectionType,
     user_id: &UserId,
-    modification: &ModificationType,
     count: Option<u32>,
     state: &mut UserUsageStable,
 ) {
@@ -79,7 +75,7 @@ fn update_user_usage_impl(
 
     let current_usage = state.get(&key);
 
-    let update_usage = UserUsage::increase_or_decrease(&current_usage, modification, count);
+    let update_usage = UserUsage::increment(&current_usage, count);
 
     state.insert(key, update_usage);
 }

--- a/src/libs/satellite/src/usage/types.rs
+++ b/src/libs/satellite/src/usage/types.rs
@@ -26,13 +26,13 @@ pub mod state {
     ///
     ///
     /// Fields:
-    /// - `items_count`: The total number of changes by the user. Is not necessary equals to the number of items due to the lack of migration and the fact that controllers can reset the value.
+    /// - `changes_count`: The total number of changes (create/update/delete) by the user.
     /// - `created_at`: The timestamp when this user usage entry was first recorded.
     /// - `updated_at`: The timestamp of the last update to this user usage entry.
     /// - `version`: An optional field representing the version of this usage entry. In the future we might implement checks to avoid overwrite but, this is not the case currently.
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct UserUsage {
-        pub items_count: u32,
+        pub changes_count: u32,
         pub created_at: Timestamp,
         pub updated_at: Timestamp,
         pub version: Option<Version>,
@@ -43,19 +43,14 @@ pub mod interface {
     use candid::{CandidType, Deserialize};
     use serde::Serialize;
 
-    pub enum ModificationType {
-        Set,
-        Delete,
-    }
-
     /// Represents the parameters for setting or updating a user's usage entry for a controller.
     ///
     /// This is useful if one want to set a value after the upgrade, given the lack of migration, or if a controller ever wants to reset the value to allow a user who would hit the limit to continue submitted changes.
     ///
     /// It includes:
-    /// - `items_count`: The total number of changes the user has in a specific collection.
+    /// - `changes_count`: The total number of changes the user has in a specific collection.
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct SetUserUsage {
-        pub items_count: u32,
+        pub changes_count: u32,
     }
 }

--- a/src/libs/satellite/src/usage/user_usage.rs
+++ b/src/libs/satellite/src/usage/user_usage.rs
@@ -3,7 +3,6 @@ use crate::types::state::CollectionType;
 use crate::usage::store::{
     get_user_usage as get_user_usage_store, set_user_usage, update_user_usage,
 };
-use crate::usage::types::interface::ModificationType;
 use crate::usage::types::state::UserUsage;
 use candid::Principal;
 use junobuild_collections::constants::{
@@ -54,7 +53,6 @@ pub fn increase_db_usage(collection: &CollectionKey, user_id: &UserId) {
         collection,
         &CollectionType::Db,
         user_id,
-        &ModificationType::Set,
         None,
     );
 }
@@ -76,7 +74,7 @@ pub fn set_db_usage(
     Ok(usage)
 }
 
-pub fn decrease_db_usage(collection: &CollectionKey, user_id: &UserId) {
+pub fn increase_db_usage_by(collection: &CollectionKey, user_id: &UserId, count: u32) {
     if is_db_collection_no_usage(collection) {
         return;
     }
@@ -85,21 +83,6 @@ pub fn decrease_db_usage(collection: &CollectionKey, user_id: &UserId) {
         collection,
         &CollectionType::Db,
         user_id,
-        &ModificationType::Delete,
-        None,
-    );
-}
-
-pub fn decrease_db_usage_by(collection: &CollectionKey, user_id: &UserId, count: u32) {
-    if is_db_collection_no_usage(collection) {
-        return;
-    }
-
-    update_user_usage(
-        collection,
-        &CollectionType::Db,
-        user_id,
-        &ModificationType::Delete,
         Some(count),
     );
 }
@@ -113,7 +96,6 @@ pub fn increase_storage_usage(collection: &CollectionKey, user_id: &UserId) {
         collection,
         &CollectionType::Storage,
         user_id,
-        &ModificationType::Set,
         None,
     );
 }
@@ -135,7 +117,7 @@ pub fn set_storage_usage(
     Ok(usage)
 }
 
-pub fn decrease_storage_usage(collection: &CollectionKey, user_id: &UserId) {
+pub fn increase_storage_usage_by(collection: &CollectionKey, user_id: &UserId, count: u32) {
     if is_storage_collection_no_usage(collection) {
         return;
     }
@@ -144,21 +126,6 @@ pub fn decrease_storage_usage(collection: &CollectionKey, user_id: &UserId) {
         collection,
         &CollectionType::Storage,
         user_id,
-        &ModificationType::Delete,
-        None,
-    );
-}
-
-pub fn decrease_storage_usage_by(collection: &CollectionKey, user_id: &UserId, count: u32) {
-    if is_storage_collection_no_usage(collection) {
-        return;
-    }
-
-    update_user_usage(
-        collection,
-        &CollectionType::Storage,
-        user_id,
-        &ModificationType::Delete,
         Some(count),
     );
 }

--- a/src/libs/satellite/src/usage/user_usage.rs
+++ b/src/libs/satellite/src/usage/user_usage.rs
@@ -49,12 +49,7 @@ pub fn increase_db_usage(collection: &CollectionKey, user_id: &UserId) {
         return;
     }
 
-    update_user_usage(
-        collection,
-        &CollectionType::Db,
-        user_id,
-        None,
-    );
+    update_user_usage(collection, &CollectionType::Db, user_id, None);
 }
 
 pub fn set_db_usage(
@@ -79,12 +74,7 @@ pub fn increase_db_usage_by(collection: &CollectionKey, user_id: &UserId, count:
         return;
     }
 
-    update_user_usage(
-        collection,
-        &CollectionType::Db,
-        user_id,
-        Some(count),
-    );
+    update_user_usage(collection, &CollectionType::Db, user_id, Some(count));
 }
 
 pub fn increase_storage_usage(collection: &CollectionKey, user_id: &UserId) {
@@ -92,12 +82,7 @@ pub fn increase_storage_usage(collection: &CollectionKey, user_id: &UserId) {
         return;
     }
 
-    update_user_usage(
-        collection,
-        &CollectionType::Storage,
-        user_id,
-        None,
-    );
+    update_user_usage(collection, &CollectionType::Storage, user_id, None);
 }
 
 pub fn set_storage_usage(
@@ -122,12 +107,7 @@ pub fn increase_storage_usage_by(collection: &CollectionKey, user_id: &UserId, c
         return;
     }
 
-    update_user_usage(
-        collection,
-        &CollectionType::Storage,
-        user_id,
-        Some(count),
-    );
+    update_user_usage(collection, &CollectionType::Storage, user_id, Some(count));
 }
 
 fn is_db_collection_no_usage(collection: &CollectionKey) -> bool {

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -157,7 +157,7 @@ type SetRule = record {
   rate_config : opt RateConfig;
   write : Permission;
 };
-type SetUserUsage = record { items_count : nat32 };
+type SetUserUsage = record { changes_count : nat32 };
 type StorageConfig = record {
   iframe : opt StorageConfigIFrame;
   rewrites : vec record { text; text };
@@ -204,7 +204,7 @@ type UserUsage = record {
   updated_at : nat64;
   created_at : nat64;
   version : opt nat64;
-  items_count : nat32;
+  changes_count : nat32;
 };
 service : () -> {
   commit_asset_upload : (CommitBatch) -> ();

--- a/src/tests/satellite.user-usage.spec.ts
+++ b/src/tests/satellite.user-usage.spec.ts
@@ -173,7 +173,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.changes_count).toEqual(countSetManyDocs + countSetDocs - countDelDoc);
+				expect(usage.changes_count).toEqual(countSetManyDocs + countSetDocs + countDelDoc);
 				expect(usage.version).toEqual(
 					toNullable(BigInt(countSetManyDocs + countSetDocs + countDelDoc))
 				);
@@ -205,7 +205,7 @@ describe('Satellite User Usage', () => {
 				assertNonNullish(usage);
 
 				expect(usage.changes_count).toEqual(
-					countSetManyDocs + countSetDocs - countDelDoc - countDelManyDocs
+					countSetManyDocs + countSetDocs + countDelDoc + countDelManyDocs
 				);
 				expect(usage.version).toEqual(
 					toNullable(BigInt(countSetManyDocs + countSetDocs + countDelDoc + countDelManyDocs))
@@ -226,9 +226,13 @@ describe('Satellite User Usage', () => {
 				assertNonNullish(usage);
 
 				countTotalTestVersion =
-					countSetManyDocs + countSetDocs + countDelDoc + countDelManyDocs + 1;
+					countSetManyDocs + countSetDocs + countDelDoc + countDelManyDocs + 1; // + 1 for del_filtered_docs
 
-				expect(usage.changes_count).toEqual(0);
+				const countRemainingDocs = countSetManyDocs + countSetDocs - countDelDoc - countDelManyDocs;
+
+				expect(usage.changes_count).toEqual(
+					countSetManyDocs + countSetDocs + countDelDoc + countDelManyDocs + countRemainingDocs
+				);
 				expect(usage.version).toEqual(toNullable(BigInt(countTotalTestVersion)));
 			});
 		});
@@ -430,7 +434,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.changes_count).toEqual(countUploadAssets - countDelAsset);
+				expect(usage.changes_count).toEqual(countUploadAssets + countDelAsset);
 				expect(usage.version).toEqual(toNullable(BigInt(countUploadAssets + countDelAsset)));
 			});
 
@@ -456,7 +460,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.changes_count).toEqual(countUploadAssets - countDelAsset - countDelManyAssets);
+				expect(usage.changes_count).toEqual(countUploadAssets + countDelAsset + countDelManyAssets);
 				expect(usage.version).toEqual(
 					toNullable(BigInt(countUploadAssets + countDelAsset + countDelManyAssets))
 				);
@@ -475,9 +479,13 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				countTotalTestVersion = countUploadAssets + countDelAsset + countDelManyAssets + 1;
+				countTotalTestVersion = countUploadAssets + countDelAsset + countDelManyAssets + 1; // + 1 for del_filtered_assets
 
-				expect(usage.changes_count).toEqual(0);
+				const countRemainingAssets = countUploadAssets - countDelAsset - countDelManyAssets;
+
+				expect(usage.changes_count).toEqual(
+					countUploadAssets + countDelAsset + countDelManyAssets + countRemainingAssets
+				);
 				expect(usage.version).toEqual(toNullable(BigInt(countTotalTestVersion)));
 			});
 		});

--- a/src/tests/satellite.user-usage.spec.ts
+++ b/src/tests/satellite.user-usage.spec.ts
@@ -110,7 +110,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(countSetDocs);
+				expect(usage.changes_count).toEqual(countSetDocs);
 
 				expect(usage.updated_at).not.toBeUndefined();
 				expect(usage.updated_at).toBeGreaterThan(0n);
@@ -148,7 +148,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(countSetManyDocs + countSetDocs);
+				expect(usage.changes_count).toEqual(countSetManyDocs + countSetDocs);
 				expect(usage.version).toEqual(toNullable(BigInt(countSetManyDocs + countSetDocs)));
 			});
 
@@ -173,7 +173,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(countSetManyDocs + countSetDocs - countDelDoc);
+				expect(usage.changes_count).toEqual(countSetManyDocs + countSetDocs - countDelDoc);
 				expect(usage.version).toEqual(
 					toNullable(BigInt(countSetManyDocs + countSetDocs + countDelDoc))
 				);
@@ -204,7 +204,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(
+				expect(usage.changes_count).toEqual(
 					countSetManyDocs + countSetDocs - countDelDoc - countDelManyDocs
 				);
 				expect(usage.version).toEqual(
@@ -228,7 +228,7 @@ describe('Satellite User Usage', () => {
 				countTotalTestVersion =
 					countSetManyDocs + countSetDocs + countDelDoc + countDelManyDocs + 1;
 
-				expect(usage.items_count).toEqual(0);
+				expect(usage.changes_count).toEqual(0);
 				expect(usage.version).toEqual(toNullable(BigInt(countTotalTestVersion)));
 			});
 		});
@@ -257,7 +257,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(1);
+				expect(usage.changes_count).toEqual(1);
 
 				const user2 = Ed25519KeyIdentity.generate();
 
@@ -275,7 +275,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(1);
+				expect(usage.changes_count).toEqual(1);
 			});
 
 			it('should throw errors on set usage', async () => {
@@ -285,7 +285,7 @@ describe('Satellite User Usage', () => {
 
 				await expect(
 					set_user_usage(TEST_COLLECTION, COLLECTION_TYPE, user1.getPrincipal(), {
-						items_count: 345
+						changes_count: 345
 					})
 				).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 			});
@@ -324,10 +324,10 @@ describe('Satellite User Usage', () => {
 				const { set_user_usage } = actor;
 
 				const usage = await set_user_usage(TEST_COLLECTION, COLLECTION_TYPE, user.getPrincipal(), {
-					items_count: 345
+					changes_count: 345
 				});
 
-				expect(usage.items_count).toEqual(345);
+				expect(usage.changes_count).toEqual(345);
 
 				expect(usage.updated_at).not.toBeUndefined();
 				expect(usage.updated_at).toBeGreaterThan(0n);
@@ -400,7 +400,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(countUploadAssets);
+				expect(usage.changes_count).toEqual(countUploadAssets);
 
 				expect(usage.updated_at).not.toBeUndefined();
 				expect(usage.updated_at).toBeGreaterThan(0n);
@@ -430,7 +430,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(countUploadAssets - countDelAsset);
+				expect(usage.changes_count).toEqual(countUploadAssets - countDelAsset);
 				expect(usage.version).toEqual(toNullable(BigInt(countUploadAssets + countDelAsset)));
 			});
 
@@ -456,7 +456,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(countUploadAssets - countDelAsset - countDelManyAssets);
+				expect(usage.changes_count).toEqual(countUploadAssets - countDelAsset - countDelManyAssets);
 				expect(usage.version).toEqual(
 					toNullable(BigInt(countUploadAssets + countDelAsset + countDelManyAssets))
 				);
@@ -477,7 +477,7 @@ describe('Satellite User Usage', () => {
 
 				countTotalTestVersion = countUploadAssets + countDelAsset + countDelManyAssets + 1;
 
-				expect(usage.items_count).toEqual(0);
+				expect(usage.changes_count).toEqual(0);
 				expect(usage.version).toEqual(toNullable(BigInt(countTotalTestVersion)));
 			});
 		});
@@ -508,7 +508,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(1);
+				expect(usage.changes_count).toEqual(1);
 
 				const user2 = Ed25519KeyIdentity.generate();
 
@@ -527,7 +527,7 @@ describe('Satellite User Usage', () => {
 
 				assertNonNullish(usage);
 
-				expect(usage.items_count).toEqual(1);
+				expect(usage.changes_count).toEqual(1);
 			});
 
 			it('should throw errors on set usage', async () => {
@@ -537,7 +537,7 @@ describe('Satellite User Usage', () => {
 
 				await expect(
 					set_user_usage(TEST_COLLECTION, COLLECTION_TYPE, user1.getPrincipal(), {
-						items_count: 345
+						changes_count: 345
 					})
 				).rejects.toThrow(SATELLITE_ADMIN_ERROR_MSG);
 			});
@@ -578,10 +578,10 @@ describe('Satellite User Usage', () => {
 				const { set_user_usage } = actor;
 
 				const usage = await set_user_usage(TEST_COLLECTION, COLLECTION_TYPE, user.getPrincipal(), {
-					items_count: 456
+					changes_count: 456
 				});
 
-				expect(usage.items_count).toEqual(456);
+				expect(usage.changes_count).toEqual(456);
 
 				expect(usage.updated_at).not.toBeUndefined();
 				expect(usage.updated_at).toBeGreaterThan(0n);


### PR DESCRIPTION
# Motivation

If we increase and decrease the counter, then one "offender" can just keep update and delete entities to consume most resources. If we count set and del as changes, then there is a real max.
