### PR TITLE
feat: increment user_usage with internal direct access to state db

### DIFF
--- a/src/libs/satellite/src/db/internal.rs
+++ b/src/libs/satellite/src/db/internal.rs
@@ -1,0 +1,42 @@
+use crate::db::state::{get_doc as get_state_doc, insert_doc as insert_state_doc};
+use crate::db::types::state::{Doc, DocUpsert};
+use crate::SetDoc;
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::rules::Rule;
+use junobuild_shared::types::core::Key;
+use junobuild_shared::types::state::UserId;
+
+/// Retrieves a document directly from the state.
+///
+/// ⚠️ **Warning:** This function is for internal use only and does not perform any assertions.
+///
+pub fn unsafe_get_doc(
+    collection: &CollectionKey,
+    key: &Key,
+    rule: &Rule,
+) -> Result<Option<Doc>, String> {
+    get_state_doc(collection, key, rule)
+}
+
+/// Inserts or updates a document directly in the state.
+///
+/// ⚠️ **Warning:** This function is for internal use only and does not perform any assertions.
+///
+pub fn unsafe_set_doc(
+    caller: UserId,
+    collection: &CollectionKey,
+    key: &Key,
+    value: SetDoc,
+    rule: &Rule,
+) -> Result<DocUpsert, String> {
+    let current_doc = get_state_doc(collection, &key, rule)?;
+
+    let doc: Doc = Doc::prepare(caller, &current_doc, value);
+
+    let (_evicted_doc, after) = insert_state_doc(collection, &key, &doc, rule)?;
+
+    Ok(DocUpsert {
+        before: current_doc,
+        after,
+    })
+}

--- a/src/libs/satellite/src/db/mod.rs
+++ b/src/libs/satellite/src/db/mod.rs
@@ -1,5 +1,6 @@
 mod assert;
 pub mod impls;
+pub mod internal;
 mod msg;
 mod runtime;
 mod state;

--- a/src/libs/satellite/src/usage/store.rs
+++ b/src/libs/satellite/src/usage/store.rs
@@ -2,7 +2,7 @@ use crate::db::internal::{unsafe_get_doc, unsafe_set_doc};
 use crate::rules::store::get_rule_db;
 use crate::types::state::CollectionType;
 use crate::usage::types::state::{UserUsage, UserUsageKey};
-use crate::{get_doc_store, set_doc_store, SetDoc};
+use crate::{SetDoc};
 use ic_cdk::id;
 use junobuild_collections::constants::db::COLLECTION_USER_USAGE_KEY;
 use junobuild_collections::msg::msg_db_collection_not_found;

--- a/src/libs/satellite/src/usage/store.rs
+++ b/src/libs/satellite/src/usage/store.rs
@@ -1,8 +1,11 @@
+use crate::db::internal::{unsafe_get_doc, unsafe_set_doc};
+use crate::rules::store::get_rule_db;
 use crate::types::state::CollectionType;
 use crate::usage::types::state::{UserUsage, UserUsageKey};
 use crate::{get_doc_store, set_doc_store, SetDoc};
 use ic_cdk::id;
 use junobuild_collections::constants::db::COLLECTION_USER_USAGE_KEY;
+use junobuild_collections::msg::msg_db_collection_not_found;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_shared::types::state::UserId;
 use junobuild_utils::{decode_doc_data, encode_doc_data};
@@ -12,10 +15,14 @@ pub fn increment_usage(
     collection_type: &CollectionType,
     user_id: &UserId,
 ) -> Result<UserUsage, String> {
-    let user_usage_key = UserUsageKey::create(user_id, collection_key, collection_type);
-    let key = user_usage_key.to_key();
+    let user_usage_key = UserUsageKey::create(user_id, collection_key, collection_type).to_key();
 
-    let doc = get_doc_store(id(), COLLECTION_USER_USAGE_KEY.to_string(), key.clone())?;
+    let user_usage_collection = COLLECTION_USER_USAGE_KEY.to_string();
+
+    let rule = get_rule_db(&user_usage_collection)
+        .ok_or_else(|| msg_db_collection_not_found(&user_usage_collection))?;
+
+    let doc = unsafe_get_doc(&user_usage_collection.to_string(), &user_usage_key, &rule)?;
 
     let current_usage = doc
         .as_ref()
@@ -30,7 +37,13 @@ pub fn increment_usage(
         version: doc.as_ref().and_then(|d| d.version),
     };
 
-    set_doc_store(id(), COLLECTION_USER_USAGE_KEY.to_string(), key, update_doc)?;
+    unsafe_set_doc(
+        id(),
+        &user_usage_collection.to_string(),
+        &user_usage_key,
+        update_doc,
+        &rule,
+    )?;
 
     Ok(update_usage)
 }


### PR DESCRIPTION
# Motivation

When we increment the user usage, all assertions on the user interaction (create, set or delete) have already been performed. Therefore when we save the user usage state we can directly save the value in the db without going through all the assertions since it's an internal process. Furthermore this avoid potentially infinite loop if someday an assertion would call the "assert and increment user usage" assertion. It's better for performance as well.
