### PR TITLE
feat: upgrade to getrandom v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,13 +419,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -896,9 +903,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -1115,20 +1122,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1136,11 +1143,12 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1529,9 +1537,12 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "winapi"
@@ -1563,6 +1574,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "write16"
@@ -1598,6 +1682,26 @@ dependencies = [
  "quote",
  "syn 2.0.98",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ sha2 = "0.10.8"
 hex = "0.4.3"
 url = "2.5.4"
 regex = "1.11.1"
-getrandom = { version = "0.2", features = ["custom"] }
-rand = { version = "0.8.5", features = ["getrandom"]}
+getrandom = "0.3.1"
+rand = { version = "0.9.0", features = ["os_rng"]}
 
 [patch.crates-io]
 junobuild-shared = { path = "./src/libs/shared" }

--- a/docker/build
+++ b/docker/build
@@ -43,6 +43,7 @@ EOF
 
 ONLY_DEPS=
 CANISTER=
+
 # Candid metadata supported_certificate_versions 1 and 2
 WITH_CERTIFICATION=0
 # Candid metadata juno:build
@@ -128,9 +129,14 @@ function build_canister() {
 
     SRC_DIR="$SRC_ROOT_DIR/$canister"
     TARGET="wasm32-unknown-unknown"
-    # standardize source references
+
+    # Standardize source references
     CARGO_HOME="${CARGO_HOME:-"$HOME/.cargo"}"
-    RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo -C link-args=-zstack-size=3000000"
+
+    # Flags required by third party dependencies such as getrandom
+    FEATURES="--cfg getrandom_backend=\"custom\""
+
+    RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo -C link-args=-zstack-size=3000000 $FEATURES"
 
     cargo_build_args=(
         --manifest-path "$SRC_DIR/Cargo.toml"

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -35,7 +35,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 TARGET="wasm32-unknown-unknown"
-RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo -C link-args=-zstack-size=3000000"
+
+# Flags required by third party dependencies such as getrandom
+FEATURES="--cfg getrandom_backend=\"custom\""
+
+RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo -C link-args=-zstack-size=3000000 $FEATURES"
 
 # Build module WASM
 RUSTFLAGS="$RUSTFLAGS" cargo build --target "$TARGET" -p "$MODULE" --release --locked

--- a/src/libs/satellite/src/logs/loggers.rs
+++ b/src/libs/satellite/src/logs/loggers.rs
@@ -107,7 +107,7 @@ fn random() -> Result<i32, String> {
 
         match rng {
             None => Err("The random number generator has not been initialized.".to_string()),
-            Some(rng) => Ok(rng.gen()),
+            Some(rng) => Ok(rng.random()),
         }
     })
 }

--- a/src/libs/satellite/src/random.rs
+++ b/src/libs/satellite/src/random.rs
@@ -1,16 +1,13 @@
 use crate::memory::STATE;
-use getrandom::register_custom_getrandom;
 use getrandom::Error;
 use ic_cdk::spawn;
 use ic_cdk_timers::set_timer;
 use junobuild_shared::random::get_random_seed;
 use rand::RngCore;
-use std::num::NonZeroU32;
 use std::time::Duration;
 
 pub fn defer_init_random_seed() {
     set_timer(Duration::ZERO, || spawn(set_random_seed()));
-    register_custom_getrandom!(custom_getrandom);
 }
 
 async fn set_random_seed() {
@@ -21,13 +18,22 @@ async fn set_random_seed() {
     });
 }
 
-fn custom_getrandom(buf: &mut [u8]) -> Result<(), Error> {
+/// Source: https://github.com/rust-random/getrandom?tab=readme-ov-file#custom-backend
+#[no_mangle]
+unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize,) -> Result<(), Error> {
     STATE.with(|state| {
         let rng = &mut state.borrow_mut().runtime.rng;
 
         match rng {
-            None => Err(Error::from(NonZeroU32::new(Error::CUSTOM_START).unwrap())),
+            None => Err(Error::new_custom(0)),
             Some(rng) => {
+                let buf: &mut [u8] = unsafe {
+                    // fill the buffer with zeros
+                    core::ptr::write_bytes(dest, 0, len);
+                    // create mutable byte slice
+                    core::slice::from_raw_parts_mut(dest, len)
+                };
+
                 rng.fill_bytes(buf);
                 Ok(())
             }

--- a/src/mission_control/src/random.rs
+++ b/src/mission_control/src/random.rs
@@ -1,16 +1,13 @@
 use crate::memory::RUNTIME_STATE;
-use getrandom::register_custom_getrandom;
 use getrandom::Error;
 use ic_cdk::spawn;
 use ic_cdk_timers::set_timer;
 use junobuild_shared::random::get_random_seed;
 use rand::{Rng, RngCore};
-use std::num::NonZeroU32;
 use std::time::Duration;
 
 pub fn defer_init_random_seed() {
     set_timer(Duration::ZERO, || spawn(set_random_seed()));
-    register_custom_getrandom!(custom_getrandom);
 }
 
 async fn set_random_seed() {
@@ -21,13 +18,22 @@ async fn set_random_seed() {
     });
 }
 
-fn custom_getrandom(buf: &mut [u8]) -> Result<(), Error> {
+/// Source: https://github.com/rust-random/getrandom?tab=readme-ov-file#custom-backend
+#[no_mangle]
+unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize,) -> Result<(), Error> {
     RUNTIME_STATE.with(|state| {
         let rng = &mut state.borrow_mut().rng;
 
         match rng {
-            None => Err(Error::from(NonZeroU32::new(Error::CUSTOM_START).unwrap())),
+            None => Err(Error::new_custom(0)),
             Some(rng) => {
+                let buf: &mut [u8] = unsafe {
+                    // fill the buffer with zeros
+                    core::ptr::write_bytes(dest, 0, len);
+                    // create mutable byte slice
+                    core::slice::from_raw_parts_mut(dest, len)
+                };
+
                 rng.fill_bytes(buf);
                 Ok(())
             }
@@ -41,7 +47,7 @@ pub fn random() -> Result<i32, String> {
 
         match rng {
             None => Err("The random number generator has not been initialized.".to_string()),
-            Some(rng) => Ok(rng.gen()),
+            Some(rng) => Ok(rng.random()),
         }
     })
 }

--- a/src/observatory/src/random.rs
+++ b/src/observatory/src/random.rs
@@ -1,16 +1,13 @@
 use crate::memory::RUNTIME_STATE;
-use getrandom::register_custom_getrandom;
 use getrandom::Error;
 use ic_cdk::spawn;
 use ic_cdk_timers::set_timer;
 use junobuild_shared::random::get_random_seed;
 use rand::{Rng, RngCore};
-use std::num::NonZeroU32;
 use std::time::Duration;
 
 pub fn defer_init_random_seed() {
     set_timer(Duration::ZERO, || spawn(set_random_seed()));
-    register_custom_getrandom!(custom_getrandom);
 }
 
 async fn set_random_seed() {
@@ -21,13 +18,22 @@ async fn set_random_seed() {
     });
 }
 
-fn custom_getrandom(buf: &mut [u8]) -> Result<(), Error> {
+/// Source: https://github.com/rust-random/getrandom?tab=readme-ov-file#custom-backend
+#[no_mangle]
+unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize,) -> Result<(), Error> {
     RUNTIME_STATE.with(|state| {
         let rng = &mut state.borrow_mut().rng;
 
         match rng {
-            None => Err(Error::from(NonZeroU32::new(Error::CUSTOM_START).unwrap())),
+            None => Err(Error::new_custom(0)),
             Some(rng) => {
+                let buf: &mut [u8] = unsafe {
+                    // fill the buffer with zeros
+                    core::ptr::write_bytes(dest, 0, len);
+                    // create mutable byte slice
+                    core::slice::from_raw_parts_mut(dest, len)
+                };
+
                 rng.fill_bytes(buf);
                 Ok(())
             }
@@ -41,7 +47,7 @@ pub fn random() -> Result<i32, String> {
 
         match rng {
             None => Err("The random number generator has not been initialized.".to_string()),
-            Some(rng) => Ok(rng.gen()),
+            Some(rng) => Ok(rng.random()),
         }
     })
 }


### PR DESCRIPTION
# Motivation

There were few breaking changes in latest `getrandom`.

See:

- https://github.com/rust-random/getrandom/pull/504
- https://github.com/rust-random/getrandom/blob/master/CHANGELOG.md#030---2025-01-25
- https://github.com/rust-random/getrandom#opt-in-backends
- https://github.com/rust-random/getrandom#custom-backend
