### PR TITLE
feat: init rules context

### DIFF
--- a/src/frontend/src/lib/components/db/Db.svelte
+++ b/src/frontend/src/lib/components/db/Db.svelte
@@ -20,9 +20,7 @@
 	});
 
 	$effect(() => {
-		satelliteId;
-
-		context.reload();
+		context.init(satelliteId);
 	});
 
 	setContext<RulesContext>(RULES_CONTEXT_KEY, context);

--- a/src/frontend/src/lib/components/storage/Storage.svelte
+++ b/src/frontend/src/lib/components/storage/Storage.svelte
@@ -20,9 +20,7 @@
 	});
 
 	$effect(() => {
-		satelliteId;
-
-		context.reload();
+		context.init(satelliteId);
 	});
 
 	setContext<RulesContext>(RULES_CONTEXT_KEY, context);

--- a/src/frontend/src/lib/stores/rules.store.ts
+++ b/src/frontend/src/lib/stores/rules.store.ts
@@ -1,5 +1,4 @@
 import type { CollectionType } from '$declarations/satellite/satellite.did';
-import { DbCollectionType } from '$lib/constants/rules.constants';
 import { authStore } from '$lib/stores/auth.store';
 import type { RulesContext, RulesData } from '$lib/types/rules.context';
 import { reloadContextRules } from '$lib/utils/rules.utils';
@@ -7,29 +6,40 @@ import type { Principal } from '@dfinity/principal';
 import { get, writable } from 'svelte/store';
 
 export const initRulesContext = ({
-	satelliteId,
+	satelliteId: initialSatelliteId,
 	type
 }: {
 	satelliteId: Principal;
 	type: CollectionType;
 }): RulesContext => {
 	const store = writable<RulesData>({
-		satelliteId,
+		satelliteId: initialSatelliteId,
 		rules: undefined,
 		rule: undefined
 	});
 
 	const reloadRules = async () =>
 		await reloadContextRules({
-			satelliteId,
+			satelliteId: get(store).satelliteId,
 			type,
 			store,
 			// TODO: pass auth as argument
 			identity: get(authStore).identity
 		});
 
+	const initRules = async (satelliteId: Principal) => {
+		store.set({
+			satelliteId,
+			rules: undefined,
+			rule: undefined
+		});
+
+		await reloadRules();
+	};
+
 	return {
 		store,
-		reload: reloadRules
+		reload: reloadRules,
+		init: initRules
 	};
 };

--- a/src/frontend/src/lib/types/rules.context.ts
+++ b/src/frontend/src/lib/types/rules.context.ts
@@ -11,6 +11,7 @@ export interface RulesData {
 export interface RulesContext {
 	store: Writable<RulesData>;
 	reload: () => Promise<void>;
+	init: (satelliteId: Principal) => Promise<void>;
 }
 
 export const RULES_CONTEXT_KEY = Symbol('rules');


### PR DESCRIPTION
# Motivation

It's more readable and cleaner to express the fact that we init the store context.
