### PR TITLE
chore: getrandom_backend custom for clippy

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"ledger:transfer": "scripts/ledger.transfer.sh",
 		"i18n": "node scripts/i18n.mjs && prettier --write ./src/frontend/src/lib/types/i18n.d.ts",
 		"observatory:statuses": "node scripts/observatory.statuses.mjs",
-		"clippy": "cargo clippy --target=wasm32-unknown-unknown -- -A deprecated",
+		"clippy": "cargo clippy --target=wasm32-unknown-unknown -- -A deprecated --cfg getrandom_backend=\"custom\"",
 		"test": "tsc --project tsconfig.spec.json --noEmit && vitest",
 		"test:frontend": "tsc --project tsconfig.spec.json --noEmit && vitest --dir src/frontend",
 		"build:console": "scripts/cargo.sh console --with-certification",


### PR DESCRIPTION
# Motivation

We need the "custom" config for random when running clippy as well

```
error: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" configuration flag. Note that enabling the `wasm_js` feature flag alone is insufficient. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/daviddalbusco/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.3.1/src/backends.rs:159:9
    |
159 | /         compile_error!(
160 | |             "The wasm32-unknown-unknown targets are not supported by default; \
161 | |             you may need to enable the \"wasm_js\" configuration flag. Note \
162 | |             that enabling the `wasm_js` feature flag alone is insufficient. \
163 | |             For more information see: \
164 | |             https://docs.rs/getrandom/#webassembly-support"
165 | |         );
    | |_________^

error[E0425]: cannot find function `fill_inner` in module `backends`
  --> /Users/daviddalbusco/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.3.1/src/lib.rs:98:19
   |
98 |         backends::fill_inner(dest)?;

```

