### PR TITLE
feat: extract assert get doc

### DIFF
--- a/src/libs/satellite/src/db/assert.rs
+++ b/src/libs/satellite/src/db/assert.rs
@@ -1,4 +1,4 @@
-use crate::db::msg::ERROR_CANNOT_WRITE;
+use crate::db::msg::{ERROR_CANNOT_READ, ERROR_CANNOT_WRITE};
 use crate::db::runtime::increment_and_assert_rate;
 use crate::db::types::config::DbConfig;
 use crate::db::types::state::{DocAssertDelete, DocAssertSet, DocContext};
@@ -15,6 +15,20 @@ use junobuild_collections::types::rules::{Permission, Rule};
 use junobuild_shared::assert::{assert_description_length, assert_max_memory_size, assert_version};
 use junobuild_shared::types::core::Key;
 use junobuild_shared::types::state::{Controllers, Version};
+
+pub fn assert_get_doc(
+    &StoreContext {
+        caller,
+        controllers,
+        collection: _,
+    }: &StoreContext,
+    rule: &Rule,
+    current_doc: &Doc,
+) -> Result<(), String> {
+    assert_read_permission(caller, controllers, current_doc, &rule.read)?;
+
+    Ok(())
+}
 
 pub fn assert_set_doc(
     &StoreContext {
@@ -99,6 +113,19 @@ fn assert_memory_size(config: &Option<DbConfig>) -> Result<(), String> {
         None => Ok(()),
         Some(config) => assert_max_memory_size(&config.max_memory_size),
     }
+}
+
+fn assert_read_permission(
+    caller: Principal,
+    controllers: &Controllers,
+    current_doc: &Doc,
+    rule: &Permission,
+) -> Result<(), String> {
+    if !assert_permission(rule, current_doc.owner, caller, controllers) {
+        return Err(ERROR_CANNOT_READ.to_string());
+    }
+
+    Ok(())
 }
 
 fn assert_write_permission(

--- a/src/libs/satellite/src/db/msg.rs
+++ b/src/libs/satellite/src/db/msg.rs
@@ -1,2 +1,2 @@
-/// Db
 pub const ERROR_CANNOT_WRITE: &str = "Cannot write.";
+pub const ERROR_CANNOT_READ: &str = "Cannot read.";

--- a/src/libs/satellite/src/db/store.rs
+++ b/src/libs/satellite/src/db/store.rs
@@ -1,5 +1,5 @@
 use crate::controllers::store::get_controllers;
-use crate::db::assert::{assert_delete_doc, assert_set_doc};
+use crate::db::assert::{assert_delete_doc, assert_get_doc, assert_set_doc};
 use crate::db::state::{
     count_docs_heap, count_docs_stable, delete_collection as delete_state_collection,
     delete_doc as delete_state_doc, get_config, get_doc as get_state_doc, get_docs_heap,
@@ -14,7 +14,6 @@ use crate::db::utils::filter_values;
 use crate::memory::STATE;
 use crate::types::store::StoreContext;
 use candid::Principal;
-use junobuild_collections::assert::stores::assert_permission;
 use junobuild_collections::msg::msg_db_collection_not_empty;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::{Memory, Rule};
@@ -104,7 +103,7 @@ fn get_doc_impl(context: &StoreContext, key: Key, rule: &Rule) -> Result<Option<
     match value {
         None => Ok(None),
         Some(value) => {
-            if !assert_permission(&rule.read, value.owner, context.caller, context.controllers) {
+            if let Err(_) = assert_get_doc(context, rule, &value) {
                 return Ok(None);
             }
 

--- a/src/libs/satellite/src/usage/assert.rs
+++ b/src/libs/satellite/src/usage/assert.rs
@@ -3,7 +3,7 @@ use crate::usage::store::increment_usage;
 use crate::usage::types::state::UserUsageData;
 use crate::usage::utils::{is_db_collection_no_usage, is_storage_collection_no_usage};
 use crate::SetDoc;
-use junobuild_collections::constants::db::{COLLECTION_USER_USAGE_KEY};
+use junobuild_collections::constants::db::COLLECTION_USER_USAGE_KEY;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_shared::controllers::is_controller;
 use junobuild_shared::types::state::{Controllers, UserId};


### PR DESCRIPTION
# Motivation

It's more consistent to have a separate assertion for `get_doc_store` too.
