### PR TITLE
feat: pre-assertions for origins format

### DIFF
--- a/src/libs/satellite/src/auth/alternative_origins.rs
+++ b/src/libs/satellite/src/auth/alternative_origins.rs
@@ -1,3 +1,4 @@
+use crate::auth::msg::ERROR_INVALID_ORIGIN;
 use crate::auth::types::config::AuthenticationConfig;
 use crate::storage::store::get_custom_domains_store;
 use crate::storage::strategy_impls::StorageState;
@@ -75,10 +76,7 @@ fn set_alternative_origins_with_custom_domains(
         let parsed_url = Url::parse(&format!("https://{}", domain));
 
         match parsed_url {
-            Err(_) => Err(format!(
-                "Invalid domain {} to configure an alternative origin.",
-                domain
-            )),
+            Err(_) => Err(format!("{} ({})", ERROR_INVALID_ORIGIN, domain)),
             Ok(url) => {
                 let mut url_str = url.to_string();
 

--- a/src/libs/satellite/src/auth/assert.rs
+++ b/src/libs/satellite/src/auth/assert.rs
@@ -1,0 +1,30 @@
+use crate::auth::msg::ERROR_INVALID_ORIGIN;
+use crate::auth::types::config::AuthenticationConfig;
+use junobuild_shared::types::core::DomainName;
+use url::Url;
+
+pub fn assert_config_origin_urls(config: &AuthenticationConfig) -> Result<(), String> {
+    if let Some(internet_identity) = &config.internet_identity {
+        if let Some(derivation_origin) = &internet_identity.derivation_origin {
+            assert_url(derivation_origin)?;
+        }
+
+        if let Some(external_alternative_origins) = &internet_identity.external_alternative_origins
+        {
+            for origin in external_alternative_origins {
+                assert_url(origin)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn assert_url(domain: &DomainName) -> Result<(), String> {
+    let parsed_url = Url::parse(&format!("https://{}", domain));
+
+    match parsed_url {
+        Err(_) => Err(format!("{} ({})", ERROR_INVALID_ORIGIN, domain)),
+        Ok(_url) => Ok(()),
+    }
+}

--- a/src/libs/satellite/src/auth/mod.rs
+++ b/src/libs/satellite/src/auth/mod.rs
@@ -1,4 +1,6 @@
 mod alternative_origins;
+mod assert;
+mod msg;
 mod state;
 pub mod store;
 pub mod types;

--- a/src/libs/satellite/src/auth/msg.rs
+++ b/src/libs/satellite/src/auth/msg.rs
@@ -1,0 +1,2 @@
+/// Error message indicating that a domain - derivation or external alternative origins - cannot be parsed to a valid URL.
+pub const ERROR_INVALID_ORIGIN: &str = "error_invalid_origin";

--- a/src/libs/satellite/src/auth/store.rs
+++ b/src/libs/satellite/src/auth/store.rs
@@ -1,8 +1,11 @@
 use crate::auth::alternative_origins::update_alternative_origins;
+use crate::auth::assert::assert_config_origin_urls;
 use crate::auth::state::{get_config as get_state_config, insert_config as insert_state_config};
 use crate::auth::types::config::AuthenticationConfig;
 
 pub fn set_config(config: &AuthenticationConfig) -> Result<(), String> {
+    assert_config_origin_urls(config)?;
+
     insert_state_config(config);
 
     update_alternative_origins(config)

--- a/src/tests/satellite.auth.spec.ts
+++ b/src/tests/satellite.auth.spec.ts
@@ -55,6 +55,42 @@ describe('Satellite authentication', () => {
 			expect(config).toEqual([]);
 		});
 
+		const invalidDomain = 'domain%20.com';
+
+		it('should throw if derivation origin is malformed', async () => {
+			const { set_auth_config } = actor;
+
+			const config: AuthenticationConfig = {
+				internet_identity: [
+					{
+						derivation_origin: [invalidDomain],
+						external_alternative_origins: toNullable()
+					}
+				]
+			};
+
+			await expect(set_auth_config(config)).rejects.toThrow(
+				`error_invalid_origin (${invalidDomain})`
+			);
+		});
+
+		it('should throw if external alternative origin is malformed', async () => {
+			const { set_auth_config } = actor;
+
+			const config: AuthenticationConfig = {
+				internet_identity: [
+					{
+						derivation_origin: toNullable(),
+						external_alternative_origins: [[invalidDomain]]
+					}
+				]
+			};
+
+			await expect(set_auth_config(config)).rejects.toThrow(
+				`error_invalid_origin (${invalidDomain})`
+			);
+		});
+
 		it('should set config auth domain', async () => {
 			const { set_auth_config, get_auth_config } = actor;
 


### PR DESCRIPTION
# Motivation

We already parse the URLs, therefore they are asserted already but, it's a bit cleaner to be proactive and more expressive code wise.

Relates to #1164.
