### PR TITLE
feat(orbiter): http upgrade only on valid payload

### DIFF
--- a/src/orbiter/src/handler/adapters/assert.rs
+++ b/src/orbiter/src/handler/adapters/assert.rs
@@ -1,12 +1,13 @@
 use crate::config::store::get_satellite_config;
 use crate::http::types::request::HttpRequestBody;
+use crate::msg::ERROR_EMPTY_PAYLOAD;
 use crate::state::types::state::SatelliteConfig;
 use crate::types::interface::http::SetRequest;
 use candid::Principal;
 use junobuild_utils::decode_doc_data;
 use serde::Deserialize;
 
-pub fn assert_request_feature_enabled<T>(
+pub fn assert_request<T>(
     body: &HttpRequestBody,
     feature_check: fn(&Option<SatelliteConfig>) -> Result<(), String>,
 ) -> Result<(), String>
@@ -15,6 +16,22 @@ where
 {
     let request_payload = decode_doc_data::<T>(body)?;
 
+    assert_request_feature_enabled::<T>(&request_payload, feature_check)?;
+
+    if request_payload.empty_payload() {
+        return Err(ERROR_EMPTY_PAYLOAD.to_string());
+    }
+
+    Ok(())
+}
+
+fn assert_request_feature_enabled<T>(
+    request_payload: &T,
+    feature_check: fn(&Option<SatelliteConfig>) -> Result<(), String>,
+) -> Result<(), String>
+where
+    T: SetRequest,
+{
     let principal =
         Principal::from_text(request_payload.satellite_id()).map_err(|e| e.to_string())?;
 

--- a/src/orbiter/src/handler/adapters/assert.rs
+++ b/src/orbiter/src/handler/adapters/assert.rs
@@ -1,0 +1,22 @@
+use crate::config::store::get_satellite_config;
+use crate::http::types::request::HttpRequestBody;
+use crate::state::types::state::SatelliteConfig;
+use crate::types::interface::http::SetRequest;
+use candid::Principal;
+use junobuild_utils::decode_doc_data;
+use serde::Deserialize;
+
+pub fn assert_request_feature_enabled<T>(
+    body: &HttpRequestBody,
+    feature_check: fn(&Option<SatelliteConfig>) -> Result<(), String>,
+) -> Result<(), String>
+where
+    T: SetRequest + for<'de> Deserialize<'de>,
+{
+    let request_payload = decode_doc_data::<T>(body)?;
+
+    let principal =
+        Principal::from_text(request_payload.satellite_id()).map_err(|e| e.to_string())?;
+
+    feature_check(&get_satellite_config(&principal))
+}

--- a/src/orbiter/src/handler/adapters/mod.rs
+++ b/src/orbiter/src/handler/adapters/mod.rs
@@ -1,3 +1,4 @@
+mod assert;
 pub mod page_views;
 pub mod performance_metrics;
 mod response_builder;

--- a/src/orbiter/src/handler/adapters/page_views.rs
+++ b/src/orbiter/src/handler/adapters/page_views.rs
@@ -1,6 +1,6 @@
 use crate::assert::config::assert_page_views_enabled;
 use crate::events::helpers::assert_and_insert_page_view;
-use crate::handler::adapters::assert::assert_request_feature_enabled;
+use crate::handler::adapters::assert::assert_request;
 use crate::handler::adapters::response_builder::build_payload_response;
 use crate::http::types::handler::HandledUpdateResult;
 use crate::http::types::request::HttpRequestBody;
@@ -12,11 +12,11 @@ use crate::types::interface::http::{
 use junobuild_utils::decode_doc_data;
 
 pub fn assert_request_page_view(body: &HttpRequestBody) -> Result<(), String> {
-    assert_request_feature_enabled::<SetPageViewRequest>(body, assert_page_views_enabled)
+    assert_request::<SetPageViewRequest>(body, assert_page_views_enabled)
 }
 
 pub fn assert_request_page_views(body: &HttpRequestBody) -> Result<(), String> {
-    assert_request_feature_enabled::<SetPageViewsRequest>(body, assert_page_views_enabled)
+    assert_request::<SetPageViewsRequest>(body, assert_page_views_enabled)
 }
 
 pub fn handle_insert_page_view(body: &HttpRequestBody) -> Result<HandledUpdateResult, String> {

--- a/src/orbiter/src/handler/adapters/page_views.rs
+++ b/src/orbiter/src/handler/adapters/page_views.rs
@@ -1,6 +1,6 @@
 use crate::assert::config::assert_page_views_enabled;
-use crate::config::store::get_satellite_config;
 use crate::events::helpers::assert_and_insert_page_view;
+use crate::handler::adapters::assert::assert_request_feature_enabled;
 use crate::handler::adapters::response_builder::build_payload_response;
 use crate::http::types::handler::HandledUpdateResult;
 use crate::http::types::request::HttpRequestBody;
@@ -9,23 +9,14 @@ use crate::types::interface::http::{
     PageViewPayload, SetPageViewPayload, SetPageViewRequest, SetPageViewsRequest,
     SetPageViewsRequestEntry,
 };
-use candid::Principal;
 use junobuild_utils::decode_doc_data;
 
 pub fn assert_request_page_view(body: &HttpRequestBody) -> Result<(), String> {
-    let payload = decode_doc_data::<SetPageViewRequest>(body).map_err(|e| e.to_string())?;
-
-    assert_page_views_enabled(&get_satellite_config(
-        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
-    ))
+    assert_request_feature_enabled::<SetPageViewRequest>(body, assert_page_views_enabled)
 }
 
 pub fn assert_request_page_views(body: &HttpRequestBody) -> Result<(), String> {
-    let payload = decode_doc_data::<SetPageViewsRequest>(body).map_err(|e| e.to_string())?;
-
-    assert_page_views_enabled(&get_satellite_config(
-        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
-    ))
+    assert_request_feature_enabled::<SetPageViewsRequest>(body, assert_page_views_enabled)
 }
 
 pub fn handle_insert_page_view(body: &HttpRequestBody) -> Result<HandledUpdateResult, String> {

--- a/src/orbiter/src/handler/adapters/performance_metrics.rs
+++ b/src/orbiter/src/handler/adapters/performance_metrics.rs
@@ -1,6 +1,6 @@
 use crate::assert::config::assert_performance_metrics_enabled;
 use crate::events::helpers::assert_and_insert_performance_metric;
-use crate::handler::adapters::assert::assert_request_feature_enabled;
+use crate::handler::adapters::assert::assert_request;
 use crate::handler::adapters::response_builder::build_payload_response;
 use crate::http::types::handler::HandledUpdateResult;
 use crate::http::types::request::HttpRequestBody;
@@ -12,17 +12,11 @@ use crate::types::interface::http::{
 use junobuild_utils::decode_doc_data;
 
 pub fn assert_request_performance_metric(body: &HttpRequestBody) -> Result<(), String> {
-    assert_request_feature_enabled::<SetPerformanceMetricRequest>(
-        body,
-        assert_performance_metrics_enabled,
-    )
+    assert_request::<SetPerformanceMetricRequest>(body, assert_performance_metrics_enabled)
 }
 
 pub fn assert_request_performance_metrics(body: &HttpRequestBody) -> Result<(), String> {
-    assert_request_feature_enabled::<SetPerformanceMetricsRequest>(
-        body,
-        assert_performance_metrics_enabled,
-    )
+    assert_request::<SetPerformanceMetricsRequest>(body, assert_performance_metrics_enabled)
 }
 
 pub fn handle_insert_performance_metric(

--- a/src/orbiter/src/handler/adapters/performance_metrics.rs
+++ b/src/orbiter/src/handler/adapters/performance_metrics.rs
@@ -1,6 +1,6 @@
 use crate::assert::config::assert_performance_metrics_enabled;
-use crate::config::store::get_satellite_config;
 use crate::events::helpers::assert_and_insert_performance_metric;
+use crate::handler::adapters::assert::assert_request_feature_enabled;
 use crate::handler::adapters::response_builder::build_payload_response;
 use crate::http::types::handler::HandledUpdateResult;
 use crate::http::types::request::HttpRequestBody;
@@ -9,25 +9,20 @@ use crate::types::interface::http::{
     PerformanceMetricPayload, SetPerformanceMetricPayload, SetPerformanceMetricRequest,
     SetPerformanceMetricsRequest, SetPerformanceMetricsRequestEntry,
 };
-use candid::Principal;
 use junobuild_utils::decode_doc_data;
 
 pub fn assert_request_performance_metric(body: &HttpRequestBody) -> Result<(), String> {
-    let payload =
-        decode_doc_data::<SetPerformanceMetricRequest>(body).map_err(|e| e.to_string())?;
-
-    assert_performance_metrics_enabled(&get_satellite_config(
-        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
-    ))
+    assert_request_feature_enabled::<SetPerformanceMetricRequest>(
+        body,
+        assert_performance_metrics_enabled,
+    )
 }
 
 pub fn assert_request_performance_metrics(body: &HttpRequestBody) -> Result<(), String> {
-    let payload =
-        decode_doc_data::<SetPerformanceMetricsRequest>(body).map_err(|e| e.to_string())?;
-
-    assert_performance_metrics_enabled(&get_satellite_config(
-        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
-    ))
+    assert_request_feature_enabled::<SetPerformanceMetricsRequest>(
+        body,
+        assert_performance_metrics_enabled,
+    )
 }
 
 pub fn handle_insert_performance_metric(

--- a/src/orbiter/src/handler/adapters/performance_metrics.rs
+++ b/src/orbiter/src/handler/adapters/performance_metrics.rs
@@ -1,23 +1,44 @@
+use crate::assert::config::assert_performance_metrics_enabled;
+use crate::config::store::get_satellite_config;
 use crate::events::helpers::assert_and_insert_performance_metric;
 use crate::handler::adapters::response_builder::build_payload_response;
 use crate::http::types::handler::HandledUpdateResult;
+use crate::http::types::request::HttpRequestBody;
 use crate::state::types::state::AnalyticKey;
 use crate::types::interface::http::{
-    PerformanceMetricPayload, SetPerformanceMetricPayload,
-    SetPerformanceMetricRequest, SetPerformanceMetricsRequest, SetPerformanceMetricsRequestEntry,
+    PerformanceMetricPayload, SetPerformanceMetricPayload, SetPerformanceMetricRequest,
+    SetPerformanceMetricsRequest, SetPerformanceMetricsRequestEntry,
 };
-use ic_http_certification::HttpRequest;
+use candid::Principal;
 use junobuild_utils::decode_doc_data;
 
+pub fn assert_request_performance_metric(body: &HttpRequestBody) -> Result<(), String> {
+    let payload =
+        decode_doc_data::<SetPerformanceMetricRequest>(body).map_err(|e| e.to_string())?;
+
+    assert_performance_metrics_enabled(&get_satellite_config(
+        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
+    ))
+}
+
+pub fn assert_request_performance_metrics(body: &HttpRequestBody) -> Result<(), String> {
+    let payload =
+        decode_doc_data::<SetPerformanceMetricsRequest>(body).map_err(|e| e.to_string())?;
+
+    assert_performance_metrics_enabled(&get_satellite_config(
+        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
+    ))
+}
+
 pub fn handle_insert_performance_metric(
-    request: &HttpRequest,
+    body: &HttpRequestBody,
 ) -> Result<HandledUpdateResult, String> {
     let SetPerformanceMetricRequest {
         key,
         performance_metric,
         satellite_id,
-    }: SetPerformanceMetricRequest = decode_doc_data::<SetPerformanceMetricRequest>(request.body())
-        .map_err(|e| e.to_string())?;
+    }: SetPerformanceMetricRequest =
+        decode_doc_data::<SetPerformanceMetricRequest>(body).map_err(|e| e.to_string())?;
 
     let inserted_performance_metric = assert_and_insert_performance_metric(
         key.into_domain(),
@@ -31,11 +52,10 @@ pub fn handle_insert_performance_metric(
 }
 
 pub fn handle_insert_performance_metrics(
-    request: &HttpRequest,
+    body: &HttpRequestBody,
 ) -> Result<HandledUpdateResult, String> {
     let performance_metrics: SetPerformanceMetricsRequest =
-        decode_doc_data::<SetPerformanceMetricsRequest>(request.body())
-            .map_err(|e| e.to_string())?;
+        decode_doc_data::<SetPerformanceMetricsRequest>(body).map_err(|e| e.to_string())?;
 
     let mut errors: Vec<(AnalyticKey, String)> = Vec::new();
 

--- a/src/orbiter/src/handler/adapters/response_builder.rs
+++ b/src/orbiter/src/handler/adapters/response_builder.rs
@@ -1,10 +1,10 @@
 use crate::config::store::get_satellite_config;
 use crate::http::types::handler::HandledUpdateResult;
-use crate::http::types::interface::ApiResponse;
+use crate::http::types::response::ApiResponse;
 use crate::msg::ERROR_FEATURE_DISABLED;
 use crate::types::interface::http::SatelliteIdText;
 use candid::Principal;
-use ic_http_certification::{StatusCode};
+use ic_http_certification::StatusCode;
 use serde::Serialize;
 
 pub fn build_payload_response<T: Serialize>(

--- a/src/orbiter/src/handler/adapters/track_events.rs
+++ b/src/orbiter/src/handler/adapters/track_events.rs
@@ -1,6 +1,6 @@
 use crate::assert::config::assert_track_events_enabled;
 use crate::events::helpers::assert_and_insert_track_event;
-use crate::handler::adapters::assert::assert_request_feature_enabled;
+use crate::handler::adapters::assert::assert_request;
 use crate::handler::adapters::response_builder::build_payload_response;
 use crate::http::types::handler::HandledUpdateResult;
 use crate::http::types::request::HttpRequestBody;
@@ -12,11 +12,11 @@ use crate::types::interface::http::{
 use junobuild_utils::decode_doc_data;
 
 pub fn assert_request_track_event(body: &HttpRequestBody) -> Result<(), String> {
-    assert_request_feature_enabled::<SetTrackEventRequest>(body, assert_track_events_enabled)
+    assert_request::<SetTrackEventRequest>(body, assert_track_events_enabled)
 }
 
 pub fn assert_request_track_events(body: &HttpRequestBody) -> Result<(), String> {
-    assert_request_feature_enabled::<SetTrackEventsRequest>(body, assert_track_events_enabled)
+    assert_request::<SetTrackEventsRequest>(body, assert_track_events_enabled)
 }
 
 pub fn handle_insert_track_event(body: &HttpRequestBody) -> Result<HandledUpdateResult, String> {

--- a/src/orbiter/src/handler/adapters/track_events.rs
+++ b/src/orbiter/src/handler/adapters/track_events.rs
@@ -1,6 +1,6 @@
 use crate::assert::config::assert_track_events_enabled;
-use crate::config::store::get_satellite_config;
 use crate::events::helpers::assert_and_insert_track_event;
+use crate::handler::adapters::assert::assert_request_feature_enabled;
 use crate::handler::adapters::response_builder::build_payload_response;
 use crate::http::types::handler::HandledUpdateResult;
 use crate::http::types::request::HttpRequestBody;
@@ -9,23 +9,14 @@ use crate::types::interface::http::{
     SetTrackEventPayload, SetTrackEventRequest, SetTrackEventsRequest, SetTrackEventsRequestEntry,
     TrackEventPayload,
 };
-use candid::Principal;
 use junobuild_utils::decode_doc_data;
 
 pub fn assert_request_track_event(body: &HttpRequestBody) -> Result<(), String> {
-    let payload = decode_doc_data::<SetTrackEventRequest>(body).map_err(|e| e.to_string())?;
-
-    assert_track_events_enabled(&get_satellite_config(
-        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
-    ))
+    assert_request_feature_enabled::<SetTrackEventRequest>(body, assert_track_events_enabled)
 }
 
 pub fn assert_request_track_events(body: &HttpRequestBody) -> Result<(), String> {
-    let payload = decode_doc_data::<SetTrackEventsRequest>(body).map_err(|e| e.to_string())?;
-
-    assert_track_events_enabled(&get_satellite_config(
-        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
-    ))
+    assert_request_feature_enabled::<SetTrackEventsRequest>(body, assert_track_events_enabled)
 }
 
 pub fn handle_insert_track_event(body: &HttpRequestBody) -> Result<HandledUpdateResult, String> {

--- a/src/orbiter/src/handler/adapters/track_events.rs
+++ b/src/orbiter/src/handler/adapters/track_events.rs
@@ -1,21 +1,40 @@
+use crate::assert::config::assert_track_events_enabled;
+use crate::config::store::get_satellite_config;
 use crate::events::helpers::assert_and_insert_track_event;
 use crate::handler::adapters::response_builder::build_payload_response;
 use crate::http::types::handler::HandledUpdateResult;
+use crate::http::types::request::HttpRequestBody;
 use crate::state::types::state::AnalyticKey;
 use crate::types::interface::http::{
-    SetTrackEventPayload, SetTrackEventRequest, SetTrackEventsRequest,
-    SetTrackEventsRequestEntry, TrackEventPayload,
+    SetTrackEventPayload, SetTrackEventRequest, SetTrackEventsRequest, SetTrackEventsRequestEntry,
+    TrackEventPayload,
 };
-use ic_http_certification::HttpRequest;
+use candid::Principal;
 use junobuild_utils::decode_doc_data;
 
-pub fn handle_insert_track_event(request: &HttpRequest) -> Result<HandledUpdateResult, String> {
+pub fn assert_request_track_event(body: &HttpRequestBody) -> Result<(), String> {
+    let payload = decode_doc_data::<SetTrackEventRequest>(body).map_err(|e| e.to_string())?;
+
+    assert_track_events_enabled(&get_satellite_config(
+        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
+    ))
+}
+
+pub fn assert_request_track_events(body: &HttpRequestBody) -> Result<(), String> {
+    let payload = decode_doc_data::<SetTrackEventsRequest>(body).map_err(|e| e.to_string())?;
+
+    assert_track_events_enabled(&get_satellite_config(
+        &Principal::from_text(payload.satellite_id).map_err(|e| e.to_string())?,
+    ))
+}
+
+pub fn handle_insert_track_event(body: &HttpRequestBody) -> Result<HandledUpdateResult, String> {
     let SetTrackEventRequest {
         key,
         track_event,
         satellite_id,
     }: SetTrackEventRequest =
-        decode_doc_data::<SetTrackEventRequest>(request.body()).map_err(|e| e.to_string())?;
+        decode_doc_data::<SetTrackEventRequest>(body).map_err(|e| e.to_string())?;
 
     let inserted_track_event = assert_and_insert_track_event(
         key.into_domain(),
@@ -28,9 +47,9 @@ pub fn handle_insert_track_event(request: &HttpRequest) -> Result<HandledUpdateR
     build_payload_response(payload, &satellite_id)
 }
 
-pub fn handle_insert_track_events(request: &HttpRequest) -> Result<HandledUpdateResult, String> {
+pub fn handle_insert_track_events(body: &HttpRequestBody) -> Result<HandledUpdateResult, String> {
     let track_events: SetTrackEventsRequest =
-        decode_doc_data::<SetTrackEventsRequest>(request.body()).map_err(|e| e.to_string())?;
+        decode_doc_data::<SetTrackEventsRequest>(body).map_err(|e| e.to_string())?;
 
     let mut errors: Vec<(AnalyticKey, String)> = Vec::new();
 

--- a/src/orbiter/src/handler/orbiter.rs
+++ b/src/orbiter/src/handler/orbiter.rs
@@ -1,16 +1,22 @@
-use crate::handler::adapters::page_views::{handle_insert_page_view, handle_insert_page_views};
+use crate::handler::adapters::page_views::{
+    assert_request_page_view, assert_request_page_views, handle_insert_page_view,
+    handle_insert_page_views,
+};
 use crate::handler::adapters::performance_metrics::{
+    assert_request_performance_metric, assert_request_performance_metrics,
     handle_insert_performance_metric, handle_insert_performance_metrics,
 };
 use crate::handler::adapters::track_events::{
-    handle_insert_track_event, handle_insert_track_events,
+    assert_request_track_event, assert_request_track_events, handle_insert_track_event,
+    handle_insert_track_events,
 };
 use crate::http::constants::{
     EVENTS_PATH, EVENT_PATH, KNOWN_ROUTES, METRICS_PATH, METRIC_PATH, VIEWS_PATH, VIEW_PATH,
 };
 use crate::http::types::handler::{HandledUpdateResult, HttpRequestHandler};
-use crate::http::types::interface::{ApiResponse};
-use ic_http_certification::{HttpRequest, StatusCode};
+use crate::http::types::request::{HttpRequestBody, HttpRequestPath};
+use crate::http::types::response::ApiResponse;
+use ic_http_certification::{HttpRequest, Method, StatusCode};
 
 pub struct OrbiterHttpRequestHandler;
 
@@ -19,28 +25,39 @@ impl HttpRequestHandler for OrbiterHttpRequestHandler {
         matches!(request.get_path().as_deref(), Ok(path) if KNOWN_ROUTES.contains(&path))
     }
 
-    fn is_allowed_method(&self, method: &str) -> bool {
+    fn is_allowed_method(&self, method: &Method) -> bool {
         method == "POST"
     }
 
-    fn handle_update(&self, request: &HttpRequest) -> HandledUpdateResult {
-        let uri_request_path = request.get_path();
-
-        if let Err(err) = uri_request_path {
+    fn assert_request_upgrade_allowed(
+        &self,
+        request_path: &HttpRequestPath,
+        body: &HttpRequestBody,
+    ) -> Result<(), String> {
+        match request_path.as_str() {
+            VIEW_PATH => assert_request_page_view(body),
+            VIEWS_PATH => assert_request_page_views(body),
+            EVENT_PATH => assert_request_track_event(body),
+            EVENTS_PATH => assert_request_track_events(body),
+            METRIC_PATH => assert_request_performance_metric(body),
+            METRICS_PATH => assert_request_performance_metrics(body),
             // Likely unexpected given is_known_route and is_allowed_method both were proven before reaching this handler.
-            let body = ApiResponse::<()>::err(StatusCode::BAD_REQUEST, err.to_string()).encode();
-            return HandledUpdateResult::new(StatusCode::BAD_REQUEST, body, None);
+            _ => Err(format!("Unsupported path: {}", request_path)),
         }
+    }
 
-        let request_path = uri_request_path.unwrap();
-
+    fn handle_update(
+        &self,
+        request_path: &HttpRequestPath,
+        body: &HttpRequestBody,
+    ) -> HandledUpdateResult {
         let response_data = match request_path.as_str() {
-            VIEW_PATH => handle_insert_page_view(request),
-            VIEWS_PATH => handle_insert_page_views(request),
-            EVENT_PATH => handle_insert_track_event(request),
-            EVENTS_PATH => handle_insert_track_events(request),
-            METRIC_PATH => handle_insert_performance_metric(request),
-            METRICS_PATH => handle_insert_performance_metrics(request),
+            VIEW_PATH => handle_insert_page_view(body),
+            VIEWS_PATH => handle_insert_page_views(body),
+            EVENT_PATH => handle_insert_track_event(body),
+            EVENTS_PATH => handle_insert_track_events(body),
+            METRIC_PATH => handle_insert_performance_metric(body),
+            METRICS_PATH => handle_insert_performance_metrics(body),
             // Likely unexpected given is_known_route and is_allowed_method both were proven before reaching this handler.
             _ => Err(format!("Unsupported path: {}", request_path)),
         };

--- a/src/orbiter/src/http/impls.rs
+++ b/src/orbiter/src/http/impls.rs
@@ -1,5 +1,5 @@
 use crate::http::types::handler::HandledUpdateResult;
-use crate::http::types::interface::{ApiResponse, ResponseBody};
+use crate::http::types::response::{ApiResponse, ResponseBody};
 use ic_http_certification::StatusCode;
 use junobuild_shared::types::core::DomainName;
 use serde::Serialize;

--- a/src/orbiter/src/http/routes/api/not_allowed.rs
+++ b/src/orbiter/src/http/routes/api/not_allowed.rs
@@ -3,7 +3,7 @@ use crate::http::routes::api::routes::{
     EVENTS_ROUTE, EVENT_ROUTE, METRICS_ROUTE, METRIC_ROUTE, VIEWS_ROUTE, VIEW_ROUTE,
 };
 use crate::http::routes::api::types::CertifiedExactRoute;
-use crate::http::types::interface::ErrorResponse;
+use crate::http::types::response::ErrorResponse;
 use crate::http::utils::create_json_response;
 use ic_http_certification::{HttpResponse, Method, StatusCode};
 

--- a/src/orbiter/src/http/routes/not_found.rs
+++ b/src/orbiter/src/http/routes/not_found.rs
@@ -2,7 +2,7 @@ use crate::http::constants::NOT_FOUND_PATH;
 use crate::http::routes::services::prepare_certified_response;
 use crate::http::state::store::insert_certified_response;
 use crate::http::state::types::CertifiedHttpResponse;
-use crate::http::types::interface::ErrorResponse;
+use crate::http::types::response::ErrorResponse;
 use crate::http::utils::create_json_response;
 use ic_http_certification::{
     DefaultCelBuilder, DefaultResponseCertification, DefaultResponseOnlyCelExpression,

--- a/src/orbiter/src/http/server.rs
+++ b/src/orbiter/src/http/server.rs
@@ -24,6 +24,7 @@ pub fn on_http_request(
             return HttpResponse::builder().with_upgrade(true).build();
         }
 
+        // TODO: responde with BAD REQUEST
         certified_response(request_path, method)
     };
 

--- a/src/orbiter/src/http/state/store.rs
+++ b/src/orbiter/src/http/state/store.rs
@@ -1,11 +1,12 @@
 use crate::http::state::services::{mutate_state, read_state};
-use crate::http::state::types::{CertifiedHttpResponse, Method, Path, StorageRuntimeState};
+use crate::http::state::types::{CertifiedHttpResponse, StorageRuntimeState};
+use crate::http::types::request::{HttpRequestMethod, HttpRequestPath};
 use ic_cdk::api::set_certified_data;
 use ic_http_certification::{HttpCertification, HttpCertificationPath, HttpCertificationTreeEntry};
 
 pub fn insert_certified_response(
-    path: &Path,
-    method: &Option<Method>,
+    path: &HttpRequestPath,
+    method: &Option<HttpRequestMethod>,
     tree_path: &HttpCertificationPath,
     response: &CertifiedHttpResponse<'static>,
 ) {
@@ -19,8 +20,8 @@ pub fn insert_certified_response(
 }
 
 pub fn get_certified_response(
-    path: &Path,
-    method: &Option<Method>,
+    path: &HttpRequestPath,
+    method: &Option<HttpRequestMethod>,
 ) -> Option<CertifiedHttpResponse<'static>> {
     read_state(|state| {
         state
@@ -33,8 +34,8 @@ pub fn get_certified_response(
 
 fn insert_response(
     storage: &mut StorageRuntimeState,
-    path: &Path,
-    method: &Option<Method>,
+    path: &HttpRequestPath,
+    method: &Option<HttpRequestMethod>,
     response: &CertifiedHttpResponse<'static>,
 ) {
     storage

--- a/src/orbiter/src/http/state/types.rs
+++ b/src/orbiter/src/http/state/types.rs
@@ -1,8 +1,6 @@
+use crate::http::types::request::HttpRequestMethod;
 use ic_http_certification::{HttpCertification, HttpCertificationTree, HttpResponse};
 use std::collections::HashMap;
-
-pub type Method = String;
-pub type Path = String;
 
 #[derive(Default, Clone)]
 pub struct RuntimeState {
@@ -12,7 +10,7 @@ pub struct RuntimeState {
 #[derive(Default, Clone)]
 pub struct StorageRuntimeState {
     pub tree: HttpCertificationTree,
-    pub responses: HashMap<(Option<Method>, String), CertifiedHttpResponse<'static>>,
+    pub responses: HashMap<(Option<HttpRequestMethod>, String), CertifiedHttpResponse<'static>>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/orbiter/src/http/types.rs
+++ b/src/orbiter/src/http/types.rs
@@ -1,4 +1,4 @@
-pub mod interface {
+pub mod response {
     use junobuild_shared::types::core::Blob;
     use serde::Serialize;
 
@@ -15,15 +15,31 @@ pub mod interface {
     pub type ResponseBody = Blob;
 }
 
+pub mod request {
+    pub type HttpRequestBody = [u8];
+    pub type HttpRequestPath = String;
+    pub type HttpRequestMethod = String;
+}
+
 pub mod handler {
-    use crate::http::types::interface::ResponseBody;
-    use ic_http_certification::{HttpRequest, StatusCode};
+    use crate::http::types::request::{HttpRequestBody, HttpRequestPath};
+    use crate::http::types::response::ResponseBody;
+    use ic_http_certification::{HttpRequest, Method, StatusCode};
     use junobuild_shared::types::core::DomainName;
 
     pub trait HttpRequestHandler {
         fn is_known_route(&self, request: &HttpRequest) -> bool;
-        fn is_allowed_method(&self, method: &str) -> bool;
-        fn handle_update(&self, request: &HttpRequest) -> HandledUpdateResult;
+        fn is_allowed_method(&self, method: &Method) -> bool;
+        fn assert_request_upgrade_allowed(
+            &self,
+            request_path: &HttpRequestPath,
+            body: &HttpRequestBody,
+        ) -> Result<(), String>;
+        fn handle_update(
+            &self,
+            request_path: &HttpRequestPath,
+            body: &HttpRequestBody,
+        ) -> HandledUpdateResult;
     }
 
     pub struct HandledUpdateResult {

--- a/src/orbiter/src/http/utils.rs
+++ b/src/orbiter/src/http/utils.rs
@@ -1,4 +1,4 @@
-use crate::http::types::interface::ResponseBody;
+use crate::http::types::response::ResponseBody;
 use ic_http_certification::{HttpResponse, StatusCode};
 use junobuild_shared::types::core::DomainName;
 

--- a/src/orbiter/src/impls.rs
+++ b/src/orbiter/src/impls.rs
@@ -7,11 +7,19 @@ impl SetRequest for SetPageViewRequest {
     fn satellite_id(&self) -> &str {
         &self.satellite_id
     }
+
+    fn empty_payload(&self) -> bool {
+        false
+    }
 }
 
 impl SetRequest for SetTrackEventRequest {
     fn satellite_id(&self) -> &str {
         &self.satellite_id
+    }
+
+    fn empty_payload(&self) -> bool {
+        false
     }
 }
 
@@ -19,11 +27,19 @@ impl SetRequest for SetPerformanceMetricRequest {
     fn satellite_id(&self) -> &str {
         &self.satellite_id
     }
+
+    fn empty_payload(&self) -> bool {
+        false
+    }
 }
 
 impl SetRequest for SetPageViewsRequest {
     fn satellite_id(&self) -> &str {
         &self.satellite_id
+    }
+
+    fn empty_payload(&self) -> bool {
+        self.page_views.is_empty()
     }
 }
 
@@ -31,10 +47,18 @@ impl SetRequest for SetTrackEventsRequest {
     fn satellite_id(&self) -> &str {
         &self.satellite_id
     }
+
+    fn empty_payload(&self) -> bool {
+        self.track_events.is_empty()
+    }
 }
 
 impl SetRequest for SetPerformanceMetricsRequest {
     fn satellite_id(&self) -> &str {
         &self.satellite_id
+    }
+
+    fn empty_payload(&self) -> bool {
+        self.performance_metrics.is_empty()
     }
 }

--- a/src/orbiter/src/impls.rs
+++ b/src/orbiter/src/impls.rs
@@ -1,0 +1,40 @@
+use crate::types::interface::http::{
+    SetPageViewRequest, SetPageViewsRequest, SetPerformanceMetricRequest,
+    SetPerformanceMetricsRequest, SetRequest, SetTrackEventRequest, SetTrackEventsRequest,
+};
+
+impl SetRequest for SetPageViewRequest {
+    fn satellite_id(&self) -> &str {
+        &self.satellite_id
+    }
+}
+
+impl SetRequest for SetTrackEventRequest {
+    fn satellite_id(&self) -> &str {
+        &self.satellite_id
+    }
+}
+
+impl SetRequest for SetPerformanceMetricRequest {
+    fn satellite_id(&self) -> &str {
+        &self.satellite_id
+    }
+}
+
+impl SetRequest for SetPageViewsRequest {
+    fn satellite_id(&self) -> &str {
+        &self.satellite_id
+    }
+}
+
+impl SetRequest for SetTrackEventsRequest {
+    fn satellite_id(&self) -> &str {
+        &self.satellite_id
+    }
+}
+
+impl SetRequest for SetPerformanceMetricsRequest {
+    fn satellite_id(&self) -> &str {
+        &self.satellite_id
+    }
+}

--- a/src/orbiter/src/lib.rs
+++ b/src/orbiter/src/lib.rs
@@ -7,6 +7,7 @@ mod events;
 mod guards;
 mod handler;
 mod http;
+mod impls;
 mod msg;
 mod serializers;
 mod state;

--- a/src/orbiter/src/msg.rs
+++ b/src/orbiter/src/msg.rs
@@ -4,3 +4,4 @@ pub const ERROR_PERFORMANCE_METRICS_FEATURE_DISABLED: &str =
     "error_performance_metrics_feature_disabled";
 pub const ERROR_BOT_CALL: &str = "error_bot_call";
 pub const ERROR_FEATURE_DISABLED: &str = "error_feature_disabled";
+pub const ERROR_EMPTY_PAYLOAD: &str = "error_empty_payload";

--- a/src/orbiter/src/types.rs
+++ b/src/orbiter/src/types.rs
@@ -148,6 +148,10 @@ pub mod interface {
         pub type PrincipalText = String;
         pub type SatelliteIdText = PrincipalText;
 
+        pub trait SetRequest {
+            fn satellite_id(&self) -> &str;
+        }
+
         #[derive(Deserialize)]
         pub struct SetPageViewRequest {
             pub satellite_id: SatelliteIdText,

--- a/src/orbiter/src/types.rs
+++ b/src/orbiter/src/types.rs
@@ -150,6 +150,7 @@ pub mod interface {
 
         pub trait SetRequest {
             fn satellite_id(&self) -> &str;
+            fn empty_payload(&self) -> bool;
         }
 
         #[derive(Deserialize)]

--- a/src/orbiter/src/types.rs
+++ b/src/orbiter/src/types.rs
@@ -3,13 +3,13 @@ pub mod interface {
         PageViewDevice, PerformanceData, PerformanceMetricName, SessionId,
     };
     use candid::CandidType;
+    use junobuild_shared::types::core::DomainName;
     use junobuild_shared::types::state::{
         Metadata, OrbiterSatelliteFeatures, SatelliteId, Timestamp, Version,
     };
     use junobuild_shared::types::utils::CalendarDate;
     use serde::Deserialize;
     use std::collections::HashMap;
-    use junobuild_shared::types::core::DomainName;
 
     #[derive(CandidType, Deserialize, Clone)]
     pub struct SetPageView {

--- a/src/tests/specs/orbiter/orbiter.http.page-views.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.http.page-views.spec.ts
@@ -143,6 +143,28 @@ describe('Orbiter > HTTP > Page views', () => {
 					expect(fromNullable(response.upgrade)).toBeUndefined();
 				});
 
+				it.each([
+					['invalid payload', { ...pageView, key: 'invalid' }],
+					['unknown satellite id', { ...pageView, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }]
+					// eslint-disable-next-line local-rules/prefer-object-params
+				])('should not upgrade http_request for %s', async (_title, payload) => {
+					const { http_request } = actor;
+
+					const request: HttpRequest = {
+						body: toBodyJson(payload),
+						certificate_version: toNullable(2),
+						headers: [],
+						method: 'POST',
+						url: '/view'
+					};
+
+					const response = await http_request(request);
+
+					expect(fromNullable(response.upgrade)).toBeUndefined();
+
+					expect(response.status_code).toEqual(404);
+				});
+
 				it('should not set a page view with invalid satellite id', async () => {
 					const { http_request_update } = actor;
 
@@ -288,6 +310,39 @@ describe('Orbiter > HTTP > Page views', () => {
 					const response = await http_request(request);
 
 					expect(fromNullable(response.upgrade)).toBeUndefined();
+				});
+
+				it.each([
+					[
+						'invalid payload',
+						{
+							...pagesViews,
+							page_views: [
+								{
+									...pagesViews.page_views[0],
+									key: 'invalid'
+								}
+							]
+						}
+					],
+					['unknown satellite id', { ...pagesViews, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }]
+					// eslint-disable-next-line local-rules/prefer-object-params
+				])('should not upgrade http_request for %s', async (_title, payload) => {
+					const { http_request } = actor;
+
+					const request: HttpRequest = {
+						body: toBodyJson(payload),
+						certificate_version: toNullable(2),
+						headers: [],
+						method: 'POST',
+						url: '/views'
+					};
+
+					const response = await http_request(request);
+
+					expect(fromNullable(response.upgrade)).toBeUndefined();
+
+					expect(response.status_code).toEqual(404);
 				});
 
 				it('should not set page views with invalid satellite id', async () => {

--- a/src/tests/specs/orbiter/orbiter.http.page-views.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.http.page-views.spec.ts
@@ -145,6 +145,7 @@ describe('Orbiter > HTTP > Page views', () => {
 
 				it.each([
 					['invalid payload', { ...pageView, key: 'invalid' }],
+					['empty payload', { key: pageView.key, satellite_id: pageView.satellite_id }],
 					['unknown satellite id', { ...pageView, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }]
 					// eslint-disable-next-line local-rules/prefer-object-params
 				])('should not upgrade http_request for %s', async (_title, payload) => {
@@ -325,6 +326,7 @@ describe('Orbiter > HTTP > Page views', () => {
 							]
 						}
 					],
+					['empty payload', { satellite_id: pagesViews.satellite_id, page_views: [] }],
 					['unknown satellite id', { ...pagesViews, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }]
 					// eslint-disable-next-line local-rules/prefer-object-params
 				])('should not upgrade http_request for %s', async (_title, payload) => {

--- a/src/tests/specs/orbiter/orbiter.http.performance-metrics.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.http.performance-metrics.spec.ts
@@ -143,6 +143,31 @@ describe('Orbiter > HTTP > Performance metrics', () => {
 					expect(fromNullable(response.upgrade)).toBeUndefined();
 				});
 
+				it.each([
+					['invalid payload', { ...performanceMetric, key: 'invalid' }],
+					[
+						'unknown satellite id',
+						{ ...performanceMetric, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }
+					]
+					// eslint-disable-next-line local-rules/prefer-object-params
+				])('should not upgrade http_request for %s', async (_title, payload) => {
+					const { http_request } = actor;
+
+					const request: HttpRequest = {
+						body: toBodyJson(payload),
+						certificate_version: toNullable(2),
+						headers: [],
+						method: 'POST',
+						url: '/metric'
+					};
+
+					const response = await http_request(request);
+
+					expect(fromNullable(response.upgrade)).toBeUndefined();
+
+					expect(response.status_code).toEqual(404);
+				});
+
 				it('should not set a performance metric with invalid satellite id', async () => {
 					const { http_request_update } = actor;
 
@@ -290,6 +315,42 @@ describe('Orbiter > HTTP > Performance metrics', () => {
 					const response = await http_request(request);
 
 					expect(fromNullable(response.upgrade)).toBeUndefined();
+				});
+
+				it.each([
+					[
+						'invalid payload',
+						{
+							...performanceMetrics,
+							page_views: [
+								{
+									...performanceMetrics.performance_metrics[0],
+									key: 'invalid'
+								}
+							]
+						}
+					],
+					[
+						'unknown satellite id',
+						{ ...performanceMetrics, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }
+					]
+					// eslint-disable-next-line local-rules/prefer-object-params
+				])('should not upgrade http_request for %s', async (_title, payload) => {
+					const { http_request } = actor;
+
+					const request: HttpRequest = {
+						body: toBodyJson(payload),
+						certificate_version: toNullable(2),
+						headers: [],
+						method: 'POST',
+						url: '/metrics'
+					};
+
+					const response = await http_request(request);
+
+					expect(fromNullable(response.upgrade)).toBeUndefined();
+
+					expect(response.status_code).toEqual(404);
 				});
 
 				it('should not set pperformance metrics with invalid satellite id', async () => {

--- a/src/tests/specs/orbiter/orbiter.http.performance-metrics.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.http.performance-metrics.spec.ts
@@ -146,6 +146,10 @@ describe('Orbiter > HTTP > Performance metrics', () => {
 				it.each([
 					['invalid payload', { ...performanceMetric, key: 'invalid' }],
 					[
+						'empty payload',
+						{ key: performanceMetric.key, satellite_id: performanceMetric.satellite_id }
+					],
+					[
 						'unknown satellite id',
 						{ ...performanceMetric, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }
 					]
@@ -329,6 +333,10 @@ describe('Orbiter > HTTP > Performance metrics', () => {
 								}
 							]
 						}
+					],
+					[
+						'empty payload',
+						{ satellite_id: performanceMetrics.satellite_id, performanceMetrics: [] }
 					],
 					[
 						'unknown satellite id',

--- a/src/tests/specs/orbiter/orbiter.http.performance-metrics.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.http.performance-metrics.spec.ts
@@ -322,7 +322,7 @@ describe('Orbiter > HTTP > Performance metrics', () => {
 						'invalid payload',
 						{
 							...performanceMetrics,
-							page_views: [
+							performance_metrics: [
 								{
 									...performanceMetrics.performance_metrics[0],
 									key: 'invalid'

--- a/src/tests/specs/orbiter/orbiter.http.track-events.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.http.track-events.spec.ts
@@ -145,6 +145,7 @@ describe('Orbiter > HTTP > Track events', () => {
 
 				it.each([
 					['invalid payload', { ...trackEvent, key: 'invalid' }],
+					['empty payload', { key: trackEvent.key, satellite_id: trackEvent.satellite_id }],
 					['unknown satellite id', { ...trackEvent, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }]
 					// eslint-disable-next-line local-rules/prefer-object-params
 				])('should not upgrade http_request for %s', async (_title, payload) => {
@@ -327,6 +328,7 @@ describe('Orbiter > HTTP > Track events', () => {
 							]
 						}
 					],
+					['empty payload', { satellite_id: trackEvents.satellite_id, performanceMetrics: [] }],
 					['unknown satellite id', { ...trackEvents, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }]
 					// eslint-disable-next-line local-rules/prefer-object-params
 				])('should not upgrade http_request for %s', async (_title, payload) => {

--- a/src/tests/specs/orbiter/orbiter.http.track-events.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.http.track-events.spec.ts
@@ -143,6 +143,28 @@ describe('Orbiter > HTTP > Track events', () => {
 					expect(fromNullable(response.upgrade)).toBeUndefined();
 				});
 
+				it.each([
+					['invalid payload', { ...trackEvent, key: 'invalid' }],
+					['unknown satellite id', { ...trackEvent, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }]
+					// eslint-disable-next-line local-rules/prefer-object-params
+				])('should not upgrade http_request for %s', async (_title, payload) => {
+					const { http_request } = actor;
+
+					const request: HttpRequest = {
+						body: toBodyJson(payload),
+						certificate_version: toNullable(2),
+						headers: [],
+						method: 'POST',
+						url: '/event'
+					};
+
+					const response = await http_request(request);
+
+					expect(fromNullable(response.upgrade)).toBeUndefined();
+
+					expect(response.status_code).toEqual(404);
+				});
+
 				it('should not set a track event with invalid satellite id', async () => {
 					const { http_request_update } = actor;
 
@@ -290,6 +312,39 @@ describe('Orbiter > HTTP > Track events', () => {
 					const response = await http_request(request);
 
 					expect(fromNullable(response.upgrade)).toBeUndefined();
+				});
+
+				it.each([
+					[
+						'invalid payload',
+						{
+							...trackEvents,
+							page_views: [
+								{
+									...trackEvents.track_events[0],
+									key: 'invalid'
+								}
+							]
+						}
+					],
+					['unknown satellite id', { ...trackEvents, satellite_id: 'nkzsw-gyaaa-aaaal-ada3a-cai' }]
+					// eslint-disable-next-line local-rules/prefer-object-params
+				])('should not upgrade http_request for %s', async (_title, payload) => {
+					const { http_request } = actor;
+
+					const request: HttpRequest = {
+						body: toBodyJson(payload),
+						certificate_version: toNullable(2),
+						headers: [],
+						method: 'POST',
+						url: '/events'
+					};
+
+					const response = await http_request(request);
+
+					expect(fromNullable(response.upgrade)).toBeUndefined();
+
+					expect(response.status_code).toEqual(404);
 				});
 
 				it('should not set track events with invalid satellite id', async () => {

--- a/src/tests/specs/orbiter/orbiter.http.track-events.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.http.track-events.spec.ts
@@ -319,7 +319,7 @@ describe('Orbiter > HTTP > Track events', () => {
 						'invalid payload',
 						{
 							...trackEvents,
-							page_views: [
+							track_events: [
 								{
 									...trackEvents.track_events[0],
 									key: 'invalid'


### PR DESCRIPTION
# Motivation

I we can spare few updates while queries are basically free with a little performance tradeoff, why not.
