### PR TITLE
fix: loading data when accessing page directly and version not loaded

### DIFF
--- a/src/frontend/src/lib/components/db/DbData.svelte
+++ b/src/frontend/src/lib/components/db/DbData.svelte
@@ -34,17 +34,19 @@
 
 	const list = async () => {
 		try {
-			// There is guard for loading the version. If we reach this point with `undefined`, it's probably a race condition.
-			// We fallback to the newest API since the version check is only needed for backward compatibility.
-			const version = $versionStore?.satellites[$store.satelliteId.toText()]?.current;
-
 			if (isNullish(collection)) {
 				setItems({ items: undefined, matches_length: undefined, items_length: undefined });
 				return;
 			}
 
-			const list =
-				isNullish(version) || compare(version, SATELLITE_v0_0_9) >= 0 ? listDocs : listDocs008;
+			const version = $versionStore?.satellites[$store.satelliteId.toText()]?.current;
+
+			if (isNullish(version)) {
+				setItems({ items: undefined, matches_length: undefined, items_length: undefined });
+				return;
+			}
+
+			const list = compare(version, SATELLITE_v0_0_9) >= 0 ? listDocs : listDocs008;
 
 			const { items, matches_length, items_length } = await list({
 				collection,

--- a/src/frontend/src/lib/components/docs/Docs.svelte
+++ b/src/frontend/src/lib/components/docs/Docs.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { Principal } from '@dfinity/principal';
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { getContext } from 'svelte';
-	import { run } from 'svelte/legacy';
+	import { getContext, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import type { Doc as DocType } from '$declarations/satellite/satellite.did';
 	import { deleteDocs } from '$lib/api/satellites.api';
@@ -16,6 +15,7 @@
 	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { listParamsStore } from '$lib/stores/list-params.store';
+	import { versionStore } from '$lib/stores/version.store';
 	import { DATA_CONTEXT_KEY, type DataContext } from '$lib/types/data.context';
 	import { PAGINATION_CONTEXT_KEY, type PaginationContext } from '$lib/types/pagination.context';
 	import { RULES_CONTEXT_KEY, type RulesContext } from '$lib/types/rules.context';
@@ -24,10 +24,7 @@
 
 	const { store, hasAnyRules }: RulesContext = getContext<RulesContext>(RULES_CONTEXT_KEY);
 
-	let collection: string | undefined = $state();
-	run(() => {
-		collection = $store.rule?.[0];
-	});
+	let collection = $derived($store.rule?.[0]);
 
 	const {
 		store: paginationStore,
@@ -35,10 +32,7 @@
 		list
 	}: PaginationContext<DocType> = getContext<PaginationContext<DocType>>(PAGINATION_CONTEXT_KEY);
 
-	let empty = $state(false);
-	run(() => {
-		empty = $paginationStore.items?.length === 0 && nonNullish(collection);
-	});
+	let empty = $derived($paginationStore.items?.length === 0 && nonNullish(collection));
 
 	const { store: docsStore, resetData }: DataContext<DocType> =
 		getContext<DataContext<DocType>>(DATA_CONTEXT_KEY);
@@ -49,9 +43,14 @@
 		await list();
 	};
 
-	run(() => {
-		// @ts-expect-error TODO: to be migrated to Svelte v5
-		collection, $listParamsStore, (async () => await load())();
+	$effect(() => {
+		collection;
+		$listParamsStore;
+		$versionStore;
+
+		untrack(() => {
+			load();
+		});
 	});
 
 	/**

--- a/src/frontend/src/lib/components/hosting/HostingCount.svelte
+++ b/src/frontend/src/lib/components/hosting/HostingCount.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { compare } from 'semver';
-	import { onMount } from 'svelte';
+	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import type { Satellite } from '$declarations/mission_control/mission_control.did';
 	import { countCollectionAssets } from '$lib/api/satellites.api';
@@ -19,10 +19,8 @@
 
 	let assets = $state(0n);
 
-	onMount(async () => {
+	const load = async () => {
 		try {
-			// There is guard for loading the version. If we reach this point with `undefined`, it's probably a race condition.
-			// We fallback to the newest API since the version check is only needed for backward compatibility.
 			const version = $versionStore?.satellites[satellite.satellite_id.toText()]?.current;
 
 			if (nonNullish(version) && compare(version, SATELLITE_v0_0_20) < 0) {
@@ -42,6 +40,14 @@
 				detail: err
 			});
 		}
+	};
+
+	$effect(() => {
+		$versionStore;
+
+		untrack(() => {
+			load();
+		});
 	});
 </script>
 

--- a/src/frontend/src/lib/components/storage/StorageData.svelte
+++ b/src/frontend/src/lib/components/storage/StorageData.svelte
@@ -37,9 +37,12 @@
 		}
 
 		try {
-			// There is guard for loading the version. If we reach this point with `undefined`, it's probably a race condition.
-			// We fallback to the newest API since the version check is only needed for backward compatibility.
 			const version = $versionStore?.satellites[$store.satelliteId.toText()]?.current;
+
+			if (isNullish(version)) {
+				setItems({ items: undefined, matches_length: undefined, items_length: undefined });
+				return;
+			}
 
 			if (isNullish(collection)) {
 				setItems({ items: undefined, matches_length: undefined, items_length: undefined });
@@ -47,7 +50,7 @@
 			}
 
 			const list =
-				isNullish(version) || compare(version, SATELLITE_v0_0_10) >= 0
+				compare(version, SATELLITE_v0_0_10) >= 0
 					? listAssets
 					: compare(version, SATELLITE_v0_0_9) >= 0
 						? listAssets009


### PR DESCRIPTION
# Motivation

Ultimately there is a version loader but not a guard. As a result, when a page is accessed directly (fresh browsing or reload), then the version might not be loaded yet when data are fetched which can lead to not being able to list data (if the incorrect service according version is used). That was the case for the authentication page.

<img width="1536" alt="Capture d’écran 2025-04-27 à 20 50 24" src="https://github.com/user-attachments/assets/5e93fa6b-e590-4ba3-986f-1468bfd9ce10" />
