### PR TITLE
chore: lint for rule `vitest/no-identical-title`

### DIFF
--- a/src/tests/specs/mission-control/mission-control.spec.ts
+++ b/src/tests/specs/mission-control/mission-control.spec.ts
@@ -61,7 +61,7 @@ describe('Mission Control', () => {
 			await expect(get_metadata()).rejects.toThrow(CONTROLLER_ERROR_MSG);
 		});
 
-		it('should throw errors on get metadata', async () => {
+		it('should throw errors on set metadata', async () => {
 			const { set_metadata } = actor;
 
 			await expect(set_metadata(metadata)).rejects.toThrow(CONTROLLER_ERROR_MSG);

--- a/src/tests/specs/orbiter/orbiter.no-configuration.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.no-configuration.spec.ts
@@ -95,7 +95,7 @@ describe('Orbiter > No configuration', () => {
 			);
 		});
 
-		it('should not set page views', async () => {
+		it('should not set track events', async () => {
 			const { set_track_events } = actor;
 
 			const trackEvents: [AnalyticKey, SetTrackEvent][] = [


### PR DESCRIPTION
# Motivation

In PR https://github.com/junobuild/juno/pull/1479, the new lint configurations for `vitest` raises a few warnings. In this PR, we tackle the specific case for rule [vitest/no-identical-title](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-identical-title.md) that requires a manual fix.

