### PR TITLE
feat(observatory): send failed deposit cycles email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ satellite-v*.wasm.gz
 orbiter-v*.wasm.gz
 mission_control-v*.wasm.gz
 console-v*.wasm.gz
+observatory-v*.wasm.gz
 out/
 tmp/
 juno.package.json

--- a/src/declarations/deprecated/observatory-0-0-9.did.d.ts
+++ b/src/declarations/deprecated/observatory-0-0-9.did.d.ts
@@ -1,0 +1,70 @@
+import type { ActorMethod } from '@dfinity/agent';
+import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@dfinity/principal';
+
+export interface Controller {
+	updated_at: bigint;
+	metadata: Array<[string, string]>;
+	created_at: bigint;
+	scope: ControllerScope;
+	expires_at: [] | [bigint];
+}
+export type ControllerScope = { Write: null } | { Admin: null };
+export interface CyclesBalance {
+	timestamp: bigint;
+	amount: bigint;
+}
+export interface DeleteControllersArgs {
+	controllers: Array<Principal>;
+}
+export interface DepositedCyclesEmailNotification {
+	to: string;
+	deposited_cycles: CyclesBalance;
+}
+export interface Env {
+	email_api_key: [] | [string];
+}
+export interface GetNotifications {
+	to: [] | [bigint];
+	from: [] | [bigint];
+	segment_id: [] | [Principal];
+}
+export type NotificationKind = {
+	DepositedCyclesEmail: DepositedCyclesEmailNotification;
+};
+export interface NotifyArgs {
+	kind: NotificationKind;
+	user: Principal;
+	segment: Segment;
+}
+export interface NotifyStatus {
+	pending: bigint;
+	sent: bigint;
+	failed: bigint;
+}
+export interface Segment {
+	id: Principal;
+	metadata: [] | [Array<[string, string]>];
+	kind: SegmentKind;
+}
+export type SegmentKind = { Orbiter: null } | { MissionControl: null } | { Satellite: null };
+export interface SetController {
+	metadata: Array<[string, string]>;
+	scope: ControllerScope;
+	expires_at: [] | [bigint];
+}
+export interface SetControllersArgs {
+	controller: SetController;
+	controllers: Array<Principal>;
+}
+export interface _SERVICE {
+	del_controllers: ActorMethod<[DeleteControllersArgs], undefined>;
+	get_notify_status: ActorMethod<[GetNotifications], NotifyStatus>;
+	list_controllers: ActorMethod<[], Array<[Principal, Controller]>>;
+	notify: ActorMethod<[NotifyArgs], undefined>;
+	ping: ActorMethod<[NotifyArgs], undefined>;
+	set_controllers: ActorMethod<[SetControllersArgs], undefined>;
+	set_env: ActorMethod<[Env], undefined>;
+}
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/deprecated/observatory-0-0-9.factory.did.js
+++ b/src/declarations/deprecated/observatory-0-0-9.factory.did.js
@@ -1,0 +1,76 @@
+// @ts-ignore
+export const idlFactory = ({ IDL }) => {
+	const DeleteControllersArgs = IDL.Record({
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const GetNotifications = IDL.Record({
+		to: IDL.Opt(IDL.Nat64),
+		from: IDL.Opt(IDL.Nat64),
+		segment_id: IDL.Opt(IDL.Principal)
+	});
+	const NotifyStatus = IDL.Record({
+		pending: IDL.Nat64,
+		sent: IDL.Nat64,
+		failed: IDL.Nat64
+	});
+	const ControllerScope = IDL.Variant({
+		Write: IDL.Null,
+		Admin: IDL.Null
+	});
+	const Controller = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		created_at: IDL.Nat64,
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const CyclesBalance = IDL.Record({
+		timestamp: IDL.Nat64,
+		amount: IDL.Nat
+	});
+	const DepositedCyclesEmailNotification = IDL.Record({
+		to: IDL.Text,
+		deposited_cycles: CyclesBalance
+	});
+	const NotificationKind = IDL.Variant({
+		DepositedCyclesEmail: DepositedCyclesEmailNotification
+	});
+	const SegmentKind = IDL.Variant({
+		Orbiter: IDL.Null,
+		MissionControl: IDL.Null,
+		Satellite: IDL.Null
+	});
+	const Segment = IDL.Record({
+		id: IDL.Principal,
+		metadata: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
+		kind: SegmentKind
+	});
+	const NotifyArgs = IDL.Record({
+		kind: NotificationKind,
+		user: IDL.Principal,
+		segment: Segment
+	});
+	const SetController = IDL.Record({
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		scope: ControllerScope,
+		expires_at: IDL.Opt(IDL.Nat64)
+	});
+	const SetControllersArgs = IDL.Record({
+		controller: SetController,
+		controllers: IDL.Vec(IDL.Principal)
+	});
+	const Env = IDL.Record({ email_api_key: IDL.Opt(IDL.Text) });
+	return IDL.Service({
+		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
+		get_notify_status: IDL.Func([GetNotifications], [NotifyStatus], ['query']),
+		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], ['query']),
+		notify: IDL.Func([NotifyArgs], [], []),
+		ping: IDL.Func([NotifyArgs], [], []),
+		set_controllers: IDL.Func([SetControllersArgs], [], []),
+		set_env: IDL.Func([Env], [], [])
+	});
+};
+// @ts-ignore
+export const init = ({ IDL }) => {
+	return [];
+};

--- a/src/declarations/observatory/observatory.did.d.ts
+++ b/src/declarations/observatory/observatory.did.d.ts
@@ -24,14 +24,30 @@ export interface DepositedCyclesEmailNotification {
 export interface Env {
 	email_api_key: [] | [string];
 }
+export interface FailedCyclesDepositEmailNotification {
+	to: string;
+	funding_failure: FundingFailure;
+}
+export type FundingErrorCode =
+	| { BalanceCheckFailed: null }
+	| { ObtainCyclesFailed: null }
+	| { DepositFailed: null }
+	| { InsufficientCycles: null }
+	| { Other: string };
+export interface FundingFailure {
+	timestamp: bigint;
+	error_code: FundingErrorCode;
+}
 export interface GetNotifications {
 	to: [] | [bigint];
 	from: [] | [bigint];
 	segment_id: [] | [Principal];
 }
-export type NotificationKind = {
-	DepositedCyclesEmail: DepositedCyclesEmailNotification;
-};
+export type NotificationKind =
+	| {
+			DepositedCyclesEmail: DepositedCyclesEmailNotification;
+	  }
+	| { FailedCyclesDepositEmail: FailedCyclesDepositEmailNotification };
 export interface NotifyArgs {
 	kind: NotificationKind;
 	user: Principal;

--- a/src/declarations/observatory/observatory.factory.certified.did.js
+++ b/src/declarations/observatory/observatory.factory.certified.did.js
@@ -32,8 +32,24 @@ export const idlFactory = ({ IDL }) => {
 		to: IDL.Text,
 		deposited_cycles: CyclesBalance
 	});
+	const FundingErrorCode = IDL.Variant({
+		BalanceCheckFailed: IDL.Null,
+		ObtainCyclesFailed: IDL.Null,
+		DepositFailed: IDL.Null,
+		InsufficientCycles: IDL.Null,
+		Other: IDL.Text
+	});
+	const FundingFailure = IDL.Record({
+		timestamp: IDL.Nat64,
+		error_code: FundingErrorCode
+	});
+	const FailedCyclesDepositEmailNotification = IDL.Record({
+		to: IDL.Text,
+		funding_failure: FundingFailure
+	});
 	const NotificationKind = IDL.Variant({
-		DepositedCyclesEmail: DepositedCyclesEmailNotification
+		DepositedCyclesEmail: DepositedCyclesEmailNotification,
+		FailedCyclesDepositEmail: FailedCyclesDepositEmailNotification
 	});
 	const SegmentKind = IDL.Variant({
 		Orbiter: IDL.Null,

--- a/src/declarations/observatory/observatory.factory.did.js
+++ b/src/declarations/observatory/observatory.factory.did.js
@@ -32,8 +32,24 @@ export const idlFactory = ({ IDL }) => {
 		to: IDL.Text,
 		deposited_cycles: CyclesBalance
 	});
+	const FundingErrorCode = IDL.Variant({
+		BalanceCheckFailed: IDL.Null,
+		ObtainCyclesFailed: IDL.Null,
+		DepositFailed: IDL.Null,
+		InsufficientCycles: IDL.Null,
+		Other: IDL.Text
+	});
+	const FundingFailure = IDL.Record({
+		timestamp: IDL.Nat64,
+		error_code: FundingErrorCode
+	});
+	const FailedCyclesDepositEmailNotification = IDL.Record({
+		to: IDL.Text,
+		funding_failure: FundingFailure
+	});
 	const NotificationKind = IDL.Variant({
-		DepositedCyclesEmail: DepositedCyclesEmailNotification
+		DepositedCyclesEmail: DepositedCyclesEmailNotification,
+		FailedCyclesDepositEmail: FailedCyclesDepositEmailNotification
 	});
 	const SegmentKind = IDL.Variant({
 		Orbiter: IDL.Null,

--- a/src/declarations/observatory/observatory.factory.did.mjs
+++ b/src/declarations/observatory/observatory.factory.did.mjs
@@ -32,8 +32,24 @@ export const idlFactory = ({ IDL }) => {
 		to: IDL.Text,
 		deposited_cycles: CyclesBalance
 	});
+	const FundingErrorCode = IDL.Variant({
+		BalanceCheckFailed: IDL.Null,
+		ObtainCyclesFailed: IDL.Null,
+		DepositFailed: IDL.Null,
+		InsufficientCycles: IDL.Null,
+		Other: IDL.Text
+	});
+	const FundingFailure = IDL.Record({
+		timestamp: IDL.Nat64,
+		error_code: FundingErrorCode
+	});
+	const FailedCyclesDepositEmailNotification = IDL.Record({
+		to: IDL.Text,
+		funding_failure: FundingFailure
+	});
 	const NotificationKind = IDL.Variant({
-		DepositedCyclesEmail: DepositedCyclesEmailNotification
+		DepositedCyclesEmail: DepositedCyclesEmailNotification,
+		FailedCyclesDepositEmail: FailedCyclesDepositEmailNotification
 	});
 	const SegmentKind = IDL.Variant({
 		Orbiter: IDL.Null,

--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -1,6 +1,6 @@
 pub mod state {
     use crate::types::core::DomainName;
-    use crate::types::monitoring::CyclesBalance;
+    use crate::types::monitoring::{CyclesBalance, FundingFailure};
     use candid::Principal;
     use candid::{CandidType, Nat};
     use ic_cdk::api::management_canister::main::CanisterStatusType;
@@ -125,12 +125,19 @@ pub mod state {
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub enum NotificationKind {
         DepositedCyclesEmail(DepositedCyclesEmailNotification),
+        FailedCyclesDepositEmail(FailedCyclesDepositEmailNotification),
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct DepositedCyclesEmailNotification {
         pub to: String,
         pub deposited_cycles: CyclesBalance,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct FailedCyclesDepositEmailNotification {
+        pub to: String,
+        pub funding_failure: FundingFailure,
     }
 }
 
@@ -365,6 +372,21 @@ pub mod monitoring {
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct CyclesBalance {
         pub amount: u128,
+        pub timestamp: Timestamp,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub enum FundingErrorCode {
+        InsufficientCycles, // Funding canister has insufficient cycles
+        DepositFailed,      // The deposit of cycles failed
+        ObtainCyclesFailed, // Obtaining cycles failed
+        BalanceCheckFailed, // Fetching cycles balance failed
+        Other(String),      // Other errors with a custom message
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct FundingFailure {
+        pub error_code: FundingErrorCode,
         pub timestamp: Timestamp,
     }
 }

--- a/src/observatory/observatory.did
+++ b/src/observatory/observatory.did
@@ -13,6 +13,21 @@ type DepositedCyclesEmailNotification = record {
   deposited_cycles : CyclesBalance;
 };
 type Env = record { email_api_key : opt text };
+type FailedCyclesDepositEmailNotification = record {
+  to : text;
+  funding_failure : FundingFailure;
+};
+type FundingErrorCode = variant {
+  BalanceCheckFailed;
+  ObtainCyclesFailed;
+  DepositFailed;
+  InsufficientCycles;
+  Other : text;
+};
+type FundingFailure = record {
+  timestamp : nat64;
+  error_code : FundingErrorCode;
+};
 type GetNotifications = record {
   to : opt nat64;
   from : opt nat64;
@@ -20,6 +35,7 @@ type GetNotifications = record {
 };
 type NotificationKind = variant {
   DepositedCyclesEmail : DepositedCyclesEmailNotification;
+  FailedCyclesDepositEmail : FailedCyclesDepositEmailNotification;
 };
 type NotifyArgs = record {
   kind : NotificationKind;

--- a/src/observatory/src/http/send.rs
+++ b/src/observatory/src/http/send.rs
@@ -9,11 +9,12 @@ use junobuild_shared::types::state::NotificationKind;
 pub async fn send_notification(key: NotificationKey) {
     let notification = get_notification(&key).unwrap_or_else(|| trap("Notification not found."));
 
-    let result = match &notification.kind {
-        NotificationKind::DepositedCyclesEmail(email) => {
-            send_email(&key, &email.to, &notification).await
-        }
+    let email_to = match &notification.kind {
+        NotificationKind::DepositedCyclesEmail(email) => &email.to,
+        NotificationKind::FailedCyclesDepositEmail(email) => &email.to,
     };
+
+    let result = send_email(&key, &email_to, &notification).await;
 
     let updated_notification = match result {
         Ok(_) => Notification::sent(&notification),

--- a/src/observatory/src/templates.rs
+++ b/src/observatory/src/templates.rs
@@ -1,2 +1,6 @@
 pub const DEPOSITED_CYCLES_HTML: &[u8] = include_bytes!("../resources/deposited-cycles.html");
 pub const DEPOSITED_CYCLES_TXT: &[u8] = include_bytes!("../resources/deposited-cycles.txt");
+pub const FAILED_DEPOSIT_CYCLES_HTML: &[u8] =
+    include_bytes!("../resources/failed-deposit-cycles.html");
+pub const FAILED_DEPOSIT_CYCLES_TXT: &[u8] =
+    include_bytes!("../resources/failed-deposit-cycles.txt");

--- a/src/tests/specs/observatory/observatory.ping.spec.ts
+++ b/src/tests/specs/observatory/observatory.ping.spec.ts
@@ -6,7 +6,8 @@ import { inject } from 'vitest';
 import { mockMissionControlId } from '../../../frontend/tests/mocks/modules.mock';
 import {
 	mockObservatoryProxyBearerKey,
-	testDepositedCyclesNotification, testFailedDepositCyclesNotification
+	testDepositedCyclesNotification,
+	testFailedDepositCyclesNotification
 } from '../../utils/observatory-tests.utils';
 import { tick } from '../../utils/pic-tests.utils';
 import { OBSERVATORY_WASM_PATH } from '../../utils/setup-tests.utils';

--- a/src/tests/specs/observatory/observatory.ping.spec.ts
+++ b/src/tests/specs/observatory/observatory.ping.spec.ts
@@ -6,7 +6,7 @@ import { inject } from 'vitest';
 import { mockMissionControlId } from '../../../frontend/tests/mocks/modules.mock';
 import {
 	mockObservatoryProxyBearerKey,
-	testDepositCyclesNotification
+	testDepositedCyclesNotification, testFailedDepositCyclesNotification
 } from '../../utils/observatory-tests.utils';
 import { tick } from '../../utils/pic-tests.utils';
 import { OBSERVATORY_WASM_PATH } from '../../utils/setup-tests.utils';
@@ -43,9 +43,9 @@ describe('Observatory > Ping', () => {
 		await pic?.tearDown();
 	});
 
-	describe('Deposit cycles notifications', () => {
+	describe('Deposited cycles notifications', () => {
 		it('should notify Mission Control', async () => {
-			await testDepositCyclesNotification({
+			await testDepositedCyclesNotification({
 				kind: { MissionControl: null },
 				url: 'https://console.juno.build/mission-control',
 				moduleName: 'Mission Control',
@@ -55,7 +55,7 @@ describe('Observatory > Ping', () => {
 		});
 
 		it('should notify Orbiter', async () => {
-			await testDepositCyclesNotification({
+			await testDepositedCyclesNotification({
 				kind: { Orbiter: null },
 				url: 'https://console.juno.build/analytics',
 				moduleName: 'Orbiter',
@@ -65,7 +65,7 @@ describe('Observatory > Ping', () => {
 		});
 
 		it('should notify Satellite', async () => {
-			await testDepositCyclesNotification({
+			await testDepositedCyclesNotification({
 				kind: { Satellite: null },
 				url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
 				moduleName: 'Satellite',
@@ -75,7 +75,50 @@ describe('Observatory > Ping', () => {
 		});
 
 		it('should notify Satellite with name', async () => {
-			await testDepositCyclesNotification({
+			await testDepositedCyclesNotification({
+				kind: { Satellite: null },
+				url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
+				moduleName: 'Satellite',
+				metadataName: 'This is a test name',
+				actor,
+				pic
+			});
+		});
+	});
+
+	describe('Failed deposit cycles notifications', () => {
+		it('should notify Mission Control', async () => {
+			await testFailedDepositCyclesNotification({
+				kind: { MissionControl: null },
+				url: 'https://console.juno.build/mission-control',
+				moduleName: 'Mission Control',
+				actor,
+				pic
+			});
+		});
+
+		it('should notify Orbiter', async () => {
+			await testFailedDepositCyclesNotification({
+				kind: { Orbiter: null },
+				url: 'https://console.juno.build/analytics',
+				moduleName: 'Orbiter',
+				actor,
+				pic
+			});
+		});
+
+		it('should notify Satellite', async () => {
+			await testFailedDepositCyclesNotification({
+				kind: { Satellite: null },
+				url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
+				moduleName: 'Satellite',
+				actor,
+				pic
+			});
+		});
+
+		it('should notify Satellite with name', async () => {
+			await testFailedDepositCyclesNotification({
 				kind: { Satellite: null },
 				url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
 				moduleName: 'Satellite',

--- a/src/tests/specs/observatory/observatory.ping.spec.ts
+++ b/src/tests/specs/observatory/observatory.ping.spec.ts
@@ -1,16 +1,13 @@
-import type {
-	_SERVICE as ObservatoryActor,
-	SegmentKind
-} from '$declarations/observatory/observatory.did';
+import type { _SERVICE as ObservatoryActor } from '$declarations/observatory/observatory.did';
 import { idlFactory as idlFactorObservatory } from '$declarations/observatory/observatory.factory.did';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
-import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { type Actor, PocketIc } from '@hadronous/pic';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { inject } from 'vitest';
 import { mockMissionControlId } from '../../../frontend/tests/mocks/modules.mock';
-import { toBodyJson } from '../../utils/orbiter-test.utils';
+import {
+	mockObservatoryProxyBearerKey,
+	testDepositCyclesNotification
+} from '../../utils/observatory-tests.utils';
 import { tick } from '../../utils/pic-tests.utils';
 import { OBSERVATORY_WASM_PATH } from '../../utils/setup-tests.utils';
 
@@ -19,18 +16,6 @@ describe('Observatory > Ping', () => {
 	let actor: Actor<ObservatoryActor>;
 
 	const controller = Ed25519KeyIdentity.generate();
-
-	const EMAIL_API_KEY = 'test-key';
-
-	const DEPOSITED_CYCLES_TEMPLATE_TEXT = readFileSync(
-		join(process.cwd(), 'src/observatory/resources/deposited-cycles.txt'),
-		'utf-8'
-	);
-
-	const DEPOSITED_CYCLES_TEMPLATE_HTML = readFileSync(
-		join(process.cwd(), 'src/observatory/resources/deposited-cycles.html'),
-		'utf-8'
-	);
 
 	beforeAll(async () => {
 		pic = await PocketIc.create(inject('PIC_URL'));
@@ -50,7 +35,7 @@ describe('Observatory > Ping', () => {
 		const { set_env } = actor;
 
 		await set_env({
-			email_api_key: [EMAIL_API_KEY]
+			email_api_key: [mockObservatoryProxyBearerKey]
 		});
 	});
 
@@ -59,105 +44,13 @@ describe('Observatory > Ping', () => {
 	});
 
 	describe('Deposit cycles notifications', () => {
-		const testDepositCyclesNotification = async ({
-			kind,
-			url: expectedUrl,
-			moduleName,
-			metadataName
-		}: {
-			kind: SegmentKind;
-			url: string;
-			moduleName: 'Mission Control' | 'Satellite' | 'Orbiter';
-			metadataName?: string;
-		}) => {
-			const { ping } = actor;
-
-			await ping({
-				kind: {
-					DepositedCyclesEmail: {
-						to: 'test@test.com',
-						deposited_cycles: {
-							amount: 123456789n,
-							timestamp: 1747036399590000000n
-						}
-					}
-				},
-				segment: {
-					id: mockMissionControlId,
-					metadata: nonNullish(metadataName) ? [[['name', metadataName]]] : [],
-					kind
-				},
-				user: Ed25519KeyIdentity.generate().getPrincipal()
-			});
-
-			await tick(pic);
-
-			const [pendingHttpOutCall] = await pic.getPendingHttpsOutcalls();
-
-			assertNonNullish(pendingHttpOutCall);
-
-			const { requestId, subnetId, url, headers: headersArray, body } = pendingHttpOutCall;
-
-			expect(url).toEqual(
-				'https://europe-west6-juno-observatory.cloudfunctions.net/observatory/notifications/email'
-			);
-
-			const headers = headersArray.reduce<Record<string, string>>(
-				(acc, [key, value]) => ({ ...acc, [key]: value }),
-				{}
-			);
-
-			expect(headers['Content-Type']).toEqual('application/json');
-			expect(headers['authorization']).toEqual(`Bearer ${EMAIL_API_KEY}`);
-
-			// e.g. rdmx6-jaaaa-aaaaa-aaadq-cai___1620328630000000105___747495116
-			const idempotencyKey = headers['idempotency-key'].split('___');
-
-			expect(idempotencyKey[0]).toEqual(mockMissionControlId.toText());
-			expect(BigInt(idempotencyKey[1])).toBeGreaterThan(0n);
-			expect(Number(idempotencyKey[1])).toBeGreaterThan(0);
-
-			const decoder = new TextDecoder();
-			const { from, subject, text, html } = JSON.parse(decoder.decode(body));
-
-			expect(from).toEqual('Juno <notify@notifications.juno.build>');
-			expect(subject).toEqual(`🚀 0.00012346 T Cycles Deposited on Your ${moduleName}`);
-
-			const parseTemplate = (template: string): string =>
-				template
-					.replaceAll('{{cycles}}', '0.00012346')
-					.replaceAll('{{module}}', moduleName)
-					.replaceAll(' ({{name}})', nonNullish(metadataName) ? ` (${metadataName})` : '')
-					.replaceAll(
-						' (<!-- -->{{name}}<!-- -->)',
-						nonNullish(metadataName) ? ` (<!-- -->${metadataName}<!-- -->)` : ''
-					)
-					.replaceAll('{{timestamp}}', '2025-05-12T07:53:19+00:00')
-					.replaceAll('{{url}}', expectedUrl);
-
-			expect(text).toEqual(parseTemplate(DEPOSITED_CYCLES_TEMPLATE_TEXT));
-			expect(html).toEqual(parseTemplate(DEPOSITED_CYCLES_TEMPLATE_HTML));
-
-			// Finalize
-			await pic.mockPendingHttpsOutcall({
-				requestId,
-				subnetId,
-				response: {
-					type: 'success',
-					body: toBodyJson({}),
-					statusCode: 200,
-					headers: []
-				}
-			});
-
-			await tick(pic);
-		};
-
 		it('should notify Mission Control', async () => {
 			await testDepositCyclesNotification({
 				kind: { MissionControl: null },
 				url: 'https://console.juno.build/mission-control',
-				moduleName: 'Mission Control'
+				moduleName: 'Mission Control',
+				actor,
+				pic
 			});
 		});
 
@@ -165,7 +58,9 @@ describe('Observatory > Ping', () => {
 			await testDepositCyclesNotification({
 				kind: { Orbiter: null },
 				url: 'https://console.juno.build/analytics',
-				moduleName: 'Orbiter'
+				moduleName: 'Orbiter',
+				actor,
+				pic
 			});
 		});
 
@@ -173,7 +68,9 @@ describe('Observatory > Ping', () => {
 			await testDepositCyclesNotification({
 				kind: { Satellite: null },
 				url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
-				moduleName: 'Satellite'
+				moduleName: 'Satellite',
+				actor,
+				pic
 			});
 		});
 
@@ -182,7 +79,9 @@ describe('Observatory > Ping', () => {
 				kind: { Satellite: null },
 				url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
 				moduleName: 'Satellite',
-				metadataName: 'This is a test name'
+				metadataName: 'This is a test name',
+				actor,
+				pic
 			});
 		});
 	});

--- a/src/tests/specs/observatory/observatory.upgrade.spec.ts
+++ b/src/tests/specs/observatory/observatory.upgrade.spec.ts
@@ -1,0 +1,114 @@
+import type { _SERVICE as ObservatoryActor_0_0_9 } from '$declarations/deprecated/observatory-0-0-9.did';
+import { idlFactory as idlFactorObservatory_0_0_8 } from '$declarations/deprecated/observatory-0-0-9.factory.did';
+import type { _SERVICE as ObservatoryActor } from '$declarations/observatory/observatory.did';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Principal } from '@dfinity/principal';
+import { type Actor, PocketIc } from '@hadronous/pic';
+import { beforeEach, describe, inject } from 'vitest';
+import { mockMissionControlId } from '../../../frontend/tests/mocks/modules.mock';
+import { missionControlUserInitArgs } from '../../utils/mission-control-tests.utils';
+import {
+	mockObservatoryProxyBearerKey,
+	testDepositCyclesNotification
+} from '../../utils/observatory-tests.utils';
+import { tick } from '../../utils/pic-tests.utils';
+import { downloadObservatory, OBSERVATORY_WASM_PATH } from '../../utils/setup-tests.utils';
+
+describe('Observatory > Upgrade', () => {
+	let pic: PocketIc;
+	let actor: Actor<ObservatoryActor>;
+	let observatoryId: Principal;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	describe('v0.0.9 -> v0.1.0', () => {
+		const upgradeCurrent = async () => {
+			await tick(pic);
+
+			await pic.upgradeCanister({
+				canisterId: observatoryId,
+				wasm: OBSERVATORY_WASM_PATH,
+				sender: controller.getPrincipal()
+			});
+		};
+
+		beforeEach(async () => {
+			pic = await PocketIc.create(inject('PIC_URL'));
+
+			const destination = await downloadObservatory({ junoVersion: '0.0.41', version: '0.0.9' });
+
+			const { actor: c, canisterId: mId } = await pic.setupCanister<ObservatoryActor_0_0_9>({
+				idlFactory: idlFactorObservatory_0_0_8,
+				wasm: destination,
+				arg: missionControlUserInitArgs(controller.getPrincipal()),
+				sender: controller.getPrincipal()
+			});
+
+			observatoryId = mId;
+
+			actor = c;
+			actor.setIdentity(controller);
+
+			// The random seed generator init is deferred
+			await tick(pic);
+
+			const { set_env } = actor;
+
+			await set_env({
+				email_api_key: [mockObservatoryProxyBearerKey]
+			});
+
+			await upgradeCurrent();
+
+			// The random seed generator init is deferred
+			await tick(pic);
+		});
+
+		describe('Deposit cycles notifications', () => {
+			it('should still notify Mission Control with previous interface', async () => {
+				await testDepositCyclesNotification({
+					kind: { MissionControl: null },
+					url: 'https://console.juno.build/mission-control',
+					moduleName: 'Mission Control',
+					actor,
+					pic
+				});
+			});
+
+			it('should still notify Orbiter with previous interface', async () => {
+				await testDepositCyclesNotification({
+					kind: { Orbiter: null },
+					url: 'https://console.juno.build/analytics',
+					moduleName: 'Orbiter',
+					actor,
+					pic
+				});
+			});
+
+			it('should still notify Satellite with previous interface', async () => {
+				await testDepositCyclesNotification({
+					kind: { Satellite: null },
+					url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
+					moduleName: 'Satellite',
+					actor,
+					pic
+				});
+			});
+
+			it('should notify Satellite with name', async () => {
+				await testDepositCyclesNotification({
+					kind: { Satellite: null },
+					url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
+					moduleName: 'Satellite',
+					metadataName: 'This is a test name',
+					actor,
+					pic
+				});
+			});
+		});
+	});
+});

--- a/src/tests/specs/observatory/observatory.upgrade.spec.ts
+++ b/src/tests/specs/observatory/observatory.upgrade.spec.ts
@@ -1,6 +1,5 @@
 import type { _SERVICE as ObservatoryActor_0_0_9 } from '$declarations/deprecated/observatory-0-0-9.did';
 import { idlFactory as idlFactorObservatory_0_0_8 } from '$declarations/deprecated/observatory-0-0-9.factory.did';
-import type { _SERVICE as ObservatoryActor } from '$declarations/observatory/observatory.did';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Principal } from '@dfinity/principal';
 import { type Actor, PocketIc } from '@hadronous/pic';
@@ -16,7 +15,7 @@ import { downloadObservatory, OBSERVATORY_WASM_PATH } from '../../utils/setup-te
 
 describe('Observatory > Upgrade', () => {
 	let pic: PocketIc;
-	let actor: Actor<ObservatoryActor>;
+	let actor: Actor<ObservatoryActor_0_0_9>;
 	let observatoryId: Principal;
 
 	const controller = Ed25519KeyIdentity.generate();

--- a/src/tests/specs/observatory/observatory.upgrade.spec.ts
+++ b/src/tests/specs/observatory/observatory.upgrade.spec.ts
@@ -8,7 +8,7 @@ import { mockMissionControlId } from '../../../frontend/tests/mocks/modules.mock
 import { missionControlUserInitArgs } from '../../utils/mission-control-tests.utils';
 import {
 	mockObservatoryProxyBearerKey,
-	testDepositCyclesNotification
+	testDepositedCyclesNotification
 } from '../../utils/observatory-tests.utils';
 import { tick } from '../../utils/pic-tests.utils';
 import { downloadObservatory, OBSERVATORY_WASM_PATH } from '../../utils/setup-tests.utils';
@@ -69,7 +69,7 @@ describe('Observatory > Upgrade', () => {
 
 		describe('Deposit cycles notifications', () => {
 			it('should still notify Mission Control with previous interface', async () => {
-				await testDepositCyclesNotification({
+				await testDepositedCyclesNotification({
 					kind: { MissionControl: null },
 					url: 'https://console.juno.build/mission-control',
 					moduleName: 'Mission Control',
@@ -79,7 +79,7 @@ describe('Observatory > Upgrade', () => {
 			});
 
 			it('should still notify Orbiter with previous interface', async () => {
-				await testDepositCyclesNotification({
+				await testDepositedCyclesNotification({
 					kind: { Orbiter: null },
 					url: 'https://console.juno.build/analytics',
 					moduleName: 'Orbiter',
@@ -89,7 +89,7 @@ describe('Observatory > Upgrade', () => {
 			});
 
 			it('should still notify Satellite with previous interface', async () => {
-				await testDepositCyclesNotification({
+				await testDepositedCyclesNotification({
 					kind: { Satellite: null },
 					url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
 					moduleName: 'Satellite',
@@ -99,7 +99,7 @@ describe('Observatory > Upgrade', () => {
 			});
 
 			it('should notify Satellite with name', async () => {
-				await testDepositCyclesNotification({
+				await testDepositedCyclesNotification({
 					kind: { Satellite: null },
 					url: `https://console.juno.build/satellite/?s=${mockMissionControlId.toText()}`,
 					moduleName: 'Satellite',

--- a/src/tests/utils/observatory-tests.utils.ts
+++ b/src/tests/utils/observatory-tests.utils.ts
@@ -1,0 +1,123 @@
+import type { _SERVICE as ObservatoryActor_0_0_9 } from '$declarations/deprecated/observatory-0-0-9.did';
+import type {
+	_SERVICE as ObservatoryActor,
+	SegmentKind
+} from '$declarations/observatory/observatory.did';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { assertNonNullish, nonNullish } from '@dfinity/utils';
+import type { PocketIc } from '@hadronous/pic';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { mockMissionControlId } from '../../frontend/tests/mocks/modules.mock';
+import { toBodyJson } from './orbiter-test.utils';
+import { tick } from './pic-tests.utils';
+
+export const mockObservatoryProxyBearerKey = 'test-key';
+
+const DEPOSITED_CYCLES_TEMPLATE_TEXT = readFileSync(
+	join(process.cwd(), 'src/observatory/resources/deposited-cycles.txt'),
+	'utf-8'
+);
+
+const DEPOSITED_CYCLES_TEMPLATE_HTML = readFileSync(
+	join(process.cwd(), 'src/observatory/resources/deposited-cycles.html'),
+	'utf-8'
+);
+
+export const testDepositCyclesNotification = async ({
+	kind,
+	url: expectedUrl,
+	moduleName,
+	metadataName,
+	actor,
+	pic
+}: {
+	kind: SegmentKind;
+	url: string;
+	moduleName: 'Mission Control' | 'Satellite' | 'Orbiter';
+	metadataName?: string;
+	actor: ObservatoryActor | ObservatoryActor_0_0_9;
+	pic: PocketIc;
+}) => {
+	const { ping } = actor;
+
+	await ping({
+		kind: {
+			DepositedCyclesEmail: {
+				to: 'test@test.com',
+				deposited_cycles: {
+					amount: 123456789n,
+					timestamp: 1747036399590000000n
+				}
+			}
+		},
+		segment: {
+			id: mockMissionControlId,
+			metadata: nonNullish(metadataName) ? [[['name', metadataName]]] : [],
+			kind
+		},
+		user: Ed25519KeyIdentity.generate().getPrincipal()
+	});
+
+	await tick(pic);
+
+	const [pendingHttpOutCall] = await pic.getPendingHttpsOutcalls();
+
+	assertNonNullish(pendingHttpOutCall);
+
+	const { requestId, subnetId, url, headers: headersArray, body } = pendingHttpOutCall;
+
+	expect(url).toEqual(
+		'https://europe-west6-juno-observatory.cloudfunctions.net/observatory/notifications/email'
+	);
+
+	const headers = headersArray.reduce<Record<string, string>>(
+		(acc, [key, value]) => ({ ...acc, [key]: value }),
+		{}
+	);
+
+	expect(headers['Content-Type']).toEqual('application/json');
+	expect(headers['authorization']).toEqual(`Bearer ${mockObservatoryProxyBearerKey}`);
+
+	// e.g. rdmx6-jaaaa-aaaaa-aaadq-cai___1620328630000000105___747495116
+	const idempotencyKey = headers['idempotency-key'].split('___');
+
+	expect(idempotencyKey[0]).toEqual(mockMissionControlId.toText());
+	expect(BigInt(idempotencyKey[1])).toBeGreaterThan(0n);
+	expect(Number(idempotencyKey[1])).toBeGreaterThan(0);
+
+	const decoder = new TextDecoder();
+	const { from, subject, text, html } = JSON.parse(decoder.decode(body));
+
+	expect(from).toEqual('Juno <notify@notifications.juno.build>');
+	expect(subject).toEqual(`🚀 0.00012346 T Cycles Deposited on Your ${moduleName}`);
+
+	const parseTemplate = (template: string): string =>
+		template
+			.replaceAll('{{cycles}}', '0.00012346')
+			.replaceAll('{{module}}', moduleName)
+			.replaceAll(' ({{name}})', nonNullish(metadataName) ? ` (${metadataName})` : '')
+			.replaceAll(
+				' (<!-- -->{{name}}<!-- -->)',
+				nonNullish(metadataName) ? ` (<!-- -->${metadataName}<!-- -->)` : ''
+			)
+			.replaceAll('{{timestamp}}', '2025-05-12T07:53:19+00:00')
+			.replaceAll('{{url}}', expectedUrl);
+
+	expect(text).toEqual(parseTemplate(DEPOSITED_CYCLES_TEMPLATE_TEXT));
+	expect(html).toEqual(parseTemplate(DEPOSITED_CYCLES_TEMPLATE_HTML));
+
+	// Finalize
+	await pic.mockPendingHttpsOutcall({
+		requestId,
+		subnetId,
+		response: {
+			type: 'success',
+			body: toBodyJson({}),
+			statusCode: 200,
+			headers: []
+		}
+	});
+
+	await tick(pic);
+};

--- a/src/tests/utils/setup-tests.utils.ts
+++ b/src/tests/utils/setup-tests.utils.ts
@@ -102,6 +102,15 @@ export const downloadConsole = async ({
 	version: string;
 }): Promise<string> => await downloadGitHub({ junoVersion, wasm: `console-v${version}.wasm.gz` });
 
+export const downloadObservatory = async ({
+	junoVersion,
+	version
+}: {
+	junoVersion: string;
+	version: string;
+}): Promise<string> =>
+	await downloadGitHub({ junoVersion, wasm: `observatory-v${version}.wasm.gz` });
+
 const downloadCdn = async (wasm: string): Promise<string> =>
 	await download({ wasm, url: `https://cdn.juno.build/releases/${wasm}` });
 


### PR DESCRIPTION
# Motivation

We want to send developer an info when an auto-refill failed. For that reason, the observervatory needs to be extended to support sending that kind of message.
