### PR TITLE
feat: deprecate memory_size in Satellite and Orbiter

### DIFF
--- a/src/declarations/orbiter/orbiter.did.d.ts
+++ b/src/declarations/orbiter/orbiter.did.d.ts
@@ -101,10 +101,6 @@ export interface HttpResponse {
 	upgrade: [] | [boolean];
 	status_code: number;
 }
-export interface MemorySize {
-	stable: bigint;
-	heap: bigint;
-}
 export type NavigationType =
 	| { Navigate: null }
 	| { Restore: null }
@@ -249,7 +245,6 @@ export interface _SERVICE {
 	http_request_update: ActorMethod<[HttpRequest], HttpResponse>;
 	list_controllers: ActorMethod<[], Array<[Principal, Controller]>>;
 	list_satellite_configs: ActorMethod<[], Array<[Principal, OrbiterSatelliteConfig]>>;
-	memory_size: ActorMethod<[], MemorySize>;
 	set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
 	set_page_view: ActorMethod<[AnalyticKey, SetPageView], Result>;
 	set_page_views: ActorMethod<[Array<[AnalyticKey, SetPageView]>], Result_1>;

--- a/src/declarations/orbiter/orbiter.factory.certified.did.js
+++ b/src/declarations/orbiter/orbiter.factory.certified.did.js
@@ -178,7 +178,6 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -263,7 +262,6 @@ export const idlFactory = ({ IDL }) => {
 			[IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
 			[]
 		),
-		memory_size: IDL.Func([], [MemorySize], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/src/declarations/orbiter/orbiter.factory.did.js
+++ b/src/declarations/orbiter/orbiter.factory.did.js
@@ -178,7 +178,6 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -279,7 +278,6 @@ export const idlFactory = ({ IDL }) => {
 			[IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
 			['query']
 		),
-		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/src/declarations/orbiter/orbiter.factory.did.mjs
+++ b/src/declarations/orbiter/orbiter.factory.did.mjs
@@ -178,7 +178,6 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -279,7 +278,6 @@ export const idlFactory = ({ IDL }) => {
 			[IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
 			['query']
 		),
-		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -143,10 +143,6 @@ export interface ListResults_1 {
 	items_length: bigint;
 }
 export type Memory = { Heap: null } | { Stable: null };
-export interface MemorySize {
-	stable: bigint;
-	heap: bigint;
-}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -278,7 +274,6 @@ export interface _SERVICE {
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_docs: ActorMethod<[string, ListParams], ListResults_1>;
 	list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
-	memory_size: ActorMethod<[], MemorySize>;
 	set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
 	set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -208,7 +208,6 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -291,7 +290,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
-		memory_size: IDL.Func([], [MemorySize], []),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -208,7 +208,6 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -291,7 +290,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
-		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -208,7 +208,6 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -291,7 +290,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
-		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -143,10 +143,6 @@ export interface ListResults_1 {
 	items_length: bigint;
 }
 export type Memory = { Heap: null } | { Stable: null };
-export interface MemorySize {
-	stable: bigint;
-	heap: bigint;
-}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -278,7 +274,6 @@ export interface _SERVICE {
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_docs: ActorMethod<[string, ListParams], ListResults_1>;
 	list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
-	memory_size: ActorMethod<[], MemorySize>;
 	set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
 	set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -208,7 +208,6 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -291,7 +290,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
-		memory_size: IDL.Func([], [MemorySize], []),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -208,7 +208,6 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -291,7 +290,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
-		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -117,7 +117,6 @@ type ListResults_1 = record {
   items_length : nat64;
 };
 type Memory = variant { Heap; Stable };
-type MemorySize = record { stable : nat64; heap : nat64 };
 type Permission = variant { Controllers; Private; Public; Managed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Rule = record {
@@ -243,7 +242,6 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_docs : (text, ListParams) -> (ListResults_1) query;
   list_rules : (CollectionType) -> (vec record { text; Rule }) query;
-  memory_size : () -> (MemorySize) query;
   set_auth_config : (AuthenticationConfig) -> ();
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -31,7 +31,7 @@ use junobuild_shared::types::core::DomainName;
 use junobuild_shared::types::core::{Blob, Key};
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::interface::{
-    DeleteControllersArgs, DepositCyclesArgs, MemorySize, SetControllersArgs,
+    DeleteControllersArgs, DepositCyclesArgs, SetControllersArgs,
 };
 use junobuild_shared::types::list::ListParams;
 use junobuild_shared::types::list::ListResults;
@@ -381,12 +381,6 @@ pub async fn deposit_cycles(args: DepositCyclesArgs) {
         .unwrap_or_else(|e| trap(&e))
 }
 
-#[doc(hidden)]
-#[query(guard = "caller_is_controller")]
-pub fn memory_size() -> MemorySize {
-    junobuild_shared::canister::memory_size()
-}
-
 /// Include the stock Juno satellite features into your Juno application.
 ///
 /// The `include_satellite!` macro allows you to easily import and use all the essential features and
@@ -412,7 +406,7 @@ macro_rules! include_satellite {
             del_rule, deposit_cycles, get_asset, get_auth_config, get_config, get_db_config,
             get_doc, get_many_assets, get_many_docs, get_storage_config, http_request,
             http_request_streaming_callback, init, init_asset_upload, list_assets,
-            list_controllers, list_custom_domains, list_docs, list_rules, memory_size,
+            list_controllers, list_custom_domains, list_docs, list_rules,
             post_upgrade, pre_upgrade, set_auth_config, set_controllers, set_custom_domain,
             set_db_config, set_doc, set_many_docs, set_rule, set_storage_config,
             upload_asset_chunk,

--- a/src/orbiter/orbiter.did
+++ b/src/orbiter/orbiter.did
@@ -81,7 +81,6 @@ type HttpResponse = record {
   upgrade : opt bool;
   status_code : nat16;
 };
-type MemorySize = record { stable : nat64; heap : nat64 };
 type NavigationType = variant {
   Navigate;
   Restore;
@@ -233,7 +232,6 @@ service : () -> {
   list_satellite_configs : () -> (
       vec record { principal; OrbiterSatelliteConfig },
     ) query;
-  memory_size : () -> (MemorySize) query;
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },
     );

--- a/src/orbiter/src/lib.rs
+++ b/src/orbiter/src/lib.rs
@@ -47,14 +47,13 @@ use ic_cdk::api::call::{arg_data, ArgDecoderConfig};
 use ic_cdk::trap;
 use ic_cdk_macros::{export_candid, init, post_upgrade, pre_upgrade, query, update};
 use ic_http_certification::{HttpRequest, HttpResponse};
-use junobuild_shared::canister::memory_size as canister_memory_size;
 use junobuild_shared::constants_shared::MAX_NUMBER_OF_SATELLITE_CONTROLLERS;
 use junobuild_shared::controllers::{
     assert_controllers, assert_max_number_of_controllers, init_controllers,
 };
 use junobuild_shared::mgmt::ic::deposit_cycles as deposit_cycles_shared;
 use junobuild_shared::types::interface::{
-    DeleteControllersArgs, DepositCyclesArgs, MemorySize, SegmentArgs, SetControllersArgs,
+    DeleteControllersArgs, DepositCyclesArgs, SegmentArgs, SetControllersArgs,
 };
 use junobuild_shared::types::memory::Memory;
 use junobuild_shared::types::state::{ControllerScope, Controllers, SatelliteId};
@@ -361,11 +360,6 @@ async fn deposit_cycles(args: DepositCyclesArgs) {
     deposit_cycles_shared(args)
         .await
         .unwrap_or_else(|e| trap(&e))
-}
-
-#[query(guard = "caller_is_admin_controller")]
-fn memory_size() -> MemorySize {
-    canister_memory_size()
 }
 
 // Generate did files

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -119,7 +119,6 @@ type ListResults_1 = record {
   items_length : nat64;
 };
 type Memory = variant { Heap; Stable };
-type MemorySize = record { stable : nat64; heap : nat64 };
 type Permission = variant { Controllers; Private; Public; Managed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Rule = record {
@@ -245,7 +244,6 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_docs : (text, ListParams) -> (ListResults_1) query;
   list_rules : (CollectionType) -> (vec record { text; Rule }) query;
-  memory_size : () -> (MemorySize) query;
   set_auth_config : (AuthenticationConfig) -> ();
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -119,7 +119,6 @@ type ListResults_1 = record {
   items_length : nat64;
 };
 type Memory = variant { Heap; Stable };
-type MemorySize = record { stable : nat64; heap : nat64 };
 type Permission = variant { Controllers; Private; Public; Managed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Rule = record {
@@ -245,7 +244,6 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_docs : (text, ListParams) -> (ListResults_1) query;
   list_rules : (CollectionType) -> (vec record { text; Rule }) query;
-  memory_size : () -> (MemorySize) query;
   set_auth_config : (AuthenticationConfig) -> ();
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -143,10 +143,6 @@ export interface ListResults_1 {
 	items_length: bigint;
 }
 export type Memory = { Heap: null } | { Stable: null };
-export interface MemorySize {
-	stable: bigint;
-	heap: bigint;
-}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -280,7 +276,6 @@ export interface _SERVICE {
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_docs: ActorMethod<[string, ListParams], ListResults_1>;
 	list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
-	memory_size: ActorMethod<[], MemorySize>;
 	set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
 	set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -209,7 +209,6 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -293,7 +292,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
-		memory_size: IDL.Func([], [MemorySize], []),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -209,7 +209,6 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
-	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -293,7 +292,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
-		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -119,7 +119,6 @@ type ListResults_1 = record {
   items_length : nat64;
 };
 type Memory = variant { Heap; Stable };
-type MemorySize = record { stable : nat64; heap : nat64 };
 type Permission = variant { Controllers; Private; Public; Managed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Rule = record {
@@ -245,7 +244,6 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_docs : (text, ListParams) -> (ListResults_1) query;
   list_rules : (CollectionType) -> (vec record { text; Rule }) query;
-  memory_size : () -> (MemorySize) query;
   set_auth_config : (AuthenticationConfig) -> ();
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },

--- a/src/tests/specs/satellite/stock/satellite.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.spec.ts
@@ -711,12 +711,6 @@ describe('Satellite', () => {
 			).rejects.toThrow(JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER);
 		});
 
-		it('should throw errors on getting memory size', async () => {
-			const { memory_size } = actor;
-
-			await expect(memory_size()).rejects.toThrow(JUNO_AUTH_ERROR_NOT_CONTROLLER);
-		});
-
 		it('should throw errors on trying to deploy dapp', async () => {
 			const { init_asset_upload } = actor;
 


### PR DESCRIPTION
# Motivation

We are now using the IC mgmt memory metrics therefore we do not need to expose those endpoints anymore.

The Console UI is using those new data and the Docker environment has been updated to provide them as well.

