### PR TITLE
feat: create #user-admin collection on initialization

### DIFF
--- a/src/libs/collections/src/constants/db.rs
+++ b/src/libs/collections/src/constants/db.rs
@@ -6,6 +6,7 @@ use junobuild_shared::rate::constants::DEFAULT_RATE_CONFIG;
 pub const COLLECTION_USER_KEY: &str = "#user";
 pub const COLLECTION_LOG_KEY: &str = "#log";
 pub const COLLECTION_USER_USAGE_KEY: &str = "#user-usage";
+pub const COLLECTION_USER_ADMIN_KEY: &str = "#user-admin";
 
 const COLLECTION_USER_DEFAULT_RULE: SetRule = SetRule {
     read: Managed,
@@ -44,11 +45,21 @@ pub const COLLECTION_USER_USAGE_DEFAULT_RULE: SetRule = SetRule {
     rate_config: None,
 };
 
-pub const DEFAULT_DB_COLLECTIONS: [(&str, SetRule); 3] = [
+pub const COLLECTION_USER_ADMIN_DEFAULT_RULE: SetRule = SetRule {
+    read: Controllers,
+    write: Controllers,
+    memory: Some(Memory::Stable),
+    mutable_permissions: Some(false),
+    max_size: None,
+    max_capacity: Some(100),
+    max_changes_per_user: None,
+    version: None,
+    rate_config: None,
+};
+
+pub const DEFAULT_DB_COLLECTIONS: [(&str, SetRule); 4] = [
     (COLLECTION_USER_KEY, COLLECTION_USER_DEFAULT_RULE),
     (COLLECTION_LOG_KEY, COLLECTION_LOG_DEFAULT_RULE),
-    (
-        COLLECTION_USER_USAGE_KEY,
-        COLLECTION_USER_USAGE_DEFAULT_RULE,
-    ),
+    (COLLECTION_USER_USAGE_KEY, COLLECTION_USER_USAGE_DEFAULT_RULE),
+    (COLLECTION_USER_ADMIN_KEY, COLLECTION_USER_ADMIN_DEFAULT_RULE),
 ];

--- a/src/libs/satellite/src/rules/upgrade.rs
+++ b/src/libs/satellite/src/rules/upgrade.rs
@@ -1,8 +1,5 @@
 use crate::memory::STATE;
 use ic_cdk::api::time;
-use junobuild_collections::constants::db::{
-    COLLECTION_USER_USAGE_DEFAULT_RULE, COLLECTION_USER_USAGE_KEY,
-};
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::interface::SetRule;
 use junobuild_collections::types::rules::Rule;
@@ -10,13 +7,6 @@ use junobuild_collections::types::rules::Rule;
 // ---------------------------------------------------------
 // One time upgrade
 // ---------------------------------------------------------
-
-pub fn init_new_user_collections() {
-    init_collection(
-        &COLLECTION_USER_USAGE_KEY.to_string(),
-        COLLECTION_USER_USAGE_DEFAULT_RULE,
-    );
-}
 
 fn init_collection(collection: &CollectionKey, default_rule: SetRule) {
     let col = STATE.with(|state| {

--- a/src/libs/satellite/src/satellite.rs
+++ b/src/libs/satellite/src/satellite.rs
@@ -27,7 +27,6 @@ use crate::rules::store::{
     del_rule_db, del_rule_storage, get_rule_db, get_rule_storage, get_rules_db, get_rules_storage,
     set_rule_db, set_rule_storage,
 };
-use crate::rules::upgrade::init_new_user_collections;
 use crate::storage::certified_assets::upgrade::defer_init_certified_assets;
 use crate::storage::store::{
     commit_batch_store, count_assets_store, count_collection_assets_store, create_batch_store,
@@ -112,9 +111,6 @@ pub fn post_upgrade() {
     defer_init_random_seed();
 
     invoke_on_post_upgrade();
-
-    // TODO: to be removed - one time upgrade!
-    init_new_user_collections();
 }
 
 // ---------------------------------------------------------

--- a/src/tests/specs/satellite.spec.ts
+++ b/src/tests/specs/satellite.spec.ts
@@ -533,6 +533,45 @@ describe('Satellite', () => {
 				expect(updated_at).toBeGreaterThan(0n);
 			});
 
+			it('should get #user-admin system collection', async () => {
+				const { get_rule } = actor;
+
+				const result = await get_rule({ Db: null }, '#user-admin');
+
+				const rule = fromNullable(result);
+
+				assertNonNullish(rule);
+
+				const { updated_at, created_at, memory, mutable_permissions, read, write, max_capacity } = rule;
+
+				expect(memory).toEqual(toNullable({ Stable: null }));
+				expect(read).toEqual({ Controllers: null });
+				expect(write).toEqual({ Controllers: null });
+				expect(mutable_permissions).toEqual([false]);
+				expect(max_capacity).toEqual([100]);
+				expect(created_at).toBeGreaterThan(0n);
+				expect(updated_at).toBeGreaterThan(0n);
+			});
+
+			it('should get #user-usage system collection', async () => {
+				const { get_rule } = actor;
+
+				const result = await get_rule({ Db: null }, '#user-usage');
+
+				const rule = fromNullable(result);
+
+				assertNonNullish(rule);
+
+				const { updated_at, created_at, memory, mutable_permissions, read, write } = rule;
+
+				expect(memory).toEqual(toNullable({ Stable: null }));
+				expect(read).toEqual({ Controllers: null });
+				expect(write).toEqual({ Controllers: null });
+				expect(mutable_permissions).toEqual([false]);
+				expect(created_at).toBeGreaterThan(0n);
+				expect(updated_at).toBeGreaterThan(0n);
+			});
+
 			describe('errors', () => {
 				it('should throw errors on creating reserved collection', async () => {
 					const { set_rule } = actor;


### PR DESCRIPTION


# Motivation

<!-- Describe the motivation that lead to the PR -->
- Add #user-admin collection to DEFAULT_DB_COLLECTIONS with Controllers permissions

- Remove post-upgrade initialization in favor of direct initialization

- Add tests to verify both #user-admin and #user-usage collections

Fixes #1254
