### PR TITLE
feat(sputnik): better error stacktrace

### DIFF
--- a/src/sputnik/src/hooks/db/assert_set_doc.rs
+++ b/src/sputnik/src/hooks/db/assert_set_doc.rs
@@ -4,6 +4,7 @@ use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::execute_sync_js;
 use crate::state::store::get_assert_set_docs_collections;
 use junobuild_satellite::AssertSetDocContext;
+use rquickjs::CatchResultExt;
 
 #[no_mangle]
 pub extern "Rust" fn juno_assert_set_doc(context: AssertSetDocContext) -> Result<(), String> {
@@ -12,6 +13,7 @@ pub extern "Rust" fn juno_assert_set_doc(context: AssertSetDocContext) -> Result
 
         AssertSetDoc
             .execute(ctx, context.clone())
+            .catch(&ctx)
             .map_err(|e| e.to_string())?;
 
         Ok(())

--- a/src/sputnik/src/js/runtime.rs
+++ b/src/sputnik/src/js/runtime.rs
@@ -5,7 +5,9 @@ use crate::errors::js::{
 };
 use crate::js::apis::init_apis;
 use crate::js::dev::script::declare_dev_script;
-use rquickjs::{async_with, AsyncContext, AsyncRuntime, Context, Ctx, Error as JsError, Runtime};
+use rquickjs::{
+    async_with, AsyncContext, AsyncRuntime, CatchResultExt, Context, Ctx, Error as JsError, Runtime,
+};
 
 pub trait RunAsyncJsFn {
     async fn run<'js>(&self, ctx: &Ctx<'js>) -> Result<(), JsError>;
@@ -26,7 +28,7 @@ where
 
         declare_dev_script(&ctx).map_err(|e| e.to_string())?;
 
-        f.run(&ctx).await.map_err(|e| format!("{} ({})", JUNO_SPUTNIK_ERROR_RUNTIME_ASYNC_EXECUTE, e))?;
+        f.run(&ctx).await.catch(&ctx).map_err(|e| format!("{} ({})", JUNO_SPUTNIK_ERROR_RUNTIME_ASYNC_EXECUTE, e))?;
 
         Ok::<(), String>(())
     })

--- a/src/tests/fixtures/test_sputnik/resources/index.ts
+++ b/src/tests/fixtures/test_sputnik/resources/index.ts
@@ -67,7 +67,6 @@ const onSetDocUpdate = async (context: OnSetDocContext) => {
 	const encodedData = encodeDocData(updateData);
 
 	setDocStore({
-		// TODO: can we get a better stacktrace if owner is allowed?
 		// TODO: a test for this too?
 		caller: id(),
 		collection: context.data.collection,


### PR DESCRIPTION
# Motivation

For debugging purpose it would be better to print more information about the stactrace of the errors and right now we often just print "Exception generated by QuickJS".
