### PR TITLE
feat(orbiter): one http request equals one satellite

### DIFF
--- a/src/orbiter/src/handler/adapters/page_views.rs
+++ b/src/orbiter/src/handler/adapters/page_views.rs
@@ -1,16 +1,24 @@
 use crate::events::helpers::assert_and_insert_page_view;
 use crate::state::types::state::AnalyticKey;
-use crate::types::interface::http::{PageViewPayload, SetPageViewRequest, SetPageViewsRequest};
+use crate::types::interface::http::{
+    PageViewPayload, SetPageViewPayload, SetPageViewRequest, SetPageViewsRequest,
+    SetPageViewsRequestEntry,
+};
 use ic_http_certification::HttpRequest;
 use junobuild_utils::decode_doc_data;
 
 pub fn handle_insert_page_view(request: &HttpRequest) -> Result<PageViewPayload, String> {
-    let SetPageViewRequest { key, page_view }: SetPageViewRequest =
+    let SetPageViewRequest {
+        key,
+        page_view,
+        satellite_id,
+    }: SetPageViewRequest =
         decode_doc_data::<SetPageViewRequest>(request.body()).map_err(|e| e.to_string())?;
 
     let inserted_page_view = assert_and_insert_page_view(
         key.into_domain(),
-        page_view.into_domain().map_err(|e| e.to_string())?,
+        SetPageViewPayload::convert_to_setter(page_view, &satellite_id)
+            .map_err(|e| e.to_string())?,
     )?;
 
     Ok(PageViewPayload::from_domain(inserted_page_view))
@@ -22,12 +30,13 @@ pub fn handle_insert_page_views(request: &HttpRequest) -> Result<(), String> {
 
     let mut errors: Vec<(AnalyticKey, String)> = Vec::new();
 
-    for SetPageViewRequest { key, page_view } in page_views {
+    for SetPageViewsRequestEntry { key, page_view } in page_views.page_views {
         let key_domain = key.into_domain();
 
         let result = assert_and_insert_page_view(
             key_domain.clone(),
-            page_view.into_domain().map_err(|e| e.to_string())?,
+            SetPageViewPayload::convert_to_setter(page_view, &page_views.satellite_id)
+                .map_err(|e| e.to_string())?,
         );
 
         match result {

--- a/src/orbiter/src/handler/adapters/performance_metrics.rs
+++ b/src/orbiter/src/handler/adapters/performance_metrics.rs
@@ -1,7 +1,8 @@
 use crate::events::helpers::assert_and_insert_performance_metric;
 use crate::state::types::state::AnalyticKey;
 use crate::types::interface::http::{
-    PerformanceMetricPayload, SetPerformanceMetricRequest, SetPerformanceMetricsRequest,
+    PerformanceMetricPayload, SetPerformanceMetricPayload, SetPerformanceMetricRequest,
+    SetPerformanceMetricsRequest, SetPerformanceMetricsRequestEntry,
 };
 use ic_http_certification::HttpRequest;
 use junobuild_utils::decode_doc_data;
@@ -12,13 +13,13 @@ pub fn handle_insert_performance_metric(
     let SetPerformanceMetricRequest {
         key,
         performance_metric,
+        satellite_id,
     }: SetPerformanceMetricRequest = decode_doc_data::<SetPerformanceMetricRequest>(request.body())
         .map_err(|e| e.to_string())?;
 
     let inserted_performance_metric = assert_and_insert_performance_metric(
         key.into_domain(),
-        performance_metric
-            .into_domain()
+        SetPerformanceMetricPayload::convert_to_setter(performance_metric, &satellite_id)
             .map_err(|e| e.to_string())?,
     )?;
 
@@ -34,18 +35,20 @@ pub fn handle_insert_performance_metrics(request: &HttpRequest) -> Result<(), St
 
     let mut errors: Vec<(AnalyticKey, String)> = Vec::new();
 
-    for SetPerformanceMetricRequest {
+    for SetPerformanceMetricsRequestEntry {
         key,
         performance_metric,
-    } in performance_metrics
+    } in performance_metrics.performance_metrics
     {
         let key_domain = key.into_domain();
 
         let result = assert_and_insert_performance_metric(
             key_domain.clone(),
-            performance_metric
-                .into_domain()
-                .map_err(|e| e.to_string())?,
+            SetPerformanceMetricPayload::convert_to_setter(
+                performance_metric,
+                &performance_metrics.satellite_id,
+            )
+            .map_err(|e| e.to_string())?,
         );
 
         match result {

--- a/src/orbiter/src/handler/adapters/track_events.rs
+++ b/src/orbiter/src/handler/adapters/track_events.rs
@@ -1,18 +1,24 @@
 use crate::events::helpers::assert_and_insert_track_event;
 use crate::state::types::state::AnalyticKey;
 use crate::types::interface::http::{
-    SetTrackEventRequest, SetTrackEventsRequest, TrackEventPayload,
+    SetTrackEventPayload, SetTrackEventRequest, SetTrackEventsRequest, SetTrackEventsRequestEntry,
+    TrackEventPayload,
 };
 use ic_http_certification::HttpRequest;
 use junobuild_utils::decode_doc_data;
 
 pub fn handle_insert_track_event(request: &HttpRequest) -> Result<TrackEventPayload, String> {
-    let SetTrackEventRequest { key, track_event }: SetTrackEventRequest =
+    let SetTrackEventRequest {
+        key,
+        track_event,
+        satellite_id,
+    }: SetTrackEventRequest =
         decode_doc_data::<SetTrackEventRequest>(request.body()).map_err(|e| e.to_string())?;
 
     let inserted_track_event = assert_and_insert_track_event(
         key.into_domain(),
-        track_event.into_domain().map_err(|e| e.to_string())?,
+        SetTrackEventPayload::convert_to_setter(track_event, &satellite_id)
+            .map_err(|e| e.to_string())?,
     )?;
 
     Ok(TrackEventPayload::from_domain(inserted_track_event))
@@ -24,12 +30,13 @@ pub fn handle_insert_track_events(request: &HttpRequest) -> Result<(), String> {
 
     let mut errors: Vec<(AnalyticKey, String)> = Vec::new();
 
-    for SetTrackEventRequest { key, track_event } in track_events {
+    for SetTrackEventsRequestEntry { key, track_event } in track_events.track_events {
         let key_domain = key.into_domain();
 
         let result = assert_and_insert_track_event(
             key_domain.clone(),
-            track_event.into_domain().map_err(|e| e.to_string())?,
+            SetTrackEventPayload::convert_to_setter(track_event, &track_events.satellite_id)
+                .map_err(|e| e.to_string())?,
         );
 
         match result {

--- a/src/orbiter/src/handler/impls.rs
+++ b/src/orbiter/src/handler/impls.rs
@@ -48,7 +48,6 @@ impl PageViewPayload {
             device: page_view.device,
             user_agent: page_view.user_agent,
             time_zone: page_view.time_zone,
-            satellite_id: page_view.satellite_id.to_text(),
             session_id: page_view.session_id,
             created_at: DocDataBigInt {
                 value: page_view.created_at,
@@ -87,7 +86,6 @@ impl TrackEventPayload {
         Self {
             name: track_event.name,
             metadata: track_event.metadata,
-            satellite_id: track_event.satellite_id.to_text(),
             session_id: track_event.session_id,
             created_at: DocDataBigInt {
                 value: track_event.created_at,
@@ -127,7 +125,6 @@ impl PerformanceMetricPayload {
             href: performance_metric.href,
             metric_name: performance_metric.metric_name,
             data: performance_metric.data,
-            satellite_id: performance_metric.satellite_id.to_text(),
             session_id: performance_metric.session_id,
             created_at: DocDataBigInt {
                 value: performance_metric.created_at,

--- a/src/orbiter/src/handler/impls.rs
+++ b/src/orbiter/src/handler/impls.rs
@@ -1,7 +1,7 @@
 use crate::state::types::state::{AnalyticKey, PageView, PerformanceMetric, TrackEvent};
 use crate::types::interface::http::{
-    AnalyticKeyPayload, PageViewPayload, PerformanceMetricPayload, SetPageViewPayload,
-    SetPerformanceMetricPayload, SetTrackEventPayload, TrackEventPayload,
+    AnalyticKeyPayload, PageViewPayload, PerformanceMetricPayload, SatelliteIdText,
+    SetPageViewPayload, SetPerformanceMetricPayload, SetTrackEventPayload, TrackEventPayload,
 };
 use crate::types::interface::{SetPageView, SetPerformanceMetric, SetTrackEvent};
 use candid::types::principal::PrincipalError;
@@ -18,18 +18,21 @@ impl AnalyticKeyPayload {
 }
 
 impl SetPageViewPayload {
-    pub fn into_domain(self) -> Result<SetPageView, PrincipalError> {
+    pub fn convert_to_setter(
+        payload: SetPageViewPayload,
+        satellite_id: &SatelliteIdText,
+    ) -> Result<SetPageView, PrincipalError> {
         let page_view = SetPageView {
-            title: self.title,
-            href: self.href,
-            referrer: self.referrer,
-            device: self.device,
-            time_zone: self.time_zone,
-            user_agent: self.user_agent,
-            satellite_id: Principal::from_text(self.satellite_id)?,
-            session_id: self.session_id,
+            title: payload.title,
+            href: payload.href,
+            referrer: payload.referrer,
+            device: payload.device,
+            time_zone: payload.time_zone,
+            user_agent: payload.user_agent,
+            satellite_id: Principal::from_text(satellite_id)?,
+            session_id: payload.session_id,
             updated_at: None,
-            version: self.version.map(|version| version.value),
+            version: payload.version.map(|version| version.value),
         };
 
         Ok(page_view)
@@ -61,15 +64,18 @@ impl PageViewPayload {
 }
 
 impl SetTrackEventPayload {
-    pub fn into_domain(self) -> Result<SetTrackEvent, PrincipalError> {
+    pub fn convert_to_setter(
+        payload: SetTrackEventPayload,
+        satellite_id: &SatelliteIdText,
+    ) -> Result<SetTrackEvent, PrincipalError> {
         let track_event = SetTrackEvent {
-            name: self.name,
-            metadata: self.metadata,
-            user_agent: self.user_agent,
-            satellite_id: Principal::from_text(self.satellite_id)?,
-            session_id: self.session_id,
+            name: payload.name,
+            metadata: payload.metadata,
+            user_agent: payload.user_agent,
+            satellite_id: Principal::from_text(satellite_id)?,
+            session_id: payload.session_id,
             updated_at: None,
-            version: self.version.map(|version| version.value),
+            version: payload.version.map(|version| version.value),
         };
 
         Ok(track_event)
@@ -97,15 +103,18 @@ impl TrackEventPayload {
 }
 
 impl SetPerformanceMetricPayload {
-    pub fn into_domain(self) -> Result<SetPerformanceMetric, PrincipalError> {
+    pub fn convert_to_setter(
+        payload: SetPerformanceMetricPayload,
+        satellite_id: &SatelliteIdText,
+    ) -> Result<SetPerformanceMetric, PrincipalError> {
         let metric = SetPerformanceMetric {
-            href: self.href,
-            metric_name: self.metric_name,
-            data: self.data,
-            user_agent: self.user_agent,
-            satellite_id: Principal::from_text(self.satellite_id)?,
-            session_id: self.session_id,
-            version: self.version.map(|version| version.value),
+            href: payload.href,
+            metric_name: payload.metric_name,
+            data: payload.data,
+            user_agent: payload.user_agent,
+            satellite_id: Principal::from_text(satellite_id)?,
+            session_id: payload.session_id,
+            version: payload.version.map(|version| version.value),
         };
 
         Ok(metric)

--- a/src/orbiter/src/types.rs
+++ b/src/orbiter/src/types.rs
@@ -148,25 +148,60 @@ pub mod interface {
 
         #[derive(Deserialize)]
         pub struct SetPageViewRequest {
+            pub satellite_id: SatelliteIdText,
             pub key: AnalyticKeyPayload,
             pub page_view: SetPageViewPayload,
         }
 
         #[derive(Deserialize)]
         pub struct SetTrackEventRequest {
+            pub satellite_id: SatelliteIdText,
             pub key: AnalyticKeyPayload,
             pub track_event: SetTrackEventPayload,
         }
 
         #[derive(Deserialize)]
         pub struct SetPerformanceMetricRequest {
+            pub satellite_id: SatelliteIdText,
             pub key: AnalyticKeyPayload,
             pub performance_metric: SetPerformanceMetricPayload,
         }
 
-        pub type SetPageViewsRequest = Vec<SetPageViewRequest>;
-        pub type SetTrackEventsRequest = Vec<SetTrackEventRequest>;
-        pub type SetPerformanceMetricsRequest = Vec<SetPerformanceMetricRequest>;
+        #[derive(Deserialize)]
+        pub struct SetPageViewsRequest {
+            pub satellite_id: SatelliteIdText,
+            pub page_views: Vec<SetPageViewsRequestEntry>,
+        }
+
+        #[derive(Deserialize)]
+        pub struct SetPageViewsRequestEntry {
+            pub key: AnalyticKeyPayload,
+            pub page_view: SetPageViewPayload,
+        }
+
+        #[derive(Deserialize)]
+        pub struct SetTrackEventsRequest {
+            pub satellite_id: SatelliteIdText,
+            pub track_events: Vec<SetTrackEventsRequestEntry>,
+        }
+
+        #[derive(Deserialize)]
+        pub struct SetTrackEventsRequestEntry {
+            pub key: AnalyticKeyPayload,
+            pub track_event: SetTrackEventPayload,
+        }
+
+        #[derive(Deserialize)]
+        pub struct SetPerformanceMetricsRequest {
+            pub satellite_id: SatelliteIdText,
+            pub performance_metrics: Vec<SetPerformanceMetricsRequestEntry>,
+        }
+
+        #[derive(Deserialize)]
+        pub struct SetPerformanceMetricsRequestEntry {
+            pub key: AnalyticKeyPayload,
+            pub performance_metric: SetPerformanceMetricPayload,
+        }
 
         #[derive(Deserialize)]
         pub struct AnalyticKeyPayload {
@@ -182,7 +217,6 @@ pub mod interface {
             pub device: PageViewDevice,
             pub time_zone: String,
             pub user_agent: Option<String>,
-            pub satellite_id: SatelliteIdText,
             pub session_id: SessionId,
             pub version: VersionPayload,
         }
@@ -192,7 +226,6 @@ pub mod interface {
             pub name: String,
             pub metadata: Option<Metadata>,
             pub user_agent: Option<String>,
-            pub satellite_id: SatelliteIdText,
             pub session_id: SessionId,
             pub version: VersionPayload,
         }
@@ -203,7 +236,6 @@ pub mod interface {
             pub metric_name: PerformanceMetricName,
             pub data: PerformanceData,
             pub user_agent: Option<String>,
-            pub satellite_id: SatelliteIdText,
             pub session_id: SessionId,
             pub version: VersionPayload,
         }

--- a/src/orbiter/src/types.rs
+++ b/src/orbiter/src/types.rs
@@ -250,7 +250,6 @@ pub mod interface {
             pub time_zone: String,
             #[serde(skip_serializing_if = "Option::is_none")]
             pub user_agent: Option<String>,
-            pub satellite_id: SatelliteIdText,
             pub session_id: SessionId,
             pub created_at: TimestampPayload,
             pub updated_at: TimestampPayload,
@@ -263,7 +262,6 @@ pub mod interface {
             pub name: String,
             #[serde(skip_serializing_if = "Option::is_none")]
             pub metadata: Option<Metadata>,
-            pub satellite_id: SatelliteIdText,
             pub session_id: SessionId,
             pub created_at: TimestampPayload,
             pub updated_at: TimestampPayload,
@@ -276,7 +274,6 @@ pub mod interface {
             pub href: String,
             pub metric_name: PerformanceMetricName,
             pub data: PerformanceData,
-            pub satellite_id: SatelliteIdText,
             pub session_id: SessionId,
             pub created_at: TimestampPayload,
             pub updated_at: TimestampPayload,

--- a/src/tests/mocks/orbiter.mocks.ts
+++ b/src/tests/mocks/orbiter.mocks.ts
@@ -1,4 +1,5 @@
 import type {
+	AnalyticKey,
 	PageViewDevice,
 	SetPageView,
 	SetPerformanceMetric,
@@ -8,22 +9,46 @@ import type { SatelliteIdText } from '$lib/types/satellite';
 import { Principal } from '@dfinity/principal';
 import { nanoid } from 'nanoid';
 
+export interface SetPageViewsRequestEntry {
+	key: AnalyticKey;
+	page_view: SetPageViewPayload;
+}
+
+export type SetPageViewRequest = {
+	satellite_id: SatelliteIdText;
+} & SetPageViewsRequestEntry;
+
+export type SetPageViewsRequest = Pick<SetPageViewRequest, 'satellite_id'> & {
+	page_views: SetPageViewsRequestEntry[];
+};
+
 export interface SetPageViewPayload {
 	title: string;
 	referrer?: string;
 	time_zone: string;
 	session_id: string;
 	href: string;
-	satellite_id: SatelliteIdText;
 	device: PageViewDevice;
 	version?: bigint;
 	user_agent?: string;
 }
 
+export interface SetTrackEventRequestEntry {
+	key: AnalyticKey;
+	track_event: SetTrackEventPayload;
+}
+
+export type SetTrackEventRequest = {
+	satellite_id: SatelliteIdText;
+} & SetTrackEventRequestEntry;
+
+export type SetTrackEventsRequest = Pick<SetPageViewRequest, 'satellite_id'> & {
+	track_events: SetTrackEventRequestEntry[];
+};
+
 export interface SetTrackEventPayload {
 	name: string;
 	metadata?: Record<string, string>;
-	satellite_id: SatelliteIdText;
 	session_id: string;
 	version?: bigint;
 	user_agent?: string;
@@ -50,12 +75,24 @@ export type NavigationType =
 	| 'Prerender'
 	| 'Restore';
 
+export interface SetPerformanceRequestEntry {
+	key: AnalyticKey;
+	performance_metric: SetPerformanceMetricPayload;
+}
+
+export type SetPerformanceRequest = {
+	satellite_id: SatelliteIdText;
+} & SetPerformanceRequestEntry;
+
+export type SetPerformancesRequest = Pick<SetPageViewRequest, 'satellite_id'> & {
+	performance_metrics: SetPerformanceRequestEntry[];
+};
+
 export interface SetPerformanceMetricPayload {
 	href: string;
 	metric_name: PerformanceMetricName;
 	data: PerformanceData;
 	user_agent?: string;
-	satellite_id: SatelliteIdText;
 	session_id: string;
 	version?: bigint;
 }
@@ -105,7 +142,6 @@ export const pageViewPayloadMock: SetPageViewPayload = {
 		inner_height: 300,
 		inner_width: 600
 	},
-	satellite_id: satelliteIdMock.toText(),
 	session_id: sessionId,
 	title: 'Test',
 	time_zone: timeZone,
@@ -135,7 +171,6 @@ export const trackEventPayloadMock: SetTrackEventPayload = {
 		event1: 'Lorem ipsum dolor sit amet',
 		event2: ' Praesent congue, mauris id commodo vulputate'
 	},
-	satellite_id: satelliteIdMock.toText(),
 	session_id: sessionId,
 	user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0'
 };
@@ -171,6 +206,5 @@ export const performanceMetricPayloadMock: SetPerformanceMetricPayload = {
 	},
 	href: 'https://test.com',
 	metric_name: 'LCP',
-	satellite_id: satelliteIdMock.toText(),
 	user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0'
 };


### PR DESCRIPTION
# Motivation

We need to scope the request to one satellite this way in #1483 we can resolve the related optional restricted domain.

Even if it's a manual entry, the domain will prevail as set in the backend.
