### PR TITLE
build: support for wasm32-wasip1

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -50,6 +50,8 @@ WITH_CERTIFICATION=0
 BUILD_TYPE=
 # Source directory where to find $CANISTER/Cargo.toml
 SRC_ROOT_DIR="$PWD/src"
+# Default target is wasm32-unknown-unknown
+TARGET=wasm32-unknown-unknown
 
 while [[ $# -gt 0  ]]
 do
@@ -121,4 +123,4 @@ fi
 # Source the script to effectively build the canister
 source "$SCRIPTS_DIR/build-canister"
 
-build_canister "$CANISTER" "$SRC_ROOT_DIR" "." "$ONLY_DEPS" "$WITH_CERTIFICATION" "$BUILD_TYPE"
+build_canister "$CANISTER" "$SRC_ROOT_DIR" "." "$ONLY_DEPS" "$WITH_CERTIFICATION" "$BUILD_TYPE" "$TARGET"

--- a/docker/build-canister
+++ b/docker/build-canister
@@ -8,7 +8,8 @@ function build_canister() {
     local only_deps=$4
     local with_certification=$5
     local build_type=$6
-    shift 6
+    local target=$7
+    shift 7
     local extra_build_args=("$@")
 
     if [ -z "$canister" ]; then
@@ -31,11 +32,26 @@ function build_canister() {
         exit 1
     fi
 
+    TARGET="wasm32-unknown-unknown"
+
+    case "$target" in
+        wasm32-wasip1)
+            TARGET="wasm32-wasip1"
+            USE_WASI=1
+            ;;
+        wasm32-unknown-unknown | "")
+            USE_WASI=0
+            ;;
+        *)
+            echo "ERROR: Invalid target specified. Use 'wasm32' (default) or 'wasi'."
+            exit 1
+            ;;
+    esac
+
     echo "Building $canister"
     echo
 
     SRC_DIR="$src_root_dir/$canister"
-    TARGET="wasm32-unknown-unknown"
 
     # Standardize source references
     CARGO_HOME="${CARGO_HOME:-"$HOME/.cargo"}"
@@ -66,6 +82,12 @@ function build_canister() {
 
       # Generate did file
       candid-extractor "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" > "$output_dir/$canister.did"
+
+      if [ "$USE_WASI" -eq 1 ]; then
+          echo
+          echo "Converting WASI to IC..."
+          wasi2ic "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" --quiet
+      fi
 
       # Optimize WASM and set metadata
       ic-wasm \

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-USAGE="Usage: $0 <module_name> [--with-certification] [--build-type=stock|extended] [--fixture]"
+USAGE="Usage: $0 <module_name> [--with-certification] [--build-type=stock|extended] [--fixture] [--target=wasm32-unknown-unknown|wasm32-wasip1]"
 
 if [ -z "$1" ]; then
   echo "$USAGE"
@@ -19,6 +19,9 @@ BUILD_TYPE=
 # Source directory where to find $CANISTER/Cargo.toml
 SRC_ROOT_DIR="$PWD/src"
 
+# Default target is wasm32-unknown-unknown
+TARGET=wasm32-unknown-unknown
+
 # Parse optional arguments
 shift
 while [[ $# -gt 0 ]]; do
@@ -33,6 +36,15 @@ while [[ $# -gt 0 ]]; do
       ;;
     --fixture)
       SRC_ROOT_DIR="$PWD/src/tests/fixtures"
+      shift
+      ;;
+    --target=*)
+      TARGET="${1#--target=}"
+      if [[ "$TARGET" != "wasm32-unknown-unknown" && "$TARGET" != "wasm32-wasip1" ]]; then
+        echo "ERROR: Invalid target specified. Use 'wasm32-unknown-unknown' (default) or 'wasm32-wasip1'."
+        echo "$USAGE"
+        exit 1
+      fi
       shift
       ;;
     *)
@@ -71,7 +83,7 @@ mkdir -p "${DEPLOY_DIR}"
 source "$PWD/docker/build-canister"
 
 # Build the canister
-build_canister "$MODULE" "$SRC_ROOT_DIR" "$BUILD_DIR" "$ONLY_DEPS" "$WITH_CERTIFICATION" "$BUILD_TYPE"
+build_canister "$MODULE" "$SRC_ROOT_DIR" "$BUILD_DIR" "$ONLY_DEPS" "$WITH_CERTIFICATION" "$BUILD_TYPE" "$TARGET"
 
 # Move the result to the deploy directory to upgrade the module in the local replica
 mv "$BUILD_DIR/${WASM_MODULE}.gz" "${DEPLOY_DIR}/${WASM_MODULE}.gz"


### PR DESCRIPTION
# Motivation

Add build support for `wasm32-wasip1` target. Needed for Sputnik.
