### PR TITLE
feat: revert total_sessions

### DIFF
--- a/src/declarations/orbiter/orbiter.did.d.ts
+++ b/src/declarations/orbiter/orbiter.did.d.ts
@@ -25,7 +25,6 @@ export interface AnalyticsDevicesPageViews {
 	mobile: number;
 }
 export interface AnalyticsMetricsPageViews {
-	total_sessions: bigint;
 	bounce_rate: number;
 	average_page_views_per_session: number;
 	daily_total_page_views: Array<[CalendarDate, number]>;

--- a/src/declarations/orbiter/orbiter.factory.certified.did.js
+++ b/src/declarations/orbiter/orbiter.factory.certified.did.js
@@ -85,7 +85,6 @@ export const idlFactory = ({ IDL }) => {
 		year: IDL.Int32
 	});
 	const AnalyticsMetricsPageViews = IDL.Record({
-		total_sessions: IDL.Nat64,
 		bounce_rate: IDL.Float64,
 		average_page_views_per_session: IDL.Float64,
 		daily_total_page_views: IDL.Vec(IDL.Tuple(CalendarDate, IDL.Nat32)),

--- a/src/declarations/orbiter/orbiter.factory.did.js
+++ b/src/declarations/orbiter/orbiter.factory.did.js
@@ -85,7 +85,6 @@ export const idlFactory = ({ IDL }) => {
 		year: IDL.Int32
 	});
 	const AnalyticsMetricsPageViews = IDL.Record({
-		total_sessions: IDL.Nat64,
 		bounce_rate: IDL.Float64,
 		average_page_views_per_session: IDL.Float64,
 		daily_total_page_views: IDL.Vec(IDL.Tuple(CalendarDate, IDL.Nat32)),

--- a/src/declarations/orbiter/orbiter.factory.did.mjs
+++ b/src/declarations/orbiter/orbiter.factory.did.mjs
@@ -85,7 +85,6 @@ export const idlFactory = ({ IDL }) => {
 		year: IDL.Int32
 	});
 	const AnalyticsMetricsPageViews = IDL.Record({
-		total_sessions: IDL.Nat64,
 		bounce_rate: IDL.Float64,
 		average_page_views_per_session: IDL.Float64,
 		daily_total_page_views: IDL.Vec(IDL.Tuple(CalendarDate, IDL.Nat32)),

--- a/src/frontend/src/lib/api/orbiter.deprecated.api.ts
+++ b/src/frontend/src/lib/api/orbiter.deprecated.api.ts
@@ -2,10 +2,7 @@ import type {
 	OrbiterSatelliteConfig as SatelliteConfig,
 	SetSatelliteConfig
 } from '$declarations/deprecated/orbiter-0-0-7.did';
-import type {
-	AnalyticsClientsPageViews,
-	AnalyticsMetricsPageViews
-} from '$declarations/deprecated/orbiter-0-0-8.did';
+import type { AnalyticsClientsPageViews } from '$declarations/deprecated/orbiter-0-0-8.did';
 import { getOrbiterActor007, getOrbiterActor008 } from '$lib/api/actors/actor.deprecated.api';
 import type { OptionIdentity } from '$lib/types/itentity';
 import type { PageViewsParams } from '$lib/types/orbiter';
@@ -58,25 +55,7 @@ export const orbiterVersion = async ({
 };
 
 /**
- * @deprecated total_sessions was introduced in v1.0.0
- */
-export const getAnalyticsMetricsPageViews008 = async ({
-	satelliteId,
-	orbiterId,
-	from,
-	to,
-	identity
-}: PageViewsParams): Promise<AnalyticsMetricsPageViews> => {
-	const { get_page_views_analytics_metrics } = await getOrbiterActor008({ orbiterId, identity });
-	return await get_page_views_analytics_metrics({
-		satellite_id: toNullable(satelliteId),
-		from: nonNullish(from) ? [toBigIntNanoSeconds(from)] : [],
-		to: nonNullish(to) ? [toBigIntNanoSeconds(to)] : []
-	});
-};
-
-/**
- * @deprecated total_sessions was introduced in v1.0.0
+ * @deprecated operating systems was introduced in v1.0.0
  */
 export const getAnalyticsClientsPageViews008 = async ({
 	satelliteId,

--- a/src/frontend/src/lib/services/orbiter.paginated.services.ts
+++ b/src/frontend/src/lib/services/orbiter.paginated.services.ts
@@ -165,7 +165,6 @@ const aggregateMetrics = ({
 				total_page_views: totalPageViews,
 				unique_page_views: uniquePageViews,
 				unique_sessions: uniqueSessions,
-				total_sessions: totalSessions,
 				bounce_rate: bounceRate,
 				average_page_views_per_session: averagePageViewsPerSessions
 			} = metrics;
@@ -174,7 +173,6 @@ const aggregateMetrics = ({
 				total_page_views: accTotalPageViews,
 				unique_page_views: accUniquePageViews,
 				unique_sessions: accUniqueSessions,
-				total_sessions: accTotalSessions,
 				bounce_rate: accBounceRate,
 				average_page_views_per_session: accAveragePageViewsPerSessions
 			} = acc;
@@ -202,21 +200,20 @@ const aggregateMetrics = ({
 			return {
 				...metrics,
 				bounce_rate: average({
-					totalSessions: Number(accTotalSessions ?? accUniqueSessions),
+					totalSessions: Number(accUniqueSessions),
 					averageRate: accBounceRate,
 					ratePeriod: bounceRate,
-					sessionsPeriod: Number(totalSessions ?? uniqueSessions)
+					sessionsPeriod: Number(uniqueSessions)
 				}),
 				average_page_views_per_session: average({
-					totalSessions: Number(accTotalSessions ?? accUniqueSessions),
+					totalSessions: Number(accUniqueSessions),
 					averageRate: accAveragePageViewsPerSessions,
 					ratePeriod: averagePageViewsPerSessions,
-					sessionsPeriod: Number(totalSessions ?? uniqueSessions)
+					sessionsPeriod: Number(uniqueSessions)
 				}),
 				total_page_views: accTotalPageViews + totalPageViews,
 				unique_page_views: accUniquePageViews + uniquePageViews,
 				unique_sessions: accUniqueSessions + uniqueSessions,
-				total_sessions: (accTotalSessions ?? 0n) + (totalSessions ?? 0n),
 				daily_total_page_views: {
 					...acc.daily_total_page_views,
 					...metrics.daily_total_page_views

--- a/src/frontend/src/lib/services/orbiters.deprecated.services.ts
+++ b/src/frontend/src/lib/services/orbiters.deprecated.services.ts
@@ -2,16 +2,12 @@ import type {
 	AnalyticKey,
 	AnalyticsClientsPageViews,
 	AnalyticsDevicesPageViews,
-	AnalyticsMetricsPageViews,
 	AnalyticsTop10PageViews,
 	AnalyticsTrackEvents,
 	PageView
 } from '$declarations/orbiter/orbiter.did';
 import { getPageViews, getTrackEvents } from '$lib/api/orbiter.api';
-import {
-	getAnalyticsClientsPageViews008,
-	getAnalyticsMetricsPageViews008
-} from '$lib/api/orbiter.deprecated.api';
+import { getAnalyticsClientsPageViews008 } from '$lib/api/orbiter.deprecated.api';
 import type {
 	AnalyticsMetrics,
 	AnalyticsPageViews,
@@ -22,19 +18,6 @@ import { fromBigIntNanoSeconds } from '$lib/utils/date.utils';
 import { isAndroid, isAndroidTablet, isIPhone } from '$lib/utils/device.utils';
 import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 import { startOfDay } from 'date-fns';
-
-export const getDeprecatedAnalyticsMetricsPageViews = async (
-	params: PageViewsParams
-): Promise<AnalyticsMetricsPageViews> => {
-	const { unique_sessions, ...rest } = await getAnalyticsMetricsPageViews008(params);
-
-	return {
-		...rest,
-		unique_sessions,
-		// Introduce a relatively negligible (to some extension) difference when presenting analytics averages. Better than throwing errors.
-		total_sessions: BigInt(unique_sessions)
-	};
-};
 
 export const getDeprecatedAnalyticsClientsPageViews = async (
 	params: PageViewsParams
@@ -136,8 +119,6 @@ const mapDeprecatedAnalyticsMetricsPageViews = (
 
 	return {
 		unique_sessions: BigInt(uniqueSessions),
-		// Introduce a relatively negligible difference when presenting analytics averages. Better than throwing errors.
-		total_sessions: BigInt(uniqueSessions),
 		unique_page_views: BigInt(uniquePageViews),
 		total_page_views: pageViews.length,
 		daily_total_page_views: totalPageViews,

--- a/src/frontend/src/lib/services/orbiters.services.ts
+++ b/src/frontend/src/lib/services/orbiters.services.ts
@@ -25,7 +25,6 @@ import { orbiterConfigs } from '$lib/derived/orbiter.derived';
 import { loadDataStore } from '$lib/services/loader.services';
 import {
 	getDeprecatedAnalyticsClientsPageViews,
-	getDeprecatedAnalyticsMetricsPageViews,
 	getDeprecatedAnalyticsPageViews,
 	getDeprecatedAnalyticsTrackEvents
 } from '$lib/services/orbiters.deprecated.services';
@@ -177,18 +176,13 @@ export const getAnalyticsPageViews = async ({
 	orbiterVersion: string;
 }): Promise<AnalyticsPageViews> => {
 	if (compare(orbiterVersion, ORBITER_v0_0_4) >= 0) {
-		const getMetrics =
-			compare(orbiterVersion, ORBITER_v0_0_8) > 0
-				? getAnalyticsMetricsPageViews
-				: getDeprecatedAnalyticsMetricsPageViews;
-
 		const getClients =
 			compare(orbiterVersion, ORBITER_v0_0_8) > 0
 				? getAnalyticsClientsPageViews
 				: getDeprecatedAnalyticsClientsPageViews;
 
 		const [metrics, top10, clients] = await Promise.all([
-			getMetrics(params),
+			getAnalyticsMetricsPageViews(params),
 			getAnalyticsTop10PageViews(params),
 			getClients(params)
 		]);

--- a/src/orbiter/orbiter.did
+++ b/src/orbiter/orbiter.did
@@ -18,7 +18,6 @@ type AnalyticsDevicesPageViews = record {
   mobile : float64;
 };
 type AnalyticsMetricsPageViews = record {
-  total_sessions : nat64;
   bounce_rate : float64;
   average_page_views_per_session : float64;
   daily_total_page_views : vec record { CalendarDate; nat32 };

--- a/src/orbiter/src/analytics.rs
+++ b/src/orbiter/src/analytics.rs
@@ -101,7 +101,6 @@ pub fn analytics_page_views_metrics(
 
     AnalyticsMetricsPageViews {
         daily_total_page_views,
-        total_sessions,
         unique_sessions: unique_sessions_count,
         unique_page_views,
         total_page_views,
@@ -172,7 +171,7 @@ pub fn analytics_page_views_clients(
         firefox: Regex::new(r"(?i)firefox|fxios").unwrap(),
         safari: Regex::new(r"(?i)safari").unwrap(),
     };
-    
+
     for (
         _,
         PageView {
@@ -198,7 +197,7 @@ pub fn analytics_page_views_clients(
         // it provides a good estimate, especially since web apps are typically built responsively.
         // Additionally, both UA parsing and regex-based approaches have reliability limitations.
         // Screen size collection was introduced in v0.1.0 — hence the need for fallbacks when unavailable.
-        
+
         if let Some(screen_width) = device.screen_width {
             analytics_devices_with_sizes(&screen_width, &mut total_devices);
         } else if let Some(client) = client {

--- a/src/orbiter/src/types.rs
+++ b/src/orbiter/src/types.rs
@@ -78,7 +78,6 @@ pub mod interface {
     #[derive(CandidType, Deserialize, Clone)]
     pub struct AnalyticsMetricsPageViews {
         pub daily_total_page_views: HashMap<CalendarDate, u32>,
-        pub total_sessions: usize,
         pub unique_sessions: usize,
         pub unique_page_views: usize,
         pub total_page_views: u32,

--- a/src/tests/specs/orbiter/orbiter.analytics.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.analytics.spec.ts
@@ -225,7 +225,6 @@ describe('Orbiter > Analytics', () => {
 			const averagePageViewsPerSession = dailyTotalPageViews / uniqueSessions;
 
 			expect(result).toEqual({
-				total_sessions: 70n,
 				bounce_rate: bounceRate,
 				average_page_views_per_session: averagePageViewsPerSession,
 				daily_total_page_views: [


### PR DESCRIPTION
# Motivation

The field I added recently `total_sessions` is actually, in the implementation, equals to the existing `unique_sessions`. So by reverting it we just avoid a breaking change.
