### PR TITLE
feat: sort satellites in nav switcher

### DIFF
--- a/src/frontend/src/lib/components/satellites/SatellitesSwitcher.svelte
+++ b/src/frontend/src/lib/components/satellites/SatellitesSwitcher.svelte
@@ -3,7 +3,7 @@
 	import IconArrowDropDown from '$lib/components/icons/IconArrowDropDown.svelte';
 	import Popover from '$lib/components/ui/Popover.svelte';
 	import { satelliteStore } from '$lib/derived/satellite.derived';
-	import { satellitesStore } from '$lib/derived/satellites.derived';
+	import { sortedSatellites } from '$lib/derived/satellites.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { overviewLink } from '$lib/utils/nav.utils';
 	import { satelliteName } from '$lib/utils/satellite.utils';
@@ -34,22 +34,20 @@
 		<hr />
 
 		<div class="satellites">
-			{#if nonNullish($satellitesStore)}
-				{#each $satellitesStore as satellite}
-					{@const satName = satelliteName(satellite)}
+			{#each $sortedSatellites as satellite}
+				{@const satName = satelliteName(satellite)}
 
-					<a
-						aria-label={`To satellite ${satName}`}
-						href={overviewLink(satellite.satellite_id)}
-						class="menu"
-						role="menuitem"
-						aria-haspopup="menu"
-						rel="external noopener norefferer"
-					>
-						<span>{satName}</span>
-					</a>
-				{/each}
-			{/if}
+				<a
+					aria-label={`To satellite ${satName}`}
+					href={overviewLink(satellite.satellite_id)}
+					class="menu"
+					role="menuitem"
+					aria-haspopup="menu"
+					rel="external noopener norefferer"
+				>
+					<span>{satName}</span>
+				</a>
+			{/each}
 		</div>
 	</div>
 </Popover>


### PR DESCRIPTION
# Motivation

Satellites were already sorted on the launchpad but, not on the switcher.
