### PR TITLE
feat: cap pagination check

### DIFF
--- a/src/libs/shared/src/list.rs
+++ b/src/libs/shared/src/list.rs
@@ -172,7 +172,7 @@ fn paginate_values<T: Clone + Timestamped>(
                 return Vec::new();
             }
 
-            if (start + length) > max - 1 {
+            if start.saturating_add(length) > max - 1 {
                 return matches[start..=(max - 1)]
                     .iter()
                     .map(|(key, value)| ((*key).clone(), (*value).clone()))


### PR DESCRIPTION
# Motivation

The edge case would happen if the developer abuse limit in a paginated list request if I get it right. Using my new favorite `saturation_add` function should gap the check.
