### PR TITLE
chore: lint based on PR #1479

### DIFF
--- a/src/frontend/tests/lib/api/call/query.api.test.ts
+++ b/src/frontend/tests/lib/api/call/query.api.test.ts
@@ -26,7 +26,7 @@ describe('query.api', () => {
 
 		expect(request).toHaveBeenCalledTimes(2);
 		expect(onLoad).toHaveBeenCalledTimes(2);
-		expect(onError).not.toBeCalled();
+		expect(onError).not.toHaveBeenCalled();
 	});
 
 	it('should work w/o await call', async () => {
@@ -45,7 +45,7 @@ describe('query.api', () => {
 
 		expect(request).toHaveBeenCalledTimes(2);
 		expect(onLoad).toHaveBeenCalledTimes(2);
-		expect(onError).not.toBeCalled();
+		expect(onError).not.toHaveBeenCalled();
 	});
 
 	it('should support "query_and_update" strategy', async () => {
@@ -113,9 +113,9 @@ describe('query.api', () => {
 			identity
 		});
 
-		expect(onLoad).not.toBeCalled();
-		expect(onError).toBeCalledTimes(2);
-		expect(onError).toBeCalledWith({
+		expect(onLoad).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledTimes(2);
+		expect(onError).toHaveBeenCalledWith({
 			certified: false,
 			error: 'test',
 			identity
@@ -136,20 +136,20 @@ describe('query.api', () => {
 			identity
 		});
 
-		expect(onLoad).not.toBeCalled();
-		expect(onError).toBeCalledTimes(2);
-		expect(onCertifiedError).toBeCalledTimes(1);
-		expect(onError).toBeCalledWith({
+		expect(onLoad).not.toHaveBeenCalled();
+		expect(onError).toHaveBeenCalledTimes(2);
+		expect(onCertifiedError).toHaveBeenCalledTimes(1);
+		expect(onError).toHaveBeenCalledWith({
 			certified: false,
 			error: 'test',
 			identity
 		});
-		expect(onError).toBeCalledWith({
+		expect(onError).toHaveBeenCalledWith({
 			certified: true,
 			error: 'test',
 			identity
 		});
-		expect(onCertifiedError).toBeCalledWith({
+		expect(onCertifiedError).toHaveBeenCalledWith({
 			error: 'test',
 			identity
 		});
@@ -178,10 +178,10 @@ describe('query.api', () => {
 		});
 		await new Promise((resolve) => setTimeout(resolve, 10));
 
-		expect(queryDone).toBe(true);
-		expect(request).toBeCalledTimes(2);
-		expect(onLoad).toBeCalledTimes(1);
-		expect(onError).not.toBeCalled();
+		expect(queryDone).toBeTruthy();
+		expect(request).toHaveBeenCalledTimes(2);
+		expect(onLoad).toHaveBeenCalledTimes(1);
+		expect(onError).not.toHaveBeenCalled();
 	});
 
 	it('should resolve promise when the first response is done', async () => {
@@ -204,15 +204,17 @@ describe('query.api', () => {
 		);
 		const onLoad = vi.fn();
 
-		expect(updateDone).toBe(false);
-		expect(queryDone).toBe(false);
+		expect(updateDone).toBeFalsy();
+		expect(queryDone).toBeFalsy();
+
 		await queryAndUpdate<number, unknown>({
 			request,
 			onLoad,
 			identity
 		});
+
 		expect(updateDone).toBeTruthy();
-		expect(queryDone).toBe(false);
+		expect(queryDone).toBeFalsy();
 	});
 
 	it('should not resolve promise when the first response is done', async () => {
@@ -235,14 +237,16 @@ describe('query.api', () => {
 		);
 		const onLoad = vi.fn();
 
-		expect(updateDone).toBe(false);
-		expect(queryDone).toBe(false);
+		expect(updateDone).toBeFalsy();
+		expect(queryDone).toBeFalsy();
+
 		await queryAndUpdate<number, unknown>({
 			request,
 			onLoad,
 			identity,
 			resolution: 'all_settled'
 		});
+
 		expect(updateDone).toBeTruthy();
 		expect(queryDone).toBeTruthy();
 	});

--- a/src/tests/specs/console/console.metadata.spec.ts
+++ b/src/tests/specs/console/console.metadata.spec.ts
@@ -51,6 +51,7 @@ describe('Console > Metadata', () => {
 
 			const decoder = new TextDecoder();
 			const responseBody = decoder.decode(body as Uint8Array<ArrayBufferLike>);
+
 			expect(responseBody).toEqual(
 				JSON.stringify({
 					mission_controls: [WASM_VERSIONS.mission_control],

--- a/src/tests/specs/console/console.spec.ts
+++ b/src/tests/specs/console/console.spec.ts
@@ -32,8 +32,8 @@ describe('Console', () => {
 	});
 
 	it('should throw errors if too many users are created quickly', async () => {
-		await expect(
-			async () => await initMissionControls({ actor, pic, length: 2 })
-		).rejects.toThrow(new RegExp('Rate limit reached, try again later', 'i'));
+		await expect(async () => await initMissionControls({ actor, pic, length: 2 })).rejects.toThrow(
+			new RegExp('Rate limit reached, try again later', 'i')
+		);
 	});
 });

--- a/src/tests/specs/console/console.spec.ts
+++ b/src/tests/specs/console/console.spec.ts
@@ -34,6 +34,6 @@ describe('Console', () => {
 	it('should throw errors if too many users are created quickly', async () => {
 		await expect(
 			async () => await initMissionControls({ actor, pic, length: 2 })
-		).rejects.toThrowError(new RegExp('Rate limit reached, try again later', 'i'));
+		).rejects.toThrow(new RegExp('Rate limit reached, try again later', 'i'));
 	});
 });

--- a/src/tests/specs/console/console.storage.spec.ts
+++ b/src/tests/specs/console/console.storage.spec.ts
@@ -394,7 +394,7 @@ describe('Console > Storage', () => {
 							sha256: fromNullable(sha256)!,
 							proposal_id: proposalId
 						})
-					).resolves.not.toThrowError();
+					).resolves.not.toThrow();
 				});
 
 				it('should have updated proposal to executed', async () => {
@@ -453,6 +453,7 @@ describe('Console > Storage', () => {
 					});
 
 					const decoder = new TextDecoder();
+
 					expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toEqual(mockHtml);
 				});
 

--- a/src/tests/specs/mission-control/mission-control.controllers.spec.ts
+++ b/src/tests/specs/mission-control/mission-control.controllers.spec.ts
@@ -71,7 +71,7 @@ describe('Mission Control > Controllers', () => {
 	it('should not be able to set an orbiter because mission control is effectively not a controller', async () => {
 		const { set_orbiter } = actor;
 
-		await expect(set_orbiter(orbiterId, ['Hello'])).rejects.toThrowError(
+		await expect(set_orbiter(orbiterId, ['Hello'])).rejects.toThrow(
 			new RegExp(ORBITER_CONTROLLER_ERR_MSG)
 		);
 	});
@@ -79,7 +79,7 @@ describe('Mission Control > Controllers', () => {
 	it('should not be able to set a satellite because mission control is effectively not a controller', async () => {
 		const { set_satellite } = actor;
 
-		await expect(set_satellite(satelliteId, ['Hello'])).rejects.toThrowError(
+		await expect(set_satellite(satelliteId, ['Hello'])).rejects.toThrow(
 			new RegExp(JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER)
 		);
 	});

--- a/src/tests/specs/mission-control/mission-control.monitoring.history.spec.ts
+++ b/src/tests/specs/mission-control/mission-control.monitoring.history.spec.ts
@@ -81,7 +81,7 @@ describe('Mission Control > History', () => {
 
 		const results = await get_monitoring_history(filter);
 
-		expect(results.length).toEqual(0);
+		expect(results).toHaveLength(0);
 	};
 
 	const testHistory = async ({
@@ -101,7 +101,7 @@ describe('Mission Control > History', () => {
 
 		const results = await get_monitoring_history(filter);
 
-		expect(results.length).toEqual(expectedLength);
+		expect(results).toHaveLength(expectedLength);
 
 		results.forEach((result) => {
 			const [key, history] = result;
@@ -253,10 +253,12 @@ describe('Mission Control > History', () => {
 
 				const [beforeKey1] = before[1];
 				const [afterKey0] = after[0];
+
 				expect(beforeKey1.created_at).toEqual(afterKey0.created_at);
 
 				const [beforeKey2] = before[2];
 				const [afterKey1] = after[1];
+
 				expect(beforeKey2.created_at).toEqual(afterKey1.created_at);
 
 				expect(

--- a/src/tests/specs/mission-control/mission-control.upgrade.spec.ts
+++ b/src/tests/specs/mission-control/mission-control.upgrade.spec.ts
@@ -89,6 +89,7 @@ describe('Mission control > Upgrade', () => {
 			expect(satellites[0][1].updated_at).toBeGreaterThan(0n);
 
 			const [_, satName] = satellites[0][1].metadata.find(([key]) => key === 'name') ?? [];
+
 			expect(satName).toEqual(satelliteName);
 
 			const orbiters = await list_orbiters();
@@ -101,6 +102,7 @@ describe('Mission control > Upgrade', () => {
 			expect(orbiters[0][1].updated_at).toBeGreaterThan(0n);
 
 			const [__, orbName] = orbiters[0][1].metadata.find(([key]) => key === 'name') ?? [];
+
 			expect(orbName).toEqual(orbiterName);
 		};
 

--- a/src/tests/specs/orbiter/orbiter.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.spec.ts
@@ -72,7 +72,7 @@ describe('Orbiter', () => {
 							}
 						]
 					])
-				).resolves.not.toThrowError();
+				).resolves.not.toThrow();
 			});
 
 			it('should not configure satellite if no version', async () => {
@@ -104,7 +104,7 @@ describe('Orbiter', () => {
 							}
 						]
 					])
-				).rejects.toThrowError(new RegExp(JUNO_ERROR_VERSION_OUTDATED_OR_FUTURE, 'i'));
+				).rejects.toThrow(new RegExp(JUNO_ERROR_VERSION_OUTDATED_OR_FUTURE, 'i'));
 			});
 		});
 
@@ -125,7 +125,7 @@ describe('Orbiter', () => {
 					[{ key: nanoid(), collected_at: 123n }, pageViewMock]
 				];
 
-				await expect(set_page_views(pagesViews)).resolves.not.toThrowError();
+				await expect(set_page_views(pagesViews)).resolves.not.toThrow();
 			});
 
 			it('should not set page views if no version', async () => {
@@ -174,7 +174,7 @@ describe('Orbiter', () => {
 					[{ key: nanoid(), collected_at: 123n }, trackEventMock]
 				];
 
-				await expect(set_track_events(trackEvents)).resolves.not.toThrowError();
+				await expect(set_track_events(trackEvents)).resolves.not.toThrow();
 			});
 
 			it('should not set track events if no version', async () => {
@@ -223,7 +223,7 @@ describe('Orbiter', () => {
 					[{ key: nanoid(), collected_at: 123n }, performanceMetricMock]
 				];
 
-				await expect(set_performance_metrics(performanceMetrics)).resolves.not.toThrowError();
+				await expect(set_performance_metrics(performanceMetrics)).resolves.not.toThrow();
 			});
 
 			it('should not set performance metrics if no version', async () => {
@@ -323,8 +323,9 @@ describe('Orbiter', () => {
 						satellite_id: [satelliteIdMock]
 					});
 
-					expect(Array.isArray(result)).toBe(true);
-					expect(result.length).toEqual(pagesViews.length);
+					expect(Array.isArray(result)).toBeTruthy();
+					expect(result).toHaveLength(pagesViews.length);
+
 					result.forEach(([key, pageView]) => {
 						expect(key.collected_at).toBeGreaterThanOrEqual(1000n);
 						expect(key.collected_at).toBeLessThanOrEqual(5000n);
@@ -349,8 +350,9 @@ describe('Orbiter', () => {
 						satellite_id: [satelliteIdMock]
 					});
 
-					expect(Array.isArray(result)).toBe(true);
-					expect(result.length).toEqual(trackEvents.length);
+					expect(Array.isArray(result)).toBeTruthy();
+					expect(result).toHaveLength(trackEvents.length);
+
 					result.forEach(([key, trackEvent]) => {
 						expect(key.collected_at).toBeGreaterThanOrEqual(1000n);
 						expect(key.collected_at).toBeLessThanOrEqual(5000n);
@@ -375,8 +377,9 @@ describe('Orbiter', () => {
 						satellite_id: [satelliteIdMock]
 					});
 
-					expect(Array.isArray(result)).toBe(true);
+					expect(Array.isArray(result)).toBeTruthy();
 					expect(result.length).toBeGreaterThan(0);
+
 					result.forEach(([key, performanceMetric]) => {
 						expect(key.collected_at).toBeGreaterThanOrEqual(1000n);
 						expect(key.collected_at).toBeLessThanOrEqual(5000n);

--- a/src/tests/specs/orbiter/orbiter.upgrade-configuration.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.upgrade-configuration.spec.ts
@@ -75,7 +75,8 @@ describe('Orbiter > Upgrade > Configuration', () => {
 			const { list_satellite_configs } = newActor;
 
 			const configs = await list_satellite_configs();
-			expect(configs.length).toBe(0);
+
+			expect(configs).toHaveLength(0);
 		});
 
 		it('should migrate configuration disabled to none', async () => {
@@ -91,7 +92,7 @@ describe('Orbiter > Upgrade > Configuration', () => {
 						}
 					]
 				])
-			).resolves.not.toThrowError();
+			).resolves.not.toThrow();
 
 			await upgradeVersion();
 
@@ -101,7 +102,8 @@ describe('Orbiter > Upgrade > Configuration', () => {
 			const { list_satellite_configs } = newActor;
 
 			const configs = await list_satellite_configs();
-			expect(configs.length).toBe(1);
+
+			expect(configs).toHaveLength(1);
 
 			expect(configs[0][0].toText()).toEqual(satelliteIdMock.toText());
 			expect(fromNullable(configs[0][1].version)).toBe(1n);
@@ -121,7 +123,7 @@ describe('Orbiter > Upgrade > Configuration', () => {
 						}
 					]
 				])
-			).resolves.not.toThrowError();
+			).resolves.not.toThrow();
 
 			await upgradeVersion();
 
@@ -131,7 +133,8 @@ describe('Orbiter > Upgrade > Configuration', () => {
 			const { list_satellite_configs } = newActor;
 
 			const configs = await list_satellite_configs();
-			expect(configs.length).toBe(1);
+
+			expect(configs).toHaveLength(1);
 
 			expect(configs[0][0].toText()).toEqual(satelliteIdMock.toText());
 			expect(fromNullable(configs[0][1].version)).toBe(1n);
@@ -157,7 +160,7 @@ describe('Orbiter > Upgrade > Configuration', () => {
 						}
 					]
 				])
-			).resolves.not.toThrowError();
+			).resolves.not.toThrow();
 
 			await upgradeVersion();
 
@@ -169,7 +172,8 @@ describe('Orbiter > Upgrade > Configuration', () => {
 			const { list_satellite_configs } = newActor;
 
 			const configs = await list_satellite_configs();
-			expect(configs.length).toBe(1);
+
+			expect(configs).toHaveLength(1);
 
 			expect(configs[0][0].toText()).toEqual(satelliteIdMock.toText());
 			expect(fromNullable(configs[0][1].version)).toBe(1n);

--- a/src/tests/specs/orbiter/orbiter.upgrade.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.upgrade.spec.ts
@@ -253,7 +253,7 @@ describe('Orbiter > Upgrade', () => {
 						}
 					]
 				])
-			).resolves.not.toThrowError();
+			).resolves.not.toThrow();
 		});
 
 		describe('Page views', { timeout: 1200000 }, () => {

--- a/src/tests/specs/satellite/extended/satellite.hooks.random.spec.ts
+++ b/src/tests/specs/satellite/extended/satellite.hooks.random.spec.ts
@@ -44,7 +44,7 @@ describe('Satellite > Hooks > Random', () => {
 
 		const { items: logs } = await list_docs('#log', mockListParams);
 
-		expect(logs.length).toEqual(0);
+		expect(logs).toHaveLength(0);
 	});
 
 	it('should call on init_random_seed after upgrade', async () => {
@@ -60,7 +60,7 @@ describe('Satellite > Hooks > Random', () => {
 
 		const { items: logs } = await list_docs('#log', mockListParams);
 
-		expect(logs.length).toEqual(1);
+		expect(logs).toHaveLength(1);
 
 		const [log] = logs;
 		const [__, doc] = log;

--- a/src/tests/specs/satellite/extended/satellite.logs.spec.ts
+++ b/src/tests/specs/satellite/extended/satellite.logs.spec.ts
@@ -112,12 +112,14 @@ describe('Satellite > Logging', () => {
 		expect(logs).toHaveLength(13);
 
 		const keys = new Set([...logs.map(([key, _]) => key)]);
+
 		expect(keys).toHaveLength(13);
 
 		// Log key is format!("{}-{}", time(), nonce)
 		// When we create doc and log with serverless without tick, the time should be the same
 		// Therefore, without nonce, the count of entry should be smaller than the effective count of time we logged
 		const trimmedKey = new Set([...logs.map(([key, _]) => key.split('-')[0])]);
+
 		expect(trimmedKey.size).toBeLessThan(13);
 	});
 

--- a/src/tests/specs/satellite/extended/satellite.random.spec.ts
+++ b/src/tests/specs/satellite/extended/satellite.random.spec.ts
@@ -44,10 +44,11 @@ describe('Satellite > Random', () => {
 
 		const result = await get_random();
 
-		expect('Err' in result).toBe(true);
+		expect('Err' in result).toBeTruthy();
 
 		if ('Ok' in result) {
-			expect(true).toBe(false);
+			expect(true).toBeFalsy();
+
 			return;
 		}
 
@@ -65,10 +66,11 @@ describe('Satellite > Random', () => {
 
 		const result = await get_random();
 
-		expect('Ok' in result).toBe(true);
+		expect('Ok' in result).toBeTruthy();
 
 		if ('Err' in result) {
-			expect(true).toBe(false);
+			expect(true).toBeFalsy();
+
 			return;
 		}
 
@@ -88,11 +90,13 @@ describe('Satellite > Random', () => {
 		const results = await Promise.all(Array.from({ length }).map(() => getRandom()));
 
 		const oks = results.filter((result) => 'Ok' in result);
-		expect(oks.length).toEqual(length);
+
+		expect(oks).toHaveLength(length);
 
 		const numbers = oks.map((result) => (result as unknown as { Ok: number }).Ok);
 
 		const uniqueNumbers = new Set(numbers);
+
 		expect(uniqueNumbers.size).toEqual(length);
 	});
 });

--- a/src/tests/specs/satellite/stock/satellite.auth.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.auth.spec.ts
@@ -54,6 +54,7 @@ describe('Satellite > Authentication', () => {
 			const { get_auth_config } = actor;
 
 			const config = await get_auth_config();
+
 			expect(config).toEqual([]);
 		});
 
@@ -108,6 +109,7 @@ describe('Satellite > Authentication', () => {
 			await set_auth_config(config);
 
 			const result = await get_auth_config();
+
 			expect(result).toEqual([config]);
 		});
 
@@ -124,6 +126,7 @@ describe('Satellite > Authentication', () => {
 
 			const decoder = new TextDecoder();
 			const responseBody = decoder.decode(body as Uint8Array<ArrayBufferLike>);
+
 			expect(responseBody).toEqual(JSON.stringify({ alternativeOrigins: [canisterIdUrl] }));
 			expect(JSON.parse(responseBody).alternativeOrigins).toEqual([canisterIdUrl]);
 		});
@@ -148,6 +151,7 @@ describe('Satellite > Authentication', () => {
 			await set_auth_config(config);
 
 			const result = await get_auth_config();
+
 			expect(result).toEqual([config]);
 		});
 
@@ -164,6 +168,7 @@ describe('Satellite > Authentication', () => {
 
 			const decoder = new TextDecoder();
 			const responseBody = decoder.decode(body as Uint8Array<ArrayBufferLike>);
+
 			expect(responseBody).toEqual(
 				JSON.stringify({ alternativeOrigins: [canisterIdUrl, ...externalAlternativeOriginsUrls] })
 			);
@@ -188,6 +193,7 @@ describe('Satellite > Authentication', () => {
 			await set_auth_config(config);
 
 			const result = await get_auth_config();
+
 			expect(result).toEqual([config]);
 		});
 
@@ -215,6 +221,7 @@ describe('Satellite > Authentication', () => {
 			await set_auth_config(config);
 
 			const result = await get_auth_config();
+
 			expect(result).toEqual([config]);
 		});
 

--- a/src/tests/specs/satellite/stock/satellite.custom-domains.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.custom-domains.spec.ts
@@ -58,6 +58,7 @@ describe('Satellite > Custom domains', () => {
 
 			// We assumed previous test has run
 			const asset = await get_asset('#dapp', '/.well-known/ic-domains');
+
 			expect(asset[0]?.key.full_path).toEqual('/.well-known/ic-domains');
 		});
 
@@ -67,6 +68,7 @@ describe('Satellite > Custom domains', () => {
 			await del_assets('#dapp');
 
 			const asset = await get_asset('#dapp', '/.well-known/ic-domains');
+
 			expect(asset[0]?.key.full_path).toEqual('/.well-known/ic-domains');
 		});
 

--- a/src/tests/specs/satellite/stock/satellite.datastore.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.datastore.spec.ts
@@ -116,6 +116,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				};
 
 				const results = await Promise.all(keys.map(delDoc));
+
 				expect(results).toHaveLength(10);
 			});
 
@@ -167,7 +168,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 						...doc!,
 						version: [123n]
 					})
-				).rejects.toThrowError(new RegExp(JUNO_ERROR_VERSION_OUTDATED_OR_FUTURE, 'i'));
+				).rejects.toThrow(new RegExp(JUNO_ERROR_VERSION_OUTDATED_OR_FUTURE, 'i'));
 			});
 		});
 
@@ -190,6 +191,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				const { get_db_config } = actor;
 
 				const config = await get_db_config();
+
 				expect(config).toEqual([]);
 			});
 
@@ -208,6 +210,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				await set_db_config(config);
 
 				const result = await get_db_config();
+
 				expect(result).toEqual([config]);
 
 				// Redo for next test
@@ -243,9 +246,11 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				};
 
 				const { items_length, items } = await list_docs(TEST_COLLECTION, paramsCreatedAt);
+
 				expect(items_length).toBe(10n);
 
 				const countCreatedAt = await count_docs(TEST_COLLECTION, paramsCreatedAt);
+
 				expect(countCreatedAt).toBe(10n);
 
 				const paramsGreaterThan: ListParams = {
@@ -266,9 +271,11 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 					TEST_COLLECTION,
 					paramsGreaterThan
 				);
+
 				expect(items_length_from).toBe(5n);
 
 				const countGreaterThan = await count_docs(TEST_COLLECTION, paramsGreaterThan);
+
 				expect(countGreaterThan).toBe(5n);
 
 				const paramsLessThen: ListParams = {
@@ -286,9 +293,11 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				};
 
 				const { items_length: items_length_to } = await list_docs(TEST_COLLECTION, paramsLessThen);
+
 				expect(items_length_to).toBe(4n);
 
 				const countLessThan = await count_docs(TEST_COLLECTION, paramsLessThen);
+
 				expect(countLessThan).toBe(4n);
 
 				const paramsBetween: ListParams = {
@@ -309,9 +318,11 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 					TEST_COLLECTION,
 					paramsBetween
 				);
+
 				expect(items_length_between).toBe(5n);
 
 				const countBetween = await count_docs(TEST_COLLECTION, paramsBetween);
+
 				expect(countBetween).toBe(5n);
 			});
 
@@ -329,9 +340,11 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				};
 
 				const { items_length, items } = await list_docs(TEST_COLLECTION, paramsUpdatedAt);
+
 				expect(items_length).toBe(10n);
 
 				const countUpdatedAt = await count_docs(TEST_COLLECTION, paramsUpdatedAt);
+
 				expect(countUpdatedAt).toBe(10n);
 
 				const paramsGreaterThan: ListParams = {
@@ -352,9 +365,11 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 					TEST_COLLECTION,
 					paramsGreaterThan
 				);
+
 				expect(items_length_from).toBe(5n);
 
 				const countGreaterThan = await count_docs(TEST_COLLECTION, paramsGreaterThan);
+
 				expect(countGreaterThan).toBe(5n);
 
 				const paramsLessThan: ListParams = {
@@ -372,9 +387,11 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				};
 
 				const { items_length: items_length_to } = await list_docs(TEST_COLLECTION, paramsLessThan);
+
 				expect(items_length_to).toBe(4n);
 
 				const countLessThan = await count_docs(TEST_COLLECTION, paramsLessThan);
+
 				expect(countLessThan).toBe(4n);
 
 				const paramsBetween: ListParams = {
@@ -395,9 +412,11 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 					TEST_COLLECTION,
 					paramsBetween
 				);
+
 				expect(items_length_between).toBe(5n);
 
 				const countBetween = await count_docs(TEST_COLLECTION, paramsBetween);
+
 				expect(countBetween).toBe(5n);
 			});
 		});
@@ -440,14 +459,17 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				};
 
 				const initialCount = await count_docs(TEST_COLLECTION, filterParams);
+
 				expect(initialCount).toBe(10n);
 
 				await del_filtered_docs(TEST_COLLECTION, filterParams);
 
 				const finalCount = await count_docs(TEST_COLLECTION, filterParams);
+
 				expect(finalCount).toBe(0n);
 
 				const { items_length } = await list_docs(TEST_COLLECTION, filterParams);
+
 				expect(items_length).toBe(0n);
 			});
 
@@ -479,11 +501,13 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				};
 
 				const initialSpecificCount = await count_docs(TEST_COLLECTION, filterParamsSpecific);
+
 				expect(initialSpecificCount).toBe(5n);
 
 				await del_filtered_docs(TEST_COLLECTION, filterParamsSpecific);
 
 				const finalSpecificCount = await count_docs(TEST_COLLECTION, filterParamsSpecific);
+
 				expect(finalSpecificCount).toBe(0n);
 			});
 
@@ -514,6 +538,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				actor.setIdentity(controller);
 
 				const initialCount = await count_collection_docs(TEST_COLLECTION);
+
 				expect(initialCount).toBe(11n);
 
 				actor.setIdentity(user1);
@@ -521,14 +546,17 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				await del_filtered_docs(TEST_COLLECTION, filterParams);
 
 				const finalCount = await count_docs(TEST_COLLECTION, filterParams);
+
 				expect(finalCount).toBe(0n);
 
 				const { items_length } = await list_docs(TEST_COLLECTION, filterParams);
+
 				expect(items_length).toBe(0n);
 
 				actor.setIdentity(controller);
 
 				const updatedCount = await count_collection_docs(TEST_COLLECTION);
+
 				expect(updatedCount).toBe(6n);
 			});
 
@@ -569,6 +597,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				await del_filtered_docs(TEST_COLLECTION, filterDelete);
 
 				const finalSpecificCount = await count_docs(TEST_COLLECTION, filterList);
+
 				expect(finalSpecificCount).toBe(2n);
 			});
 		});
@@ -706,7 +735,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				try {
 					await del_rule({ Db: null }, TEST_COLLECTION, { version: [1n] });
 
-					expect(true).toBe(false);
+					expect(true).toBeFalsy();
 				} catch (error: unknown) {
 					expect((error as Error).message).toContain(
 						`The "${TEST_COLLECTION}" collection in Datastore is not empty.`
@@ -726,7 +755,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 						version: toNullable()
 					});
 
-					expect(true).toBe(false);
+					expect(true).toBeFalsy();
 				} catch (error: unknown) {
 					expect((error as Error).message).toContain(
 						`Collection "${collectionUnknown}" not found in Datastore.`
@@ -782,7 +811,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 				});
 
 				it('should not allow to set a document', async () => {
-					await expect(createDoc()).rejects.toThrowError(new RegExp(errorMsg, 'i'));
+					await expect(createDoc()).rejects.toThrow(new RegExp(errorMsg, 'i'));
 				});
 
 				it('should not allow to set many documents', async () => {

--- a/src/tests/specs/satellite/stock/satellite.rate.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.rate.spec.ts
@@ -116,7 +116,7 @@ describe('Satellite > Rate', () => {
 				// DEFAULT 100 per minutes. So 1 for very first token + 100
 				await testDocs({ length: 102, collection: '#user' });
 
-				expect(true).toBe(false);
+				expect(true).toBeFalsy();
 			} catch (error: unknown) {
 				expect((error as Error).message).toContain('Rate limit reached, try again later.');
 			}
@@ -137,13 +137,13 @@ describe('Satellite > Rate', () => {
 
 			const docs = await testDocs({ length, collection: '#user' });
 
-			expect(docs.length).toBe(length);
+			expect(docs).toHaveLength(length);
 
 			try {
 				// One too many
 				await testDocs({ length: 1, collection: '#user' });
 
-				expect(true).toBe(false);
+				expect(true).toBeFalsy();
 			} catch (error: unknown) {
 				expect((error as Error).message).toContain('Rate limit reached, try again later.');
 			}
@@ -214,7 +214,7 @@ describe('Satellite > Rate', () => {
 				try {
 					await testDocs({ length: 11, collection });
 
-					expect(true).toBe(false);
+					expect(true).toBeFalsy();
 				} catch (error: unknown) {
 					expect((error as Error).message).toContain('Rate limit reached, try again later.');
 				}
@@ -275,7 +275,7 @@ describe('Satellite > Rate', () => {
 				try {
 					await deleteDocs(docs);
 
-					expect(true).toBe(false);
+					expect(true).toBeFalsy();
 				} catch (error: unknown) {
 					expect((error as Error).message).toContain('Rate limit reached, try again later.');
 				}
@@ -344,7 +344,7 @@ describe('Satellite > Rate', () => {
 				try {
 					await testBatches(11);
 
-					expect(true).toBe(false);
+					expect(true).toBeFalsy();
 				} catch (error: unknown) {
 					expect((error as Error).message).toContain('Rate limit reached, try again later.');
 				}
@@ -415,7 +415,7 @@ describe('Satellite > Rate', () => {
 				try {
 					await testChunks(batches);
 
-					expect(true).toBe(false);
+					expect(true).toBeFalsy();
 				} catch (error: unknown) {
 					expect((error as Error).message).toContain('Rate limit reached, try again later.');
 				}

--- a/src/tests/specs/satellite/stock/satellite.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.spec.ts
@@ -154,6 +154,7 @@ describe('Satellite', () => {
 			await set_rule({ Db: null }, 'test2', setRule);
 
 			const rules = await list_rules({ Db: null });
+
 			expect(rules).toHaveLength(2);
 
 			const [_, { version }] = rules[1];
@@ -194,6 +195,7 @@ describe('Satellite', () => {
 			});
 
 			const updatedControllers = await list_controllers();
+
 			expect(updatedControllers).toHaveLength(1);
 			expect(updatedControllers[0][0].toText()).toEqual(controller.getPrincipal().toText());
 		});
@@ -352,7 +354,7 @@ describe('Satellite', () => {
 							read: { Public: null }
 						});
 
-						expect(true).toBe(false);
+						expect(true).toBeFalsy();
 					} catch (error: unknown) {
 						expect((error as Error).message).toContain(errorMessage);
 					}
@@ -373,7 +375,7 @@ describe('Satellite', () => {
 							write: { Public: null }
 						});
 
-						expect(true).toBe(false);
+						expect(true).toBeFalsy();
 					} catch (error: unknown) {
 						expect((error as Error).message).toContain(errorMessage);
 					}
@@ -399,7 +401,7 @@ describe('Satellite', () => {
 									: toNullable({ Stable: null })
 						});
 
-						expect(true).toBe(false);
+						expect(true).toBeFalsy();
 					} catch (error: unknown) {
 						expect((error as Error).message).toContain(errorMessage);
 					}
@@ -420,7 +422,7 @@ describe('Satellite', () => {
 							mutable_permissions: [true]
 						});
 
-						expect(true).toBe(false);
+						expect(true).toBeFalsy();
 					} catch (error: unknown) {
 						expect((error as Error).message).toContain(errorMessage);
 					}
@@ -441,7 +443,7 @@ describe('Satellite', () => {
 							max_size: [666n]
 						});
 
-						expect(true).toBe(false);
+						expect(true).toBeFalsy();
 					} catch (error: unknown) {
 						expect((error as Error).message).toContain(errorMessage);
 					}
@@ -462,7 +464,7 @@ describe('Satellite', () => {
 							max_capacity: [666]
 						});
 
-						expect(true).toBe(false);
+						expect(true).toBeFalsy();
 					} catch (error: unknown) {
 						expect((error as Error).message).toContain(errorMessage);
 					}
@@ -483,7 +485,7 @@ describe('Satellite', () => {
 							rate_config: []
 						});
 
-						expect(true).toBe(false);
+						expect(true).toBeFalsy();
 					} catch (error: unknown) {
 						expect((error as Error).message).toContain('Rate config cannot be disabled.');
 					}
@@ -596,7 +598,7 @@ describe('Satellite', () => {
 						version: [123n]
 					});
 
-					expect(true).toBe(false);
+					expect(true).toBeFalsy();
 				} catch (error: unknown) {
 					expect((error as Error).message).toContain(JUNO_ERROR_VERSION_OUTDATED_OR_FUTURE);
 				}

--- a/src/tests/specs/satellite/stock/satellite.storage.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.storage.spec.ts
@@ -248,6 +248,7 @@ describe('Satellite > Storage', () => {
 			});
 
 			const decoder = new TextDecoder();
+
 			expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toEqual(mockHtml);
 		});
 
@@ -374,6 +375,7 @@ describe('Satellite > Storage', () => {
 					});
 
 					const decoder = new TextDecoder();
+
 					expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toEqual(mockHtml);
 				});
 
@@ -383,6 +385,7 @@ describe('Satellite > Storage', () => {
 					await del_assets('#dapp');
 
 					const assetUploaded = await get_asset(collection, `/${collection}/hello.html`);
+
 					expect(fromNullable(assetUploaded)).not.toBeUndefined();
 				});
 
@@ -412,7 +415,7 @@ describe('Satellite > Storage', () => {
 
 					const full_path = `/${collection}/update.html`;
 
-					await expect(del_asset(collection, full_path)).resolves.not.toThrowError();
+					await expect(del_asset(collection, full_path)).resolves.not.toThrow();
 
 					const asset = fromNullable(await get_asset(collection, full_path));
 
@@ -463,6 +466,7 @@ describe('Satellite > Storage', () => {
 				expect(status_code).toEqual(200);
 
 				const decoder = new TextDecoder();
+
 				expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toEqual(HTML);
 			});
 
@@ -578,6 +582,7 @@ describe('Satellite > Storage', () => {
 				expect(status_code).toEqual(200);
 
 				const decoder = new TextDecoder();
+
 				expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toEqual(mockHtml);
 			});
 
@@ -631,6 +636,7 @@ describe('Satellite > Storage', () => {
 				expect(status_code).toEqual(200);
 
 				const decoder = new TextDecoder();
+
 				expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toEqual(mockHtml);
 			});
 		});
@@ -721,6 +727,7 @@ describe('Satellite > Storage', () => {
 					});
 
 					const decoder = new TextDecoder();
+
 					expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toEqual(SVG);
 				});
 
@@ -734,6 +741,7 @@ describe('Satellite > Storage', () => {
 					const assetUpdated = fromNullable(
 						await get_asset(collection, `/${collection}/hello.svg`)
 					);
+
 					expect(assetUpdated).not.toBeUndefined();
 					expect(assetUpdated?.key.owner.toText()).not.toBeUndefined();
 					expect(assetUpdated?.key.owner.toText()).toEqual(user.getPrincipal().toText());
@@ -775,9 +783,11 @@ describe('Satellite > Storage', () => {
 						};
 
 						const { items_length, items } = await list_assets(collection, paramsCreatedAt);
+
 						expect(items_length).toBe(10n);
 
 						const countCreatedAt = await count_assets(collection, paramsCreatedAt);
+
 						expect(countCreatedAt).toBe(10n);
 
 						const paramsGreaterThan: ListParams = {
@@ -798,9 +808,11 @@ describe('Satellite > Storage', () => {
 							collection,
 							paramsGreaterThan
 						);
+
 						expect(items_length_from).toBe(5n);
 
 						const countGreaterThan = await count_assets(collection, paramsGreaterThan);
+
 						expect(countGreaterThan).toBe(5n);
 
 						const paramsLessThan: ListParams = {
@@ -818,9 +830,11 @@ describe('Satellite > Storage', () => {
 						};
 
 						const { items_length: items_length_to } = await list_assets(collection, paramsLessThan);
+
 						expect(items_length_to).toBe(4n);
 
 						const countLessThan = await count_assets(collection, paramsLessThan);
+
 						expect(countLessThan).toBe(4n);
 
 						const paramsBetween: ListParams = {
@@ -841,9 +855,11 @@ describe('Satellite > Storage', () => {
 							collection,
 							paramsBetween
 						);
+
 						expect(items_length_between).toBe(5n);
 
 						const countBetween = await count_assets(collection, paramsBetween);
+
 						expect(countBetween).toBe(5n);
 					});
 
@@ -861,9 +877,11 @@ describe('Satellite > Storage', () => {
 						};
 
 						const { items_length, items } = await list_assets(collection, paramsUpdatedAt);
+
 						expect(items_length).toBe(10n);
 
 						const countUpdatedAt = await count_assets(collection, paramsUpdatedAt);
+
 						expect(countUpdatedAt).toBe(10n);
 
 						const paramsGreaterThan: ListParams = {
@@ -884,9 +902,11 @@ describe('Satellite > Storage', () => {
 							collection,
 							paramsGreaterThan
 						);
+
 						expect(items_length_from).toBe(5n);
 
 						const countGreaterThan = await count_assets(collection, paramsGreaterThan);
+
 						expect(countGreaterThan).toBe(5n);
 
 						const paramsLessThan: ListParams = {
@@ -904,9 +924,11 @@ describe('Satellite > Storage', () => {
 						};
 
 						const { items_length: items_length_to } = await list_assets(collection, paramsLessThan);
+
 						expect(items_length_to).toBe(4n);
 
 						const countLessThan = await count_assets(collection, paramsLessThan);
+
 						expect(countLessThan).toBe(4n);
 
 						const paramsBetween: ListParams = {
@@ -927,9 +949,11 @@ describe('Satellite > Storage', () => {
 							collection,
 							paramsBetween
 						);
+
 						expect(items_length_between).toBe(5n);
 
 						const countBetween = await count_assets(collection, paramsBetween);
+
 						expect(countBetween).toBe(5n);
 					});
 				});
@@ -1024,6 +1048,7 @@ describe('Satellite > Storage', () => {
 						};
 
 						const remainingAssets = await list_assets(collection, listParams);
+
 						expect(remainingAssets.items.map((item) => item[1].key.full_path)).toEqual([
 							`/${collection}/asset3.svg`
 						]);
@@ -1046,6 +1071,7 @@ describe('Satellite > Storage', () => {
 						actor.setIdentity(user2);
 
 						const user2Assets = await list_assets(collection, listParamsUser2);
+
 						expect(user2Assets.items.map((item) => item[1].key.full_path)).toEqual([
 							`/${collection}/user2_asset.svg`
 						]);
@@ -1088,6 +1114,7 @@ describe('Satellite > Storage', () => {
 						actor.setIdentity(user);
 
 						const remainingAssets = await list_assets(collection, listParams);
+
 						expect(remainingAssets.items_length).toBeGreaterThan(0n);
 					});
 				});
@@ -1108,7 +1135,7 @@ describe('Satellite > Storage', () => {
 			try {
 				await del_rule({ Storage: null }, collection, { version: [1n] });
 
-				expect(true).toBe(false);
+				expect(true).toBeFalsy();
 			} catch (error: unknown) {
 				expect((error as Error).message).toContain(
 					`The "${collection}" collection in Storage is not empty.`
@@ -1126,7 +1153,7 @@ describe('Satellite > Storage', () => {
 					collection: collectionUnknown
 				});
 
-				expect(true).toBe(false);
+				expect(true).toBeFalsy();
 			} catch (error: unknown) {
 				expect((error as Error).message).toContain(
 					`Collection "${collectionUnknown}" not found in Storage.`

--- a/src/tests/specs/satellite/stock/satellite.upgrade.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.upgrade.spec.ts
@@ -338,7 +338,7 @@ describe('Satellite > Upgrade', () => {
 					version: toNullable()
 				};
 
-				await expect(set_rule({ Db: null }, 'test', setUpdateRule)).resolves.not.toThrowError();
+				await expect(set_rule({ Db: null }, 'test', setUpdateRule)).resolves.not.toThrow();
 			});
 
 			it('should be able to update rule after upgrade only once without version provided', async () => {
@@ -364,7 +364,7 @@ describe('Satellite > Upgrade', () => {
 				};
 
 				// We do not provide the version so it counts as a first set
-				await expect(set_rule({ Db: null }, 'test', setNewRule)).resolves.not.toThrowError();
+				await expect(set_rule({ Db: null }, 'test', setNewRule)).resolves.not.toThrow();
 			});
 		});
 
@@ -412,7 +412,7 @@ describe('Satellite > Upgrade', () => {
 					version: toNullable()
 				};
 
-				await expect(set_doc(collection, key, setUpdateDoc)).resolves.not.toThrowError();
+				await expect(set_doc(collection, key, setUpdateDoc)).resolves.not.toThrow();
 			});
 
 			it('should be able to update doc after upgrade only once without version provided', async () => {
@@ -439,7 +439,7 @@ describe('Satellite > Upgrade', () => {
 				};
 
 				// We do not provide the version so it counts as a first set
-				await expect(set_doc(collection, key, setNewDoc)).resolves.not.toThrowError();
+				await expect(set_doc(collection, key, setNewDoc)).resolves.not.toThrow();
 			});
 		});
 
@@ -769,7 +769,7 @@ describe('Satellite > Upgrade', () => {
 
 			await upgrade();
 
-			expect(async () => await actor.version()).rejects.toThrowError(
+			await expect(async () => await actor.version()).rejects.toThrow(
 				new RegExp("Canister has no query method 'version'.", 'i')
 			);
 		});
@@ -781,7 +781,7 @@ describe('Satellite > Upgrade', () => {
 
 			await upgrade();
 
-			expect(async () => await actor.version()).rejects.toThrowError(
+			await expect(async () => await actor.version()).rejects.toThrow(
 				new RegExp("Canister has no query method 'version'.", 'i')
 			);
 		});

--- a/src/tests/specs/satellite/stock/satellite.user-ban.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.user-ban.spec.ts
@@ -339,7 +339,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not set documents if banned', async () => {
-					await expect(createDocs()).resolves.not.toThrowError();
+					await expect(createDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -347,12 +347,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should set documents if unbanned', async () => {
-					await expect(createDocs()).resolves.not.toThrowError();
+					await expect(createDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(createDocs()).resolves.not.toThrowError();
+					await expect(createDocs()).resolves.not.toThrow();
 				});
 			});
 
@@ -372,7 +372,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not delete document if banned', async () => {
-					await expect(deleteDoc()).resolves.not.toThrowError();
+					await expect(deleteDoc()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -380,12 +380,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should delete document if unbanned', async () => {
-					await expect(deleteDoc()).resolves.not.toThrowError();
+					await expect(deleteDoc()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(deleteDoc()).resolves.not.toThrowError();
+					await expect(deleteDoc()).resolves.not.toThrow();
 				});
 			});
 
@@ -410,7 +410,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not delete documents if banned', async () => {
-					await expect(deleteDocs()).resolves.not.toThrowError();
+					await expect(deleteDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -418,12 +418,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should delete documents if unbanned', async () => {
-					await expect(deleteDocs()).resolves.not.toThrowError();
+					await expect(deleteDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(deleteDocs()).resolves.not.toThrowError();
+					await expect(deleteDocs()).resolves.not.toThrow();
 				});
 			});
 
@@ -441,7 +441,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not delete documents if banned', async () => {
-					await expect(deleteFilteredDocs()).resolves.not.toThrowError();
+					await expect(deleteFilteredDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -449,12 +449,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should get documents if unbanned', async () => {
-					await expect(deleteFilteredDocs()).resolves.not.toThrowError();
+					await expect(deleteFilteredDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(deleteFilteredDocs()).resolves.not.toThrowError();
+					await expect(deleteFilteredDocs()).resolves.not.toThrow();
 				});
 			});
 
@@ -472,7 +472,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not list documents if banned', async () => {
-					await expect(listDocs()).resolves.not.toThrowError();
+					await expect(listDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -480,12 +480,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should list documents if unbanned', async () => {
-					await expect(listDocs()).resolves.not.toThrowError();
+					await expect(listDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(listDocs()).resolves.not.toThrowError();
+					await expect(listDocs()).resolves.not.toThrow();
 				});
 			});
 
@@ -503,7 +503,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not count documents if banned', async () => {
-					await expect(countDocs()).resolves.not.toThrowError();
+					await expect(countDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -511,12 +511,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should count documents if unbanned', async () => {
-					await expect(countDocs()).resolves.not.toThrowError();
+					await expect(countDocs()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(countDocs()).resolves.not.toThrowError();
+					await expect(countDocs()).resolves.not.toThrow();
 				});
 			});
 		});
@@ -560,7 +560,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not init asset upload if banned', async () => {
-					await expect(initAsset()).resolves.not.toThrowError();
+					await expect(initAsset()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -568,12 +568,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should init asset upload if unbanned', async () => {
-					await expect(initAsset()).resolves.not.toThrowError();
+					await expect(initAsset()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(initAsset()).resolves.not.toThrowError();
+					await expect(initAsset()).resolves.not.toThrow();
 				});
 			});
 
@@ -629,7 +629,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not delete assets if banned', async () => {
-					await expect(deleteFilteredAssets()).resolves.not.toThrowError();
+					await expect(deleteFilteredAssets()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -639,12 +639,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should get assets if unbanned', async () => {
-					await expect(deleteFilteredAssets()).resolves.not.toThrowError();
+					await expect(deleteFilteredAssets()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(deleteFilteredAssets()).resolves.not.toThrowError();
+					await expect(deleteFilteredAssets()).resolves.not.toThrow();
 				});
 			});
 
@@ -662,7 +662,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not list assets if banned', async () => {
-					await expect(listAssets()).resolves.not.toThrowError();
+					await expect(listAssets()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -670,12 +670,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should list assets if unbanned', async () => {
-					await expect(listAssets()).resolves.not.toThrowError();
+					await expect(listAssets()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(listAssets()).resolves.not.toThrowError();
+					await expect(listAssets()).resolves.not.toThrow();
 				});
 			});
 
@@ -693,7 +693,7 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should not count assets if banned', async () => {
-					await expect(countAssets()).resolves.not.toThrowError();
+					await expect(countAssets()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 
@@ -701,12 +701,12 @@ describe('Satellite > User Ban', () => {
 				});
 
 				it('should count assets if unbanned', async () => {
-					await expect(countAssets()).resolves.not.toThrowError();
+					await expect(countAssets()).resolves.not.toThrow();
 
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(countAssets()).resolves.not.toThrowError();
+					await expect(countAssets()).resolves.not.toThrow();
 				});
 			});
 
@@ -780,7 +780,7 @@ describe('Satellite > User Ban', () => {
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(deleteAsset()).resolves.not.toThrowError();
+					await expect(deleteAsset()).resolves.not.toThrow();
 				});
 			});
 
@@ -814,7 +814,7 @@ describe('Satellite > User Ban', () => {
 					await banUser({ user, version: [1n] });
 					await unbanUser({ user, version: [2n] });
 
-					await expect(deleteAssets()).resolves.not.toThrowError();
+					await expect(deleteAssets()).resolves.not.toThrow();
 				});
 			});
 		});

--- a/src/tests/specs/satellite/stock/satellite.user-usage.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.user-usage.spec.ts
@@ -308,7 +308,7 @@ describe('Satellite > User Usage', () => {
 					actorIdentity
 				});
 
-			it('should not get usage ', async () => {
+			it('should not get usage', async () => {
 				actor.setIdentity(user);
 
 				await createDoc();
@@ -366,6 +366,7 @@ describe('Satellite > User Usage', () => {
 				});
 
 				const doc = await get_doc('#log', key);
+
 				expect(fromNullable(doc)).not.toBeUndefined();
 
 				const { doc: usageDoc } = await get_user_usage({
@@ -373,6 +374,7 @@ describe('Satellite > User Usage', () => {
 					collectionType: COLLECTION_TYPE,
 					userId: controller.getPrincipal()
 				});
+
 				expect(usageDoc).toBeUndefined();
 			});
 
@@ -393,6 +395,7 @@ describe('Satellite > User Usage', () => {
 				});
 
 				const doc = await get_doc('#user', key);
+
 				expect(fromNullable(doc)).not.toBeUndefined();
 
 				const { doc: usageDoc } = await get_user_usage({
@@ -400,6 +403,7 @@ describe('Satellite > User Usage', () => {
 					collectionType: COLLECTION_TYPE,
 					userId: controller.getPrincipal()
 				});
+
 				expect(usageDoc).toBeUndefined();
 			});
 
@@ -415,6 +419,7 @@ describe('Satellite > User Usage', () => {
 				});
 
 				const doc = await get_doc('#log', key);
+
 				expect(fromNullable(doc)).not.toBeUndefined();
 
 				const { doc: usageDoc } = await get_user_usage({
@@ -422,6 +427,7 @@ describe('Satellite > User Usage', () => {
 					collectionType: COLLECTION_TYPE,
 					userId: controller.getPrincipal()
 				});
+
 				expect(usageDoc).toBeUndefined();
 			});
 		});
@@ -654,7 +660,7 @@ describe('Satellite > User Usage', () => {
 					actorIdentity
 				});
 
-			it('should not get usage ', async () => {
+			it('should not get usage', async () => {
 				actor.setIdentity(user);
 
 				await upload({ index: 100 });
@@ -714,6 +720,7 @@ describe('Satellite > User Usage', () => {
 				});
 
 				const asset = await get_asset('#dapp', full_path);
+
 				expect(fromNullable(asset)).not.toBeUndefined();
 
 				const { doc: usageDoc } = await get_user_usage({
@@ -721,6 +728,7 @@ describe('Satellite > User Usage', () => {
 					collectionType: COLLECTION_TYPE,
 					userId: controller.getPrincipal()
 				});
+
 				expect(usageDoc).toBeUndefined();
 			});
 		});

--- a/src/tests/specs/satellite/stock/satellite.user.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.user.spec.ts
@@ -117,7 +117,7 @@ describe('Satellite > User', () => {
 					del_doc('#user', user.getPrincipal().toText(), {
 						version: fromNullable(before)?.version ?? []
 					})
-				).resolves.not.toThrowError();
+				).resolves.not.toThrow();
 			});
 		});
 
@@ -303,7 +303,7 @@ describe('Satellite > User', () => {
 						description: toNullable(),
 						version: fromNullable(before)?.version ?? []
 					})
-				).resolves.not.toThrowError();
+				).resolves.not.toThrow();
 			});
 		});
 
@@ -333,7 +333,7 @@ describe('Satellite > User', () => {
 					del_doc('#user', user.getPrincipal().toText(), {
 						version: fromNullable(before)?.version ?? []
 					})
-				).resolves.not.toThrowError();
+				).resolves.not.toThrow();
 			});
 		});
 	});
@@ -400,7 +400,7 @@ describe('Satellite > User', () => {
 					del_doc('#user', user.getPrincipal().toText(), {
 						version: before.version
 					})
-				).resolves.not.toThrowError();
+				).resolves.not.toThrow();
 			});
 
 			it('should delete a banned user', async () => {
@@ -435,7 +435,7 @@ describe('Satellite > User', () => {
 					del_doc('#user', user.getPrincipal().toText(), {
 						version: afterBan.version
 					})
-				).resolves.not.toThrowError();
+				).resolves.not.toThrow();
 			});
 		});
 

--- a/src/tests/specs/sputnik/sputnik.assert-delete-asset.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.assert-delete-asset.spec.ts
@@ -117,7 +117,7 @@ describe('Sputnik > assert_delete_asset', () => {
 
 		expect(asset).not.toBeUndefined();
 
-		await expect(del_asset(TEST_ASSERTED_COLLECTION, full_path)).resolves.not.toThrowError();
+		await expect(del_asset(TEST_ASSERTED_COLLECTION, full_path)).resolves.not.toThrow();
 
 		const afterAsset = fromNullable(await get_asset(TEST_ASSERTED_COLLECTION, full_path));
 
@@ -137,7 +137,7 @@ describe('Sputnik > assert_delete_asset', () => {
 
 		expect(asset).not.toBeUndefined();
 
-		await expect(del_asset(TEST_ASSERTED_COLLECTION, full_path)).rejects.toThrowError(
+		await expect(del_asset(TEST_ASSERTED_COLLECTION, full_path)).rejects.toThrow(
 			new RegExp('test.html name not allowed', 'i')
 		);
 	});

--- a/src/tests/specs/sputnik/sputnik.assert-delete-doc.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.assert-delete-doc.spec.ts
@@ -99,7 +99,7 @@ describe('Sputnik > assert_delete_doc', () => {
 			del_doc(TEST_ASSERTED_COLLECTION, key, {
 				version: doc?.version ?? []
 			})
-		).resolves.not.toThrowError();
+		).resolves.not.toThrow();
 
 		const afterDoc = fromNullable(await get_doc(TEST_ASSERTED_COLLECTION, key));
 
@@ -130,6 +130,6 @@ describe('Sputnik > assert_delete_doc', () => {
 			del_doc(TEST_ASSERTED_COLLECTION, key, {
 				version: doc?.version ?? []
 			})
-		).rejects.toThrowError(new RegExp('test keyword not allowed', 'i'));
+		).rejects.toThrow(new RegExp('test keyword not allowed', 'i'));
 	});
 });

--- a/src/tests/specs/sputnik/sputnik.assert-upload-asset.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.assert-upload-asset.spec.ts
@@ -107,7 +107,7 @@ describe('Sputnik > assert_upload_asset', () => {
 
 		await expect(
 			upload({ collection: TEST_ASSERTED_COLLECTION, name, full_path })
-		).resolves.not.toThrowError();
+		).resolves.not.toThrow();
 
 		const { get_asset } = actor;
 
@@ -123,7 +123,7 @@ describe('Sputnik > assert_upload_asset', () => {
 
 		await expect(
 			upload({ collection: TEST_ASSERTED_COLLECTION, name, full_path })
-		).rejects.toThrowError(new RegExp('test.html name not allowed', 'i'));
+		).rejects.toThrow(new RegExp('test.html name not allowed', 'i'));
 
 		const { get_asset } = actor;
 

--- a/src/tests/specs/sputnik/sputnik.assert-upload-asset.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.assert-upload-asset.spec.ts
@@ -121,9 +121,9 @@ describe('Sputnik > assert_upload_asset', () => {
 		const name = 'test.html';
 		const full_path = `/${TEST_ASSERTED_COLLECTION}/${name}`;
 
-		await expect(
-			upload({ collection: TEST_ASSERTED_COLLECTION, name, full_path })
-		).rejects.toThrow(new RegExp('test.html name not allowed', 'i'));
+		await expect(upload({ collection: TEST_ASSERTED_COLLECTION, name, full_path })).rejects.toThrow(
+			new RegExp('test.html name not allowed', 'i')
+		);
 
 		const { get_asset } = actor;
 

--- a/src/tests/specs/sputnik/sputnik.sdk.controllers.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.controllers.spec.ts
@@ -93,6 +93,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} caller: ${caller()}`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 
@@ -108,6 +109,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} isController: true`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 
@@ -123,6 +125,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} isAdminController: true`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 
@@ -165,6 +168,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} caller: ${caller()}`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 
@@ -180,6 +184,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} isController: false`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 
@@ -195,6 +200,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} isAdminController: false`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 	});
@@ -238,6 +244,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} caller: ${caller()}`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 
@@ -253,6 +260,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} isController: true`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 
@@ -268,6 +276,7 @@ describe('Sputnik > sdk > controllers', () => {
 			const log = logs.find(([_, { message }]) =>
 				message.includes(`${callerText()} isAdminController: false`)
 			);
+
 			expect(log).not.toBeUndefined();
 		});
 
@@ -307,7 +316,7 @@ describe('Sputnik > sdk > controllers', () => {
 
 			const controllers = await list_controllers();
 
-			expect(data.length).toEqual(controllers.filter((c) => 'Admin' in c[1].scope).length);
+			expect(data).toHaveLength(controllers.filter((c) => 'Admin' in c[1].scope).length);
 		});
 	});
 });

--- a/src/tests/specs/sputnik/sputnik.sdk.count-assets-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.count-assets-store.spec.ts
@@ -71,6 +71,7 @@ describe('Sputnik > sdk > countAssetsStore', () => {
 		});
 
 		const countMsg = logs.find(([_, { message }]) => message.includes('Count:'));
+
 		expect(countMsg).not.toBeUndefined();
 
 		const count = BigInt((countMsg?.[1].message ?? '').replace('Count:', '').trim());

--- a/src/tests/specs/sputnik/sputnik.sdk.count-collection-assets-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.count-collection-assets-store.spec.ts
@@ -73,6 +73,7 @@ describe('Sputnik > sdk > countCollectionAssetsStore', () => {
 		});
 
 		const countMsg = logs.find(([_, { message }]) => message.includes('Count:'));
+
 		expect(countMsg).not.toBeUndefined();
 
 		const count = BigInt((countMsg?.[1].message ?? '').replace('Count:', '').trim());

--- a/src/tests/specs/sputnik/sputnik.sdk.count-collection-docs-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.count-collection-docs-store.spec.ts
@@ -73,6 +73,7 @@ describe('Sputnik > sdk > countCollectionDocsStore', () => {
 		});
 
 		const countMsg = logs.find(([_, { message }]) => message.includes('Count:'));
+
 		expect(countMsg).not.toBeUndefined();
 
 		const count = BigInt((countMsg?.[1].message ?? '').replace('Count:', '').trim());

--- a/src/tests/specs/sputnik/sputnik.sdk.count-docs-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.count-docs-store.spec.ts
@@ -71,6 +71,7 @@ describe('Sputnik > sdk > countDocsStore', () => {
 		});
 
 		const countMsg = logs.find(([_, { message }]) => message.includes('Count:'));
+
 		expect(countMsg).not.toBeUndefined();
 
 		const count = BigInt((countMsg?.[1].message ?? '').replace('Count:', '').trim());

--- a/src/tests/specs/sputnik/sputnik.sdk.delete-filtered-assets-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.delete-filtered-assets-store.spec.ts
@@ -74,6 +74,7 @@ describe('Sputnik > sdk > deleteFilteredDocsStore', () => {
 		});
 
 		const countMsg = logs.find(([_, { message }]) => message.includes('Count:'));
+
 		expect(countMsg).not.toBeUndefined();
 
 		const count = BigInt((countMsg?.[1].message ?? '').replace('Count:', '').trim());

--- a/src/tests/specs/sputnik/sputnik.sdk.delete-filtered-docs-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.delete-filtered-docs-store.spec.ts
@@ -70,6 +70,7 @@ describe('Sputnik > sdk > deleteFilteredDocsStore', () => {
 		});
 
 		const countMsg = logs.find(([_, { message }]) => message.includes('Count:'));
+
 		expect(countMsg).not.toBeUndefined();
 
 		const count = BigInt((countMsg?.[1].message ?? '').replace('Count:', '').trim());

--- a/src/tests/specs/sputnik/sputnik.sdk.get-asset-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.get-asset-store.spec.ts
@@ -73,6 +73,8 @@ describe('Sputnik > sdk > getAssetStore', () => {
 
 		expect(nullishMsg).not.toBeUndefined();
 
-		expect((nullishMsg?.[1].message ?? 'true').replace('Nullish:', '').trim() === 'false').toBeTruthy();
+		expect(
+			(nullishMsg?.[1].message ?? 'true').replace('Nullish:', '').trim() === 'false'
+		).toBeTruthy();
 	});
 });

--- a/src/tests/specs/sputnik/sputnik.sdk.get-asset-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.get-asset-store.spec.ts
@@ -70,10 +70,9 @@ describe('Sputnik > sdk > getAssetStore', () => {
 		});
 
 		const nullishMsg = logs.find(([_, { message }]) => message.includes('Nullish:'));
+
 		expect(nullishMsg).not.toBeUndefined();
 
-		expect((nullishMsg?.[1].message ?? 'true').replace('Nullish:', '').trim() === 'false').toEqual(
-			true
-		);
+		expect((nullishMsg?.[1].message ?? 'true').replace('Nullish:', '').trim() === 'false').toBeTruthy();
 	});
 });

--- a/src/tests/specs/sputnik/sputnik.sdk.get-doc-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.get-doc-store.spec.ts
@@ -48,6 +48,7 @@ describe('Sputnik > sdk > getDocStore', () => {
 		assertNonNullish(doc);
 
 		const resultData: SputnikMock = await fromArray(doc.data);
+
 		expect(resultData.value).toEqual('Validated');
 
 		expect(doc.version).toEqual([2n]);

--- a/src/tests/specs/sputnik/sputnik.sdk.list-assets-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.list-assets-store.spec.ts
@@ -103,22 +103,27 @@ describe('Sputnik > sdk > listAssetsStore', () => {
 
 		// Matcher
 		const logKey1 = logs.find(([_, { message }]) => message.includes(KEY_1));
+
 		expect(logKey1).not.toBeUndefined();
 
 		const logKey2 = logs.find(([_, { message }]) => message.includes(KEY_2));
+
 		expect(logKey2).toBeUndefined();
 
 		const logKey3 = logs.find(([_, { message }]) => message.includes(KEY_3));
+
 		expect(logKey3).toBeUndefined();
 
 		const logKey4 = logs.find(([_, { message }]) => message.includes(KEY_4));
+
 		expect(logKey4).not.toBeUndefined();
 
 		// Owner
 		const logKey5 = logs.find(([_, { message }]) => message.includes(KEY_5));
+
 		expect(logKey5).toBeUndefined();
 
 		// Sorting
-		expect(logs[0][1].message.includes(KEY_4)).toBe(true);
+		expect(logs[0][1].message).toContain(KEY_4);
 	});
 });

--- a/src/tests/specs/sputnik/sputnik.sdk.list-docs-store.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.sdk.list-docs-store.spec.ts
@@ -102,22 +102,27 @@ describe('Sputnik > sdk > listDocsStore', () => {
 
 		// Matcher
 		const logKey1 = logs.find(([_, { message }]) => message.includes(KEY_1));
+
 		expect(logKey1).not.toBeUndefined();
 
 		const logKey2 = logs.find(([_, { message }]) => message.includes(KEY_2));
+
 		expect(logKey2).toBeUndefined();
 
 		const logKey3 = logs.find(([_, { message }]) => message.includes(KEY_3));
+
 		expect(logKey3).toBeUndefined();
 
 		const logKey4 = logs.find(([_, { message }]) => message.includes(KEY_4));
+
 		expect(logKey4).not.toBeUndefined();
 
 		// Owner
 		const logKey5 = logs.find(([_, { message }]) => message.includes(KEY_5));
+
 		expect(logKey5).toBeUndefined();
 
 		// Sorting
-		expect(logs[0][1].message.includes(KEY_4)).toBe(true);
+		expect(logs[0][1].message).toContain(KEY_4);
 	});
 });

--- a/src/tests/specs/sputnik/sputnik.text-encoding.spec.ts
+++ b/src/tests/specs/sputnik/sputnik.text-encoding.spec.ts
@@ -66,10 +66,10 @@ describe('Sputnik > text-encoding', () => {
 		const resultData: SputnikTestTextEncodingData = await fromArray(doc.data);
 
 		expect(resultData.output?.decoded.value).toEqual(mockString);
-		expect(resultData.output?.decoded.labelNotSupported).toBe(true);
-		expect(resultData.output?.decoded.inputIsNotArrayBuffer).toBe(true);
+		expect(resultData.output?.decoded.labelNotSupported).toBeTruthy();
+		expect(resultData.output?.decoded.inputIsNotArrayBuffer).toBeTruthy();
 
 		expect(resultData.output?.encoded.value).toEqual(utf8Bytes);
-		expect(resultData.output?.encoded.encodeIntoNotSupported).toBe(true);
+		expect(resultData.output?.encoded.encodeIntoNotSupported).toBeTruthy();
 	});
 });

--- a/src/tests/utils/custom-domains-tests.utils.ts
+++ b/src/tests/utils/custom-domains-tests.utils.ts
@@ -79,6 +79,7 @@ export const adminCustomDomainsTests = <T extends SatelliteActor | ConsoleActor>
 		});
 
 		const decoder = new TextDecoder();
+
 		expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toContain('hello.com');
 		expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toContain('test2.com');
 	});
@@ -108,6 +109,7 @@ export const adminCustomDomainsTests = <T extends SatelliteActor | ConsoleActor>
 		});
 
 		const decoder = new TextDecoder();
+
 		expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).not.toContain('hello.com');
 	});
 
@@ -123,6 +125,7 @@ export const adminCustomDomainsTests = <T extends SatelliteActor | ConsoleActor>
 		});
 
 		const decoder = new TextDecoder();
+
 		expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toContain('test3.com');
 		expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toContain('test2.com');
 	});

--- a/src/tests/utils/sputnik-tests.utils.ts
+++ b/src/tests/utils/sputnik-tests.utils.ts
@@ -70,7 +70,7 @@ export const setDocAndAssertLogsLength = async ({
 
 	const logsWithKey = logs.filter(([_, { message }]) => message.includes(docKey));
 
-	expect(logsWithKey.length).toEqual(length);
+	expect(logsWithKey).toHaveLength(length);
 };
 
 /**

--- a/src/tests/utils/wasm-tests.utils.ts
+++ b/src/tests/utils/wasm-tests.utils.ts
@@ -24,6 +24,7 @@ const customSection = async ({
 
 	// Read the public custom section
 	const pkgSections = WebAssembly.Module.customSections(wasmModule, sectionName);
+
 	expect(pkgSections).toHaveLength(1);
 
 	// Parse content to object


### PR DESCRIPTION
# Motivation

In PR #1479, the new lint configurations for `vitest` raises a few warnings. So, I ran `eslint --fix .` in a fork and I am submitting the auto-fixes in this PR.
