### PR TITLE
chore: lint for rule `vitest/prefer-hooks-in-order`

### DIFF
--- a/src/tests/specs/mission-control/mission-control.user.spec.ts
+++ b/src/tests/specs/mission-control/mission-control.user.spec.ts
@@ -50,12 +50,12 @@ describe('Mission Control', () => {
 		satelliteId = cId;
 	});
 
-	afterAll(async () => {
-		await pic?.tearDown();
-	});
-
 	beforeEach(() => {
 		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
 	});
 
 	it('should throw errors on set satellite because the user of the mission control has been incorrectly set to another identity than the controller', async () => {

--- a/src/tests/specs/satellite/stock/satellite.playground.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.playground.spec.ts
@@ -26,12 +26,12 @@ describe.skip('Satellite > Playground (kind of)', () => {
 		actor = c;
 	});
 
-	afterAll(async () => {
-		await pic?.tearDown();
-	});
-
 	beforeEach(() => {
 		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
 	});
 
 	it('should create lots of users', async () => {


### PR DESCRIPTION
# Motivation

In PR https://github.com/junobuild/juno/pull/1479, the new lint configurations for `vitest` raises a few warnings. In this PR, we tackle the specific case for rule [vitest/prefer-hooks-in-order](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/prefer-hooks-in-order.md) that requires a manual fix.
