### PR TITLE
fix: missing submit button when collection immutable

### DIFF
--- a/src/frontend/src/lib/components/collections/CollectionEdit.svelte
+++ b/src/frontend/src/lib/components/collections/CollectionEdit.svelte
@@ -322,9 +322,7 @@
 				<CollectionDelete {collection} {rule} {type} on:junoCollectionSuccess />
 			{/if}
 
-			{#if !currentImmutable}
-				<button type="submit" class="primary" {disabled}>{$i18n.core.submit}</button>
-			{/if}
+			<button type="submit" class="primary" {disabled}>{$i18n.core.submit}</button>
 		</div>
 	</form>
 </article>


### PR DESCRIPTION
# Motivation

A collection details now contains options, those can be edited even if the collection's permissions are set as immatable. Therefore it makes sense to still be able to submit changes.
