### PR TITLE
refactor(sputnik): move wasi polyfill lifecycle to module

### DIFF
--- a/src/sputnik/src/lib.rs
+++ b/src/sputnik/src/lib.rs
@@ -5,23 +5,6 @@ mod js;
 mod polyfill;
 mod state;
 
-use junobuild_macros::{on_init_random_seed, on_init_sync, on_post_upgrade_sync};
 use junobuild_satellite::include_satellite;
-use polyfill::wasi::{init_wasi, update_wasi_seed};
-
-#[on_init_sync]
-fn on_init_sync() {
-    init_wasi();
-}
-
-#[on_post_upgrade_sync]
-fn on_post_upgrade_sync() {
-    init_wasi();
-}
-
-#[on_init_random_seed]
-fn on_init_random_seed() -> Result<(), String> {
-    update_wasi_seed()
-}
 
 include_satellite!();

--- a/src/sputnik/src/polyfill/lifecycle.rs
+++ b/src/sputnik/src/polyfill/lifecycle.rs
@@ -1,0 +1,17 @@
+use crate::polyfill::wasi::{init_wasi, update_wasi_seed};
+use junobuild_macros::{on_init_random_seed, on_init_sync, on_post_upgrade_sync};
+
+#[on_init_sync]
+fn on_init_sync() {
+    init_wasi();
+}
+
+#[on_post_upgrade_sync]
+fn on_post_upgrade_sync() {
+    init_wasi();
+}
+
+#[on_init_random_seed]
+fn on_init_random_seed() -> Result<(), String> {
+    update_wasi_seed()
+}

--- a/src/sputnik/src/polyfill/mod.rs
+++ b/src/sputnik/src/polyfill/mod.rs
@@ -1,1 +1,2 @@
-pub mod wasi;
+mod lifecycle;
+mod wasi;


### PR DESCRIPTION
# Motivation

I'm not sure but, at this point feels cleaner and more consistent to "hide" the lifecycles within the polyfill crate for sputnik.
