### PR TITLE
build: setup config.toml with getrandom_backend custom to fix docs.rs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', "getrandom_backend=\"custom\""]


### PR DESCRIPTION
# Motivation

While we are using the RUSTFLAGS through scripts, I did not find another way to fix the docs.rs than adding a `config.toml` file with the option as well.

Resolve #1288

