### PR TITLE
feat: similarly to set_user restrict delete to controller

### DIFF
--- a/src/libs/satellite/src/db/assert.rs
+++ b/src/libs/satellite/src/db/assert.rs
@@ -63,8 +63,8 @@ pub fn assert_set_doc(
 
     assert_user_collection_caller_key(caller, collection, key, &current_doc)?;
     assert_user_collection_data(collection, value)?;
-    assert_user_write_permission(caller, controllers, collection, &current_doc)?;
 
+    assert_user_write_permission(caller, controllers, collection, &current_doc)?;
     assert_write_permission(caller, controllers, current_doc, &rule.write)?;
 
     assert_memory_size(config)?;
@@ -107,6 +107,7 @@ pub fn assert_delete_doc(
 ) -> Result<(), String> {
     assert_user_is_not_banned(caller, controllers)?;
 
+    assert_user_write_permission(caller, controllers, collection, &current_doc)?;
     assert_write_permission(caller, controllers, current_doc, &rule.write)?;
 
     assert_write_version(current_doc, value.version)?;

--- a/src/tests/specs/satellite.user.spec.ts
+++ b/src/tests/specs/satellite.user.spec.ts
@@ -127,6 +127,30 @@ describe('Satellite > User', () => {
 					})
 				).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE);
 			});
+
+			it('should not delete a user', async () => {
+				actor.setIdentity(user);
+
+				const { set_doc, get_doc } = actor;
+
+				await set_doc('#user', user.getPrincipal().toText(), {
+					data: await toArray({
+						provider: 'internet_identity'
+					}),
+					description: toNullable(),
+					version: toNullable()
+				});
+
+				const before = await get_doc('#user', user.getPrincipal().toText());
+
+				const { del_doc } = actor;
+
+				await expect(
+					del_doc('#user', user.getPrincipal().toText(), {
+						version: fromNullable(before)?.version ?? []
+					})
+				).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE);
+			});
 		});
 	});
 
@@ -165,6 +189,34 @@ describe('Satellite > User', () => {
 					version: toNullable()
 				})
 			).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_CALLER_KEY);
+		});
+
+		it('should not delete a user', async () => {
+			const user = Ed25519KeyIdentity.generate();
+
+			actor.setIdentity(user);
+
+			const { set_doc, get_doc } = actor;
+
+			await set_doc('#user', user.getPrincipal().toText(), {
+				data: await toArray({
+					provider: 'internet_identity'
+				}),
+				description: toNullable(),
+				version: toNullable()
+			});
+
+			const before = await get_doc('#user', user.getPrincipal().toText());
+
+			actor.setIdentity(anonymous);
+
+			const { del_doc } = actor;
+
+			await expect(
+				del_doc('#user', user.getPrincipal().toText(), {
+					version: fromNullable(before)?.version ?? []
+				})
+			).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE);
 		});
 	});
 
@@ -214,6 +266,34 @@ describe('Satellite > User', () => {
 							provider: 'nfid'
 						}),
 						description: toNullable(),
+						version: fromNullable(before)?.version ?? []
+					})
+				).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE);
+			});
+
+			it('should not delete a user', async () => {
+				const user = Ed25519KeyIdentity.generate();
+
+				actor.setIdentity(user);
+
+				const { set_doc, get_doc } = actor;
+
+				await set_doc('#user', user.getPrincipal().toText(), {
+					data: await toArray({
+						provider: 'internet_identity'
+					}),
+					description: toNullable(),
+					version: toNullable()
+				});
+
+				const before = await get_doc('#user', user.getPrincipal().toText());
+
+				actor.setIdentity(controllerReadWrite);
+
+				const { del_doc } = actor;
+
+				await expect(
+					del_doc('#user', user.getPrincipal().toText(), {
 						version: fromNullable(before)?.version ?? []
 					})
 				).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE);


### PR DESCRIPTION
# Motivation

If only controller can update, also only controller should be able to delete #user entity.
