### PR TITLE
refactor(sputnik): integrate rawprincipal into ic_cdk

### DIFF
--- a/src/sputnik/src/hooks/js/impls.rs
+++ b/src/sputnik/src/hooks/js/impls.rs
@@ -1,8 +1,8 @@
 use crate::hooks::js::types::hooks::{
-    JsDoc, JsDocAssertSet, JsDocContext, JsDocUpsert, JsHookContext, JsRawData, JsRawPrincipal,
+    JsDoc, JsDocAssertSet, JsDocContext, JsDocUpsert, JsHookContext, JsRawData,
 };
 use crate::hooks::js::types::interface::JsSetDoc;
-use candid::Principal;
+use crate::js::types::candid::JsRawPrincipal;
 use junobuild_satellite::{Doc, DocAssertSet, DocContext, DocUpsert, HookContext, SetDoc};
 use rquickjs::{
     BigInt, Ctx, Error as JsError, FromJs, IntoJs, Object, Result as JsResult, TypedArray, Value,
@@ -186,33 +186,6 @@ impl<'js> JsSetDoc<'js> {
             description: self.description.clone(),
             version: self.version,
         })
-    }
-}
-
-impl<'js> IntoJs<'js> for JsRawPrincipal<'js> {
-    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
-        self.0.into_js(ctx)
-    }
-}
-
-impl<'js> FromJs<'js> for JsRawPrincipal<'js> {
-    fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> JsResult<Self> {
-        let array: TypedArray<'js, u8> = TypedArray::from_value(value)?;
-        Ok(JsRawPrincipal(array))
-    }
-}
-
-impl<'js> JsRawPrincipal<'js> {
-    pub fn from_bytes(ctx: &Ctx<'js>, bytes: &[u8]) -> JsResult<Self> {
-        let typed_array = TypedArray::new(ctx.clone(), bytes)?;
-        Ok(JsRawPrincipal(typed_array))
-    }
-
-    pub fn to_principal(&self) -> JsResult<Principal> {
-        self.0
-            .as_bytes()
-            .map(Principal::from_slice)
-            .ok_or_else(|| JsError::new_from_js("JsRawPrincipal", "Principal"))
     }
 }
 

--- a/src/sputnik/src/hooks/js/types.rs
+++ b/src/sputnik/src/hooks/js/types.rs
@@ -1,5 +1,6 @@
 pub mod hooks {
     use crate::hooks::js::types::interface::JsSetDoc;
+    use crate::js::types::candid::JsRawPrincipal;
     use junobuild_collections::types::core::CollectionKey;
     use junobuild_shared::types::core::Key;
     use junobuild_shared::types::state::{Timestamp, Version};
@@ -9,9 +10,6 @@ pub mod hooks {
     pub type JsKey = Key;
     pub type JsTimestamp = Timestamp;
     pub type JsVersion = Version;
-
-    #[derive(Clone)]
-    pub struct JsRawPrincipal<'js>(pub TypedArray<'js, u8>);
 
     #[derive(Clone)]
     pub struct JsRawData<'js>(pub TypedArray<'js, u8>);

--- a/src/sputnik/src/js/apis/ic_cdk/impls.rs
+++ b/src/sputnik/src/js/apis/ic_cdk/impls.rs
@@ -1,0 +1,30 @@
+use crate::js::apis::ic_cdk::types::candid::JsRawPrincipal;
+use candid::Principal;
+use rquickjs::{Ctx, Error as JsError, FromJs, IntoJs, Result as JsResult, TypedArray, Value};
+
+impl<'js> IntoJs<'js> for JsRawPrincipal<'js> {
+    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
+        self.0.into_js(ctx)
+    }
+}
+
+impl<'js> FromJs<'js> for JsRawPrincipal<'js> {
+    fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> JsResult<Self> {
+        let array: TypedArray<'js, u8> = TypedArray::from_value(value)?;
+        Ok(JsRawPrincipal(array))
+    }
+}
+
+impl<'js> JsRawPrincipal<'js> {
+    pub fn from_bytes(ctx: &Ctx<'js>, bytes: &[u8]) -> JsResult<Self> {
+        let typed_array = TypedArray::new(ctx.clone(), bytes)?;
+        Ok(JsRawPrincipal(typed_array))
+    }
+
+    pub fn to_principal(&self) -> JsResult<Principal> {
+        self.0
+            .as_bytes()
+            .map(Principal::from_slice)
+            .ok_or_else(|| JsError::new_from_js("JsRawPrincipal", "Principal"))
+    }
+}

--- a/src/sputnik/src/js/apis/ic_cdk/mod.rs
+++ b/src/sputnik/src/js/apis/ic_cdk/mod.rs
@@ -1,4 +1,6 @@
+mod impls;
 mod print;
+pub mod types;
 
 use crate::js::apis::ic_cdk::print::init_ic_cdk_print;
 use rquickjs::{Ctx, Error as JsError};

--- a/src/sputnik/src/js/apis/ic_cdk/types.rs
+++ b/src/sputnik/src/js/apis/ic_cdk/types.rs
@@ -1,0 +1,6 @@
+pub mod candid {
+    use rquickjs::TypedArray;
+
+    #[derive(Clone)]
+    pub struct JsRawPrincipal<'js>(pub TypedArray<'js, u8>);
+}

--- a/src/sputnik/src/js/apis/mod.rs
+++ b/src/sputnik/src/js/apis/mod.rs
@@ -5,6 +5,8 @@ use crate::js::apis::ic_cdk::init_ic_cdk_apis;
 use crate::js::apis::node::init_node_apis;
 use rquickjs::{Ctx, Error as JsError};
 
+pub use ic_cdk::types;
+
 pub fn init_apis(ctx: &Ctx) -> Result<(), JsError> {
     init_ic_cdk_apis(ctx)?;
     init_node_apis(ctx)?;

--- a/src/sputnik/src/js/mod.rs
+++ b/src/sputnik/src/js/mod.rs
@@ -3,3 +3,5 @@ pub mod constants;
 mod dev;
 pub mod module;
 pub mod runtime;
+
+pub use apis::types;


### PR DESCRIPTION
# Motivation

We will need the RawPrincipal to proxy ic_cdk features therefore makes sense to move it to this module.
