### PR TITLE
feat: set a controller for the emulator CLI after create satellite (Dev Only ⚠️)

### DIFF
--- a/.env.skylab
+++ b/.env.skylab
@@ -3,3 +3,4 @@ VITE_JUNO_CDN_URL=https://cdn.juno.build
 VITE_CYCLE_EXPRESS_URL=
 VITE_KONGSWAP_API_URL=
 VITE_ICP_EXPLORER_URL=https://dashboard.internetcomputer.org
+VITE_SKYLAB_ADMIN_URL=http://localhost:5999

--- a/src/frontend/src/lib/components/canister/ProgressCreate.svelte
+++ b/src/frontend/src/lib/components/canister/ProgressCreate.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { untrack } from 'svelte';
 	import WizardProgressSteps from '$lib/components/ui/WizardProgressSteps.svelte';
+	import { SKYLAB } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ProgressStep } from '$lib/types/progress-step';
 	import { type WizardCreateProgress, WizardCreateProgressStep } from '$lib/types/progress-wizard';
@@ -19,6 +20,7 @@
 		preparing: ProgressStep;
 		create: ProgressStep;
 		monitoring?: ProgressStep;
+		finalizing?: ProgressStep;
 		reload: ProgressStep;
 	}
 
@@ -40,6 +42,13 @@
 				text: $i18n.monitoring.starting_auto_refill
 			}
 		}),
+		...(SKYLAB && {
+			finalizing: {
+				state: 'next',
+				step: 'finalizing',
+				text: $i18n.emulator.setting_emulator_controller
+			}
+		}),
 		reload: {
 			state: 'next',
 			step: 'reload',
@@ -53,7 +62,7 @@
 		progress;
 
 		untrack(() => {
-			const { preparing, create, monitoring, reload } = steps;
+			const { preparing, create, monitoring, finalizing, reload } = steps;
 
 			steps = {
 				preparing: {
@@ -74,6 +83,15 @@
 							progress?.step === WizardCreateProgressStep.Monitoring
 								? mapProgressState(progress?.state)
 								: monitoring.state
+					}
+				}),
+				...(nonNullish(finalizing) && {
+					finalizing: {
+						...finalizing,
+						state:
+							progress?.step === WizardCreateProgressStep.Finalizing
+								? mapProgressState(progress?.state)
+								: finalizing.state
 					}
 				}),
 				reload: {

--- a/src/frontend/src/lib/components/wallet/WalletGetICP.svelte
+++ b/src/frontend/src/lib/components/wallet/WalletGetICP.svelte
@@ -29,5 +29,5 @@
 		<ConfettiSpread />
 	{/if}
 
-	<button onclick={onClick}>{$i18n.wallet.dev_get_icp}</button>
+	<button onclick={onClick}>{$i18n.emulator.get_icp}</button>
 {/if}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -801,7 +801,9 @@
 	},
 	"emulator": {
 		"get_icp": "Get ICP",
+		"emulator": "Emulator",
 		"setting_emulator_controller": "Setting the emulator as a controller (Dev Only ⚠️)",
+		"error_never_execute": "⚠️ This function should never ever be executed outside the emulator environment. Setting a controller at this step is strictly for the emulator (and yes, it would fail anyway).",
 		"error_get_identities": "Fetching the emulator identities failed.",
 		"error_no_main_identity": "The emulator does not expose any main identity."
 	}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -307,8 +307,7 @@
 		"wallet_missing_account": "No account available to request the transaction. Have you connected your wallet?",
 		"balance_not_loaded": "Please wait, your balance is not yet loaded.",
 		"balance_zero": "Your balance is zero. Get some tokens to start sending.",
-		"wallet_upgrade": "Please upgrade your wallet to enable the sending feature.",
-		"dev_get_icp": "Get ICP"
+		"wallet_upgrade": "Please upgrade your wallet to enable the sending feature."
 	},
 	"authentication": {
 		"title": "Authentication",
@@ -799,5 +798,11 @@
 		"resources_description": "View a collection of sample code, applications, and microservices build with Juno",
 		"changelog": "Releases",
 		"changelog_description": "See the last updates and improvements."
+	},
+	"emulator": {
+		"get_icp": "Get ICP",
+		"setting_emulator_controller": "Setting the emulator as a controller (Dev Only ⚠️)",
+		"error_get_identities": "Fetching the emulator identities failed.",
+		"error_no_main_identity": "The emulator does not expose any main identity."
 	}
 }

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -801,7 +801,9 @@
 	},
 	"emulator": {
 		"get_icp": "Get ICP",
+		"emulator": "Emulator",
 		"setting_emulator_controller": "Setting the emulator as a controller (Dev Only ⚠️)",
+		"error_never_execute": "⚠️ This function should never ever be executed outside the emulator environment. Setting a controller at this step is strictly for the emulator (and yes, it would fail anyway).",
 		"error_get_identities": "Fetching the emulator identities failed.",
 		"error_no_main_identity": "The emulator does not expose any main identity."
 	}

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -307,8 +307,7 @@
 		"wallet_missing_account": "没有有效的账户来处理交易，你确定链接你的钱包了吗?",
 		"balance_not_loaded": "请稍后，你的余额还未加载.",
 		"balance_zero": "你的余额为零，请获取一些代币来发送.",
-		"wallet_upgrade": "请升级你的钱包来使用发送功能.",
-		"dev_get_icp": "Get ICP"
+		"wallet_upgrade": "请升级你的钱包来使用发送功能."
 	},
 	"authentication": {
 		"title": "认证",
@@ -799,5 +798,11 @@
 		"resources_description": "查看利用Juno开发的代码，应用，为服务等例子",
 		"changelog": "发布",
 		"changelog_description": "看最近的更新和优化."
+	},
+	"emulator": {
+		"get_icp": "Get ICP",
+		"setting_emulator_controller": "Setting the emulator as a controller (Dev Only ⚠️)",
+		"error_get_identities": "Fetching the emulator identities failed.",
+		"error_no_main_identity": "The emulator does not expose any main identity."
 	}
 }

--- a/src/frontend/src/lib/rest/skylab.rest.ts
+++ b/src/frontend/src/lib/rest/skylab.rest.ts
@@ -1,0 +1,31 @@
+import { i18n } from '$lib/stores/i18n.store';
+import { assertNonNullish, isNullish } from '@dfinity/utils';
+import { type PrincipalText, PrincipalTextSchema } from '@dfinity/zod-schemas';
+import { get } from 'svelte/store';
+
+export const getSkylabMainIdentity = async (): Promise<PrincipalText> => {
+	const SKYLAB_ADMIN_URL = import.meta.env.VITE_SKYLAB_ADMIN_URL;
+
+	assertNonNullish(SKYLAB_ADMIN_URL);
+
+	const response = await fetch(`${SKYLAB_ADMIN_URL}/admin/identities`, {
+		method: 'GET',
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	});
+
+	if (!response.ok) {
+		throw new Error(get(i18n).emulator.error_get_identities);
+	}
+
+	const result: Record<string, string> = await response.json();
+
+	const identity = result?.main;
+
+	if (isNullish(identity)) {
+		throw new Error(get(i18n).emulator.error_no_main_identity);
+	}
+
+	return PrincipalTextSchema.parse(identity);
+};

--- a/src/frontend/src/lib/services/skylab.services.ts
+++ b/src/frontend/src/lib/services/skylab.services.ts
@@ -11,7 +11,7 @@ import type { Principal } from '@dfinity/principal';
  * we need a way to grant the inner CLI (running inside the Docker container) access to the Satellites.
  * Without this, we can't offer live reload capabilities — which, in my opinion, is really important during development.
  *
- * To prevent any abuse, these functions are guarded by the SKYLAB flag, and the URL is blocked by the CSP.
+ * To prevent any abuse, these functions are guarded by the SKYLAB flag, and the URL is blocked by the CSP in production.
  */
 export const unsafeSetSkylabControllerForSatellite = async ({
 	missionControlId,

--- a/src/frontend/src/lib/services/skylab.services.ts
+++ b/src/frontend/src/lib/services/skylab.services.ts
@@ -1,0 +1,67 @@
+import { setSatellitesController } from '$lib/api/mission-control.api';
+import { SKYLAB } from '$lib/constants/app.constants';
+import { getSkylabMainIdentity } from '$lib/rest/skylab.rest';
+import type { SetControllerParams } from '$lib/types/controllers';
+import type { MissionControlId } from '$lib/types/mission-control';
+import type { Identity } from '@dfinity/agent';
+import type { Principal } from '@dfinity/principal';
+
+/**
+ * In the Skylab emulator environment, where developers use a version of the Console UI deployed within the container,
+ * we need a way to grant the inner CLI (running inside the Docker container) access to the Satellites.
+ * Without this, we can't offer live reload capabilities — which, in my opinion, is really important during development.
+ *
+ * To prevent any abuse, these functions are guarded by the DEV flag, and the URL is blocked by the CSP.
+ */
+export const unsafeSetSkylabControllerForSatellite = async ({
+	missionControlId,
+	satelliteId,
+	identity
+}: {
+	missionControlId: MissionControlId;
+	satelliteId: Principal;
+	identity: Identity;
+}) => {
+	const add = (
+		params: {
+			missionControlId: MissionControlId;
+		} & SetControllerParams
+	): Promise<void> =>
+		setSatellitesController({
+			...params,
+			satelliteIds: [satelliteId],
+			identity
+		});
+
+	await unsafeSetSkylabController({
+		missionControlId,
+		addController: add
+	});
+};
+
+const unsafeSetSkylabController = async ({
+	missionControlId,
+	addController
+}: {
+	missionControlId: MissionControlId;
+	addController: (
+		params: {
+			missionControlId: MissionControlId;
+		} & SetControllerParams
+	) => Promise<void>;
+}) => {
+	if (!SKYLAB) {
+		throw new Error(
+			'⚠️ This function should never ever be executed outside the emulator environment. Setting a controller at this step is strictly for the emulator (and yes, it would fail anyway).'
+		);
+	}
+
+	const mainIdentity = await getSkylabMainIdentity();
+
+	await addController({
+		controllerId: mainIdentity,
+		missionControlId,
+		profile: '⚠️ Emulator',
+		scope: 'admin'
+	});
+};

--- a/src/frontend/src/lib/services/skylab.services.ts
+++ b/src/frontend/src/lib/services/skylab.services.ts
@@ -11,7 +11,7 @@ import type { Principal } from '@dfinity/principal';
  * we need a way to grant the inner CLI (running inside the Docker container) access to the Satellites.
  * Without this, we can't offer live reload capabilities — which, in my opinion, is really important during development.
  *
- * To prevent any abuse, these functions are guarded by the DEV flag, and the URL is blocked by the CSP.
+ * To prevent any abuse, these functions are guarded by the SKYLAB flag, and the URL is blocked by the CSP.
  */
 export const unsafeSetSkylabControllerForSatellite = async ({
 	missionControlId,

--- a/src/frontend/src/lib/services/skylab.services.ts
+++ b/src/frontend/src/lib/services/skylab.services.ts
@@ -1,10 +1,12 @@
 import { setSatellitesController } from '$lib/api/mission-control.api';
 import { SKYLAB } from '$lib/constants/app.constants';
 import { getSkylabMainIdentity } from '$lib/rest/skylab.rest';
+import { i18n } from '$lib/stores/i18n.store';
 import type { SetControllerParams } from '$lib/types/controllers';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type { Identity } from '@dfinity/agent';
 import type { Principal } from '@dfinity/principal';
+import { get } from 'svelte/store';
 
 /**
  * In the Skylab emulator environment, where developers use a version of the Console UI deployed within the container,
@@ -51,9 +53,7 @@ const unsafeSetSkylabController = async ({
 	) => Promise<void>;
 }) => {
 	if (!SKYLAB) {
-		throw new Error(
-			'⚠️ This function should never ever be executed outside the emulator environment. Setting a controller at this step is strictly for the emulator (and yes, it would fail anyway).'
-		);
+		throw new Error(get(i18n).emulator.error_never_execute);
 	}
 
 	const mainIdentity = await getSkylabMainIdentity();
@@ -61,7 +61,7 @@ const unsafeSetSkylabController = async ({
 	await addController({
 		controllerId: mainIdentity,
 		missionControlId,
-		profile: '⚠️ Emulator',
+		profile: `👾 ${get(i18n).emulator.emulator}`,
 		scope: 'admin'
 	});
 };

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -316,7 +316,6 @@ interface I18nWallet {
 	balance_not_loaded: string;
 	balance_zero: string;
 	wallet_upgrade: string;
-	dev_get_icp: string;
 }
 
 interface I18nAuthentication {
@@ -829,6 +828,13 @@ interface I18nResources {
 	changelog_description: string;
 }
 
+interface I18nEmulator {
+	get_icp: string;
+	setting_emulator_controller: string;
+	error_get_identities: string;
+	error_no_main_identity: string;
+}
+
 interface I18n {
 	lang: Languages;
 	core: I18nCore;
@@ -857,4 +863,5 @@ interface I18n {
 	preferences: I18nPreferences;
 	examples: I18nExamples;
 	resources: I18nResources;
+	emulator: I18nEmulator;
 }

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -830,7 +830,9 @@ interface I18nResources {
 
 interface I18nEmulator {
 	get_icp: string;
+	emulator: string;
 	setting_emulator_controller: string;
+	error_never_execute: string;
 	error_get_identities: string;
 	error_no_main_identity: string;
 }

--- a/src/frontend/src/lib/types/progress-wizard.ts
+++ b/src/frontend/src/lib/types/progress-wizard.ts
@@ -3,7 +3,8 @@ import type { UpgradeCodeProgressState } from '@junobuild/admin';
 export enum WizardCreateProgressStep {
 	Create = 0,
 	Monitoring = 1,
-	Reload = 2
+	Finalizing = 2,
+	Reload = 3
 }
 
 export type WizardCreateProgressState = UpgradeCodeProgressState;


### PR DESCRIPTION
# Motivation

For the local envionrment of the devs:

1. I want a smooth DX
2. I want a DX close to production
3. I want auto reload

1. and 2. works well, I hope, by providing the full experience locally using the Console UI. Plus it's something unique. However, if the devs start creating Satellite in the UI, the inner CLI of the Juno Docker container won't be able to auto reload the module because it won't be a controller of the Satellite that are created at runtime.

That's why this PR, as some sort of compromise, add a feature restricted to the dev environment that set a controller for the emulator once the Satellite is created.

It works through calling a new endpoint of the local emulator that provides the identities (principals, PR https://github.com/junobuild/juno-docker/pull/108).

I'm not super pleased with the solution but, I think it's a tradeoff that smoothness the workflow.