### PR TITLE
chore: disallow ic_cdk::print

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+disallowed-methods = ["ic_cdk::print"]

--- a/src/console/src/guards.rs
+++ b/src/console/src/guards.rs
@@ -9,8 +9,6 @@ pub fn caller_is_admin_controller() -> Result<(), String> {
     let caller = caller();
     let controllers = get_controllers();
 
-    ic_cdk::print("Yolo");
-
     if is_admin_controller(caller, &controllers) {
         Ok(())
     } else {

--- a/src/console/src/guards.rs
+++ b/src/console/src/guards.rs
@@ -9,6 +9,8 @@ pub fn caller_is_admin_controller() -> Result<(), String> {
     let caller = caller();
     let controllers = get_controllers();
 
+    ic_cdk::print("Yolo");
+
     if is_admin_controller(caller, &controllers) {
         Ok(())
     } else {

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::disallowed_methods)]
+
 mod constants;
 mod controllers;
 mod factory;

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::disallowed_methods)]
+
 mod constants;
 mod controllers;
 mod guards;

--- a/src/mission_control/src/monitoring/cycles/history.rs
+++ b/src/mission_control/src/monitoring/cycles/history.rs
@@ -36,6 +36,7 @@ fn insert_monitoring_history(canister_id: &CanisterId, record: &CanisterRecord) 
 
         insert_cycles_monitoring_history(canister_id, &history_entry).unwrap_or_else(|e| {
             // Error would mean the random generator is not initialized.
+            #[allow(clippy::disallowed_methods)]
             print(format!(
                 "Failed to insert cycles monitoring history: {:?}",
                 e

--- a/src/mission_control/src/monitoring/cycles/notification.rs
+++ b/src/mission_control/src/monitoring/cycles/notification.rs
@@ -72,6 +72,7 @@ async fn try_notify_observatory(args: &Option<NotifyArgs>) {
     if let Some(args) = args {
         if let Err(e) = notify_observatory(args).await {
             // Maybe in the future, we can track the potential transmission of the notification error, but for now, we’ll simply log it.
+            #[allow(clippy::disallowed_methods)]
             print(e);
         }
     }

--- a/src/observatory/src/lib.rs
+++ b/src/observatory/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::disallowed_methods)]
+
 mod console;
 mod guards;
 mod http;

--- a/src/orbiter/src/lib.rs
+++ b/src/orbiter/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::disallowed_methods)]
+
 mod analytics;
 mod assert;
 mod config;

--- a/src/satellite/src/lib.rs
+++ b/src/satellite/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::disallowed_methods)]
+
 mod assets;
 
 use crate::assets::init_asset;

--- a/src/sputnik/src/js/apis/ic_cdk/print.rs
+++ b/src/sputnik/src/js/apis/ic_cdk/print.rs
@@ -10,6 +10,7 @@ pub fn init_ic_cdk_print(ctx: &Ctx) -> Result<(), JsError> {
 
 #[rquickjs::function]
 fn ic_cdk_print<'js>(_ctx: Ctx<'js>, msg: String<'js>) -> JsResult<()> {
+    #[allow(clippy::disallowed_methods)]
     print(&msg.to_string()?);
 
     Ok(())

--- a/src/sputnik/src/lib.rs
+++ b/src/sputnik/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::needless_lifetimes)]
+#![deny(clippy::disallowed_methods)]
 
 mod errors;
 mod hooks;

--- a/src/tests/fixtures/test_satellite/src/lib.rs
+++ b/src/tests/fixtures/test_satellite/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 use ic_cdk::update;
 use junobuild_macros::{
     on_delete_doc, on_init_random_seed, on_init_sync, on_post_upgrade_sync, on_set_doc,


### PR DESCRIPTION
# Motivation

Similar to eslint no-console, I don't want ic_cdk::print leftover in my code. That's not professional 😉

Solution provided on the forum: https://forum.dfinity.org/t/eslint-no-console-like-for-ic-cdk-print/47840/5?u=peterparker
