### PR TITLE
feat: Orbiter v0.0.9 instead of v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "orbiter"
-version = "0.2.0"
+version = "0.0.9"
 dependencies = [
  "candid",
  "ciborium",

--- a/src/frontend/src/lib/services/orbiter/orbiters.services.ts
+++ b/src/frontend/src/lib/services/orbiter/orbiters.services.ts
@@ -153,7 +153,7 @@ export const loadOrbiterConfigs = async ({
 	}
 };
 
-// We originally migrated the features to be all enabled but, in v0.2.0 decided to make the performance metrics disabled by default.
+// We originally migrated the features to be all enabled but, in v0.0.9 decided to make the performance metrics disabled by default.
 const deprecatedEnabledFeatures = {
 	performance_metrics: true,
 	track_events: true,

--- a/src/orbiter/Cargo.toml
+++ b/src/orbiter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orbiter"
-version = "0.2.0"
+version = "0.0.9"
 edition = "2021"
 publish = false
 

--- a/src/orbiter/src/analytics.rs
+++ b/src/orbiter/src/analytics.rs
@@ -201,7 +201,7 @@ pub fn analytics_page_views_clients(
         // We primarily use screen width to determine the device type. While this may be less precise than identifying the exact device,
         // it provides a good estimate, especially since web apps are typically built responsively.
         // Additionally, both UA parsing and regex-based approaches have reliability limitations.
-        // Screen size collection was introduced in v0.2.0 — hence the need for fallbacks when unavailable.
+        // Screen size collection was introduced in v0.0.9 — hence the need for fallbacks when unavailable.
 
         if let Some(screen_width) = device.screen_width {
             analytics_devices_with_sizes(&screen_width, &mut total_devices);

--- a/src/tests/specs/orbiter/orbiter.upgrade.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.upgrade.spec.ts
@@ -401,7 +401,7 @@ describe('Orbiter > Upgrade', () => {
 		});
 	});
 
-	describe('v0.0.8 -> v0.2.0', () => {
+	describe('v0.0.8 -> v0.0.9', () => {
 		let actor: Actor<OrbiterActor0_0_8>;
 
 		const setPageViews0_0_8 = async (): Promise<AnalyticKey[]> => {


### PR DESCRIPTION
# Motivation

We want to ensure upgrade iteratively so we actually use the version number as a counter.
