### PR TITLE
feat: auto-approve upgrade if only one newer release is found

### DIFF
--- a/src/frontend/src/lib/components/upgrade/SelectUpgradeVersion.svelte
+++ b/src/frontend/src/lib/components/upgrade/SelectUpgradeVersion.svelte
@@ -54,7 +54,11 @@
 			return;
 		}
 
-		const { canUpgrade } = checkUpgradeVersion({ currentVersion, selectedVersion });
+		// If there is a single newer release then it can be upgraded because all previous versions have been upgraded iteratively.
+		const { canUpgrade } =
+			newerReleases.length === 1
+				? { canUpgrade: true }
+				: checkUpgradeVersion({ currentVersion, selectedVersion });
 
 		if (!canUpgrade) {
 			toasts.error({


### PR DESCRIPTION
# Motivation

This is useful to introduce a better semver. So we can continue to check if dev upgrade iteratively (0.0.5, 0.0.6, 0.0.7) while allowing going to a minor version (0.0.7, 0.1.0).

It is also a must to introduce the Orbiter v0.2.0 going from v0.0.8
