### PR TITLE
feat: use u64 for shared::memory_size() instead of usize

### DIFF
--- a/src/libs/shared/src/assert.rs
+++ b/src/libs/shared/src/assert.rs
@@ -175,7 +175,7 @@ pub fn assert_max_memory_size(
         let MemorySize { heap, stable } = memory_size();
 
         if let Some(max_heap) = max_memory_size.heap {
-            if heap > max_heap {
+            if heap > max_heap as u64 {
                 return Err(format!(
                     "Heap memory usage exceeded: {} bytes used, {} bytes allowed.",
                     heap, max_heap
@@ -184,7 +184,7 @@ pub fn assert_max_memory_size(
         }
 
         if let Some(max_stable) = max_memory_size.stable {
-            if stable > max_stable {
+            if stable > max_stable as u64 {
                 return Err(format!(
                     "Stable memory usage exceeded: {} bytes used, {} bytes allowed.",
                     stable, max_stable

--- a/src/libs/shared/src/canister.rs
+++ b/src/libs/shared/src/canister.rs
@@ -23,7 +23,7 @@ use ic_cdk::api::stable::{stable_size, WASM_PAGE_SIZE_IN_BYTES};
 ///
 pub fn memory_size() -> MemorySize {
     MemorySize {
-        heap: wasm_memory_size(0) * WASM_PAGE_SIZE_IN_BYTES as usize,
-        stable: stable_size() as usize * WASM_PAGE_SIZE_IN_BYTES as usize,
+        heap: wasm_memory_size(0) as u64 * WASM_PAGE_SIZE_IN_BYTES,
+        stable: stable_size() * WASM_PAGE_SIZE_IN_BYTES,
     }
 }

--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -136,7 +136,6 @@ pub mod state {
 
 pub mod interface {
     use crate::mgmt::types::cmc::SubnetId;
-    use crate::types::core::Bytes;
     use crate::types::state::{
         ControllerId, ControllerScope, Metadata, MissionControlId, NotificationKind, Segment,
         Timestamp, UserId,
@@ -199,8 +198,8 @@ pub mod interface {
 
     #[derive(CandidType, Deserialize, Clone)]
     pub struct MemorySize {
-        pub heap: Bytes,
-        pub stable: Bytes,
+        pub heap: u64,
+        pub stable: u64,
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
@@ -267,9 +266,6 @@ pub mod core {
     pub trait Hashable {
         fn hash(&self) -> Hash;
     }
-
-    /// A shorthand for example to represents the type of the memory size in bytes.
-    pub type Bytes = usize;
 }
 
 pub mod list {
@@ -351,14 +347,13 @@ pub mod domain {
 }
 
 pub mod config {
-    use crate::types::core::Bytes;
     use candid::{CandidType, Deserialize};
     use serde::Serialize;
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct ConfigMaxMemorySize {
-        pub heap: Option<Bytes>,
-        pub stable: Option<Bytes>,
+        pub heap: Option<usize>,
+        pub stable: Option<usize>,
     }
 }
 


### PR DESCRIPTION
# Motivation

Prevent truncated value if downscaled to u32
