### PR TITLE
feat: improve is_known_user performance

### DIFF
--- a/src/libs/satellite/src/storage/assert.rs
+++ b/src/libs/satellite/src/storage/assert.rs
@@ -17,7 +17,7 @@ pub fn assert_create_batch(
     rule: &Rule,
 ) -> Result<(), String> {
     if !(public_permission(&rule.write)
-        || is_known_user(caller)
+        || is_known_user(caller, rule)
         || is_controller(caller, controllers))
     {
         return Err(UPLOAD_NOT_ALLOWED.to_string());

--- a/src/libs/satellite/src/usage/assert.rs
+++ b/src/libs/satellite/src/usage/assert.rs
@@ -3,7 +3,7 @@ use crate::usage::store::increment_usage;
 use crate::usage::types::state::UserUsageData;
 use crate::usage::utils::{is_db_collection_no_usage, is_storage_collection_no_usage};
 use crate::SetDoc;
-use junobuild_collections::constants::db::{COLLECTION_USER_USAGE_KEY};
+use junobuild_collections::constants::db::COLLECTION_USER_USAGE_KEY;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_shared::controllers::is_controller;
 use junobuild_shared::types::state::{Controllers, UserId};

--- a/src/libs/satellite/src/user/assert.rs
+++ b/src/libs/satellite/src/user/assert.rs
@@ -1,17 +1,18 @@
+use crate::db::internal::unsafe_get_doc;
 use crate::user::types::state::UserData;
-use crate::{get_doc_store, SetDoc};
+use crate::SetDoc;
 use candid::Principal;
-use ic_cdk::id;
 use junobuild_collections::constants::db::COLLECTION_USER_KEY;
 use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::rules::Rule;
 use junobuild_shared::types::core::Key;
 use junobuild_shared::utils::principal_not_equal;
 use junobuild_utils::decode_doc_data;
 
-pub fn is_known_user(caller: Principal) -> bool {
+pub fn is_known_user(caller: Principal, rule: &Rule) -> bool {
     let user_key = caller.to_text();
 
-    let user = get_doc_store(id(), COLLECTION_USER_KEY.to_string(), user_key).unwrap_or(None);
+    let user = unsafe_get_doc(&COLLECTION_USER_KEY.to_string(), &user_key, rule).unwrap_or(None);
 
     user.is_some()
 }


### PR DESCRIPTION
# Motivation

We can now spare a `get_rule` when calling `is_known_user`.
