### PR TITLE
chore: fix default build canister

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -106,7 +106,7 @@ done
 
 # build Mission Control by default
 if [ ${#CANISTER} -eq 0 ]; then
-    CANISTER=("mission_control")
+    CANISTER="mission_control"
 fi
 
 # Checking for dependencies


### PR DESCRIPTION
# Motivation

The default fallback should be a canister not an array of canisters.
