### PR TITLE
build: package.json metadata for modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ mission_control-v*.wasm.gz
 console-v*.wasm.gz
 out/
 tmp/
+juno.package.json

--- a/docker/build
+++ b/docker/build
@@ -53,6 +53,8 @@ WITH_CERTIFICATION=0
 BUILD_TYPE=
 # Source directory where to find $CANISTER/Cargo.toml
 SRC_ROOT_DIR="$PWD/src"
+# Source directory where to find $CANISTER/juno.package.json
+PKG_JSON_DIR=
 # Default target is wasm32-unknown-unknown
 TARGET=wasm32-unknown-unknown
 
@@ -98,6 +100,7 @@ do
             WITH_CERTIFICATION=1
             BUILD_TYPE="extended"
             TARGET="wasm32-wasip1"
+            PKG_JSON_DIR="$PWD/src/tests/fixtures/$OUTPUT"
             break
             ;;
         --sputnik)
@@ -112,6 +115,7 @@ do
             WITH_CERTIFICATION=1
             BUILD_TYPE="extended"
             SRC_ROOT_DIR="$PWD/src/tests/fixtures"
+            PKG_JSON_DIR="$PWD/src/tests/fixtures/$CANISTER"
             break
             ;;
         *)
@@ -129,10 +133,15 @@ if [ ${#CANISTER} -eq 0 ]; then
     CANISTER="mission_control"
 fi
 
+# if not set the default package.json path to search for is the source of the canister
+if [ ${#PKG_JSON_DIR} -eq 0 ]; then
+    PKG_JSON_DIR="$SRC_ROOT_DIR/$CANISTER"
+fi
+
 # Source the script to prepare the package.json metadata for the canister
 source "$SCRIPTS_DIR/prepare-package"
 
-create_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "." "$OUTPUT"
+create_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "$PKG_JSON_DIR" "$OUTPUT"
 
 # Source the script to perform tasks before building the canister
 source "$SCRIPTS_DIR/pre-build-canister"
@@ -142,7 +151,7 @@ pre_build_canister "$@"
 # Source the script to effectively build the canister
 source "$SCRIPTS_DIR/build-canister"
 
-build_canister "$CANISTER" "$SRC_ROOT_DIR" "." "$ONLY_DEPS" "$WITH_CERTIFICATION" "$BUILD_TYPE" "$TARGET"
+build_canister "$CANISTER" "$SRC_ROOT_DIR" "$PKG_JSON_DIR" "." "$ONLY_DEPS" "$WITH_CERTIFICATION" "$BUILD_TYPE" "$TARGET"
 
 # We rename the output if set and different from the canister name. Useful for test_sputnik which is the same canister built with different resources.
 if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "$CANISTER" ]; then

--- a/docker/build
+++ b/docker/build
@@ -129,6 +129,11 @@ if [ ${#CANISTER} -eq 0 ]; then
     CANISTER="mission_control"
 fi
 
+# Source the script to prepare the package.json metadata for the canister
+source "$SCRIPTS_DIR/prepare-package"
+
+create_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "." "$OUTPUT"
+
 # Source the script to perform tasks before building the canister
 source "$SCRIPTS_DIR/pre-build-canister"
 

--- a/docker/build
+++ b/docker/build
@@ -141,7 +141,7 @@ fi
 # Source the script to prepare the package.json metadata for the canister
 source "$SCRIPTS_DIR/prepare-package"
 
-create_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "$PKG_JSON_DIR" "$OUTPUT"
+create_canister_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "$PKG_JSON_DIR" "$OUTPUT"
 
 # Source the script to perform tasks before building the canister
 source "$SCRIPTS_DIR/pre-build-canister"

--- a/docker/build-canister
+++ b/docker/build-canister
@@ -4,12 +4,12 @@
 function build_canister() {
     local canister=$1
     local src_root_dir=$2
-    local output_dir=$3
-    local only_deps=$4
-    local with_certification=$5
-    local build_type=$6
-    local target=$7
-    local package_json_path="${8:-$output_dir/$canister.package.json}"
+    local package_json_dir=$3
+    local output_dir=$4
+    local only_deps=$5
+    local with_certification=$6
+    local build_type=$7
+    local target=$8
     shift 8
     local extra_build_args=("$@")
 
@@ -31,11 +31,6 @@ function build_canister() {
     if [ ! -d "$output_dir" ]; then
         echo "ERROR: The output directory '$output_dir' does not exist."
         exit 1
-    fi
-
-    if [[ ! -f "$package_json_path" ]]; then
-      echo "ERROR: metadata file not found at $package_json_path"
-      exit 1
     fi
 
     TARGET="wasm32-unknown-unknown"
@@ -63,6 +58,13 @@ function build_canister() {
     echo
 
     SRC_DIR="$src_root_dir/$canister"
+
+    PACKAGE_JSON_PATH="$package_json_dir/juno.package.json";
+
+    if [[ ! -f "$PACKAGE_JSON_PATH" ]]; then
+      echo "ERROR: juno.package.json file not found at $package_json_dir"
+      exit 1
+    fi
 
     # Standardize source references
     CARGO_HOME="${CARGO_HOME:-"$HOME/.cargo"}"
@@ -112,7 +114,7 @@ function build_canister() {
       # This file contains metadata about the build such as name, version, and dependencies.
       # The presence of dependencies indicates that the module is not stock, but extended—
       # either from the satellite (e.g., serverless functions in Rust) or from Sputnik (e.g., serverless functions in JavaScript).
-      ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata juno:package -f "$package_json_path" -v public --keep-name-section
+      ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata juno:package -f "$PACKAGE_JSON_PATH" -v public --keep-name-section
 
       if [ -n "$build_type" ]
       then

--- a/docker/build-canister
+++ b/docker/build-canister
@@ -102,6 +102,17 @@ function build_canister() {
       # adds the content of $canister.did to the `icp:public candid:service` custom section of the public metadata in the wasm
       ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public --keep-name-section
 
+      # Adds the content of $canister.package.json to the `icp:public juno:package` custom section of the WASM metadata.
+      # This file contains metadata about the build such as name, version, and dependencies.
+      # The presence of dependencies indicates that the module is not stock, but extended—
+      # either from the satellite (e.g., serverless functions in Rust) or from Sputnik (e.g., serverless functions in JavaScript).
+      if [[ ! -f "$output_dir/$canister.package.json" ]]; then
+        echo "ERROR: metadata file not found at $output_dir/$canister.did"
+        exit 1
+      fi
+
+      ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata juno:package -f "$output_dir/$canister.package.json" -v public --keep-name-section
+
       if [ -n "$build_type" ]
       then
         # add the type of build "stock" to the satellite. This way, we can identify whether it's the standard canister ("stock") or a custom build ("extended") of the developer.

--- a/docker/build-canister
+++ b/docker/build-canister
@@ -9,7 +9,8 @@ function build_canister() {
     local with_certification=$5
     local build_type=$6
     local target=$7
-    shift 7
+    local package_json_path="${8:-$output_dir/$canister.package.json}"
+    shift 8
     local extra_build_args=("$@")
 
     if [ -z "$canister" ]; then
@@ -30,6 +31,11 @@ function build_canister() {
     if [ ! -d "$output_dir" ]; then
         echo "ERROR: The output directory '$output_dir' does not exist."
         exit 1
+    fi
+
+    if [[ ! -f "$package_json_path" ]]; then
+      echo "ERROR: metadata file not found at $package_json_path"
+      exit 1
     fi
 
     TARGET="wasm32-unknown-unknown"
@@ -106,12 +112,7 @@ function build_canister() {
       # This file contains metadata about the build such as name, version, and dependencies.
       # The presence of dependencies indicates that the module is not stock, but extended—
       # either from the satellite (e.g., serverless functions in Rust) or from Sputnik (e.g., serverless functions in JavaScript).
-      if [[ ! -f "$output_dir/$canister.package.json" ]]; then
-        echo "ERROR: metadata file not found at $output_dir/$canister.did"
-        exit 1
-      fi
-
-      ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata juno:package -f "$output_dir/$canister.package.json" -v public --keep-name-section
+      ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata juno:package -f "$package_json_path" -v public --keep-name-section
 
       if [ -n "$build_type" ]
       then

--- a/docker/prepare-package
+++ b/docker/prepare-package
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function get_version_from_cargo() {
+  local manifest_path="$1"
+
+  if [[ ! -f "$manifest_path" ]]; then
+    echo "ERROR: Cargo.toml not found at $manifest_path"
+    exit 1
+  fi
+
+  local version
+    version=$(cargo metadata --no-deps --format-version 1 --manifest-path "$manifest_path" 2>/dev/null |
+      jq --arg manifest_path "$(realpath "$manifest_path")" -r '
+        .packages[] | select(.manifest_path == $manifest_path) | .version
+      ')
+
+  if [[ -z "$version" || "$version" == "null" ]]; then
+    echo "ERROR: Failed to extract version from $manifest_path"
+    exit 1
+  fi
+
+  echo "$version"
+}
+
+function create_package_json() {
+  local canister=$1
+  local src_root_dir=$2
+  local pkg_root_dir=$3
+  local output_dir=$4
+  local custom="${5:-}"
+
+  if [ -z "$src_root_dir" ]; then
+      echo "ERROR: No root directory for the source specified."
+      exit 1
+  fi
+
+  if [ -z "$output_dir" ]; then
+      echo "ERROR: No output directory specified."
+      exit 1
+  fi
+
+  local target="${custom:-$canister}"
+  local output_file="$output_dir/$canister.package.json"
+  local name=""
+  local version=""
+  local dependency_name=""
+  local dependency_version=""
+
+  case "$target" in
+    satellite)
+      name="@junobuild/satellite"
+      version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
+      ;;
+    sputnik)
+      name="@junobuild/sputnik"
+      version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
+      dependency_name="@junobuild/satellite"
+      dependency_version=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
+      ;;
+    test_sputnik)
+      name="test-sputnik"
+      version="1.2.3-patch.4"
+      dependency_name="@junobuild/sputnik"
+      dependency_version=$(get_version_from_cargo "$pkg_root_dir/sputnik/Cargo.toml")
+      ;;
+    test_satellite)
+      name="test-satellite"
+      version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
+      dependency_name="@junobuild/satellite"
+      dependency_version=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
+      ;;
+    *)
+      echo "ERROR: Unknown package type '$target'"
+      exit 1
+      ;;
+  esac
+
+  echo "Generating $output_file..."
+
+  if [ -n "$dependency_name" ]; then
+    cat <<EOF > "$output_file"
+{
+  "name": "$name",
+  "version": "$version",
+  "dependencies": {
+    "$dependency_name": "$dependency_version"
+  }
+}
+EOF
+  else
+    cat <<EOF > "$output_file"
+{
+  "name": "$name",
+  "version": "$version"
+}
+EOF
+  fi
+}

--- a/docker/prepare-package
+++ b/docker/prepare-package
@@ -49,8 +49,24 @@ function create_package_json() {
   local dependency_version=""
 
   case "$target" in
+    mission_control)
+      name="@junobuild/mission-control"
+      version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
+      ;;
     satellite)
       name="@junobuild/satellite"
+      version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
+      ;;
+    console)
+      name="@junobuild/console"
+      version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
+      ;;
+    observatory)
+      name="@junobuild/observatory"
+      version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
+      ;;
+    orbiter)
+      name="@junobuild/orbiter"
       version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
       ;;
     sputnik)

--- a/docker/prepare-package
+++ b/docker/prepare-package
@@ -28,7 +28,7 @@ function create_package_json() {
   local canister=$1
   local src_root_dir=$2
   local pkg_root_dir=$3
-  local output_dir=$4
+  local package_json_dir=$4
   local custom="${5:-}"
 
   if [ -z "$src_root_dir" ]; then
@@ -36,13 +36,8 @@ function create_package_json() {
       exit 1
   fi
 
-  if [ -z "$output_dir" ]; then
-      echo "ERROR: No output directory specified."
-      exit 1
-  fi
-
   local target="${custom:-$canister}"
-  local output_file="$output_dir/$canister.package.json"
+  local output_file="$package_json_dir/juno.package.json"
   local name=""
   local version=""
   local dependency_name=""

--- a/docker/prepare-package
+++ b/docker/prepare-package
@@ -40,8 +40,7 @@ function create_package_json() {
   local output_file="$package_json_dir/juno.package.json"
   local name=""
   local version=""
-  local dependency_name=""
-  local dependency_version=""
+  declare -A dependencies=()
 
   case "$target" in
     mission_control)
@@ -67,20 +66,18 @@ function create_package_json() {
     sputnik)
       name="@junobuild/sputnik"
       version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
-      dependency_name="@junobuild/satellite"
-      dependency_version=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
+      dependencies["@junobuild/satellite"]=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
       ;;
     test_sputnik)
       name="test-sputnik"
       version="1.2.3-patch.4"
-      dependency_name="@junobuild/sputnik"
-      dependency_version=$(get_version_from_cargo "$pkg_root_dir/sputnik/Cargo.toml")
+      dependencies["@junobuild/sputnik"]=$(get_version_from_cargo "$pkg_root_dir/sputnik/Cargo.toml")
+      dependencies["@junobuild/satellite"]=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
       ;;
     test_satellite)
       name="test-satellite"
       version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
-      dependency_name="@junobuild/satellite"
-      dependency_version=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
+      dependencies["@junobuild/satellite"]=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
       ;;
     *)
       echo "ERROR: Unknown package type '$target'"
@@ -90,22 +87,26 @@ function create_package_json() {
 
   echo "Generating $output_file..."
 
-  if [ -n "$dependency_name" ]; then
-    cat <<EOF > "$output_file"
-{
-  "name": "$name",
-  "version": "$version",
-  "dependencies": {
-    "$dependency_name": "$dependency_version"
-  }
-}
-EOF
-  else
-    cat <<EOF > "$output_file"
-{
-  "name": "$name",
-  "version": "$version"
-}
-EOF
-  fi
+  {
+    echo "{"
+    echo "  \"name\": \"$name\","
+    echo -n "  \"version\": \"$version\""
+
+    if [ ${#dependencies[@]} -gt 0 ]; then
+      echo ","
+      echo "  \"dependencies\": {"
+      local first=1
+      for dep in "${!dependencies[@]}"; do
+        if [ $first -eq 0 ]; then echo ","; fi
+        printf "    \"%s\": \"%s\"" "$dep" "${dependencies[$dep]}"
+        first=0
+      done
+      echo
+      echo "  }"
+    else
+      echo
+    fi
+
+    echo "}"
+  } > "$output_file"
 }

--- a/docker/prepare-package
+++ b/docker/prepare-package
@@ -24,7 +24,59 @@ function get_version_from_cargo() {
   echo "$version"
 }
 
-function create_package_json() {
+function generate_juno_package_json() {
+  local name="$1"
+  local version="$2"
+  local pkg_root_dir="$3"
+  local package_json_dir="$4"
+  local dependencies_csv="${5:-}"
+
+  local output_file="$package_json_dir/juno.package.json"
+
+  declare -A dependencies=()
+
+  IFS=',' read -ra dep_array <<< "$dependencies_csv"
+  for dep in "${dep_array[@]}"; do
+    # trim spaces (just in case)
+    dep=$(echo "$dep" | xargs)
+
+    # Build the path to the Cargo.toml from the package name
+    local dep_basename
+    dep_basename="$(basename "$dep")"
+    local path="$pkg_root_dir/$dep_basename/Cargo.toml"
+
+    if [[ ! -f "$path" ]]; then
+      echo "ERROR: Cargo.toml not found for dependency '$dep' at '$path'."
+      exit 1
+    fi
+
+    dependencies["@junobuild/$dep"]=$(get_version_from_cargo "$path")
+  done
+
+  echo "Generating $output_file..."
+
+  {
+    echo "{"
+    echo "  \"name\": \"$name\","
+    if [ ${#dependencies[@]} -gt 0 ]; then
+      echo "  \"version\": \"$version\","
+      echo "  \"dependencies\": {"
+      local first=1
+      for dep in "${!dependencies[@]}"; do
+        [ $first -eq 0 ] && echo ","
+        printf "    \"%s\": \"%s\"" "$dep" "${dependencies[$dep]}"
+        first=0
+      done
+      echo
+      echo "  }"
+    else
+      echo "  \"version\": \"$version\""
+    fi
+    echo "}"
+  } > "$output_file"
+}
+
+function create_canister_package_json() {
   local canister=$1
   local src_root_dir=$2
   local pkg_root_dir=$3
@@ -36,11 +88,20 @@ function create_package_json() {
       exit 1
   fi
 
+  if [ -z "$pkg_root_dir" ]; then
+      echo "ERROR: No directory for the package dependency specified."
+      exit 1
+  fi
+
+  if [ -z "$package_json_dir" ]; then
+      echo "ERROR: No directory for the package output path specified."
+      exit 1
+  fi
+
   local target="${custom:-$canister}"
-  local output_file="$package_json_dir/juno.package.json"
   local name=""
   local version=""
-  declare -A dependencies=()
+  declare -a dependencies=()
 
   case "$target" in
     mission_control)
@@ -66,18 +127,17 @@ function create_package_json() {
     sputnik)
       name="@junobuild/sputnik"
       version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
-      dependencies["@junobuild/satellite"]=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
+      dependencies+=("satellite")
       ;;
     test_sputnik)
       name="test-sputnik"
       version="1.2.3-patch.4"
-      dependencies["@junobuild/sputnik"]=$(get_version_from_cargo "$pkg_root_dir/sputnik/Cargo.toml")
-      dependencies["@junobuild/satellite"]=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
+      dependencies+=("satellite" "sputnik")
       ;;
     test_satellite)
       name="test-satellite"
       version=$(get_version_from_cargo "$src_root_dir/$canister/Cargo.toml")
-      dependencies["@junobuild/satellite"]=$(get_version_from_cargo "$pkg_root_dir/satellite/Cargo.toml")
+      dependencies+=("satellite")
       ;;
     *)
       echo "ERROR: Unknown package type '$target'"
@@ -85,28 +145,10 @@ function create_package_json() {
       ;;
   esac
 
-  echo "Generating $output_file..."
+  local dependencies_csv=""
+  if [ ${#dependencies[@]} -gt 0 ]; then
+    dependencies_csv=$(IFS=','; echo "${dependencies[*]}")
+  fi
 
-  {
-    echo "{"
-    echo "  \"name\": \"$name\","
-    echo -n "  \"version\": \"$version\""
-
-    if [ ${#dependencies[@]} -gt 0 ]; then
-      echo ","
-      echo "  \"dependencies\": {"
-      local first=1
-      for dep in "${!dependencies[@]}"; do
-        if [ $first -eq 0 ]; then echo ","; fi
-        printf "    \"%s\": \"%s\"" "$dep" "${dependencies[$dep]}"
-        first=0
-      done
-      echo
-      echo "  }"
-    else
-      echo
-    fi
-
-    echo "}"
-  } > "$output_file"
+  generate_juno_package_json "$name" "$version" "$pkg_root_dir" "$package_json_dir" "$dependencies_csv"
 }

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -117,7 +117,7 @@ mkdir -p "${DEPLOY_DIR}"
 # Source the script to prepare the package.json metadata for the canister
 source "$PWD/docker/prepare-package"
 
-create_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "$PKG_JSON_DIR" "$OUTPUT"
+create_canister_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "$PKG_JSON_DIR" "$OUTPUT"
 
 # Ensure we rebuild the canister. This is useful locally for rebuilding canisters that have no code changes but have resource changes.
 touch "$SRC_ROOT_DIR"/"$CANISTER"/src/lib.rs

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -18,6 +18,8 @@ BUILD_TYPE=
 
 # Source directory where to find $CANISTER/Cargo.toml
 SRC_ROOT_DIR="$PWD/src"
+# Source directory where to find $CANISTER/juno.package.json
+PKG_JSON_DIR=
 
 # Default target is wasm32-unknown-unknown
 TARGET=wasm32-unknown-unknown
@@ -54,6 +56,7 @@ while [[ $# -gt 0 ]]; do
       WITH_CERTIFICATION=1
       BUILD_TYPE="extended"
       TARGET="wasm32-wasip1"
+      PKG_JSON_DIR="$PWD/src/tests/fixtures/$OUTPUT"
       break
       ;;
     --sputnik)
@@ -68,6 +71,7 @@ while [[ $# -gt 0 ]]; do
       WITH_CERTIFICATION=1
       BUILD_TYPE="extended"
       SRC_ROOT_DIR="$PWD/src/tests/fixtures"
+      PKG_JSON_DIR="$PWD/src/tests/fixtures/$CANISTER"
       break
       ;;
     *)
@@ -80,6 +84,11 @@ done
 
 WASM_CANISTER="${CANISTER}.wasm"
 OUTPUT_CANISTER="${OUTPUT:-$CANISTER}.wasm"
+
+# if not set the default package.json path to search for is the source of the canister
+if [ ${#PKG_JSON_DIR} -eq 0 ]; then
+    PKG_JSON_DIR="$SRC_ROOT_DIR/$CANISTER"
+fi
 
 ############
 # Metadata #
@@ -108,7 +117,7 @@ mkdir -p "${DEPLOY_DIR}"
 # Source the script to prepare the package.json metadata for the canister
 source "$PWD/docker/prepare-package"
 
-create_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "$BUILD_DIR" "$OUTPUT"
+create_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "$PKG_JSON_DIR" "$OUTPUT"
 
 # Ensure we rebuild the canister. This is useful locally for rebuilding canisters that have no code changes but have resource changes.
 touch "$SRC_ROOT_DIR"/"$CANISTER"/src/lib.rs
@@ -123,7 +132,7 @@ pre_build_canister "$@"
 source "$PWD/docker/build-canister"
 
 # Build the canister
-build_canister "$CANISTER" "$SRC_ROOT_DIR" "$BUILD_DIR" "$ONLY_DEPS" "$WITH_CERTIFICATION" "$BUILD_TYPE" "$TARGET"
+build_canister "$CANISTER" "$SRC_ROOT_DIR" "$PKG_JSON_DIR" "$BUILD_DIR" "$ONLY_DEPS" "$WITH_CERTIFICATION" "$BUILD_TYPE" "$TARGET"
 
 # Move the result to the deploy directory to upgrade the canister in the local replica
 mv "$BUILD_DIR/${WASM_CANISTER}.gz" "${DEPLOY_DIR}/${OUTPUT_CANISTER}.gz"

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -105,6 +105,11 @@ mkdir -p "${BUILD_DIR}"
 
 mkdir -p "${DEPLOY_DIR}"
 
+# Source the script to prepare the package.json metadata for the canister
+source "$PWD/docker/prepare-package"
+
+create_package_json "$CANISTER" "$SRC_ROOT_DIR" "$PWD/src" "$BUILD_DIR" "$OUTPUT"
+
 # Ensure we rebuild the canister. This is useful locally for rebuilding canisters that have no code changes but have resource changes.
 touch "$SRC_ROOT_DIR"/"$CANISTER"/src/lib.rs
 


### PR DESCRIPTION
# Motivation

- We want to deprecate the end points `version()` and `build_version()`.
- We want to deprecate build stock or extended
- We want to support providing information if the module is sputnik and what version
- We want to allow developer to develop and provide templates for other devs

# Solution

We are going to build `package.json` files and add those to the candid metadata as `juno:package` 
