### PR TITLE
feat(sputnik): remove prefix datastore from global controllers SDK functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
 				"@junobuild/config-loader": "^0.2.1",
 				"@junobuild/console": "^0.1.7",
 				"@junobuild/errors": "^0.0.7",
-				"@junobuild/functions": "^0.0.15-next-2025-04-15.1",
+				"@junobuild/functions": "^0.0.15-next-2025-04-15.4",
 				"@junobuild/storage": "^0.1.7",
 				"@ltd/j-toml": "^1.38.0",
 				"@sveltejs/adapter-static": "^3.0.8",
@@ -1851,9 +1851,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@junobuild/functions": {
-			"version": "0.0.15-next-2025-04-15.1",
-			"resolved": "https://registry.npmjs.org/@junobuild/functions/-/functions-0.0.15-next-2025-04-15.1.tgz",
-			"integrity": "sha512-xJYn/3DasEVLRUTTvIf2SzFy2t7RcjGPhuarzr874AfrYz4L9U8Z2dsbBpX8EqbsPT3JamDFOcV6FPDsb2cmag==",
+			"version": "0.0.15-next-2025-04-15.4",
+			"resolved": "https://registry.npmjs.org/@junobuild/functions/-/functions-0.0.15-next-2025-04-15.4.tgz",
+			"integrity": "sha512-gjACEK/DsFkKNUO/BpyMpVsm+QrYwRLymJuBx9GB0r8dlnH8jByj12onyZt5oecD2s03M4ntRqiv8YysJp+UDA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@junobuild/config-loader": "^0.2.1",
 		"@junobuild/console": "^0.1.7",
 		"@junobuild/errors": "^0.0.7",
-		"@junobuild/functions": "^0.0.15-next-2025-04-15.1",
+		"@junobuild/functions": "^0.0.15-next-2025-04-15.4",
 		"@junobuild/storage": "^0.1.7",
 		"@ltd/j-toml": "^1.38.0",
 		"@sveltejs/adapter-static": "^3.0.8",

--- a/src/sputnik/src/hooks/js/sdk/controllers.rs
+++ b/src/sputnik/src/hooks/js/sdk/controllers.rs
@@ -11,19 +11,19 @@ pub fn init_controllers_sdk(ctx: &Ctx) -> Result<(), JsError> {
     let global = ctx.globals();
 
     global.set(
-        "__juno_satellite_datastore_get_admin_controllers",
+        "__juno_satellite_get_admin_controllers",
         js_get_admin_controllers,
     )?;
     global.set(
-        "__juno_satellite_datastore_get_controllers",
+        "__juno_satellite_get_controllers",
         js_get_controllers,
     )?;
 
     global.set(
-        "__juno_satellite_datastore_is_admin_controller",
+        "__juno_satellite_is_admin_controller",
         js_is_admin_controller,
     )?;
-    global.set("__juno_satellite_datastore_is_controller", js_is_controller)?;
+    global.set("__juno_satellite_is_controller", js_is_controller)?;
 
     Ok(())
 }


### PR DESCRIPTION
# Motivation

Those are not tight to the datastore.
