### PR TITLE
feat: init hook runtime state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,9 +1520,9 @@ dependencies = [
  "candid",
  "ic-cdk",
  "ic-wasi-polyfill",
+ "junobuild-collections",
  "junobuild-macros",
  "junobuild-satellite",
- "junobuild-storage",
  "rquickjs",
 ]
 

--- a/src/sputnik/Cargo.toml
+++ b/src/sputnik/Cargo.toml
@@ -15,7 +15,7 @@ junobuild-satellite = { path = "../libs/satellite", default-features = false, fe
 	"on_post_upgrade_sync",
 	"on_init_random_seed"
 ] }
-junobuild-storage = { path = "../libs/storage" }
+junobuild-collections = { path = "../libs/collections" }
 junobuild-macros = { path = "../libs/macros" }
 ic-wasi-polyfill = "0.7.0"
 rquickjs = { version = "0.9.0", features = ["macro", "futures"] }

--- a/src/sputnik/src/js/runtime.rs
+++ b/src/sputnik/src/js/runtime.rs
@@ -3,9 +3,9 @@ use crate::errors::js::{
     JUNO_SPUTNIK_ERROR_RUNTIME_ASYNC_RUNTIME, JUNO_SPUTNIK_ERROR_RUNTIME_SYNC_CONTEXT,
     JUNO_SPUTNIK_ERROR_RUNTIME_SYNC_RUNTIME,
 };
+use crate::js::dev::script::declare_dev_script;
 use crate::js::types::RunAsyncJsFn;
 use rquickjs::{async_with, AsyncContext, AsyncRuntime, Context, Ctx, Runtime};
-use crate::js::dev::script::declare_dev_script;
 
 pub async fn execute_async_js<T>(f: T) -> Result<(), String>
 where

--- a/src/sputnik/src/lib.rs
+++ b/src/sputnik/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod errors;
 mod js;
+mod state;
 mod wasi_polyfill;
 
 use crate::wasi_polyfill::{init_wasi, update_wasi_seed};

--- a/src/sputnik/src/state/memory.rs
+++ b/src/sputnik/src/state/memory.rs
@@ -1,0 +1,14 @@
+use crate::state::types::state::State;
+use std::cell::RefCell;
+
+thread_local! {
+    static STATE: RefCell<State> = RefCell::default();
+}
+
+pub fn read_state<R>(f: impl FnOnce(&State) -> R) -> R {
+    STATE.with(|cell| f(&cell.borrow()))
+}
+
+pub fn mutate_state<R>(f: impl FnOnce(&mut State) -> R) -> R {
+    STATE.with(|cell| f(&mut cell.borrow_mut()))
+}

--- a/src/sputnik/src/state/mod.rs
+++ b/src/sputnik/src/state/mod.rs
@@ -1,0 +1,3 @@
+mod memory;
+pub mod store;
+mod types;

--- a/src/sputnik/src/state/store.rs
+++ b/src/sputnik/src/state/store.rs
@@ -1,0 +1,18 @@
+use crate::state::memory::{mutate_state, read_state};
+use junobuild_collections::types::core::CollectionKey;
+
+pub fn set_on_set_docs_collections(collections: Vec<CollectionKey>) {
+    mutate_state(|state| state.runtime.hooks.on_set_docs_collections = collections.clone());
+}
+
+pub fn get_on_set_docs_collections() -> Vec<CollectionKey> {
+    read_state(|state| state.runtime.hooks.on_set_docs_collections.clone())
+}
+
+pub fn set_assert_set_docs_collections(collections: Vec<CollectionKey>) {
+    mutate_state(|state| state.runtime.hooks.assert_set_docs_collections = collections.clone());
+}
+
+pub fn get_assert_set_docs_collections() -> Vec<CollectionKey> {
+    read_state(|state| state.runtime.hooks.assert_set_docs_collections.clone())
+}

--- a/src/sputnik/src/state/types.rs
+++ b/src/sputnik/src/state/types.rs
@@ -1,0 +1,19 @@
+pub mod state {
+    use junobuild_collections::types::core::CollectionKey;
+
+    #[derive(Default)]
+    pub struct State {
+        pub runtime: RuntimeState,
+    }
+
+    #[derive(Default, Clone)]
+    pub struct RuntimeState {
+        pub hooks: Hooks,
+    }
+
+    #[derive(Default, Clone)]
+    pub struct Hooks {
+        pub on_set_docs_collections: Vec<CollectionKey>,
+        pub assert_set_docs_collections: Vec<CollectionKey>,
+    }
+}


### PR DESCRIPTION
# Motivation

A useful state to get to know on which collections should be run or not. We can initialize it on mount which allow us to avoid to reevaluate JS each time a hook kicks in.
