### PR TITLE
build: build type sputnik

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -96,14 +96,14 @@ do
             CANISTER="sputnik"
             OUTPUT="test_sputnik"
             WITH_CERTIFICATION=1
-            BUILD_TYPE="extended"
+            BUILD_TYPE="sputnik"
             TARGET="wasm32-wasip1"
             break
             ;;
         --sputnik)
             CANISTER="sputnik"
             WITH_CERTIFICATION=1
-            BUILD_TYPE="extended"
+            BUILD_TYPE="sputnik"
             TARGET="wasm32-wasip1"
             break
             ;;

--- a/docker/build-canister
+++ b/docker/build-canister
@@ -104,7 +104,7 @@ function build_canister() {
 
       if [ -n "$build_type" ]
       then
-        # add the type of build "stock" to the satellite. This way, we can identify whether it's the standard canister ("stock") or a custom build ("extended") of the developer.
+        # add the type of build "stock" to the satellite. This way, we can identify whether it's the standard canister ("stock"), a custom build in Rust ("extended") or JS/TS ("sputnik") of the developer.
         ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata juno:build -d "$build_type" -v public --keep-name-section
       fi
 


### PR DESCRIPTION
# Motivation

I can imagine that it would be interesting to distingish between serverless functions written in Rust or TypeScript. Therefore we can use a special build type for it.
