### PR TITLE
build: bump Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # The docker image. To update, run `docker pull ubuntu` locally, and update the
 # sha256:... accordingly.
-FROM --platform=linux/amd64 ubuntu@sha256:bbf3d1baa208b7649d1d0264ef7d522e1dc0deeeaaf6085bf8e4618867f03494 AS deps
+FROM --platform=linux/amd64 ubuntu@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS deps
 
 ENV TZ=UTC
 


### PR DESCRIPTION
# Motivation

Current version of Ubuntu we are using is end of life next month.

Bump Ubuntu to https://github.com/docker-library/repo-info/blob/master/repos/ubuntu/remote/latest.md.
