### PR TITLE
refactor(sputnik): group js impls db types

### DIFF
--- a/src/sputnik/src/hooks/js/impls/db.rs
+++ b/src/sputnik/src/hooks/js/impls/db.rs
@@ -1,0 +1,146 @@
+use crate::hooks::js::impls::shared::JsBigInt;
+use crate::hooks::js::impls::utils::{from_optional_bigint_js, into_optional_bigint_js};
+use crate::hooks::js::types::db::JsDoc;
+use crate::hooks::js::types::hooks::JsRawData;
+use crate::hooks::js::types::interface::{JsDelDoc, JsSetDoc};
+use crate::js::types::candid::JsRawPrincipal;
+use junobuild_satellite::{DelDoc, Doc, SetDoc};
+use rquickjs::{BigInt, Ctx, Error as JsError, FromJs, IntoJs, Object, Result as JsResult, Value};
+
+impl<'js> JsDoc<'js> {
+    pub fn from_doc(ctx: &Ctx<'js>, doc: Doc) -> JsResult<Self> {
+        Ok(Self {
+            owner: JsRawPrincipal::from_principal(ctx, &doc.owner)?,
+            data: JsRawData::from_bytes(ctx, &doc.data)?,
+            description: doc.description,
+            created_at: doc.created_at,
+            updated_at: doc.updated_at,
+            version: doc.version,
+        })
+    }
+}
+
+impl<'js> JsSetDoc<'js> {
+    pub fn from_set_doc(ctx: &Ctx<'js>, doc: SetDoc) -> JsResult<Self> {
+        Ok(Self {
+            data: JsRawData::from_bytes(ctx, &doc.data)?,
+            description: doc.description,
+            version: doc.version,
+        })
+    }
+}
+
+impl JsDelDoc {
+    pub fn from_del_doc(doc: DelDoc) -> Self {
+        Self {
+            version: doc.version,
+        }
+    }
+}
+
+impl<'js> IntoJs<'js> for JsDoc<'js> {
+    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
+        let obj = Object::new(ctx.clone())?;
+        obj.set("owner", self.owner)?;
+        obj.set("data", self.data)?;
+        obj.set("description", self.description)?;
+
+        obj.set("created_at", JsBigInt(self.created_at).into_js(ctx)?)?;
+        obj.set("updated_at", JsBigInt(self.updated_at).into_js(ctx)?)?;
+
+        obj.set("version", into_optional_bigint_js(ctx, self.version)?)?;
+
+        Ok(obj.into_value())
+    }
+}
+
+impl<'js> IntoJs<'js> for JsSetDoc<'js> {
+    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
+        let obj = Object::new(ctx.clone())?;
+        obj.set("data", self.data)?;
+        obj.set("description", self.description)?;
+
+        obj.set("version", into_optional_bigint_js(ctx, self.version)?)?;
+
+        Ok(obj.into_value())
+    }
+}
+
+impl<'js> IntoJs<'js> for JsDelDoc {
+    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
+        let obj = Object::new(ctx.clone())?;
+
+        obj.set("version", into_optional_bigint_js(ctx, self.version)?)?;
+
+        Ok(obj.into_value())
+    }
+}
+
+impl<'js> JsSetDoc<'js> {
+    pub fn to_doc(&self) -> JsResult<SetDoc> {
+        Ok(SetDoc {
+            data: self.data.to_vec()?,
+            description: self.description.clone(),
+            version: self.version,
+        })
+    }
+}
+
+impl JsDelDoc {
+    pub fn to_doc(&self) -> JsResult<DelDoc> {
+        Ok(DelDoc {
+            version: self.version,
+        })
+    }
+}
+
+impl<'js> JsRawData<'js> {
+    pub fn from_text(ctx: &Ctx<'js>, text: &str) -> JsResult<Self> {
+        Self::from_bytes(ctx, text.as_bytes())
+    }
+
+    pub fn to_vec(&self) -> JsResult<Vec<u8>> {
+        self.0
+            .as_bytes()
+            .map(|bytes| bytes.to_vec())
+            .ok_or_else(|| JsError::new_from_js("JsRawData", "Vec<u8>"))
+    }
+
+    pub fn to_text(&self) -> JsResult<String> {
+        let bytes = self
+            .0
+            .as_bytes()
+            .ok_or_else(|| JsError::new_from_js("JsRawData", "String"))?;
+        Ok(String::from_utf8_lossy(bytes).to_string())
+    }
+}
+
+impl<'js> FromJs<'js> for JsSetDoc<'js> {
+    fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> JsResult<Self> {
+        let obj = Object::from_value(value)?;
+
+        let data: JsRawData<'js> = obj.get("data")?;
+
+        let description: Option<String> = obj.get("description")?;
+
+        let version: Option<u64> =
+            from_optional_bigint_js(obj.get::<_, Option<BigInt>>("version")?)?;
+
+        Ok(JsSetDoc {
+            data,
+            description,
+            version,
+        })
+    }
+}
+
+impl<'js> FromJs<'js> for JsDelDoc {
+    fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> JsResult<Self> {
+        let obj = Object::from_value(value)?;
+
+        let version: Option<u64> =
+            from_optional_bigint_js(obj.get::<_, Option<BigInt>>("version")?)?;
+
+        Ok(JsDelDoc { version })
+    }
+}

--- a/src/sputnik/src/hooks/js/impls/hooks/context.rs
+++ b/src/sputnik/src/hooks/js/impls/hooks/context.rs
@@ -1,0 +1,14 @@
+use crate::hooks::js::types::hooks::JsHookContext;
+use rquickjs::{Ctx, IntoJs, Object, Result as JsResult, Value};
+
+impl<'js, T> IntoJs<'js> for JsHookContext<'js, T>
+where
+    T: IntoJs<'js>,
+{
+    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
+        let obj = Object::new(ctx.clone())?;
+        obj.set("caller", self.caller)?;
+        obj.set("data", self.data.into_js(ctx)?)?;
+        Ok(obj.into_value())
+    }
+}

--- a/src/sputnik/src/hooks/js/impls/hooks/db.rs
+++ b/src/sputnik/src/hooks/js/impls/hooks/db.rs
@@ -172,6 +172,7 @@ impl<'js> JsHookContext<'js, JsDocContext<JsDocAssertDelete<'js>>> {
         Ok(js_context)
     }
 }
+
 impl<'js> IntoJs<'js> for JsDocUpsert<'js> {
     fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
         let obj = Object::new(ctx.clone())?;

--- a/src/sputnik/src/hooks/js/impls/hooks/db.rs
+++ b/src/sputnik/src/hooks/js/impls/hooks/db.rs
@@ -1,17 +1,15 @@
+use crate::hooks::js::impls::hooks::utils::into_optional_jsdoc_js;
+use crate::hooks::js::types::db::JsDoc;
 use crate::hooks::js::types::hooks::{
-    JsDoc, JsDocAssertDelete, JsDocAssertSet, JsDocContext, JsDocUpsert, JsHookContext, JsRawData,
+    JsDocAssertDelete, JsDocAssertSet, JsDocContext, JsDocUpsert, JsHookContext,
 };
 use crate::hooks::js::types::interface::{JsDelDoc, JsSetDoc};
-use crate::hooks::js::utils::{
-    from_optional_bigint_js, into_optional_bigint_js, into_optional_jsdoc_js,
-};
 use crate::js::types::candid::JsRawPrincipal;
 use junobuild_satellite::{
-    AssertDeleteDocContext, AssertSetDocContext, DelDoc, Doc, OnDeleteDocContext,
-    OnDeleteFilteredDocsContext, OnDeleteManyDocsContext, OnSetDocContext, OnSetManyDocsContext,
-    SetDoc,
+    AssertDeleteDocContext, AssertSetDocContext, OnDeleteDocContext, OnDeleteFilteredDocsContext,
+    OnDeleteManyDocsContext, OnSetDocContext, OnSetManyDocsContext,
 };
-use rquickjs::{BigInt, Ctx, Error as JsError, FromJs, IntoJs, Object, Result as JsResult, Value};
+use rquickjs::{Ctx, Error as JsError, IntoJs, Object, Result as JsResult, Value};
 
 impl<'js> JsHookContext<'js, JsDocContext<JsDocUpsert<'js>>> {
     pub fn from_on_set_doc(original: OnSetDocContext, ctx: &Ctx<'js>) -> Result<Self, JsError> {
@@ -174,76 +172,6 @@ impl<'js> JsHookContext<'js, JsDocContext<JsDocAssertDelete<'js>>> {
         Ok(js_context)
     }
 }
-
-impl<'js> JsDoc<'js> {
-    pub fn from_doc(ctx: &Ctx<'js>, doc: Doc) -> JsResult<Self> {
-        Ok(Self {
-            owner: JsRawPrincipal::from_principal(ctx, &doc.owner)?,
-            data: JsRawData::from_bytes(ctx, &doc.data)?,
-            description: doc.description,
-            created_at: doc.created_at,
-            updated_at: doc.updated_at,
-            version: doc.version,
-        })
-    }
-}
-
-impl<'js> JsSetDoc<'js> {
-    pub fn from_set_doc(ctx: &Ctx<'js>, doc: SetDoc) -> JsResult<Self> {
-        Ok(Self {
-            data: JsRawData::from_bytes(ctx, &doc.data)?,
-            description: doc.description,
-            version: doc.version,
-        })
-    }
-}
-
-impl JsDelDoc {
-    pub fn from_del_doc(doc: DelDoc) -> Self {
-        Self {
-            version: doc.version,
-        }
-    }
-}
-
-impl<'js> IntoJs<'js> for JsDoc<'js> {
-    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
-        let obj = Object::new(ctx.clone())?;
-        obj.set("owner", self.owner)?;
-        obj.set("data", self.data)?;
-        obj.set("description", self.description)?;
-
-        obj.set("created_at", JsBigInt(self.created_at).into_js(ctx)?)?;
-        obj.set("updated_at", JsBigInt(self.updated_at).into_js(ctx)?)?;
-
-        obj.set("version", into_optional_bigint_js(ctx, self.version)?)?;
-
-        Ok(obj.into_value())
-    }
-}
-
-impl<'js> IntoJs<'js> for JsSetDoc<'js> {
-    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
-        let obj = Object::new(ctx.clone())?;
-        obj.set("data", self.data)?;
-        obj.set("description", self.description)?;
-
-        obj.set("version", into_optional_bigint_js(ctx, self.version)?)?;
-
-        Ok(obj.into_value())
-    }
-}
-
-impl<'js> IntoJs<'js> for JsDelDoc {
-    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
-        let obj = Object::new(ctx.clone())?;
-
-        obj.set("version", into_optional_bigint_js(ctx, self.version)?)?;
-
-        Ok(obj.into_value())
-    }
-}
-
 impl<'js> IntoJs<'js> for JsDocUpsert<'js> {
     fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
         let obj = Object::new(ctx.clone())?;
@@ -291,95 +219,5 @@ where
         obj.set("collection", self.collection)?;
         obj.set("data", self.data.into_js(ctx)?)?;
         Ok(obj.into_value())
-    }
-}
-
-impl<'js, T> IntoJs<'js> for JsHookContext<'js, T>
-where
-    T: IntoJs<'js>,
-{
-    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
-        let obj = Object::new(ctx.clone())?;
-        obj.set("caller", self.caller)?;
-        obj.set("data", self.data.into_js(ctx)?)?;
-        Ok(obj.into_value())
-    }
-}
-
-pub struct JsBigInt(pub u64);
-
-impl<'js> IntoJs<'js> for JsBigInt {
-    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
-        let bigint = BigInt::from_u64(ctx.clone(), self.0)?;
-        Ok(bigint.into_value())
-    }
-}
-
-impl<'js> JsSetDoc<'js> {
-    pub fn to_doc(&self) -> JsResult<SetDoc> {
-        Ok(SetDoc {
-            data: self.data.to_vec()?,
-            description: self.description.clone(),
-            version: self.version,
-        })
-    }
-}
-
-impl JsDelDoc {
-    pub fn to_doc(&self) -> JsResult<DelDoc> {
-        Ok(DelDoc {
-            version: self.version,
-        })
-    }
-}
-
-impl<'js> JsRawData<'js> {
-    pub fn from_text(ctx: &Ctx<'js>, text: &str) -> JsResult<Self> {
-        Self::from_bytes(ctx, text.as_bytes())
-    }
-
-    pub fn to_vec(&self) -> JsResult<Vec<u8>> {
-        self.0
-            .as_bytes()
-            .map(|bytes| bytes.to_vec())
-            .ok_or_else(|| JsError::new_from_js("JsRawData", "Vec<u8>"))
-    }
-
-    pub fn to_text(&self) -> JsResult<String> {
-        let bytes = self
-            .0
-            .as_bytes()
-            .ok_or_else(|| JsError::new_from_js("JsRawData", "String"))?;
-        Ok(String::from_utf8_lossy(bytes).to_string())
-    }
-}
-
-impl<'js> FromJs<'js> for JsSetDoc<'js> {
-    fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> JsResult<Self> {
-        let obj = Object::from_value(value)?;
-
-        let data: JsRawData<'js> = obj.get("data")?;
-
-        let description: Option<String> = obj.get("description")?;
-
-        let version: Option<u64> =
-            from_optional_bigint_js(obj.get::<_, Option<BigInt>>("version")?)?;
-
-        Ok(JsSetDoc {
-            data,
-            description,
-            version,
-        })
-    }
-}
-
-impl<'js> FromJs<'js> for JsDelDoc {
-    fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> JsResult<Self> {
-        let obj = Object::from_value(value)?;
-
-        let version: Option<u64> =
-            from_optional_bigint_js(obj.get::<_, Option<BigInt>>("version")?)?;
-
-        Ok(JsDelDoc { version })
     }
 }

--- a/src/sputnik/src/hooks/js/impls/hooks/mod.rs
+++ b/src/sputnik/src/hooks/js/impls/hooks/mod.rs
@@ -1,0 +1,3 @@
+mod context;
+mod db;
+mod utils;

--- a/src/sputnik/src/hooks/js/impls/hooks/utils.rs
+++ b/src/sputnik/src/hooks/js/impls/hooks/utils.rs
@@ -1,0 +1,12 @@
+use crate::hooks::js::types::db::JsDoc;
+use rquickjs::{Ctx, IntoJs, Result as JsResult, Value};
+
+pub fn into_optional_jsdoc_js<'js>(
+    ctx: &Ctx<'js>,
+    value: Option<JsDoc<'js>>,
+) -> JsResult<Value<'js>> {
+    match value {
+        Some(value) => value.into_js(ctx),
+        None => Ok(Value::new_undefined(ctx.clone())),
+    }
+}

--- a/src/sputnik/src/hooks/js/impls/mod.rs
+++ b/src/sputnik/src/hooks/js/impls/mod.rs
@@ -1,4 +1,4 @@
-pub mod db;
+mod db;
 mod hooks;
 mod shared;
 mod utils;

--- a/src/sputnik/src/hooks/js/impls/mod.rs
+++ b/src/sputnik/src/hooks/js/impls/mod.rs
@@ -1,0 +1,4 @@
+pub mod db;
+mod hooks;
+mod shared;
+mod utils;

--- a/src/sputnik/src/hooks/js/impls/shared.rs
+++ b/src/sputnik/src/hooks/js/impls/shared.rs
@@ -1,0 +1,10 @@
+use rquickjs::{BigInt, Ctx, IntoJs, Result as JsResult, Value};
+
+pub struct JsBigInt(pub u64);
+
+impl<'js> IntoJs<'js> for JsBigInt {
+    fn into_js(self, ctx: &Ctx<'js>) -> JsResult<Value<'js>> {
+        let bigint = BigInt::from_u64(ctx.clone(), self.0)?;
+        Ok(bigint.into_value())
+    }
+}

--- a/src/sputnik/src/hooks/js/impls/utils.rs
+++ b/src/sputnik/src/hooks/js/impls/utils.rs
@@ -1,5 +1,4 @@
-use crate::hooks::js::impls::JsBigInt;
-use crate::hooks::js::types::hooks::JsDoc;
+use crate::hooks::js::impls::shared::JsBigInt;
 use rquickjs::{BigInt, Ctx, Error as JsError, IntoJs, Result as JsResult, Value};
 
 pub fn into_optional_bigint_js<'js>(ctx: &Ctx<'js>, value: Option<u64>) -> JsResult<Value<'js>> {
@@ -25,15 +24,5 @@ pub fn from_optional_bigint_js(value: Option<BigInt>) -> JsResult<Option<u64>> {
             }
         }
         None => Ok(None),
-    }
-}
-
-pub fn into_optional_jsdoc_js<'js>(
-    ctx: &Ctx<'js>,
-    value: Option<JsDoc<'js>>,
-) -> JsResult<Value<'js>> {
-    match value {
-        Some(value) => value.into_js(ctx),
-        None => Ok(Value::new_undefined(ctx.clone())),
     }
 }

--- a/src/sputnik/src/hooks/js/mod.rs
+++ b/src/sputnik/src/hooks/js/mod.rs
@@ -3,4 +3,3 @@ pub mod loaders;
 pub mod runtime;
 pub mod sdk;
 mod types;
-mod utils;

--- a/src/sputnik/src/hooks/js/sdk/db/delete_doc_store.rs
+++ b/src/sputnik/src/hooks/js/sdk/db/delete_doc_store.rs
@@ -1,5 +1,6 @@
-use crate::hooks::js::types::hooks::{JsCollectionKey, JsKey, JsUserId};
+use crate::hooks::js::types::hooks::JsKey;
 use crate::hooks::js::types::interface::JsDelDoc;
+use crate::hooks::js::types::shared::{JsCollectionKey, JsUserId};
 use junobuild_satellite::delete_doc_store as delete_doc_store_sdk;
 use rquickjs::{Ctx, Error as JsError, Exception, Result as JsResult};
 

--- a/src/sputnik/src/hooks/js/sdk/db/set_doc_store.rs
+++ b/src/sputnik/src/hooks/js/sdk/db/set_doc_store.rs
@@ -1,5 +1,6 @@
-use crate::hooks::js::types::hooks::{JsCollectionKey, JsKey, JsUserId};
+use crate::hooks::js::types::hooks::JsKey;
 use crate::hooks::js::types::interface::JsSetDoc;
+use crate::hooks::js::types::shared::{JsCollectionKey, JsUserId};
 use junobuild_satellite::set_doc_store as set_doc_store_sdk;
 use rquickjs::{Ctx, Error as JsError, Exception, Result as JsResult};
 

--- a/src/sputnik/src/hooks/js/types.rs
+++ b/src/sputnik/src/hooks/js/types.rs
@@ -1,18 +1,26 @@
-pub mod hooks {
-    use crate::hooks::js::types::interface::{JsDelDoc, JsSetDoc};
-    use crate::js::types::candid::{JsRawPrincipal, JsUint8Array};
+pub mod shared {
+    use crate::js::types::candid::JsRawPrincipal;
     use junobuild_collections::types::core::CollectionKey;
-    use junobuild_shared::types::core::Key;
     use junobuild_shared::types::state::{Timestamp, Version};
 
     pub type JsCollectionKey = CollectionKey;
-    pub type JsKey = Key;
+
     pub type JsTimestamp = Timestamp;
     pub type JsVersion = Version;
 
-    pub type JsRawData<'js> = JsUint8Array<'js>;
-
     pub type JsUserId<'js> = JsRawPrincipal<'js>;
+}
+
+pub mod hooks {
+    use crate::hooks::js::types::db::JsDoc;
+    use crate::hooks::js::types::interface::{JsDelDoc, JsSetDoc};
+    use crate::hooks::js::types::shared::{JsCollectionKey, JsUserId};
+    use crate::js::types::candid::JsUint8Array;
+    use junobuild_shared::types::core::Key;
+
+    pub type JsKey = Key;
+
+    pub type JsRawData<'js> = JsUint8Array<'js>;
 
     #[derive(Clone)]
     pub struct JsHookContext<'js, T> {
@@ -44,6 +52,11 @@ pub mod hooks {
         pub current: Option<JsDoc<'js>>,
         pub proposed: JsDelDoc,
     }
+}
+
+pub mod db {
+    use crate::hooks::js::types::hooks::JsRawData;
+    use crate::hooks::js::types::shared::{JsTimestamp, JsUserId, JsVersion};
 
     #[derive(Clone)]
     pub struct JsDoc<'js> {
@@ -57,7 +70,8 @@ pub mod hooks {
 }
 
 pub mod interface {
-    use crate::hooks::js::types::hooks::{JsRawData, JsVersion};
+    use crate::hooks::js::types::hooks::JsRawData;
+    use crate::hooks::js::types::shared::JsVersion;
     use junobuild_shared::types::state::Version;
 
     #[derive(Clone)]


### PR DESCRIPTION
# Motivation

The types was not that well structured and the number of implementations has grow by a lot, so for readability it's good to structure a bit those. Notably useful as I am about to add even more implementations for the storage.
