### PR TITLE
feat: re-allow read+write controller to update user

### DIFF
--- a/src/libs/satellite/src/user/core/assert.rs
+++ b/src/libs/satellite/src/user/core/assert.rs
@@ -69,7 +69,7 @@ pub fn assert_user_write_permission(
         return Ok(());
     }
 
-    if is_admin_controller(caller, controllers) {
+    if is_controller(caller, controllers) {
         return Ok(());
     }
 

--- a/src/tests/specs/satellite.user.spec.ts
+++ b/src/tests/specs/satellite.user.spec.ts
@@ -273,7 +273,7 @@ describe('Satellite > User', () => {
 			});
 		});
 
-		describe('error', () => {
+		describe("success", () => {
 			it('should not update a user', async () => {
 				const user = Ed25519KeyIdentity.generate();
 
@@ -303,9 +303,11 @@ describe('Satellite > User', () => {
 						description: toNullable(),
 						version: fromNullable(before)?.version ?? []
 					})
-				).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE);
+				).resolves.not.toThrowError();
 			});
+		})
 
+		describe('error', () => {
 			it('should not delete a user', async () => {
 				const user = Ed25519KeyIdentity.generate();
 


### PR DESCRIPTION
# Motivation

I was hesitant at preventing controller with Read+Write privileges to delete user or to allow those to update user. Ultimately selected the latest because controller with Read+Write are, controllers. They have access to read and write data in the Datastore and Storage so why not users as well. We can revisit that any time.
