### PR TITLE
feat: expose only those shared constants that are actually used

### DIFF
--- a/src/console/src/factory/canister.rs
+++ b/src/console/src/factory/canister.rs
@@ -6,7 +6,7 @@ use crate::store::stable::{
 use crate::types::ledger::Payment;
 use candid::Principal;
 use ic_ledger_types::{BlockIndex, Tokens};
-use junobuild_shared::constants::{IC_TRANSACTION_FEE_ICP, MEMO_SATELLITE_CREATE_REFUND};
+use junobuild_shared::constants_shared::{IC_TRANSACTION_FEE_ICP, MEMO_SATELLITE_CREATE_REFUND};
 use junobuild_shared::ledger::icp::{
     find_payment, principal_to_account_identifier, transfer_payment, SUB_ACCOUNT,
 };

--- a/src/console/src/factory/mission_control.rs
+++ b/src/console/src/factory/mission_control.rs
@@ -6,7 +6,7 @@ use crate::store::stable::{
 use crate::types::state::MissionControl;
 use crate::wasm::mission_control_wasm_arg;
 use candid::Principal;
-use junobuild_shared::constants::CREATE_MISSION_CONTROL_CYCLES;
+use junobuild_shared::constants_shared::CREATE_MISSION_CONTROL_CYCLES;
 use junobuild_shared::mgmt::ic::create_canister_install_code;
 use junobuild_shared::types::state::UserId;
 

--- a/src/console/src/factory/orbiter.rs
+++ b/src/console/src/factory/orbiter.rs
@@ -3,7 +3,7 @@ use crate::factory::canister::create_canister;
 use crate::store::heap::{get_orbiter_fee, increment_orbiters_rate};
 use crate::wasm::orbiter_wasm_arg;
 use candid::Principal;
-use junobuild_shared::constants::CREATE_ORBITER_CYCLES;
+use junobuild_shared::constants_shared::CREATE_ORBITER_CYCLES;
 use junobuild_shared::mgmt::cmc::cmc_create_canister_install_code;
 use junobuild_shared::mgmt::ic::create_canister_install_code;
 use junobuild_shared::mgmt::types::cmc::SubnetId;

--- a/src/console/src/factory/satellite.rs
+++ b/src/console/src/factory/satellite.rs
@@ -3,7 +3,7 @@ use crate::factory::canister::create_canister;
 use crate::store::heap::{get_satellite_fee, increment_satellites_rate};
 use crate::wasm::satellite_wasm_arg;
 use candid::Principal;
-use junobuild_shared::constants::CREATE_SATELLITE_CYCLES;
+use junobuild_shared::constants_shared::CREATE_SATELLITE_CYCLES;
 use junobuild_shared::mgmt::cmc::cmc_create_canister_install_code;
 use junobuild_shared::mgmt::ic::create_canister_install_code;
 use junobuild_shared::mgmt::types::cmc::SubnetId;

--- a/src/libs/satellite/src/satellite.rs
+++ b/src/libs/satellite/src/satellite.rs
@@ -48,7 +48,7 @@ use ic_cdk::api::{caller, trap};
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::interface::{DelRule, SetRule};
 use junobuild_collections::types::rules::Rule;
-use junobuild_shared::constants::MAX_NUMBER_OF_SATELLITE_CONTROLLERS;
+use junobuild_shared::constants_shared::MAX_NUMBER_OF_SATELLITE_CONTROLLERS;
 use junobuild_shared::controllers::{
     assert_controllers, assert_max_number_of_controllers, init_controllers,
 };

--- a/src/libs/shared/src/constants_internal.rs
+++ b/src/libs/shared/src/constants_internal.rs
@@ -1,0 +1,13 @@
+use crate::types::state::Version;
+
+// Controllers / principals, hopefully only one, that were revoked following inherited security incident in February 2024.
+pub const REVOKED_CONTROLLERS: [&str; 1] =
+    ["535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe"];
+
+// The default version number when a new entity is persisted for the first time.
+pub const INITIAL_VERSION: Version = 1;
+
+// The upper limit on the WASM heap memory consumption of the canister per default on the IC is now 3_221_225_472 (3 GiB).
+// According to our experience, we start noticing issue when we upgrade canister at 1 GB. That's why the Juno CLI and Console already warn when this limited is reached - i.e. warns when 900 Mb is reached.
+// So, to enforce this limit, we set the canister maximum heap memory per default to 1_073_741_824 (1 GiB).
+pub const WASM_MEMORY_LIMIT: u32 = 1_073_741_824;

--- a/src/libs/shared/src/constants_shared.rs
+++ b/src/libs/shared/src/constants_shared.rs
@@ -1,4 +1,3 @@
-use crate::types::state::Version;
 use ic_ledger_types::{Memo, Tokens};
 
 // Specifies the transaction fee for ICP transactions.
@@ -38,15 +37,3 @@ pub const MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS: usize = 8;
 
 // 10 controllers max on the IC. User and mission control principals are copied in satellite state controllers
 pub const MAX_NUMBER_OF_SATELLITE_CONTROLLERS: usize = 10;
-
-// Controllers / principals, hopefully only one, that were revoked following inherited security incident in February 2024.
-pub const REVOKED_CONTROLLERS: [&str; 1] =
-    ["535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe"];
-
-// The default version number when a new entity is persisted for the first time.
-pub const INITIAL_VERSION: Version = 1;
-
-// The upper limit on the WASM heap memory consumption of the canister per default on the IC is now 3_221_225_472 (3 GiB).
-// According to our experience, we start noticing issue when we upgrade canister at 1 GB. That's why the Juno CLI and Console already warn when this limited is reached - i.e. warns when 900 Mb is reached.
-// So, to enforce this limit, we set the canister maximum heap memory per default to 1_073_741_824 (1 GiB).
-pub const WASM_MEMORY_LIMIT: u32 = 1_073_741_824;

--- a/src/libs/shared/src/controllers.rs
+++ b/src/libs/shared/src/controllers.rs
@@ -1,4 +1,4 @@
-use crate::constants::REVOKED_CONTROLLERS;
+use crate::constants_internal::REVOKED_CONTROLLERS;
 use crate::env::{CONSOLE, OBSERVATORY};
 use crate::types::interface::SetController;
 use crate::types::state::{Controller, ControllerId, ControllerScope, Controllers, UserId};

--- a/src/libs/shared/src/lib.rs
+++ b/src/libs/shared/src/lib.rs
@@ -2,8 +2,9 @@
 
 pub mod assert;
 pub mod canister;
+mod constants_internal;
 #[doc(hidden)]
-pub mod constants;
+pub mod constants_shared;
 pub mod controllers;
 pub mod day;
 #[doc(hidden)]

--- a/src/libs/shared/src/mgmt/cmc.rs
+++ b/src/libs/shared/src/mgmt/cmc.rs
@@ -1,4 +1,4 @@
-use crate::constants::{IC_TRANSACTION_FEE_ICP, MEMO_CANISTER_TOP_UP};
+use crate::constants_shared::{IC_TRANSACTION_FEE_ICP, MEMO_CANISTER_TOP_UP};
 use crate::env::CMC;
 use crate::ledger::icp::transfer_payment;
 use crate::mgmt::ic::install_code;

--- a/src/libs/shared/src/mgmt/settings.rs
+++ b/src/libs/shared/src/mgmt/settings.rs
@@ -1,4 +1,5 @@
-use crate::constants::{CREATE_CANISTER_CYCLES, WASM_MEMORY_LIMIT};
+use crate::constants_internal::WASM_MEMORY_LIMIT;
+use crate::constants_shared::CREATE_CANISTER_CYCLES;
 use candid::{Nat, Principal};
 use ic_cdk::api::management_canister::main::CanisterSettings;
 

--- a/src/libs/shared/src/version.rs
+++ b/src/libs/shared/src/version.rs
@@ -1,4 +1,4 @@
-use crate::constants::INITIAL_VERSION;
+use crate::constants_internal::INITIAL_VERSION;
 use crate::types::state::{Version, Versioned};
 
 pub fn next_version<T>(current: &Option<T>) -> Version

--- a/src/mission_control/src/controllers/mission_control.rs
+++ b/src/mission_control/src/controllers/mission_control.rs
@@ -1,7 +1,7 @@
 use crate::controllers::store::{delete_controllers, get_admin_controllers, set_controllers};
 use crate::user::store::get_user;
 use ic_cdk::id;
-use junobuild_shared::constants::MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS;
+use junobuild_shared::constants_shared::MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS;
 use junobuild_shared::controllers::{
     assert_controllers, assert_max_number_of_controllers, into_controller_ids,
 };

--- a/src/mission_control/src/segments/canister.rs
+++ b/src/mission_control/src/segments/canister.rs
@@ -4,7 +4,7 @@ use candid::Principal;
 use ic_cdk::api::call::CallResult;
 use ic_cdk::{call, id};
 use ic_ledger_types::{BlockIndex, Tokens};
-use junobuild_shared::constants::{IC_TRANSACTION_FEE_ICP, MEMO_CANISTER_CREATE};
+use junobuild_shared::constants_shared::{IC_TRANSACTION_FEE_ICP, MEMO_CANISTER_CREATE};
 use junobuild_shared::env::CONSOLE;
 use junobuild_shared::ledger::icp::{transfer_payment, SUB_ACCOUNT};
 use junobuild_shared::mgmt::ic::{delete_segment, stop_segment};

--- a/src/orbiter/src/lib.rs
+++ b/src/orbiter/src/lib.rs
@@ -48,7 +48,7 @@ use ic_cdk::api::call::{arg_data, ArgDecoderConfig};
 use ic_cdk::trap;
 use ic_cdk_macros::{export_candid, init, post_upgrade, pre_upgrade, query, update};
 use junobuild_shared::canister::memory_size as canister_memory_size;
-use junobuild_shared::constants::MAX_NUMBER_OF_SATELLITE_CONTROLLERS;
+use junobuild_shared::constants_shared::MAX_NUMBER_OF_SATELLITE_CONTROLLERS;
 use junobuild_shared::controllers::{
     assert_controllers, assert_max_number_of_controllers, init_controllers,
 };


### PR DESCRIPTION
# Motivation

Kind of find it a bit cleaner to not leak all constants if not needed in shared.
