### PR TITLE
chore: remove candid-extractor step from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,24 +152,18 @@ RUN sha256sum /test_satellite.wasm.gz
 
 FROM scratch AS scratch_mission_control
 COPY --from=build_mission_control /mission_control.wasm.gz /
-COPY --from=build_mission_control /mission_control.did /
 
 FROM scratch AS scratch_satellite
 COPY --from=build_satellite /satellite.wasm.gz /
-COPY --from=build_satellite /satellite.did /
 
 FROM scratch AS scratch_console
 COPY --from=build_console /console.wasm.gz /
-COPY --from=build_console /console.did /
 
 FROM scratch AS scratch_observatory
 COPY --from=build_observatory /observatory.wasm.gz /
-COPY --from=build_observatory /observatory.did /
 
 FROM scratch AS scratch_orbiter
 COPY --from=build_orbiter /orbiter.wasm.gz /
-COPY --from=build_orbiter /orbiter.did /
 
 FROM scratch AS scratch_test_satellite
 COPY --from=build_test_satellite /test_satellite.wasm.gz /
-COPY --from=build_test_satellite /test_satellite.did /

--- a/docker/build-canister
+++ b/docker/build-canister
@@ -64,9 +64,6 @@ function build_canister() {
     then
       CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$PWD/target}"
 
-      # Generate did file
-      candid-extractor "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" > "$output_dir/$canister.did"
-
       # Optimize WASM and set metadata
       ic-wasm \
           "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" \
@@ -75,7 +72,7 @@ function build_canister() {
           --keep-name-section
 
       # adds the content of $canister.did to the `icp:public candid:service` custom section of the public metadata in the wasm
-      ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata candid:service -f "$output_dir/$canister.did" -v public --keep-name-section
+      ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public --keep-name-section
 
       if [ -n "$build_type" ]
       then


### PR DESCRIPTION
# Motivation

As of now we assumed the did file within the repo is up-to-date. We remove candid-extractor from build because it is not stricto sensu related to building the canisters and in future we cannot necesseraly use the tool to generate did (e.g. wasi).
