### PR TITLE
feat: assert user data provider is internet_identity or nfid

### DIFF
--- a/src/libs/satellite/src/rules/types.rs
+++ b/src/libs/satellite/src/rules/types.rs
@@ -4,8 +4,13 @@ pub mod state {
     #[derive(Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct UserData {
-        // We use a string instead of a strict typed enum because this value was originally introduced
-        // and has been used exclusively as presentation information.
-        pub provider: Option<String>,
+        pub provider: Option<AuthProvider>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum AuthProvider {
+        InternetIdentity,
+        Nfid,
     }
 }

--- a/src/tests/specs/satellite.auth.spec.ts
+++ b/src/tests/specs/satellite.auth.spec.ts
@@ -510,20 +510,6 @@ describe('Satellite authentication', () => {
 				expect(users.find(([key]) => key === user.getPrincipal().toText())).not.toBeUndefined();
 			});
 
-			it('should create a user within unknown provider because this is just a visual information', async () => {
-				const { set_doc } = actor;
-
-				const doc = await set_doc('#user', user.getPrincipal().toText(), {
-					data: await toArray({
-						provider: 'something'
-					}),
-					description: toNullable(),
-					version: toNullable()
-				});
-
-				expect(doc).not.toBeUndefined();
-			});
-
 			it('should create a user without provider because this is optional', async () => {
 				const { set_doc } = actor;
 
@@ -583,7 +569,25 @@ describe('Satellite authentication', () => {
 					actor.setIdentity(user);
 				});
 
-				it('should not create a user with invalid data fields', async () => {
+				it('should not create a user with an unknown provider', async () => {
+					const { set_doc } = actor;
+
+					const data = await toArray({
+						provider: 'unknown'
+					});
+
+					await expect(
+						set_doc('#user', user.getPrincipal().toText(), {
+							data,
+							description: toNullable(),
+							version: toNullable()
+						})
+					).rejects.toThrow(
+						'Invalid user data: unknown variant `unknown`, expected `internet_identity` or `nfid` at line 1 column 21.'
+					);
+				});
+
+				it('should not create a user with invalid additional data fields', async () => {
 					const { set_doc } = actor;
 
 					const data = await toArray({


### PR DESCRIPTION
# Motivation

Follow-up of #1225. We want to assert that the provider for the user field, if defined, is either "nfid" or "internet_identity".
