### PR TITLE
feat: remove asset preparation duplicated code

### DIFF
--- a/src/libs/satellite/src/storage/handlers.rs
+++ b/src/libs/satellite/src/storage/handlers.rs
@@ -10,7 +10,7 @@ use junobuild_storage::http::types::HeaderField;
 use junobuild_storage::msg::SET_NOT_ALLOWED;
 use junobuild_storage::runtime::update_certified_asset as update_runtime_certified_asset;
 use junobuild_storage::types::store::{Asset, AssetKey};
-use junobuild_storage::utils::{map_content_encoding};
+use junobuild_storage::utils::map_content_encoding;
 
 /// Handles the setting of an asset within the store. This function performs
 /// various checks and operations to ensure the asset can be set and updated
@@ -66,7 +66,7 @@ fn set_asset_handler_impl(
     headers: &[HeaderField],
     rule: &Rule,
 ) -> Result<(), String> {
-    let mut asset = Asset::new(headers, existing_asset.clone(), key.clone());
+    let mut asset = Asset::prepare(key.clone(), headers.to_vec(), existing_asset);
 
     let encoding = map_content_encoding(content);
 

--- a/src/libs/storage/src/utils.rs
+++ b/src/libs/storage/src/utils.rs
@@ -145,7 +145,7 @@ pub fn create_asset_with_content(
     existing_asset: Option<Asset>,
     key: AssetKey,
 ) -> Asset {
-    let mut asset: Asset = Asset::new(headers, existing_asset, key);
+    let mut asset: Asset = Asset::prepare(key, headers.to_vec(), &existing_asset);
 
     let encoding = map_content_encoding(&content.as_bytes().to_vec());
 


### PR DESCRIPTION
# Motivation

This way we can remove code duplication and also ultimately scope the INITIAL_VERSION constant as we use next_version everywhere.
