### PR TITLE
feat: satellite lib metadata version

### DIFF
--- a/src/libs/satellite/Cargo.toml
+++ b/src/libs/satellite/Cargo.toml
@@ -10,6 +10,9 @@ documentation = "https://docs.rs/junobuild-satellite"
 readme = "README.md"
 license-file = "LICENSE.md"
 
+[package.metadata.juno.satellite]
+version = "0.0.22"
+
 [package.metadata.docs.rs]
 targets = ["wasm32-unknown-unknown"]
 rustc-args = ['--cfg', "getrandom_backend=\"custom\""]


### PR DESCRIPTION
# Motivation

When we build the Satellite serverless functions in Rust we need to know what version of the Satellite is used.
Given that many libs can relates to the same Satellite version, we need a meta information for it.
