### PR TITLE
feat(sputnik): ic_cdk::print for JS and console usage

### DIFF
--- a/src/sputnik/src/js/apis/ic_cdk/mod.rs
+++ b/src/sputnik/src/js/apis/ic_cdk/mod.rs
@@ -1,0 +1,10 @@
+mod print;
+
+use crate::js::apis::ic_cdk::print::init_ic_cdk_print;
+use rquickjs::{Ctx, Error as JsError};
+
+pub fn init_ic_cdk_apis(ctx: &Ctx) -> Result<(), JsError> {
+    init_ic_cdk_print(ctx)?;
+
+    Ok(())
+}

--- a/src/sputnik/src/js/apis/ic_cdk/print.rs
+++ b/src/sputnik/src/js/apis/ic_cdk/print.rs
@@ -1,0 +1,16 @@
+use ic_cdk::print;
+use rquickjs::{Ctx, Error as JsError, Result as JsResult, String};
+
+pub fn init_ic_cdk_print(ctx: &Ctx) -> Result<(), JsError> {
+    let global = ctx.globals();
+    global.set("__ic_cdk_print", js_ic_cdk_print)?;
+
+    Ok(())
+}
+
+#[rquickjs::function]
+fn ic_cdk_print<'js>(_ctx: Ctx<'js>, msg: String<'js>) -> JsResult<()> {
+    print(format!("{}", &msg.to_string()?));
+
+    Ok(())
+}

--- a/src/sputnik/src/js/apis/mod.rs
+++ b/src/sputnik/src/js/apis/mod.rs
@@ -1,9 +1,12 @@
+mod ic_cdk;
 mod node;
 
+use crate::js::apis::ic_cdk::init_ic_cdk_apis;
 use crate::js::apis::node::init_node_apis;
 use rquickjs::{Ctx, Error as JsError};
 
 pub fn init_apis(ctx: &Ctx) -> Result<(), JsError> {
+    init_ic_cdk_apis(ctx)?;
     init_node_apis(ctx)?;
 
     Ok(())

--- a/src/sputnik/src/js/apis/node/console.rs
+++ b/src/sputnik/src/js/apis/node/console.rs
@@ -1,40 +1,31 @@
-use ic_cdk::print;
-use rquickjs::{Ctx, Error as JsError, Result as JsResult, String};
+use rquickjs::{Ctx, Error as JsError};
 
 pub fn init_console_log(ctx: &Ctx) -> Result<(), JsError> {
-    let global = ctx.globals();
-
-    global.set("__juno_console_log", js_console_log)?;
-
     // TODO: use jsonReplace
 
     let result = ctx.eval::<(), _>(
         r#"
-const __juno_console_map = (v) => v.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : arg).join(" ");
+const __juno_console_log = (v) => {
+    const msg = v.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : arg).join(" ");
+    globalThis.__ic_cdk_print(msg);
+}
 
 globalThis.console = {
   info(...v) {
-    globalThis.__juno_console_log(__juno_console_map(v));
-  }
+    __juno_console_log(v);
+  },
   log(...v) {
-    globalThis.__juno_console_log(__juno_console_map(v));
-  }
+    __juno_console_log(v);
+  },
   warn(...v) {
-    globalThis.__juno_console_log(__juno_console_map(v));
-  }
+    __juno_console_log(v);
+  },
   error(...v) {
-    globalThis.__juno_console_log(__juno_console_map(v));
+    __juno_console_log(v);
   }
 }
 "#,
     );
 
     result
-}
-
-#[rquickjs::function]
-async fn console_log<'js>(_ctx: Ctx<'js>, msg: String<'js>) -> JsResult<()> {
-    print(format!("{}", &msg.to_string()?));
-
-    Ok(())
 }


### PR DESCRIPTION
# Motivation

It's a bit of refactoring. I also want to have some sort of ic_cdk API for JS really close to the Rust implementation.

Also fix console. There was two issues. Comma were missing and we should not use async for it.

