### PR TITLE
feat: redo narrow main max-width for launchpad and cli

### DIFF
--- a/src/frontend/src/lib/components/ui/Layout.svelte
+++ b/src/frontend/src/lib/components/ui/Layout.svelte
@@ -86,6 +86,10 @@
 
 		transition: max-width var(--animation-time) var(--menu-animation-timing-function);
 
+		&.centered {
+			max-width: calc(media.$breakpoint-extra-large - 100px);
+		}
+
 		&.full-width {
 			max-width: 100%;
 		}


### PR DESCRIPTION
# Motivation

With concreate data it just feels meh when the content is centered to have 1440px. When spit pane then it's super.
