### PR TITLE
feat: option to ban user

### DIFF
--- a/src/libs/satellite/src/db/assert.rs
+++ b/src/libs/satellite/src/db/assert.rs
@@ -35,6 +35,18 @@ pub fn assert_get_doc(
     Ok(())
 }
 
+pub fn assert_get_docs(
+    &StoreContext {
+        caller,
+        controllers,
+        collection: _,
+    }: &StoreContext,
+) -> Result<(), String> {
+    assert_user_is_not_banned(caller, controllers)?;
+
+    Ok(())
+}
+
 pub fn assert_set_doc(
     &StoreContext {
         caller,

--- a/src/libs/satellite/src/db/assert.rs
+++ b/src/libs/satellite/src/db/assert.rs
@@ -5,7 +5,10 @@ use crate::db::types::state::{DocAssertDelete, DocAssertSet, DocContext};
 use crate::hooks::{invoke_assert_delete_doc, invoke_assert_set_doc};
 use crate::types::store::StoreContext;
 use crate::usage::assert::{assert_user_usage_collection_data, increment_and_assert_db_usage};
-use crate::user::assert::{assert_user_collection_caller_key, assert_user_collection_data, assert_user_write_permission};
+use crate::user::assert::{
+    assert_user_collection_caller_key, assert_user_collection_data, assert_user_is_not_banned,
+    assert_user_write_permission,
+};
 use crate::{DelDoc, Doc, SetDoc};
 use candid::Principal;
 use junobuild_collections::assert::stores::{
@@ -25,6 +28,8 @@ pub fn assert_get_doc(
     rule: &Rule,
     current_doc: &Doc,
 ) -> Result<(), String> {
+    assert_user_is_not_banned(caller, controllers)?;
+
     assert_read_permission(caller, controllers, current_doc, &rule.read)?;
 
     Ok(())
@@ -42,6 +47,8 @@ pub fn assert_set_doc(
     rule: &Rule,
     current_doc: &Option<Doc>,
 ) -> Result<(), String> {
+    assert_user_is_not_banned(caller, controllers)?;
+
     assert_write_permission(caller, controllers, current_doc, &rule.write)?;
 
     assert_memory_size(config)?;
@@ -86,6 +93,8 @@ pub fn assert_delete_doc(
     rule: &Rule,
     current_doc: &Option<Doc>,
 ) -> Result<(), String> {
+    assert_user_is_not_banned(caller, controllers)?;
+
     assert_write_permission(caller, controllers, current_doc, &rule.write)?;
 
     assert_write_version(current_doc, value.version)?;

--- a/src/libs/satellite/src/db/store.rs
+++ b/src/libs/satellite/src/db/store.rs
@@ -1,5 +1,5 @@
 use crate::controllers::store::get_controllers;
-use crate::db::assert::{assert_delete_doc, assert_get_doc, assert_set_doc};
+use crate::db::assert::{assert_delete_doc, assert_get_doc, assert_get_docs, assert_set_doc};
 use crate::db::state::{
     count_docs_heap, count_docs_stable, delete_collection as delete_state_collection,
     delete_doc as delete_state_doc, get_config, get_doc as get_state_doc, get_docs_heap,
@@ -253,6 +253,14 @@ fn secure_get_docs(
     collection: CollectionKey,
     filter: &ListParams,
 ) -> Result<ListResults<Doc>, String> {
+    let context: StoreContext = StoreContext {
+        caller,
+        collection: &collection,
+        controllers,
+    };
+
+    assert_get_docs(&context)?;
+
     let rule = get_state_rule(&collection)?;
 
     match rule.mem() {

--- a/src/libs/satellite/src/storage/assert.rs
+++ b/src/libs/satellite/src/storage/assert.rs
@@ -4,12 +4,40 @@ use crate::usage::assert::increment_and_assert_storage_usage;
 use crate::user::assert::{assert_user_is_not_banned, is_known_user};
 use candid::Principal;
 use junobuild_collections::assert::stores::{assert_permission, public_permission};
-use junobuild_collections::types::rules::Rule;
+use junobuild_collections::types::rules::{Permission, Rule};
 use junobuild_shared::controllers::is_controller;
 use junobuild_shared::types::state::Controllers;
-use junobuild_storage::msg::{ERROR_ASSET_NOT_FOUND, UPLOAD_NOT_ALLOWED};
+use junobuild_storage::msg::{ERROR_ASSET_NOT_FOUND, ERROR_CANNOT_READ_ASSET, UPLOAD_NOT_ALLOWED};
 use junobuild_storage::runtime::increment_and_assert_rate as increment_and_assert_rate_runtime;
 use junobuild_storage::types::store::Asset;
+
+pub fn assert_get_asset(
+    &StoreContext {
+        caller,
+        controllers,
+        collection: _,
+    }: &StoreContext,
+    rule: &Rule,
+    current_asset: &Asset,
+) -> Result<(), String> {
+    assert_user_is_not_banned(caller, controllers)?;
+
+    assert_read_permission(caller, controllers, current_asset, &rule.read)?;
+
+    Ok(())
+}
+
+pub fn assert_list_assets(
+    &StoreContext {
+        caller,
+        controllers,
+        collection: _,
+    }: &StoreContext,
+) -> Result<(), String> {
+    assert_user_is_not_banned(caller, controllers)?;
+
+    Ok(())
+}
 
 pub fn assert_create_batch(
     caller: Principal,
@@ -54,6 +82,19 @@ pub fn assert_delete_asset(
     increment_and_assert_rate_runtime(context.collection, &rule.rate_config)?;
 
     invoke_assert_delete_asset(&context.caller, asset)?;
+
+    Ok(())
+}
+
+fn assert_read_permission(
+    caller: Principal,
+    controllers: &Controllers,
+    current_asset: &Asset,
+    rule: &Permission,
+) -> Result<(), String> {
+    if !assert_permission(&rule, current_asset.key.owner, caller, controllers) {
+        return Err(ERROR_CANNOT_READ_ASSET.to_string());
+    }
 
     Ok(())
 }

--- a/src/libs/satellite/src/storage/assert.rs
+++ b/src/libs/satellite/src/storage/assert.rs
@@ -1,7 +1,7 @@
 use crate::hooks::invoke_assert_delete_asset;
 use crate::types::store::StoreContext;
 use crate::usage::assert::increment_and_assert_storage_usage;
-use crate::user::assert::is_known_user;
+use crate::user::assert::{assert_user_is_not_banned, is_known_user};
 use candid::Principal;
 use junobuild_collections::assert::stores::{assert_permission, public_permission};
 use junobuild_collections::types::rules::Rule;
@@ -16,6 +16,8 @@ pub fn assert_create_batch(
     controllers: &Controllers,
     rule: &Rule,
 ) -> Result<(), String> {
+    assert_user_is_not_banned(caller, controllers)?;
+
     if !(public_permission(&rule.write)
         || is_known_user(caller)
         || is_controller(caller, controllers))
@@ -31,6 +33,8 @@ pub fn assert_delete_asset(
     rule: &Rule,
     asset: &Asset,
 ) -> Result<(), String> {
+    assert_user_is_not_banned(context.caller, context.controllers)?;
+
     if !assert_permission(
         &rule.write,
         asset.key.owner,

--- a/src/libs/satellite/src/user/assert.rs
+++ b/src/libs/satellite/src/user/assert.rs
@@ -1,7 +1,7 @@
 use crate::user::types::state::{BannedReason, UserData};
 use crate::{get_doc_store, Doc, SetDoc};
 use candid::Principal;
-use ic_cdk::{id};
+use ic_cdk::id;
 use junobuild_collections::constants::db::COLLECTION_USER_KEY;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_shared::controllers::{is_admin_controller, is_controller};

--- a/src/libs/satellite/src/user/assert.rs
+++ b/src/libs/satellite/src/user/assert.rs
@@ -93,7 +93,7 @@ pub fn assert_user_is_not_banned(
         let user_data = decode_doc_data::<UserData>(&user.data)?;
 
         if let Some(BannedReason::Indefinite) = user_data.banned {
-            return Err(format!("User {} is not allowed.", caller));
+            return Err("Not allowed.".to_string());
         }
     }
 

--- a/src/libs/satellite/src/user/types.rs
+++ b/src/libs/satellite/src/user/types.rs
@@ -5,6 +5,7 @@ pub mod state {
     #[serde(deny_unknown_fields)]
     pub struct UserData {
         pub provider: Option<AuthProvider>,
+        pub banned: Option<BannedReason>,
     }
 
     #[derive(Serialize, Deserialize)]
@@ -12,5 +13,11 @@ pub mod state {
     pub enum AuthProvider {
         InternetIdentity,
         Nfid,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum BannedReason {
+        Indefinite,
     }
 }

--- a/src/libs/storage/src/msg.rs
+++ b/src/libs/storage/src/msg.rs
@@ -2,3 +2,4 @@ pub const UPLOAD_NOT_ALLOWED: &str = "Caller not allowed to upload data.";
 pub const SET_NOT_ALLOWED: &str = "Caller not allowed to set data.";
 pub const ERROR_CANNOT_COMMIT_BATCH: &str = "Cannot commit batch.";
 pub const ERROR_ASSET_NOT_FOUND: &str = "No asset.";
+pub const ERROR_CANNOT_READ_ASSET: &str = "Cannot read asset.";

--- a/src/tests/specs/constants/satellite-tests.constants.ts
+++ b/src/tests/specs/constants/satellite-tests.constants.ts
@@ -6,3 +6,4 @@ export const NO_VERSION_ERROR_MSG = 'error_no_version_provided';
 export const INVALID_VERSION_ERROR_MSG = 'error_version_outdated_or_future';
 export const USER_CANNOT_WRITE = 'Cannot write.';
 export const CANNOT_UPDATE_USER = 'Cannot update user.';
+export const USER_NOT_ALLOWED = "Not allowed."

--- a/src/tests/specs/constants/satellite-tests.constants.ts
+++ b/src/tests/specs/constants/satellite-tests.constants.ts
@@ -6,4 +6,4 @@ export const NO_VERSION_ERROR_MSG = 'error_no_version_provided';
 export const INVALID_VERSION_ERROR_MSG = 'error_version_outdated_or_future';
 export const USER_CANNOT_WRITE = 'Cannot write.';
 export const CANNOT_UPDATE_USER = 'Cannot update user.';
-export const USER_NOT_ALLOWED = "Not allowed."
+export const USER_NOT_ALLOWED = 'Not allowed.';

--- a/src/tests/specs/satellite.user-ban.spec.ts
+++ b/src/tests/specs/satellite.user-ban.spec.ts
@@ -430,5 +430,75 @@ describe('Satellite User Usage', () => {
 				await expect(deleteFilteredDocs()).resolves.not.toThrowError();
 			});
 		});
+
+		describe('list documents', () => {
+			let user: Identity;
+
+			const listDocs = async (): Promise<void> => {
+				actor.setIdentity(user);
+
+				const { list_docs } = actor;
+
+				await list_docs(collection, mockListParams);
+			};
+
+			beforeEach(async () => {
+				user = Ed25519KeyIdentity.generate();
+
+				await createUser(user);
+			});
+
+			it('should not list documents if banned', async () => {
+				await expect(listDocs()).resolves.not.toThrowError();
+
+				await banUser({ user, version: [1n] });
+
+				await expect(listDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+			});
+
+			it('should list documents if unbanned', async () => {
+				await expect(listDocs()).resolves.not.toThrowError();
+
+				await banUser({ user, version: [1n] });
+				await unbanUser({ user, version: [2n] });
+
+				await expect(listDocs()).resolves.not.toThrowError();
+			});
+		});
+
+		describe('count documents', () => {
+			let user: Identity;
+
+			const countDocs = async (): Promise<void> => {
+				actor.setIdentity(user);
+
+				const { count_docs } = actor;
+
+				await count_docs(collection, mockListParams);
+			};
+
+			beforeEach(async () => {
+				user = Ed25519KeyIdentity.generate();
+
+				await createUser(user);
+			});
+
+			it('should not count documents if banned', async () => {
+				await expect(countDocs()).resolves.not.toThrowError();
+
+				await banUser({ user, version: [1n] });
+
+				await expect(countDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+			});
+
+			it('should count documents if unbanned', async () => {
+				await expect(countDocs()).resolves.not.toThrowError();
+
+				await banUser({ user, version: [1n] });
+				await unbanUser({ user, version: [2n] });
+
+				await expect(countDocs()).resolves.not.toThrowError();
+			});
+		});
 	});
 });

--- a/src/tests/specs/satellite.user-ban.spec.ts
+++ b/src/tests/specs/satellite.user-ban.spec.ts
@@ -15,6 +15,7 @@ import { beforeAll, describe, expect, inject } from 'vitest';
 import { USER_NOT_ALLOWED } from './constants/satellite-tests.constants';
 import { mockSetRule } from './mocks/collection.mocks';
 import { mockListParams } from './mocks/list.mocks';
+import { uploadAsset } from './utils/satellite-storage-tests.utils';
 import { controllersInitArgs, SATELLITE_WASM_PATH } from './utils/setup-tests.utils';
 
 describe('Satellite User Usage', () => {
@@ -119,6 +120,8 @@ describe('Satellite User Usage', () => {
 		};
 
 		describe('Datastore', () => {
+			let user: Identity;
+
 			beforeAll(async () => {
 				actor.setIdentity(controller);
 
@@ -127,13 +130,14 @@ describe('Satellite User Usage', () => {
 				await set_rule({ Db: null }, collection, mockSetRule);
 			});
 
+			beforeEach(() => {
+				user = Ed25519KeyIdentity.generate();
+			});
+
 			describe('get document', () => {
-				let user: Identity;
 				let docKey: string;
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 
 					const { set_doc } = actor;
@@ -176,12 +180,9 @@ describe('Satellite User Usage', () => {
 			});
 
 			describe('get many documents', () => {
-				let user: Identity;
 				let docKey: string;
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 
 					const { set_doc } = actor;
@@ -226,8 +227,6 @@ describe('Satellite User Usage', () => {
 			});
 
 			describe('set document', () => {
-				let user: Identity;
-
 				const createDoc = async (): Promise<Doc> => {
 					actor.setIdentity(user);
 
@@ -243,8 +242,6 @@ describe('Satellite User Usage', () => {
 				};
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 				});
 
@@ -271,8 +268,6 @@ describe('Satellite User Usage', () => {
 			});
 
 			describe('set many documents', () => {
-				let user: Identity;
-
 				const createDocs = async (): Promise<void> => {
 					actor.setIdentity(user);
 
@@ -293,8 +288,6 @@ describe('Satellite User Usage', () => {
 				};
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 				});
 
@@ -317,8 +310,6 @@ describe('Satellite User Usage', () => {
 			});
 
 			describe('delete a document', () => {
-				let user: Identity;
-
 				const deleteDoc = async (): Promise<void> => {
 					actor.setIdentity(user);
 
@@ -330,8 +321,6 @@ describe('Satellite User Usage', () => {
 				};
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 				});
 
@@ -354,8 +343,6 @@ describe('Satellite User Usage', () => {
 			});
 
 			describe('delete many documents', () => {
-				let user: Identity;
-
 				const deleteDocs = async (): Promise<void> => {
 					actor.setIdentity(user);
 
@@ -372,8 +359,6 @@ describe('Satellite User Usage', () => {
 				};
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 				});
 
@@ -396,8 +381,6 @@ describe('Satellite User Usage', () => {
 			});
 
 			describe('delete filtered documents', () => {
-				let user: Identity;
-
 				const deleteFilteredDocs = async (): Promise<void> => {
 					actor.setIdentity(user);
 
@@ -407,8 +390,6 @@ describe('Satellite User Usage', () => {
 				};
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 				});
 
@@ -431,8 +412,6 @@ describe('Satellite User Usage', () => {
 			});
 
 			describe('list documents', () => {
-				let user: Identity;
-
 				const listDocs = async (): Promise<void> => {
 					actor.setIdentity(user);
 
@@ -442,8 +421,6 @@ describe('Satellite User Usage', () => {
 				};
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 				});
 
@@ -466,8 +443,6 @@ describe('Satellite User Usage', () => {
 			});
 
 			describe('count documents', () => {
-				let user: Identity;
-
 				const countDocs = async (): Promise<void> => {
 					actor.setIdentity(user);
 
@@ -477,8 +452,6 @@ describe('Satellite User Usage', () => {
 				};
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 				});
 
@@ -502,6 +475,10 @@ describe('Satellite User Usage', () => {
 		});
 
 		describe('Storage', () => {
+			let user: Identity;
+			let fullPath: string;
+			let filename = 'hello.html';
+
 			beforeAll(async () => {
 				actor.setIdentity(controller);
 
@@ -510,9 +487,12 @@ describe('Satellite User Usage', () => {
 				await set_rule({ Storage: null }, collection, mockSetRule);
 			});
 
-			describe('init asset upload', () => {
-				let user: Identity;
+			beforeEach(() => {
+				user = Ed25519KeyIdentity.generate();
+				fullPath = `/${collection}/${user.getPrincipal().toText()}/hello.html`;
+			});
 
+			describe('init asset upload', () => {
 				const initAsset = async (): Promise<void> => {
 					actor.setIdentity(user);
 
@@ -522,15 +502,13 @@ describe('Satellite User Usage', () => {
 						collection,
 						description: toNullable(),
 						encoding_type: [],
-						full_path: `/${collection}/${user.getPrincipal().toText()}/hello.html`,
-						name: `hello.html`,
+						full_path: fullPath,
+						name: filename,
 						token: toNullable()
 					});
 				};
 
 				beforeEach(async () => {
-					user = Ed25519KeyIdentity.generate();
-
 					await createUser(user);
 				});
 
@@ -549,6 +527,46 @@ describe('Satellite User Usage', () => {
 					await unbanUser({ user, version: [2n] });
 
 					await expect(initAsset()).resolves.not.toThrowError();
+				});
+			});
+
+			describe('get asset', () => {
+				let docKey: string;
+
+				beforeEach(async () => {
+					await createUser(user);
+
+					await uploadAsset({
+						full_path: fullPath,
+						name: filename,
+						collection: collection,
+						actor
+					});
+				});
+
+				it('should not get asset if banned', async () => {
+					await banUser({ user, version: [1n] });
+
+					actor.setIdentity(user);
+					const { get_asset } = actor;
+
+					const result = await get_asset(collection, fullPath);
+					const asset = fromNullable(result);
+
+					expect(asset).toBeUndefined();
+				});
+
+				it('should get asset if unbanned', async () => {
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					actor.setIdentity(user);
+					const { get_asset } = actor;
+
+					const result = await get_asset(collection, fullPath);
+					const doc = fromNullable(result);
+
+					expect(doc).not.toBeUndefined();
 				});
 			});
 		});

--- a/src/tests/specs/satellite.user-ban.spec.ts
+++ b/src/tests/specs/satellite.user-ban.spec.ts
@@ -1,0 +1,173 @@
+import type { _SERVICE as SatelliteActor, SetDoc } from '$declarations/satellite/satellite.did';
+import { idlFactory as idlFactorSatellite } from '$declarations/satellite/satellite.factory.did';
+import { AnonymousIdentity, type Identity } from '@dfinity/agent';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { fromNullable, toNullable } from '@dfinity/utils';
+import { type Actor, PocketIc } from '@hadronous/pic';
+import { toArray } from '@junobuild/utils';
+import { nanoid } from 'nanoid';
+import { beforeAll, describe, expect, inject } from 'vitest';
+import { USER_CANNOT_WRITE } from './constants/satellite-tests.constants';
+import { mockSetRule } from './mocks/collection.mocks';
+import { controllersInitArgs, SATELLITE_WASM_PATH } from './utils/setup-tests.utils';
+
+describe('Satellite User Usage', () => {
+	let pic: PocketIc;
+	let actor: Actor<SatelliteActor>;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const { actor: c } = await pic.setupCanister<SatelliteActor>({
+			idlFactory: idlFactorSatellite,
+			wasm: SATELLITE_WASM_PATH,
+			arg: controllersInitArgs(controller),
+			sender: controller.getPrincipal()
+		});
+
+		actor = c;
+
+		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	describe('user', () => {
+		describe('error', () => {
+			let user: Identity;
+
+			beforeEach(() => {
+				user = Ed25519KeyIdentity.generate();
+				actor.setIdentity(user);
+			});
+
+			it('should not create a user with invalid banned data field', async () => {
+				const { set_doc } = actor;
+
+				const data = await toArray({
+					provider: 'internet_identity',
+					banned: "yolo"
+				});
+
+				await expect(
+					set_doc('#user', user.getPrincipal().toText(), {
+						data,
+						description: toNullable(),
+						version: toNullable()
+					})
+				).rejects.toThrow(
+					'Invalid user data: unknown field `unknown`, expected `provider` or `banned` at line 1 column 41.'
+				);
+			});
+		});
+	});
+
+	describe.only('Ban', () => {
+		const collection = 'test_banned';
+
+		beforeAll(async () => {
+			actor.setIdentity(controller);
+
+			const { set_rule } = actor;
+
+			await set_rule({ Db: null }, collection, mockSetRule);
+			await set_rule({ Storage: null }, collection, mockSetRule);
+		});
+
+		const createUser = async (user: Identity) => {
+			actor.setIdentity(user);
+
+			const { set_doc } = actor;
+
+			return await set_doc('#user', user.getPrincipal().toText(), {
+				data: await toArray({
+					provider: 'internet_identity'
+				}),
+				description: toNullable(),
+				version: toNullable()
+			});
+		};
+
+		const banUser = async ({user, version}: {user: Identity, version: [] | [bigint]}) => {
+			actor.setIdentity(controller);
+
+			const { set_doc } = actor;
+
+			await set_doc('#user', user.getPrincipal().toText(), {
+				data: await toArray({
+					provider: 'internet_identity',
+					banned: 'indefinite'
+				}),
+				description: toNullable(),
+				version: version
+			});
+		};
+
+		const unbanUser = async ({user, version}: {user: Identity, version: [] | [bigint]}) => {
+			actor.setIdentity(controller);
+
+			const { set_doc } = actor;
+
+			await set_doc('#user', user.getPrincipal().toText(), {
+				data: await toArray({
+					provider: 'internet_identity',
+					banned: undefined
+				}),
+				description: toNullable(),
+				version: version
+			});
+		};
+
+		describe('get document', () => {
+			let user: Identity;
+			let docKey: string;
+
+			beforeEach(async () => {
+				user = Ed25519KeyIdentity.generate();
+
+				await createUser(user);
+
+				const { set_doc } = actor;
+
+				docKey = nanoid();
+
+				await set_doc(collection, docKey, {
+					data: await toArray({
+						hello: 'world'
+					}),
+					description: toNullable(),
+					version: toNullable()
+				});
+			})
+
+			it('should not get document if banned', async () => {
+				await banUser({user, version: [1n]});
+
+				actor.setIdentity(user);
+				const { get_doc } = actor;
+
+				const result = await get_doc(collection, docKey);
+				const doc = fromNullable(result);
+
+				expect(doc).toBeUndefined();
+			});
+
+			it('should get document if unbanned', async () => {
+				await banUser({user, version: [1n]});
+				await unbanUser({user, version: [2n]});
+
+				actor.setIdentity(user);
+				const { get_doc } = actor;
+
+				const result = await get_doc(collection, docKey);
+				const doc = fromNullable(result);
+
+				expect(doc).not.toBeUndefined();
+			});
+		});
+	});
+});

--- a/src/tests/specs/satellite.user-ban.spec.ts
+++ b/src/tests/specs/satellite.user-ban.spec.ts
@@ -569,6 +569,99 @@ describe('Satellite User Usage', () => {
 					expect(doc).not.toBeUndefined();
 				});
 			});
+
+			describe('delete filtered assets', () => {
+				const deleteFilteredAssets = async (): Promise<void> => {
+					actor.setIdentity(user);
+
+					const { del_filtered_assets } = actor;
+
+					await del_filtered_assets(collection, mockListParams);
+				};
+
+				beforeEach(async () => {
+					await createUser(user);
+				});
+
+				it('should not delete assets if banned', async () => {
+					await expect(deleteFilteredAssets()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+
+					await expect(deleteFilteredAssets()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
+
+				it('should get assets if unbanned', async () => {
+					await expect(deleteFilteredAssets()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					await expect(deleteFilteredAssets()).resolves.not.toThrowError();
+				});
+			});
+
+			describe('list assets', () => {
+				const listAssets = async (): Promise<void> => {
+					actor.setIdentity(user);
+
+					const { list_assets } = actor;
+
+					await list_assets(collection, mockListParams);
+				};
+
+				beforeEach(async () => {
+					await createUser(user);
+				});
+
+				it('should not list assets if banned', async () => {
+					await expect(listAssets()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+
+					await expect(listAssets()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
+
+				it('should list assets if unbanned', async () => {
+					await expect(listAssets()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					await expect(listAssets()).resolves.not.toThrowError();
+				});
+			});
+
+			describe('count assets', () => {
+				const countAssets = async (): Promise<void> => {
+					actor.setIdentity(user);
+
+					const { count_assets } = actor;
+
+					await count_assets(collection, mockListParams);
+				};
+
+				beforeEach(async () => {
+					await createUser(user);
+				});
+
+				it('should not count assets if banned', async () => {
+					await expect(countAssets()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+
+					await expect(countAssets()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
+
+				it('should count assets if unbanned', async () => {
+					await expect(countAssets()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					await expect(countAssets()).resolves.not.toThrowError();
+				});
+			});
 		});
 	});
 });

--- a/src/tests/specs/satellite.user-ban.spec.ts
+++ b/src/tests/specs/satellite.user-ban.spec.ts
@@ -9,7 +9,7 @@ import { type Identity } from '@dfinity/agent';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { fromNullable, toNullable } from '@dfinity/utils';
 import { type Actor, PocketIc } from '@hadronous/pic';
-import { toArray } from '@junobuild/utils';
+import { fromArray, toArray } from '@junobuild/utils';
 import { nanoid } from 'nanoid';
 import { beforeAll, describe, expect, inject } from 'vitest';
 import { USER_NOT_ALLOWED } from './constants/satellite-tests.constants';
@@ -143,9 +143,20 @@ describe('Satellite User Usage', () => {
 
 			expect(items_length).toEqual(3n);
 
-			expect(items.find(([key, _]) => key === user1.getPrincipal().toText())).not.toBeUndefined();
-			expect(items.find(([key, _]) => key === user2.getPrincipal().toText())).not.toBeUndefined();
-			expect(items.find(([key, _]) => key === user3.getPrincipal().toText())).not.toBeUndefined();
+			const item1 = items.find(([key, _]) => key === user1.getPrincipal().toText());
+			const item2 = items.find(([key, _]) => key === user2.getPrincipal().toText());
+			const item3 = items.find(([key, _]) => key === user3.getPrincipal().toText());
+
+			expect(item1).not.toBeUndefined();
+			expect(item2).not.toBeUndefined();
+			expect(item3).not.toBeUndefined();
+
+			expect(await fromArray(item1?.[1].data ?? [])).toEqual({
+				provider: 'internet_identity',
+				banned: 'indefinite'
+			});
+			expect(await fromArray(item2?.[1].data ?? [])).toEqual({ provider: 'internet_identity' });
+			expect(await fromArray(item3?.[1].data ?? [])).toEqual({ provider: 'internet_identity' });
 		});
 	});
 

--- a/src/tests/specs/satellite.user-ban.spec.ts
+++ b/src/tests/specs/satellite.user-ban.spec.ts
@@ -66,13 +66,13 @@ describe('Satellite User Usage', () => {
 						version: toNullable()
 					})
 				).rejects.toThrow(
-					'Invalid user data: unknown field `unknown`, expected `provider` or `banned` at line 1 column 41.'
+					'Invalid user data: unknown variant `yolo`, expected `indefinite` at line 1 column 47.'
 				);
 			});
 		});
 	});
 
-	describe.only('Ban', () => {
+	describe('Ban', () => {
 		const collection = 'test_banned';
 
 		beforeAll(async () => {

--- a/src/tests/specs/satellite.user-ban.spec.ts
+++ b/src/tests/specs/satellite.user-ban.spec.ts
@@ -84,420 +84,430 @@ describe('Satellite User Usage', () => {
 			await set_rule({ Storage: null }, collection, mockSetRule);
 		});
 
-		const createUser = async (user: Identity) => {
-			actor.setIdentity(user);
+		describe('Datastore', () => {
+			beforeAll(async () => {
+				actor.setIdentity(controller);
 
-			const { set_doc } = actor;
+				const { set_rule } = actor;
 
-			return await set_doc('#user', user.getPrincipal().toText(), {
-				data: await toArray({
-					provider: 'internet_identity'
-				}),
-				description: toNullable(),
-				version: toNullable()
-			});
-		};
-
-		const banUser = async ({ user, version }: { user: Identity; version: [] | [bigint] }) => {
-			actor.setIdentity(controller);
-
-			const { set_doc } = actor;
-
-			await set_doc('#user', user.getPrincipal().toText(), {
-				data: await toArray({
-					provider: 'internet_identity',
-					banned: 'indefinite'
-				}),
-				description: toNullable(),
-				version: version
-			});
-		};
-
-		const unbanUser = async ({ user, version }: { user: Identity; version: [] | [bigint] }) => {
-			actor.setIdentity(controller);
-
-			const { set_doc } = actor;
-
-			await set_doc('#user', user.getPrincipal().toText(), {
-				data: await toArray({
-					provider: 'internet_identity',
-					banned: undefined
-				}),
-				description: toNullable(),
-				version: version
-			});
-		};
-
-		describe('get document', () => {
-			let user: Identity;
-			let docKey: string;
-
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
-
-				await createUser(user);
-
-				const { set_doc } = actor;
-
-				docKey = nanoid();
-
-				await set_doc(collection, docKey, {
-					data: await toArray({
-						hello: 'world'
-					}),
-					description: toNullable(),
-					version: toNullable()
-				});
+				await set_rule({ Db: null }, collection, mockSetRule);
 			});
 
-			it('should not get document if banned', async () => {
-				await banUser({ user, version: [1n] });
-
-				actor.setIdentity(user);
-				const { get_doc } = actor;
-
-				const result = await get_doc(collection, docKey);
-				const doc = fromNullable(result);
-
-				expect(doc).toBeUndefined();
-			});
-
-			it('should get document if unbanned', async () => {
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
-
-				actor.setIdentity(user);
-				const { get_doc } = actor;
-
-				const result = await get_doc(collection, docKey);
-				const doc = fromNullable(result);
-
-				expect(doc).not.toBeUndefined();
-			});
-		});
-
-		describe('get many documents', () => {
-			let user: Identity;
-			let docKey: string;
-
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
-
-				await createUser(user);
-
-				const { set_doc } = actor;
-
-				docKey = nanoid();
-
-				await set_doc(collection, docKey, {
-					data: await toArray({
-						hello: 'world'
-					}),
-					description: toNullable(),
-					version: toNullable()
-				});
-			});
-
-			it('should not get documents if banned', async () => {
-				await banUser({ user, version: [1n] });
-
-				actor.setIdentity(user);
-				const { get_many_docs } = actor;
-
-				const result = await get_many_docs([[collection, docKey]]);
-
-				const doc = fromNullable(result[0][1]);
-
-				expect(doc).toBeUndefined();
-			});
-
-			it('should get documents if unbanned', async () => {
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
-
-				actor.setIdentity(user);
-				const { get_many_docs } = actor;
-
-				const result = await get_many_docs([[collection, docKey]]);
-
-				const doc = fromNullable(result[0][1]);
-
-				expect(doc).not.toBeUndefined();
-			});
-		});
-
-		describe('set document', () => {
-			let user: Identity;
-
-			const createDoc = async (): Promise<Doc> => {
+			const createUser = async (user: Identity) => {
 				actor.setIdentity(user);
 
 				const { set_doc } = actor;
 
-				return await set_doc(collection, nanoid(), {
+				return await set_doc('#user', user.getPrincipal().toText(), {
 					data: await toArray({
-						hello: 'world'
+						provider: 'internet_identity'
 					}),
 					description: toNullable(),
 					version: toNullable()
 				});
 			};
 
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
+			const banUser = async ({ user, version }: { user: Identity; version: [] | [bigint] }) => {
+				actor.setIdentity(controller);
 
-				await createUser(user);
-			});
+				const { set_doc } = actor;
 
-			it('should not set document if banned', async () => {
-				const doc = await createDoc();
-
-				expect(doc).not.toBeUndefined();
-
-				await banUser({ user, version: [1n] });
-
-				await expect(createDoc()).rejects.toThrow(USER_NOT_ALLOWED);
-			});
-
-			it('should set document if unbanned', async () => {
-				await createDoc();
-
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
-
-				const doc = await createDoc();
-
-				expect(doc).not.toBeUndefined();
-			});
-		});
-
-		describe('set many documents', () => {
-			let user: Identity;
-
-			const createDocs = async (): Promise<void> => {
-				actor.setIdentity(user);
-
-				const { set_many_docs } = actor;
-
-				const data: SetDoc = {
+				await set_doc('#user', user.getPrincipal().toText(), {
 					data: await toArray({
-						hello: 'world'
+						provider: 'internet_identity',
+						banned: 'indefinite'
 					}),
 					description: toNullable(),
-					version: toNullable()
+					version: version
+				});
+			};
+
+			const unbanUser = async ({ user, version }: { user: Identity; version: [] | [bigint] }) => {
+				actor.setIdentity(controller);
+
+				const { set_doc } = actor;
+
+				await set_doc('#user', user.getPrincipal().toText(), {
+					data: await toArray({
+						provider: 'internet_identity',
+						banned: undefined
+					}),
+					description: toNullable(),
+					version: version
+				});
+			};
+
+			describe('get document', () => {
+				let user: Identity;
+				let docKey: string;
+
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
+
+					await createUser(user);
+
+					const { set_doc } = actor;
+
+					docKey = nanoid();
+
+					await set_doc(collection, docKey, {
+						data: await toArray({
+							hello: 'world'
+						}),
+						description: toNullable(),
+						version: toNullable()
+					});
+				});
+
+				it('should not get document if banned', async () => {
+					await banUser({ user, version: [1n] });
+
+					actor.setIdentity(user);
+					const { get_doc } = actor;
+
+					const result = await get_doc(collection, docKey);
+					const doc = fromNullable(result);
+
+					expect(doc).toBeUndefined();
+				});
+
+				it('should get document if unbanned', async () => {
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					actor.setIdentity(user);
+					const { get_doc } = actor;
+
+					const result = await get_doc(collection, docKey);
+					const doc = fromNullable(result);
+
+					expect(doc).not.toBeUndefined();
+				});
+			});
+
+			describe('get many documents', () => {
+				let user: Identity;
+				let docKey: string;
+
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
+
+					await createUser(user);
+
+					const { set_doc } = actor;
+
+					docKey = nanoid();
+
+					await set_doc(collection, docKey, {
+						data: await toArray({
+							hello: 'world'
+						}),
+						description: toNullable(),
+						version: toNullable()
+					});
+				});
+
+				it('should not get documents if banned', async () => {
+					await banUser({ user, version: [1n] });
+
+					actor.setIdentity(user);
+					const { get_many_docs } = actor;
+
+					const result = await get_many_docs([[collection, docKey]]);
+
+					const doc = fromNullable(result[0][1]);
+
+					expect(doc).toBeUndefined();
+				});
+
+				it('should get documents if unbanned', async () => {
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					actor.setIdentity(user);
+					const { get_many_docs } = actor;
+
+					const result = await get_many_docs([[collection, docKey]]);
+
+					const doc = fromNullable(result[0][1]);
+
+					expect(doc).not.toBeUndefined();
+				});
+			});
+
+			describe('set document', () => {
+				let user: Identity;
+
+				const createDoc = async (): Promise<Doc> => {
+					actor.setIdentity(user);
+
+					const { set_doc } = actor;
+
+					return await set_doc(collection, nanoid(), {
+						data: await toArray({
+							hello: 'world'
+						}),
+						description: toNullable(),
+						version: toNullable()
+					});
 				};
 
-				await set_many_docs([
-					[collection, nanoid(), data],
-					[collection, nanoid(), data]
-				]);
-			};
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
 
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
-
-				await createUser(user);
-			});
-
-			it('should not set documents if banned', async () => {
-				await expect(createDocs()).resolves.not.toThrowError();
-
-				await banUser({ user, version: [1n] });
-
-				await expect(createDocs()).rejects.toThrow(USER_NOT_ALLOWED);
-			});
-
-			it('should set documents if unbanned', async () => {
-				await expect(createDocs()).resolves.not.toThrowError();
-
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
-
-				await expect(createDocs()).resolves.not.toThrowError();
-			});
-		});
-
-		describe('delete a document', () => {
-			let user: Identity;
-
-			const deleteDoc = async (): Promise<void> => {
-				actor.setIdentity(user);
-
-				const { del_doc } = actor;
-
-				await del_doc(collection, nanoid(), {
-					version: toNullable()
+					await createUser(user);
 				});
-			};
 
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
+				it('should not set document if banned', async () => {
+					const doc = await createDoc();
 
-				await createUser(user);
+					expect(doc).not.toBeUndefined();
+
+					await banUser({ user, version: [1n] });
+
+					await expect(createDoc()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
+
+				it('should set document if unbanned', async () => {
+					await createDoc();
+
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					const doc = await createDoc();
+
+					expect(doc).not.toBeUndefined();
+				});
 			});
 
-			it('should not delete document if banned', async () => {
-				await expect(deleteDoc()).resolves.not.toThrowError();
+			describe('set many documents', () => {
+				let user: Identity;
 
-				await banUser({ user, version: [1n] });
+				const createDocs = async (): Promise<void> => {
+					actor.setIdentity(user);
 
-				await expect(deleteDoc()).rejects.toThrow(USER_NOT_ALLOWED);
-			});
+					const { set_many_docs } = actor;
 
-			it('should get document if unbanned', async () => {
-				await expect(deleteDoc()).resolves.not.toThrowError();
+					const data: SetDoc = {
+						data: await toArray({
+							hello: 'world'
+						}),
+						description: toNullable(),
+						version: toNullable()
+					};
 
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
-
-				await expect(deleteDoc()).resolves.not.toThrowError();
-			});
-		});
-
-		describe('delete many documents', () => {
-			let user: Identity;
-
-			const deleteDocs = async (): Promise<void> => {
-				actor.setIdentity(user);
-
-				const { del_many_docs } = actor;
-
-				const data: DelDoc = {
-					version: toNullable()
+					await set_many_docs([
+						[collection, nanoid(), data],
+						[collection, nanoid(), data]
+					]);
 				};
 
-				await del_many_docs([
-					[collection, nanoid(), data],
-					[collection, nanoid(), data]
-				]);
-			};
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
 
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
+					await createUser(user);
+				});
 
-				await createUser(user);
+				it('should not set documents if banned', async () => {
+					await expect(createDocs()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+
+					await expect(createDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
+
+				it('should set documents if unbanned', async () => {
+					await expect(createDocs()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					await expect(createDocs()).resolves.not.toThrowError();
+				});
 			});
 
-			it('should not delete documents if banned', async () => {
-				await expect(deleteDocs()).resolves.not.toThrowError();
+			describe('delete a document', () => {
+				let user: Identity;
 
-				await banUser({ user, version: [1n] });
+				const deleteDoc = async (): Promise<void> => {
+					actor.setIdentity(user);
 
-				await expect(deleteDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+					const { del_doc } = actor;
+
+					await del_doc(collection, nanoid(), {
+						version: toNullable()
+					});
+				};
+
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
+
+					await createUser(user);
+				});
+
+				it('should not delete document if banned', async () => {
+					await expect(deleteDoc()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+
+					await expect(deleteDoc()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
+
+				it('should get document if unbanned', async () => {
+					await expect(deleteDoc()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					await expect(deleteDoc()).resolves.not.toThrowError();
+				});
 			});
 
-			it('should get documents if unbanned', async () => {
-				await expect(deleteDocs()).resolves.not.toThrowError();
+			describe('delete many documents', () => {
+				let user: Identity;
 
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
+				const deleteDocs = async (): Promise<void> => {
+					actor.setIdentity(user);
 
-				await expect(deleteDocs()).resolves.not.toThrowError();
-			});
-		});
+					const { del_many_docs } = actor;
 
-		describe('delete filtered documents', () => {
-			let user: Identity;
+					const data: DelDoc = {
+						version: toNullable()
+					};
 
-			const deleteFilteredDocs = async (): Promise<void> => {
-				actor.setIdentity(user);
+					await del_many_docs([
+						[collection, nanoid(), data],
+						[collection, nanoid(), data]
+					]);
+				};
 
-				const { del_filtered_docs } = actor;
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
 
-				await del_filtered_docs(collection, mockListParams);
-			};
+					await createUser(user);
+				});
 
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
+				it('should not delete documents if banned', async () => {
+					await expect(deleteDocs()).resolves.not.toThrowError();
 
-				await createUser(user);
-			});
+					await banUser({ user, version: [1n] });
 
-			it('should not delete documents if banned', async () => {
-				await expect(deleteFilteredDocs()).resolves.not.toThrowError();
+					await expect(deleteDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
 
-				await banUser({ user, version: [1n] });
+				it('should get documents if unbanned', async () => {
+					await expect(deleteDocs()).resolves.not.toThrowError();
 
-				await expect(deleteFilteredDocs()).rejects.toThrow(USER_NOT_ALLOWED);
-			});
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
 
-			it('should get documents if unbanned', async () => {
-				await expect(deleteFilteredDocs()).resolves.not.toThrowError();
-
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
-
-				await expect(deleteFilteredDocs()).resolves.not.toThrowError();
-			});
-		});
-
-		describe('list documents', () => {
-			let user: Identity;
-
-			const listDocs = async (): Promise<void> => {
-				actor.setIdentity(user);
-
-				const { list_docs } = actor;
-
-				await list_docs(collection, mockListParams);
-			};
-
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
-
-				await createUser(user);
+					await expect(deleteDocs()).resolves.not.toThrowError();
+				});
 			});
 
-			it('should not list documents if banned', async () => {
-				await expect(listDocs()).resolves.not.toThrowError();
+			describe('delete filtered documents', () => {
+				let user: Identity;
 
-				await banUser({ user, version: [1n] });
+				const deleteFilteredDocs = async (): Promise<void> => {
+					actor.setIdentity(user);
 
-				await expect(listDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+					const { del_filtered_docs } = actor;
+
+					await del_filtered_docs(collection, mockListParams);
+				};
+
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
+
+					await createUser(user);
+				});
+
+				it('should not delete documents if banned', async () => {
+					await expect(deleteFilteredDocs()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+
+					await expect(deleteFilteredDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
+
+				it('should get documents if unbanned', async () => {
+					await expect(deleteFilteredDocs()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					await expect(deleteFilteredDocs()).resolves.not.toThrowError();
+				});
 			});
 
-			it('should list documents if unbanned', async () => {
-				await expect(listDocs()).resolves.not.toThrowError();
+			describe('list documents', () => {
+				let user: Identity;
 
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
+				const listDocs = async (): Promise<void> => {
+					actor.setIdentity(user);
 
-				await expect(listDocs()).resolves.not.toThrowError();
+					const { list_docs } = actor;
+
+					await list_docs(collection, mockListParams);
+				};
+
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
+
+					await createUser(user);
+				});
+
+				it('should not list documents if banned', async () => {
+					await expect(listDocs()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+
+					await expect(listDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
+
+				it('should list documents if unbanned', async () => {
+					await expect(listDocs()).resolves.not.toThrowError();
+
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
+
+					await expect(listDocs()).resolves.not.toThrowError();
+				});
 			});
-		});
 
-		describe('count documents', () => {
-			let user: Identity;
+			describe('count documents', () => {
+				let user: Identity;
 
-			const countDocs = async (): Promise<void> => {
-				actor.setIdentity(user);
+				const countDocs = async (): Promise<void> => {
+					actor.setIdentity(user);
 
-				const { count_docs } = actor;
+					const { count_docs } = actor;
 
-				await count_docs(collection, mockListParams);
-			};
+					await count_docs(collection, mockListParams);
+				};
 
-			beforeEach(async () => {
-				user = Ed25519KeyIdentity.generate();
+				beforeEach(async () => {
+					user = Ed25519KeyIdentity.generate();
 
-				await createUser(user);
-			});
+					await createUser(user);
+				});
 
-			it('should not count documents if banned', async () => {
-				await expect(countDocs()).resolves.not.toThrowError();
+				it('should not count documents if banned', async () => {
+					await expect(countDocs()).resolves.not.toThrowError();
 
-				await banUser({ user, version: [1n] });
+					await banUser({ user, version: [1n] });
 
-				await expect(countDocs()).rejects.toThrow(USER_NOT_ALLOWED);
-			});
+					await expect(countDocs()).rejects.toThrow(USER_NOT_ALLOWED);
+				});
 
-			it('should count documents if unbanned', async () => {
-				await expect(countDocs()).resolves.not.toThrowError();
+				it('should count documents if unbanned', async () => {
+					await expect(countDocs()).resolves.not.toThrowError();
 
-				await banUser({ user, version: [1n] });
-				await unbanUser({ user, version: [2n] });
+					await banUser({ user, version: [1n] });
+					await unbanUser({ user, version: [2n] });
 
-				await expect(countDocs()).resolves.not.toThrowError();
+					await expect(countDocs()).resolves.not.toThrowError();
+				});
 			});
 		});
 	});

--- a/src/tests/specs/satellite.user.spec.ts
+++ b/src/tests/specs/satellite.user.spec.ts
@@ -76,6 +76,18 @@ describe('Satellite > User', () => {
 
 				expect(doc).not.toBeUndefined();
 			});
+
+			it('should create a user without data because those is optional', async () => {
+				const { set_doc } = actor;
+
+				const doc = await set_doc('#user', user.getPrincipal().toText(), {
+					data: await toArray({}),
+					description: toNullable(),
+					version: toNullable()
+				});
+
+				expect(doc).not.toBeUndefined();
+			});
 		});
 
 		describe('error', () => {
@@ -306,7 +318,7 @@ describe('Satellite > User', () => {
 					version: toNullable()
 				})
 			).rejects.toThrow(
-				'Invalid user data: unknown field `unknown`, expected `provider` at line 1 column 41.'
+				'Invalid user data: unknown field `unknown`, expected `provider` or `banned` at line 1 column 41.'
 			);
 		});
 	});


### PR DESCRIPTION
# Motivation

Since there is a user mgmt in the Console, I always thought it would be nice to have such a feature even if it's super easy for someone to just create a new identity. I think for the state of the art it's nice to have such an option for a developer.

We can also add the flag within the user entity now that only admin controller can edit it.