### PR TITLE
test: assert skylab set controller runs only for this mode

### DIFF
--- a/src/frontend/tests/lib/services/emulator.services.test.ts
+++ b/src/frontend/tests/lib/services/emulator.services.test.ts
@@ -1,0 +1,64 @@
+import { setSatellitesController } from '$lib/api/mission-control.api';
+import { getEmulatorMainIdentity } from '$lib/rest/emulator.rest';
+import { unsafeSetEmulatorControllerForSatellite } from '$lib/services/emulator.services';
+import { Principal } from '@dfinity/principal';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import i18Mock from '../../mocks/i18n.mock';
+import { mockIdentity } from '../../mocks/identity.mock';
+
+vi.mock('$lib/api/mission-control.api');
+vi.mock('$lib/rest/emulator.rest');
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+describe('emulator.services', () => {
+	const mockMissionControlId = Principal.fromText('rdmx6-jaaaa-aaaaa-aaadq-cai');
+	const mockSatelliteId = Principal.fromText('jx5yt-yyaaa-aaaal-abzbq-cai');
+	const mockPrincipalText = 'xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe';
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.unstubAllEnvs();
+
+		vi.mocked(getEmulatorMainIdentity).mockResolvedValue(mockPrincipalText);
+	});
+
+	describe('unsafeSetEmulatorControllerForSatellite', () => {
+		it('should throw an error when mode is production', async () => {
+			vi.stubEnv('MODE', 'production');
+
+			await expect(
+				unsafeSetEmulatorControllerForSatellite({
+					missionControlId: mockMissionControlId,
+					satelliteId: mockSatelliteId,
+					identity: mockIdentity
+				})
+			).rejects.toThrow(i18Mock.emulator.error_never_execute);
+
+			expect(setSatellitesController).not.toHaveBeenCalled();
+			expect(getEmulatorMainIdentity).not.toHaveBeenCalled();
+		});
+
+		it('should set controller when in skylab mode', async () => {
+			vi.stubEnv('MODE', 'skylab');
+
+			await unsafeSetEmulatorControllerForSatellite({
+				missionControlId: mockMissionControlId,
+				satelliteId: mockSatelliteId,
+				identity: mockIdentity
+			});
+
+			expect(getEmulatorMainIdentity).toHaveBeenCalled();
+			expect(setSatellitesController).toHaveBeenCalledWith({
+				missionControlId: mockMissionControlId,
+				satelliteIds: [mockSatelliteId],
+				identity: mockIdentity,
+				controllerId: mockPrincipalText,
+				profile: '👾 Emulator',
+				scope: 'admin'
+			});
+		});
+	});
+});

--- a/src/frontend/tests/mocks/i18n.mock.ts
+++ b/src/frontend/tests/mocks/i18n.mock.ts
@@ -1,0 +1,7 @@
+import * as enCore from '$lib/i18n/en.json';
+
+const i18Mock = {
+	...enCore
+} as I18n;
+
+export default i18Mock;

--- a/src/frontend/tests/mocks/identity.mock.ts
+++ b/src/frontend/tests/mocks/identity.mock.ts
@@ -1,0 +1,23 @@
+import type { Identity } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+
+export const mockPrincipalText = 'xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe';
+
+export const mockPrincipal = Principal.fromText(mockPrincipalText);
+
+const transformRequest = () => {
+	console.error(
+		'It looks like the agent is trying to make a request that should have been mocked at',
+		new Error().stack
+	);
+	throw new Error('Not implemented');
+};
+
+export const mockIdentity = {
+	getPrincipal: () => mockPrincipal,
+	transformRequest
+} as unknown as Identity;
+
+// This is not linked/related to the mock above.
+export const mockAccountIdentifierText =
+	'217966d936e84b04ac69615cd5cf8c526667daf5ae88deb3bc2cdc44238712d5';

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -11,6 +11,7 @@
 		"./src/**/*.svelte",
 		"./env.utils.ts",
 		"./vitest.setup.ts",
+		"./vitest.global.ts",
 		"./vitest.config.ts",
 		"./tailwind.config.js",
 		"./svelte.config.js",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		globalSetup: './vitest.setup.ts',
+		globalSetup: './vitest.global.ts',
+		setupFiles: ['./vitest.setup.ts'],
 		globals: true,
 		watch: false,
 		silent: false,

--- a/vitest.global.ts
+++ b/vitest.global.ts
@@ -1,0 +1,23 @@
+import { PocketIcServer } from '@hadronous/pic';
+import type { GlobalSetupContext } from 'vitest/node';
+
+let pic: PocketIcServer | undefined;
+
+export async function setup({ provide }: GlobalSetupContext): Promise<void> {
+	pic = await PocketIcServer.start({
+		showCanisterLogs: true
+	});
+	const url = pic.getUrl();
+
+	provide('PIC_URL', url);
+}
+
+declare module 'vitest' {
+	export interface ProvidedContext {
+		PIC_URL: string;
+	}
+}
+
+export async function teardown(): Promise<void> {
+	await pic?.stop();
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,23 +1,3 @@
-import { PocketIcServer } from '@hadronous/pic';
-import type { GlobalSetupContext } from 'vitest/node';
+import { vi } from 'vitest';
 
-let pic: PocketIcServer | undefined;
-
-export async function setup({ provide }: GlobalSetupContext): Promise<void> {
-	pic = await PocketIcServer.start({
-		showCanisterLogs: true
-	});
-	const url = pic.getUrl();
-
-	provide('PIC_URL', url);
-}
-
-declare module 'vitest' {
-	export interface ProvidedContext {
-		PIC_URL: string;
-	}
-}
-
-export async function teardown(): Promise<void> {
-	await pic?.stop();
-}
+vi.stubGlobal('VITE_APP_VERSION', 'app-version');


### PR DESCRIPTION
# Motivation

We want to ensure that the function that sets a controller for the emulator nevers end in production.
