### PR TITLE
feat: introduce new collection #user-admin to handle ban

### DIFF
--- a/src/libs/collections/src/constants/db.rs
+++ b/src/libs/collections/src/constants/db.rs
@@ -6,6 +6,7 @@ use junobuild_shared::rate::constants::DEFAULT_RATE_CONFIG;
 pub const COLLECTION_USER_KEY: &str = "#user";
 pub const COLLECTION_LOG_KEY: &str = "#log";
 pub const COLLECTION_USER_USAGE_KEY: &str = "#user-usage";
+pub const COLLECTION_USER_ADMIN_KEY: &str = "#user-admin";
 
 const COLLECTION_USER_DEFAULT_RULE: SetRule = SetRule {
     read: Managed,
@@ -44,11 +45,17 @@ pub const COLLECTION_USER_USAGE_DEFAULT_RULE: SetRule = SetRule {
     rate_config: None,
 };
 
-pub const DEFAULT_DB_COLLECTIONS: [(&str, SetRule); 3] = [
+pub const COLLECTION_USER_ADMIN_DEFAULT_RULE: SetRule = COLLECTION_USER_USAGE_DEFAULT_RULE;
+
+pub const DEFAULT_DB_COLLECTIONS: [(&str, SetRule); 4] = [
     (COLLECTION_USER_KEY, COLLECTION_USER_DEFAULT_RULE),
     (COLLECTION_LOG_KEY, COLLECTION_LOG_DEFAULT_RULE),
     (
         COLLECTION_USER_USAGE_KEY,
         COLLECTION_USER_USAGE_DEFAULT_RULE,
+    ),
+    (
+        COLLECTION_USER_ADMIN_KEY,
+        COLLECTION_USER_ADMIN_DEFAULT_RULE,
     ),
 ];

--- a/src/libs/satellite/src/db/assert.rs
+++ b/src/libs/satellite/src/db/assert.rs
@@ -5,9 +5,9 @@ use crate::errors::db::{JUNO_DATASTORE_ERROR_CANNOT_READ, JUNO_DATASTORE_ERROR_C
 use crate::hooks::{invoke_assert_delete_doc, invoke_assert_set_doc};
 use crate::types::store::StoreContext;
 use crate::usage::assert::{assert_user_usage_collection_data, increment_and_assert_db_usage};
+use crate::user::admin::assert::assert_user_is_not_banned;
 use crate::user::assert::{
-    assert_user_collection_caller_key, assert_user_collection_data, assert_user_is_not_banned,
-    assert_user_write_permission,
+    assert_user_collection_caller_key, assert_user_collection_data, assert_user_write_permission,
 };
 use crate::{DelDoc, Doc, SetDoc};
 use candid::Principal;

--- a/src/libs/satellite/src/db/assert.rs
+++ b/src/libs/satellite/src/db/assert.rs
@@ -5,7 +5,7 @@ use crate::errors::db::{JUNO_DATASTORE_ERROR_CANNOT_READ, JUNO_DATASTORE_ERROR_C
 use crate::hooks::{invoke_assert_delete_doc, invoke_assert_set_doc};
 use crate::types::store::StoreContext;
 use crate::usage::assert::{assert_user_usage_collection_data, increment_and_assert_db_usage};
-use crate::user::admin::assert::assert_user_is_not_banned;
+use crate::user::admin::assert::{assert_user_admin_collection_data, assert_user_is_not_banned};
 use crate::user::assert::{
     assert_user_collection_caller_key, assert_user_collection_data, assert_user_write_permission,
 };
@@ -63,6 +63,8 @@ pub fn assert_set_doc(
 
     assert_user_collection_caller_key(caller, collection, key, &current_doc)?;
     assert_user_collection_data(collection, value)?;
+
+    assert_user_admin_collection_data(collection, value)?;
 
     assert_user_write_permission(caller, controllers, collection, &current_doc)?;
     assert_write_permission(caller, controllers, current_doc, &rule.write)?;

--- a/src/libs/satellite/src/errors/user.rs
+++ b/src/libs/satellite/src/errors/user.rs
@@ -1,5 +1,6 @@
 pub const JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE: &str = "juno.datastore.error.user.cannot_update";
 pub const JUNO_DATASTORE_ERROR_USER_INVALID_DATA: &str = "juno.datastore.error.user.invalid_data";
+pub const JUNO_DATASTORE_ERROR_USER_ADMIN_INVALID_DATA: &str = "juno.datastore.error.user.admin.invalid_data";
 // Caller and key must match to create a user.
 pub const JUNO_DATASTORE_ERROR_USER_CALLER_KEY: &str = "juno.datastore.error.user.caller_key";
 // User key must be a textual representation of a principal.

--- a/src/libs/satellite/src/rules/upgrade.rs
+++ b/src/libs/satellite/src/rules/upgrade.rs
@@ -1,18 +1,32 @@
 use crate::memory::STATE;
 use ic_cdk::api::time;
 use junobuild_collections::constants::db::{
+    COLLECTION_USER_ADMIN_DEFAULT_RULE, COLLECTION_USER_ADMIN_KEY,
     COLLECTION_USER_USAGE_DEFAULT_RULE, COLLECTION_USER_USAGE_KEY,
 };
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::interface::SetRule;
 use junobuild_collections::types::rules::Rule;
 
 // ---------------------------------------------------------
 // One time upgrade
 // ---------------------------------------------------------
 
-pub fn init_user_usage_collection() {
+pub fn init_new_user_collections() {
+    init_collection(
+        &COLLECTION_USER_USAGE_KEY.to_string(),
+        COLLECTION_USER_USAGE_DEFAULT_RULE,
+    );
+    init_collection(
+        &COLLECTION_USER_ADMIN_KEY.to_string(),
+        COLLECTION_USER_ADMIN_DEFAULT_RULE,
+    );
+}
+
+fn init_collection(collection: &CollectionKey, default_rule: SetRule) {
     let col = STATE.with(|state| {
         let rules = &state.borrow_mut().heap.db.rules;
-        rules.get(COLLECTION_USER_USAGE_KEY).cloned()
+        rules.get(collection).cloned()
     });
 
     if col.is_none() {
@@ -22,20 +36,20 @@ pub fn init_user_usage_collection() {
             let now = time();
 
             let rule = Rule {
-                read: COLLECTION_USER_USAGE_DEFAULT_RULE.read,
-                write: COLLECTION_USER_USAGE_DEFAULT_RULE.write,
-                memory: COLLECTION_USER_USAGE_DEFAULT_RULE.memory,
-                mutable_permissions: COLLECTION_USER_USAGE_DEFAULT_RULE.mutable_permissions,
-                max_size: COLLECTION_USER_USAGE_DEFAULT_RULE.max_size,
-                max_capacity: COLLECTION_USER_USAGE_DEFAULT_RULE.max_capacity,
-                max_changes_per_user: COLLECTION_USER_USAGE_DEFAULT_RULE.max_changes_per_user,
+                read: default_rule.read,
+                write: default_rule.write,
+                memory: default_rule.memory,
+                mutable_permissions: default_rule.mutable_permissions,
+                max_size: default_rule.max_size,
+                max_capacity: default_rule.max_capacity,
+                max_changes_per_user: default_rule.max_changes_per_user,
                 created_at: now,
                 updated_at: now,
-                version: COLLECTION_USER_USAGE_DEFAULT_RULE.version,
-                rate_config: COLLECTION_USER_USAGE_DEFAULT_RULE.rate_config,
+                version: default_rule.version,
+                rate_config: default_rule.rate_config,
             };
 
-            rules.insert(COLLECTION_USER_USAGE_KEY.to_string(), rule.clone());
+            rules.insert(collection.to_string(), rule.clone());
         });
     }
 }

--- a/src/libs/satellite/src/satellite.rs
+++ b/src/libs/satellite/src/satellite.rs
@@ -27,7 +27,6 @@ use crate::rules::store::{
     del_rule_db, del_rule_storage, get_rule_db, get_rule_storage, get_rules_db, get_rules_storage,
     set_rule_db, set_rule_storage,
 };
-use crate::rules::upgrade::init_user_usage_collection;
 use crate::storage::certified_assets::upgrade::defer_init_certified_assets;
 use crate::storage::store::{
     commit_batch_store, count_assets_store, count_collection_assets_store, create_batch_store,
@@ -70,6 +69,7 @@ use junobuild_storage::types::interface::{
 };
 use junobuild_storage::types::state::FullPath;
 use junobuild_storage::types::store::Asset;
+use crate::rules::upgrade::init_new_user_collections;
 
 pub fn init() {
     let call_arg = arg_data::<(Option<SegmentArgs>,)>(ArgDecoderConfig::default()).0;
@@ -114,7 +114,7 @@ pub fn post_upgrade() {
     invoke_on_post_upgrade();
 
     // TODO: to be removed - one time upgrade!
-    init_user_usage_collection();
+    init_new_user_collections();
 }
 
 // ---------------------------------------------------------

--- a/src/libs/satellite/src/storage/assert.rs
+++ b/src/libs/satellite/src/storage/assert.rs
@@ -1,7 +1,8 @@
 use crate::hooks::invoke_assert_delete_asset;
 use crate::types::store::StoreContext;
 use crate::usage::assert::increment_and_assert_storage_usage;
-use crate::user::assert::{assert_user_is_not_banned, is_known_user};
+use crate::user::admin::assert::assert_user_is_not_banned;
+use crate::user::assert::is_known_user;
 use candid::Principal;
 use junobuild_collections::assert::stores::{assert_permission, public_permission};
 use junobuild_collections::types::rules::{Permission, Rule};

--- a/src/libs/satellite/src/user/admin/assert.rs
+++ b/src/libs/satellite/src/user/admin/assert.rs
@@ -1,12 +1,13 @@
-use crate::errors::user::JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED;
-use crate::get_doc_store;
+use crate::errors::user::{JUNO_DATASTORE_ERROR_USER_ADMIN_INVALID_DATA, JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED};
+use crate::{get_doc_store, SetDoc};
 use crate::user::admin::types::state::{BannedReason, UserAdminData, UserAdminKey};
 use candid::Principal;
 use ic_cdk::id;
-use junobuild_collections::constants::db::COLLECTION_USER_ADMIN_KEY;
+use junobuild_collections::constants::db::{COLLECTION_USER_ADMIN_KEY};
 use junobuild_shared::controllers::is_controller;
 use junobuild_shared::types::state::Controllers;
 use junobuild_utils::decode_doc_data;
+use junobuild_collections::types::core::CollectionKey;
 
 pub fn assert_user_is_not_banned(
     caller: Principal,
@@ -28,6 +29,17 @@ pub fn assert_user_is_not_banned(
             return Err(JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED.to_string());
         }
     }
+
+    Ok(())
+}
+
+pub fn assert_user_admin_collection_data(collection: &CollectionKey, doc: &SetDoc) -> Result<(), String> {
+    if collection != COLLECTION_USER_ADMIN_KEY {
+        return Ok(());
+    }
+
+    decode_doc_data::<UserAdminData>(&doc.data)
+        .map_err(|err| format!("{}: {}", JUNO_DATASTORE_ERROR_USER_ADMIN_INVALID_DATA, err))?;
 
     Ok(())
 }

--- a/src/libs/satellite/src/user/admin/assert.rs
+++ b/src/libs/satellite/src/user/admin/assert.rs
@@ -1,0 +1,33 @@
+use crate::errors::user::JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED;
+use crate::get_doc_store;
+use crate::user::admin::types::state::{BannedReason, UserAdminData, UserAdminKey};
+use candid::Principal;
+use ic_cdk::id;
+use junobuild_collections::constants::db::COLLECTION_USER_ADMIN_KEY;
+use junobuild_shared::controllers::is_controller;
+use junobuild_shared::types::state::Controllers;
+use junobuild_utils::decode_doc_data;
+
+pub fn assert_user_is_not_banned(
+    caller: Principal,
+    controllers: &Controllers,
+) -> Result<(), String> {
+    // This way we spare loading the user for controllers calls.
+    if is_controller(caller, controllers) {
+        return Ok(());
+    }
+
+    let user_admin_key = UserAdminKey::create(&caller).to_key();
+
+    let user = get_doc_store(id(), COLLECTION_USER_ADMIN_KEY.to_string(), user_admin_key)?;
+
+    if let Some(user) = user {
+        let user_data = decode_doc_data::<UserAdminData>(&user.data)?;
+
+        if let Some(BannedReason::Indefinite) = user_data.banned {
+            return Err(JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED.to_string());
+        }
+    }
+
+    Ok(())
+}

--- a/src/libs/satellite/src/user/admin/impls.rs
+++ b/src/libs/satellite/src/user/admin/impls.rs
@@ -1,0 +1,12 @@
+use crate::user::admin::types::state::UserAdminKey;
+use junobuild_shared::types::state::UserId;
+
+impl UserAdminKey {
+    pub fn create(user_id: &UserId) -> Self {
+        Self { user_id: *user_id }
+    }
+
+    pub fn to_key(&self) -> String {
+        self.user_id.to_text()
+    }
+}

--- a/src/libs/satellite/src/user/admin/mod.rs
+++ b/src/libs/satellite/src/user/admin/mod.rs
@@ -1,3 +1,3 @@
-pub mod admin;
 pub mod assert;
+mod impls;
 mod types;

--- a/src/libs/satellite/src/user/admin/types.rs
+++ b/src/libs/satellite/src/user/admin/types.rs
@@ -1,0 +1,21 @@
+pub mod state {
+    use junobuild_shared::types::state::UserId;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    pub struct UserAdminKey {
+        pub user_id: UserId,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct UserAdminData {
+        pub banned: Option<BannedReason>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum BannedReason {
+        Indefinite,
+    }
+}

--- a/src/libs/satellite/src/user/types.rs
+++ b/src/libs/satellite/src/user/types.rs
@@ -5,7 +5,6 @@ pub mod state {
     #[serde(deny_unknown_fields)]
     pub struct UserData {
         pub provider: Option<AuthProvider>,
-        pub banned: Option<BannedReason>,
     }
 
     #[derive(Serialize, Deserialize)]
@@ -13,11 +12,5 @@ pub mod state {
     pub enum AuthProvider {
         InternetIdentity,
         Nfid,
-    }
-
-    #[derive(Serialize, Deserialize)]
-    #[serde(rename_all = "snake_case")]
-    pub enum BannedReason {
-        Indefinite,
     }
 }

--- a/src/tests/specs/constants/satellite-tests.constants.ts
+++ b/src/tests/specs/constants/satellite-tests.constants.ts
@@ -18,6 +18,8 @@ export const JUNO_AUTH_ERROR_NOT_CONTROLLER = 'juno.auth.error.not_controller';
 
 export const JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE = 'juno.datastore.error.user.cannot_update';
 export const JUNO_DATASTORE_ERROR_USER_INVALID_DATA = 'juno.datastore.error.user.invalid_data';
+export const JUNO_DATASTORE_ERROR_USER_ADMIN_INVALID_DATA =
+	'juno.datastore.error.user.admin.invalid_data';
 export const JUNO_DATASTORE_ERROR_USER_CALLER_KEY = 'juno.datastore.error.user.caller_key';
 export const JUNO_DATASTORE_ERROR_USER_KEY_NO_PRINCIPAL =
 	'juno.datastore.error.user.key_no_principal';

--- a/src/tests/specs/satellite.user.spec.ts
+++ b/src/tests/specs/satellite.user.spec.ts
@@ -420,7 +420,7 @@ describe('Satellite > User', () => {
 					version: toNullable()
 				})
 			).rejects.toThrow(
-				`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown field \`unknown\`, expected \`provider\` or \`banned\` at line 1 column 41.`
+				`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown field \`unknown\`, expected \`provider\` at line 1 column 41.`
 			);
 		});
 	});


### PR DESCRIPTION
# Motivation

~~After another reflexion it's better to had a separate collection `#user-admin` to handle such information as "ban". While it's easier and more performant on the UI side to have a single collection `#user` and while it can be alright to allow only controller to edit and delete this technical entity, it should be straightforward for user to delete their account. Dev should not have to write a serverless hook to do so or do it manually. So, long story short, the collection user will be set back as managed ("user can edit and delete their entry") and we introduce managing things like banned with an admin collection.~~

**UDPATE**: Yes but, we also do not want yet to allow controllers to create document for another owner. We would need to introduce quite some changes and assertions. So what we gonna, we gonna allow user to delete their entry UNLESS they are banned.

User -> can create #user
User -> cannot update #user, only controllers
User -> can delete #user is not banned
