### PR TITLE
chore: increase frequency of CI for subnet and polyfill checks

### DIFF
--- a/.github/workflows/update-env.yml
+++ b/.github/workflows/update-env.yml
@@ -2,7 +2,7 @@ name: Update Env
 
 on:
   schedule:
-    - cron: '30 3 * * MON'
+    - cron: '30 3 1-7 * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-sputnik-polyfills.yml
+++ b/.github/workflows/update-sputnik-polyfills.yml
@@ -2,7 +2,7 @@ name: Update Sputnik Polyfills
 
 on:
   schedule:
-    - cron: '30 3 * * MON'
+    - cron: '30 3 1-7 * 1'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Motivation

Same as https://github.com/dfinity/oisy-wallet/pull/5979 credits to @AntonioVentilii 

We do not need to update the list of subnets every Monday as we do not deploy once a week but, rather one a month.

Likewise, polyfill should hopefully be rather stable and therefore we can checks once a month.