### PR TITLE
fix: npm run generate

### DIFF
--- a/docker/build-canister
+++ b/docker/build-canister
@@ -89,6 +89,8 @@ function build_canister() {
         ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata supported_certificate_versions -d "1,2" -v public --keep-name-section
       fi
 
-      gzip --no-name --force "$output_dir/$canister.wasm"
+      # --no-name to avoid reproducibility issues
+      # --keep-unused in CI Docker build, but useful for local tooling and particularly for the job that generates the DID files
+      gzip --no-name --force --keep "$output_dir/$canister.wasm"
     fi
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
 		"build:satellite": "scripts/cargo.sh satellite --with-certification --build-type=stock",
 		"build:mission-control": "scripts/cargo.sh mission_control",
 		"build:orbiter": "scripts/cargo.sh orbiter",
-		"build:fixtures": "scripts/cargo.sh test_satellite --with-certification --build-type=extended --fixture",
+		"build:fixtures": "npm run build:test-satellite",
+		"build:test-satellite": "scripts/cargo.sh test_satellite --with-certification --build-type=extended --fixture",
 		"build:modules": "npm run build:console && npm run build:observatory && npm run build:satellite && npm run build:mission-control && npm run build:orbiter",
 		"emulator": "docker compose up"
 	},

--- a/scripts/did.utils.sh
+++ b/scripts/did.utils.sh
@@ -3,7 +3,7 @@ function generate_did() {
   local canister_root=$2
   local did_filename=$3
 
-  ./scripts/cargo.sh "$canister"
+  npm run build:"${canister//_/-}"
 
   if [ -z "$did_filename" ]; then
     candid-extractor "target/wasm/$canister.wasm" > "$canister_root/$canister.did"


### PR DESCRIPTION
# Motivation

Follow-up of #1315. 

`npm run generate` failed because the wasm weren't kept to generate the did files. 
