### PR TITLE
fix: build toolchain '1.85.0-x86_64-unknown-linux-gnu' is not installed

### DIFF
--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -19,7 +19,7 @@ function run() {
 rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
 echo "using rust version '$rust_version'"
 
-# Install rustup without a toolchain to 'none'.
+# Install rustup with a toolchain set to 'none'.
 # Note: rustup does NOT automatically pick up ./rust-toolchain.toml. We will install and set the correct version afterwards.
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -19,12 +19,22 @@ function run() {
 rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
 echo "using rust version '$rust_version'"
 
+targets=$(sed -n 's/^targets[[:space:]]*=[[:space:]]\[\(.*\)\]/\1/p' ./rust-toolchain.toml | tr -d '[]" ' | tr ',' ' ')
+echo "using rust targets: $targets"
+
 # Install rustup with a toolchain set to 'none'.
 # Note: rustup does NOT automatically pick up ./rust-toolchain.toml. We will install and set the correct version afterwards.
 # https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 
-rustup show active-toolchain || rustup toolchain install
+# Install the effective Rust version
+rustup install "$rust_version"
+rustup default "$rust_version"
+
+# Install Rust targets
+for target in $targets; do
+    rustup target add "$target"
+done
 
 echo "looking for ic-wasm 0.8.5"
 if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -19,6 +19,9 @@ function run() {
 rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
 echo "using rust version '$rust_version'"
 
+targets=$(sed -n 's/^targets[[:space:]]*=[[:space:]]\[\(.*\)\]/\1/p' ./rust-toolchain.toml | tr -d '[]" ' | tr ',' ' ')
+echo "Installing Rust targets: $targets"
+
 # Install rustup with a toolchain set to 'none'.
 # Note: rustup does NOT automatically pick up ./rust-toolchain.toml. We will install and set the correct version afterwards.
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
@@ -28,6 +31,11 @@ rustup install "$rust_version"
 rustup default "$rust_version"
 
 echo "Rust installed. Version: $(rustc --version)"
+
+# Install Rust targets
+for target in $targets; do
+    rustup target add "$target"
+done
 
 echo "looking for ic-wasm 0.8.5"
 if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -28,12 +28,15 @@ echo "using rust targets: $targets"
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 
 # Install the effective Rust version
-rustup install "$rust_version"
-rustup default "$rust_version"
+rustup show active-toolchain | grep -q "$rust_version" || run rustup toolchain install "$rust_version"
+
+run rustup default "$rust_version"
+
+echo "Rust installed. Version: $(rustc --version)"
 
 # Install Rust targets
 for target in $targets; do
-    rustup target add "$target"
+    run rustup target add "$target"
 done
 
 echo "looking for ic-wasm 0.8.5"

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -27,6 +27,8 @@ run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain 
 rustup install "$rust_version"
 rustup default "$rust_version"
 
+echo "Rust installed. Version: $(rustc --version)"
+
 echo "looking for ic-wasm 0.8.5"
 if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]
 then

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -19,8 +19,13 @@ function run() {
 rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
 echo "using rust version '$rust_version'"
 
-# here we set the toolchain to 'none' and rustup will pick up on ./rust-toolchain.toml
+# Install rustup without a toolchain to 'none'.
+# Note: rustup does NOT automatically pick up ./rust-toolchain.toml. We will install and set the correct version afterwards.
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
+
+# Install the effective Rust version
+rustup install "$rust_version"
+rustup default "$rust_version"
 
 echo "looking for ic-wasm 0.8.5"
 if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -20,7 +20,7 @@ rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:spa
 echo "using rust version '$rust_version'"
 
 targets=$(sed -n 's/^targets[[:space:]]*=[[:space:]]\[\(.*\)\]/\1/p' ./rust-toolchain.toml | tr -d '[]" ' | tr ',' ' ')
-echo "Installing Rust targets: $targets"
+echo "using rust targets: $targets"
 
 # Install rustup with a toolchain set to 'none'.
 # Note: rustup does NOT automatically pick up ./rust-toolchain.toml. We will install and set the correct version afterwards.
@@ -29,8 +29,6 @@ run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain 
 # Install the effective Rust version
 rustup install "$rust_version"
 rustup default "$rust_version"
-
-echo "Rust installed. Version: $(rustc --version)"
 
 # Install Rust targets
 for target in $targets; do

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -28,11 +28,10 @@ echo "using rust targets: $targets"
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 
 # Install the effective Rust version
-rustup show active-toolchain | grep -q "$rust_version" || run rustup toolchain install "$rust_version"
-
+run rustup toolchain install "$rust_version"
 run rustup default "$rust_version"
 
-echo "Rust installed. Version: $(rustc --version)"
+echo "Rust toolchain version $(rustc --version) installed."
 
 # Install Rust targets
 for target in $targets; do

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -19,21 +19,12 @@ function run() {
 rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
 echo "using rust version '$rust_version'"
 
-targets=$(sed -n 's/^targets[[:space:]]*=[[:space:]]\[\(.*\)\]/\1/p' ./rust-toolchain.toml | tr -d '[]" ' | tr ',' ' ')
-echo "using rust targets: $targets"
-
 # Install rustup with a toolchain set to 'none'.
 # Note: rustup does NOT automatically pick up ./rust-toolchain.toml. We will install and set the correct version afterwards.
+# https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 
-# Install the effective Rust version
-rustup install "$rust_version"
-rustup default "$rust_version"
-
-# Install Rust targets
-for target in $targets; do
-    rustup target add "$target"
-done
+rustup show active-toolchain || rustup toolchain install
 
 echo "looking for ic-wasm 0.8.5"
 if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]


### PR DESCRIPTION
# Motivation

Build started failing because it seems that `rustup` does not automatically pick up the `./rust-toolchain` anymore.

CI Error: https://github.com/junobuild/juno/actions/runs/13649239562/job/38153884004?pr=1305

Asserted in PR: https://github.com/junobuild/juno/pull/1305
