### PR TITLE
feat(frontend): performance metrics disabled by default

### DIFF
--- a/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
@@ -21,6 +21,7 @@
 	import type { JunoModalDetail, JunoModalEditOrbiterConfigDetail } from '$lib/types/modal';
 	import type { OrbiterSatelliteConfigEntry } from '$lib/types/orbiter';
 	import type { SatelliteIdText } from '$lib/types/satellite';
+	import { DEFAULT_FEATURES } from '$lib/constants/analytics.constants';
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -73,27 +74,21 @@
 
 	const onPageViewsToggle = () => {
 		features = {
-			...(nonNullish(features)
-				? features
-				: { page_views: true, track_events: true, performance_metrics: true }),
+			...(nonNullish(features) ? features : DEFAULT_FEATURES),
 			page_views: features?.page_views !== true
 		};
 	};
 
 	const onTrackEventsToggle = () => {
 		features = {
-			...(nonNullish(features)
-				? features
-				: { page_views: true, track_events: true, performance_metrics: true }),
+			...(nonNullish(features) ? features : DEFAULT_FEATURES),
 			track_events: features?.track_events !== true
 		};
 	};
 
 	const onPerformanceToggle = () => {
 		features = {
-			...(nonNullish(features)
-				? features
-				: { page_views: true, track_events: true, performance_metrics: true }),
+			...(nonNullish(features) ? features : DEFAULT_FEATURES),
 			performance_metrics: features?.performance_metrics !== true
 		};
 	};
@@ -230,7 +225,7 @@
 									<Checkbox>
 										<input
 											type="checkbox"
-											checked={isNullish(features) || features?.performance_metrics === true}
+											checked={features?.performance_metrics === true}
 											onchange={onPerformanceToggle}
 										/>
 										<span>{$i18n.analytics.web_vitals}</span>

--- a/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
@@ -10,6 +10,7 @@
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
+	import { DEFAULT_FEATURES } from '$lib/constants/analytics.constants';
 	import { ORBITER_v0_0_8 } from '$lib/constants/version.constants';
 	import { setOrbiterSatelliteConfigs } from '$lib/services/orbiters.services';
 	import { authStore } from '$lib/stores/auth.store';
@@ -21,7 +22,6 @@
 	import type { JunoModalDetail, JunoModalEditOrbiterConfigDetail } from '$lib/types/modal';
 	import type { OrbiterSatelliteConfigEntry } from '$lib/types/orbiter';
 	import type { SatelliteIdText } from '$lib/types/satellite';
-	import { DEFAULT_FEATURES } from '$lib/constants/analytics.constants';
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -49,7 +49,7 @@
 		if (
 			features?.page_views === false ||
 			features?.track_events === false ||
-			features?.performance_metrics === false
+			features?.performance_metrics === true
 		) {
 			collapsibleRef?.open();
 		}

--- a/src/frontend/src/lib/constants/analytics.constants.ts
+++ b/src/frontend/src/lib/constants/analytics.constants.ts
@@ -1,4 +1,10 @@
 import type { AnalyticsPeriodicity } from '$lib/types/orbiter';
 
-// A week
+// A month
 export const DEFAULT_ANALYTICS_PERIODICITY: AnalyticsPeriodicity = { periodicity: 720 };
+
+export const DEFAULT_FEATURES = {
+	page_views: true,
+	track_events: true,
+	performance_metrics: false
+};

--- a/src/frontend/src/lib/services/orbiters.services.ts
+++ b/src/frontend/src/lib/services/orbiters.services.ts
@@ -20,6 +20,7 @@ import {
 	listOrbiterSatelliteConfigs007,
 	setOrbiterSatelliteConfigs007 as setOrbiterSatelliteConfigsDeprecatedApi
 } from '$lib/api/orbiter.deprecated.api';
+import { DEFAULT_FEATURES } from '$lib/constants/analytics.constants';
 import { ORBITER_v0_0_4, ORBITER_v0_0_5, ORBITER_v0_0_8 } from '$lib/constants/version.constants';
 import { orbiterConfigs } from '$lib/derived/orbiter.derived';
 import { loadDataStore } from '$lib/services/loader.services';
@@ -248,7 +249,8 @@ export const getAnalyticsPerformanceMetrics = async ({
 	return undefined;
 };
 
-const enabledFeatures = {
+// We originally migrated the features to be all enabled but, in v0.1.0 decided to make the performance metrics disabled by default.
+const deprecatedEnabledFeatures = {
 	performance_metrics: true,
 	track_events: true,
 	page_views: true
@@ -274,7 +276,7 @@ const listOrbiterSatelliteConfigs = async ({
 		{
 			...rest,
 			restricted_origin: toNullable(),
-			features: enabled ? [enabledFeatures] : []
+			features: enabled ? [deprecatedEnabledFeatures] : []
 		}
 	]);
 };
@@ -298,7 +300,7 @@ export const setOrbiterSatelliteConfigs = async ({
 			config: Object.entries(config).map(([satelliteId, value]) => [
 				Principal.fromText(satelliteId),
 				{
-					features: value.enabled ? [features ?? enabledFeatures] : [],
+					features: value.enabled ? [features ?? DEFAULT_FEATURES] : [],
 					restricted_origin: toNullable(),
 					version: nonNullish(value.config) ? value.config.version : []
 				}
@@ -325,7 +327,7 @@ export const setOrbiterSatelliteConfigs = async ({
 		{
 			...rest,
 			restricted_origin: toNullable(),
-			features: enabled ? [enabledFeatures] : []
+			features: enabled ? [deprecatedEnabledFeatures] : []
 		}
 	]);
 };


### PR DESCRIPTION
# Motivation

Performance metrics, after thinking at it, is more an opt-in for a while that something one want all the time on. So we disable it by default when creating setup.
