### PR TITLE
fix(frontend): copy to clipboard submitting form

### DIFF
--- a/src/frontend/src/lib/components/ui/Copy.svelte
+++ b/src/frontend/src/lib/components/ui/Copy.svelte
@@ -20,7 +20,7 @@
 	);
 
 	const copyToClipboard = async ($event: UIEvent) => {
-		$event.stopPropagation();
+		$event.preventDefault();
 
 		await navigator.clipboard.writeText(value);
 


### PR DESCRIPTION
# Motivation

Notably the case when copying a satellite ID in the segment table of configuring the analytics which finds place in a modal.
