### PR TITLE
refactor: extract user collection key constant

### DIFF
--- a/src/libs/collections/src/constants.rs
+++ b/src/libs/collections/src/constants.rs
@@ -5,7 +5,20 @@ use junobuild_shared::rate::constants::DEFAULT_RATE_CONFIG;
 
 pub const SYS_COLLECTION_PREFIX: char = '#';
 
+pub const COLLECTION_USER_KEY: &str = "#user";
 pub const LOG_COLLECTION_KEY: &str = "#log";
+
+const COLLECTION_USER_DEFAULT_RULE: SetRule = SetRule {
+    read: Managed,
+    write: Managed,
+    memory: Some(Memory::Stable),
+    mutable_permissions: Some(false),
+    max_size: None,
+    max_capacity: None,
+    max_changes_per_user: None,
+    version: None,
+    rate_config: Some(DEFAULT_RATE_CONFIG),
+};
 
 pub const DEFAULT_DB_LOG_RULE: SetRule = SetRule {
     read: Controllers,
@@ -20,20 +33,7 @@ pub const DEFAULT_DB_LOG_RULE: SetRule = SetRule {
 };
 
 pub const DEFAULT_DB_COLLECTIONS: [(&str, SetRule); 2] = [
-    (
-        "#user",
-        SetRule {
-            read: Managed,
-            write: Managed,
-            memory: Some(Memory::Stable),
-            mutable_permissions: Some(false),
-            max_size: None,
-            max_capacity: None,
-            max_changes_per_user: None,
-            version: None,
-            rate_config: Some(DEFAULT_RATE_CONFIG),
-        },
-    ),
+    (COLLECTION_USER_KEY, COLLECTION_USER_DEFAULT_RULE),
     (LOG_COLLECTION_KEY, DEFAULT_DB_LOG_RULE),
 ];
 

--- a/src/libs/satellite/src/rules/assert_stores.rs
+++ b/src/libs/satellite/src/rules/assert_stores.rs
@@ -1,16 +1,15 @@
 use crate::get_doc_store;
 use candid::Principal;
 use ic_cdk::id;
-use junobuild_collections::constants::DEFAULT_DB_COLLECTIONS;
+use junobuild_collections::constants::{COLLECTION_USER_KEY, DEFAULT_DB_COLLECTIONS};
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_shared::types::core::Key;
 use junobuild_shared::utils::principal_not_equal;
 
 pub fn is_known_user(caller: Principal) -> bool {
-    let user_collection = DEFAULT_DB_COLLECTIONS[0].0;
     let user_key = caller.to_text();
 
-    let user = get_doc_store(id(), user_collection.to_string(), user_key).unwrap_or(None);
+    let user = get_doc_store(id(), COLLECTION_USER_KEY.to_string(), user_key).unwrap_or(None);
 
     user.is_some()
 }
@@ -20,9 +19,7 @@ pub fn assert_user_collection_caller_key(
     collection: &CollectionKey,
     key: &Key,
 ) -> Result<(), String> {
-    let user_collection = DEFAULT_DB_COLLECTIONS[0].0;
-
-    if collection != user_collection {
+    if collection != COLLECTION_USER_KEY {
         return Ok(());
     }
 


### PR DESCRIPTION
# Motivation

Cleaner than using `DEFAULT_DB_COLLECTIONS[0].0`
