### PR TITLE
chore: resolve FromAsCasing: 'as' and 'FROM'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # The docker image. To update, run `docker pull ubuntu` locally, and update the
 # sha256:... accordingly.
-FROM --platform=linux/amd64 ubuntu@sha256:bbf3d1baa208b7649d1d0264ef7d522e1dc0deeeaaf6085bf8e4618867f03494 as deps
+FROM --platform=linux/amd64 ubuntu@sha256:bbf3d1baa208b7649d1d0264ef7d522e1dc0deeeaaf6085bf8e4618867f03494 AS deps
 
 ENV TZ=UTC
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN mkdir -p src/console/src \
     && ./docker/build-deps \
     && rm -rf src
 
-FROM deps as build_mission_control
+FROM deps AS build_mission_control
 
 COPY . .
 
@@ -95,7 +95,7 @@ RUN touch src/tests/fixtures/*/src/lib.rs
 RUN ./docker/build
 RUN sha256sum /mission_control.wasm.gz
 
-FROM deps as build_satellite
+FROM deps AS build_satellite
 
 COPY . .
 
@@ -106,7 +106,7 @@ RUN touch src/tests/fixtures/*/src/lib.rs
 RUN ./docker/build --satellite
 RUN sha256sum /satellite.wasm.gz
 
-FROM deps as build_console
+FROM deps AS build_console
 
 COPY . .
 
@@ -117,7 +117,7 @@ RUN touch src/tests/fixtures/*/src/lib.rs
 RUN ./docker/build --console
 RUN sha256sum /console.wasm.gz
 
-FROM deps as build_observatory
+FROM deps AS build_observatory
 
 COPY . .
 
@@ -128,7 +128,7 @@ RUN touch src/tests/fixtures/*/src/lib.rs
 RUN ./docker/build --observatory
 RUN sha256sum /observatory.wasm.gz
 
-FROM deps as build_orbiter
+FROM deps AS build_orbiter
 
 COPY . .
 
@@ -139,7 +139,7 @@ RUN touch src/tests/fixtures/*/src/lib.rs
 RUN ./docker/build --orbiter
 RUN sha256sum /orbiter.wasm.gz
 
-FROM deps as build_test_satellite
+FROM deps AS build_test_satellite
 
 COPY . .
 


### PR DESCRIPTION
# Motivation

Resolve CI warning

```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 5.62kB done
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 7)
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 87)
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 98)
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 109)
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 120)
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 131)
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 142)
```

For example: https://github.com/junobuild/juno/actions/runs/13747499211/job/38444289607?pr=1322
