### PR TITLE
feat(mctrl): remove archive from upgrade on heap

### DIFF
--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -21,7 +21,6 @@ pub mod state {
 
     pub type Controllers = HashMap<ControllerId, Controller>;
 
-    pub type ArchiveTime = u64;
     pub type Timestamp = u64;
 
     pub type Version = u64;
@@ -70,26 +69,6 @@ pub mod state {
         pub compute_allocation: Nat,
         pub memory_allocation: Nat,
         pub freezing_threshold: Nat,
-    }
-
-    #[deprecated]
-    #[derive(CandidType, Serialize, Deserialize, Clone)]
-    pub struct SegmentStatus {
-        pub id: Principal,
-        pub metadata: Option<Metadata>,
-        pub status: SegmentCanisterStatus,
-        pub status_at: Timestamp,
-    }
-
-    #[deprecated]
-    pub type SegmentStatusResult = Result<SegmentStatus, String>;
-
-    #[deprecated]
-    #[derive(CandidType, Deserialize, Clone)]
-    pub struct SegmentsStatuses {
-        pub mission_control: SegmentStatusResult,
-        pub satellites: Option<Vec<SegmentStatusResult>>,
-        pub orbiters: Option<Vec<SegmentStatusResult>>,
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]

--- a/src/mission_control/src/impls.rs
+++ b/src/mission_control/src/impls.rs
@@ -2,9 +2,9 @@ use crate::memory::init_stable_state;
 use crate::types::core::{Segment, SettingsMonitoring};
 use crate::types::state::CyclesMonitoringStrategy::BelowThreshold;
 use crate::types::state::{
-    Archive, ArchiveStatuses, Config, CyclesMonitoring, CyclesMonitoringStrategy, HeapState,
-    MissionControlSettings, Monitoring, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters,
-    Satellite, Settings, State, User,
+    Config, CyclesMonitoring, CyclesMonitoringStrategy, HeapState, MissionControlSettings,
+    Monitoring, MonitoringHistory, MonitoringHistoryKey, Orbiter, Orbiters, Satellite, Settings,
+    State, User,
 };
 use canfund::manager::options::{CyclesThreshold, FundStrategy};
 use ic_cdk::api::time;
@@ -13,7 +13,7 @@ use ic_stable_structures::Storable;
 use junobuild_shared::serializers::{deserialize_from_bytes, serialize_to_bytes};
 use junobuild_shared::types::state::{Metadata, OrbiterId, SatelliteId, UserId};
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 impl Default for State {
     fn default() -> Self {
@@ -30,7 +30,6 @@ impl From<&UserId> for HeapState {
             user: User::from(user),
             satellites: HashMap::new(),
             controllers: HashMap::new(),
-            archive: Archive::new(),
             orbiters: Orbiters::new(),
             settings: None,
         }
@@ -47,18 +46,6 @@ impl From<&UserId> for User {
             config: None,
             created_at: now,
             updated_at: now,
-        }
-    }
-}
-
-impl Archive {
-    pub fn new() -> Self {
-        Archive {
-            statuses: ArchiveStatuses {
-                mission_control: BTreeMap::new(),
-                satellites: HashMap::new(),
-                orbiters: HashMap::new(),
-            },
         }
     }
 }

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -11,6 +11,7 @@ mod monitoring;
 mod random;
 mod segments;
 mod types;
+mod upgrade;
 mod user;
 
 use crate::types::interface::CreateCanisterConfig;

--- a/src/mission_control/src/lifecycle.rs
+++ b/src/mission_control/src/lifecycle.rs
@@ -41,7 +41,7 @@ fn post_upgrade() {
     let memory = get_memory_upgrades();
     let state_bytes = read_post_upgrade(&memory);
 
-    // TODO:
+    // TODO: replace UpgradeState by State after release
     let state: UpgradeState = from_reader(&*state_bytes)
         .expect("Failed to decode the state of the mission control in post_upgrade hook.");
 

--- a/src/mission_control/src/lifecycle.rs
+++ b/src/mission_control/src/lifecycle.rs
@@ -2,6 +2,7 @@ use crate::memory::{get_memory_upgrades, init_runtime_state, init_stable_state, 
 use crate::monitoring::monitor::defer_restart_monitoring;
 use crate::random::defer_init_random_seed;
 use crate::types::state::{HeapState, State};
+use crate::upgrade::types::upgrade::UpgradeState;
 use ciborium::{from_reader, into_writer};
 use ic_cdk::api::call::{arg_data, ArgDecoderConfig};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
@@ -40,10 +41,16 @@ fn post_upgrade() {
     let memory = get_memory_upgrades();
     let state_bytes = read_post_upgrade(&memory);
 
-    let state: State = from_reader(&*state_bytes)
+    // TODO:
+    let state: UpgradeState = from_reader(&*state_bytes)
         .expect("Failed to decode the state of the mission control in post_upgrade hook.");
 
-    STATE.with(|s| *s.borrow_mut() = state);
+    STATE.with(|s| {
+        *s.borrow_mut() = State {
+            stable: state.stable,
+            heap: HeapState::from(&state.heap),
+        }
+    });
 
     init_runtime_state();
 

--- a/src/mission_control/src/types.rs
+++ b/src/mission_control/src/types.rs
@@ -1,24 +1,16 @@
 pub mod state {
     use crate::memory::init_stable_state;
-    use candid::{CandidType, Principal};
+    use candid::CandidType;
     use ic_stable_structures::StableBTreeMap;
     use junobuild_shared::types::memory::Memory;
     use junobuild_shared::types::monitoring::{CyclesBalance, FundingFailure};
-    use junobuild_shared::types::state::{
-        ArchiveTime, Controllers, Metadata, OrbiterId, SegmentId, SegmentStatusResult, Timestamp,
-    };
+    use junobuild_shared::types::state::{Controllers, Metadata, OrbiterId, SegmentId, Timestamp};
     use junobuild_shared::types::state::{SatelliteId, UserId};
     use serde::{Deserialize, Serialize};
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
 
     pub type Satellites = HashMap<SatelliteId, Satellite>;
     pub type Orbiters = HashMap<OrbiterId, Orbiter>;
-
-    #[deprecated(
-        since = "0.0.14",
-        note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
-    )]
-    pub type Statuses = BTreeMap<ArchiveTime, SegmentStatusResult>;
 
     pub type MonitoringHistoryStable =
         StableBTreeMap<MonitoringHistoryKey, MonitoringHistory, Memory>;
@@ -41,10 +33,6 @@ pub mod state {
         pub user: User,
         pub satellites: Satellites,
         pub controllers: Controllers,
-        #[deprecated(
-            note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
-        )]
-        pub archive: Archive,
         pub orbiters: Orbiters,
         pub settings: Option<MissionControlSettings>,
     }
@@ -99,32 +87,6 @@ pub mod state {
         pub settings: Option<Settings>,
         pub created_at: Timestamp,
         pub updated_at: Timestamp,
-    }
-
-    #[deprecated(
-        since = "0.0.14",
-        note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
-    )]
-    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
-    pub struct Archive {
-        pub statuses: ArchiveStatuses,
-    }
-
-    #[deprecated(
-        since = "0.0.14",
-        note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
-    )]
-    pub type ArchiveStatusesSegments = HashMap<Principal, Statuses>;
-
-    #[deprecated(
-        since = "0.0.14",
-        note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
-    )]
-    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
-    pub struct ArchiveStatuses {
-        pub mission_control: Statuses,
-        pub satellites: ArchiveStatusesSegments,
-        pub orbiters: ArchiveStatusesSegments,
     }
 
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]

--- a/src/mission_control/src/upgrade/impls.rs
+++ b/src/mission_control/src/upgrade/impls.rs
@@ -1,0 +1,14 @@
+use crate::types::state::HeapState;
+use crate::upgrade::types::upgrade::UpgradeHeapState;
+
+impl From<&UpgradeHeapState> for HeapState {
+    fn from(state: &UpgradeHeapState) -> Self {
+        HeapState {
+            user: state.user.clone(),
+            satellites: state.satellites.clone(),
+            controllers: state.controllers.clone(),
+            orbiters: state.orbiters.clone(),
+            settings: state.settings.clone(),
+        }
+    }
+}

--- a/src/mission_control/src/upgrade/mod.rs
+++ b/src/mission_control/src/upgrade/mod.rs
@@ -1,0 +1,2 @@
+mod impls;
+pub mod types;

--- a/src/mission_control/src/upgrade/types.rs
+++ b/src/mission_control/src/upgrade/types.rs
@@ -1,0 +1,83 @@
+pub mod upgrade {
+    use crate::memory::init_stable_state;
+    use crate::types::state::{MissionControlSettings, Orbiters, Satellites, StableState, User};
+    use candid::{CandidType, Principal};
+    use junobuild_shared::types::state::{Controllers, Metadata, SegmentCanisterStatus, Timestamp};
+    use serde::{Deserialize, Serialize};
+    use std::collections::{BTreeMap, HashMap};
+
+    #[derive(Serialize, Deserialize)]
+    pub struct UpgradeState {
+        #[serde(skip, default = "init_stable_state")]
+        pub stable: StableState,
+
+        pub heap: UpgradeHeapState,
+    }
+
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
+    pub struct UpgradeHeapState {
+        pub user: User,
+        pub satellites: Satellites,
+        pub controllers: Controllers,
+        #[deprecated(
+            note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+        )]
+        pub archive: Archive,
+        pub orbiters: Orbiters,
+        pub settings: Option<MissionControlSettings>,
+    }
+
+    #[deprecated(
+        since = "0.0.14",
+        note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+    )]
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
+    pub struct Archive {
+        pub statuses: ArchiveStatuses,
+    }
+
+    pub type ArchiveTime = u64;
+
+    #[deprecated]
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct SegmentStatus {
+        pub id: Principal,
+        pub metadata: Option<Metadata>,
+        pub status: SegmentCanisterStatus,
+        pub status_at: Timestamp,
+    }
+
+    #[deprecated]
+    pub type SegmentStatusResult = Result<SegmentStatus, String>;
+
+    #[deprecated]
+    #[derive(CandidType, Deserialize, Clone)]
+    pub struct SegmentsStatuses {
+        pub mission_control: SegmentStatusResult,
+        pub satellites: Option<Vec<SegmentStatusResult>>,
+        pub orbiters: Option<Vec<SegmentStatusResult>>,
+    }
+
+    #[deprecated(
+        since = "0.0.14",
+        note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+    )]
+    pub type Statuses = BTreeMap<ArchiveTime, SegmentStatusResult>;
+
+    #[deprecated(
+        since = "0.0.14",
+        note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+    )]
+    pub type ArchiveStatusesSegments = HashMap<Principal, Statuses>;
+
+    #[deprecated(
+        since = "0.0.14",
+        note = "Deprecated with the introduction of monitoring features that include auto top-up capabilities."
+    )]
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
+    pub struct ArchiveStatuses {
+        pub mission_control: Statuses,
+        pub satellites: ArchiveStatusesSegments,
+        pub orbiters: ArchiveStatusesSegments,
+    }
+}

--- a/src/tests/specs/mission-control/mission-control.upgrade.spec.ts
+++ b/src/tests/specs/mission-control/mission-control.upgrade.spec.ts
@@ -1,16 +1,26 @@
-import type { _SERVICE as MissionControlActor } from '$declarations/mission_control/mission_control.did';
+import type {
+	CyclesMonitoringStrategy,
+	_SERVICE as MissionControlActor,
+	MonitoringStartConfig
+} from '$declarations/mission_control/mission_control.did';
 import { idlFactory as idlFactorMissionControl } from '$declarations/mission_control/mission_control.factory.did';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Principal } from '@dfinity/principal';
-import { fromNullable } from '@dfinity/utils';
+import { fromNullable, toNullable } from '@dfinity/utils';
 import { type Actor, PocketIc } from '@hadronous/pic';
 import { afterEach, beforeEach, describe, expect, inject } from 'vitest';
 import {
 	missionControlUserInitArgs,
 	setupMissionControlModules
 } from '../../utils/mission-control-tests.utils';
+import {
+	testMissionControlMonitoring,
+	testMonitoringHistory,
+	testOrbiterMonitoring,
+	testSatellitesMonitoring
+} from '../../utils/monitoring-tests.utils';
 import { tick } from '../../utils/pic-tests.utils';
-import { downloadMissionControl } from '../../utils/setup-tests.utils';
+import { downloadMissionControl, MISSION_CONTROL_WASM_PATH } from '../../utils/setup-tests.utils';
 
 describe('Mission control > Upgrade', () => {
 	let pic: PocketIc;
@@ -26,32 +36,83 @@ describe('Mission control > Upgrade', () => {
 		await pic?.tearDown();
 	});
 
+	const init = async (version: string) => {
+		const destination = await downloadMissionControl(version);
+
+		const { actor: c, canisterId: mId } = await pic.setupCanister<MissionControlActor>({
+			idlFactory: idlFactorMissionControl,
+			wasm: destination,
+			arg: missionControlUserInitArgs(controller.getPrincipal()),
+			sender: controller.getPrincipal()
+		});
+
+		missionControlId = mId;
+
+		actor = c;
+		actor.setIdentity(controller);
+
+		const { orbiterId: oId, satelliteId: sId } = await setupMissionControlModules({
+			pic,
+			controller,
+			missionControlId
+		});
+
+		orbiterId = oId;
+		satelliteId = sId;
+	};
+
+	const orbiterName = 'Hello 1';
+	const satelliteName = 'Hello 2';
+
+	const setModules = async () => {
+		const { set_orbiter, set_satellite } = actor;
+
+		await set_orbiter(orbiterId, [orbiterName]);
+		await set_satellite(satelliteId, [satelliteName]);
+	};
+
+	const testModules = async () => {
+		const { list_orbiters, list_satellites } = actor;
+
+		const satellites = await list_satellites();
+
+		expect(satellites).toHaveLength(1);
+
+		expect(satellites[0][0].toText()).toEqual(satelliteId.toText());
+		expect(satellites[0][1].satellite_id.toText()).toEqual(satelliteId.toText());
+		expect(satellites[0][1].created_at).toBeGreaterThan(0n);
+		expect(satellites[0][1].updated_at).toBeGreaterThan(0n);
+
+		const [_, satName] = satellites[0][1].metadata.find(([key]) => key === 'name') ?? [];
+
+		expect(satName).toEqual(satelliteName);
+
+		const orbiters = await list_orbiters();
+
+		expect(orbiters).toHaveLength(1);
+
+		expect(orbiters[0][0].toText()).toEqual(orbiterId.toText());
+		expect(orbiters[0][1].orbiter_id.toText()).toEqual(orbiterId.toText());
+		expect(orbiters[0][1].created_at).toBeGreaterThan(0n);
+		expect(orbiters[0][1].updated_at).toBeGreaterThan(0n);
+
+		const [__, orbName] = orbiters[0][1].metadata.find(([key]) => key === 'name') ?? [];
+
+		expect(orbName).toEqual(orbiterName);
+	};
+
+	const testUser = async () => {
+		const { get_user } = actor;
+		const user = await get_user();
+
+		expect(user.toText()).toEqual(controller.getPrincipal().toText());
+	};
+
 	describe('v0.0.13 -> v0.0.14', () => {
 		beforeEach(async () => {
 			pic = await PocketIc.create(inject('PIC_URL'));
 
-			const destination = await downloadMissionControl('0.0.13');
-
-			const { actor: c, canisterId: mId } = await pic.setupCanister<MissionControlActor>({
-				idlFactory: idlFactorMissionControl,
-				wasm: destination,
-				arg: missionControlUserInitArgs(controller.getPrincipal()),
-				sender: controller.getPrincipal()
-			});
-
-			missionControlId = mId;
-
-			actor = c;
-			actor.setIdentity(controller);
-
-			const { orbiterId: oId, satelliteId: sId } = await setupMissionControlModules({
-				pic,
-				controller,
-				missionControlId
-			});
-
-			orbiterId = oId;
-			satelliteId = sId;
+			await init('0.0.13');
 		});
 
 		const upgrade0_0_14 = async () => {
@@ -64,53 +125,6 @@ describe('Mission control > Upgrade', () => {
 				wasm: destination,
 				sender: controller.getPrincipal()
 			});
-		};
-
-		const orbiterName = 'Hello 1';
-		const satelliteName = 'Hello 2';
-
-		const setModules = async () => {
-			const { set_orbiter, set_satellite } = actor;
-
-			await set_orbiter(orbiterId, [orbiterName]);
-			await set_satellite(satelliteId, [satelliteName]);
-		};
-
-		const testModules = async () => {
-			const { list_orbiters, list_satellites } = actor;
-
-			const satellites = await list_satellites();
-
-			expect(satellites).toHaveLength(1);
-
-			expect(satellites[0][0].toText()).toEqual(satelliteId.toText());
-			expect(satellites[0][1].satellite_id.toText()).toEqual(satelliteId.toText());
-			expect(satellites[0][1].created_at).toBeGreaterThan(0n);
-			expect(satellites[0][1].updated_at).toBeGreaterThan(0n);
-
-			const [_, satName] = satellites[0][1].metadata.find(([key]) => key === 'name') ?? [];
-
-			expect(satName).toEqual(satelliteName);
-
-			const orbiters = await list_orbiters();
-
-			expect(orbiters).toHaveLength(1);
-
-			expect(orbiters[0][0].toText()).toEqual(orbiterId.toText());
-			expect(orbiters[0][1].orbiter_id.toText()).toEqual(orbiterId.toText());
-			expect(orbiters[0][1].created_at).toBeGreaterThan(0n);
-			expect(orbiters[0][1].updated_at).toBeGreaterThan(0n);
-
-			const [__, orbName] = orbiters[0][1].metadata.find(([key]) => key === 'name') ?? [];
-
-			expect(orbName).toEqual(orbiterName);
-		};
-
-		const testUser = async () => {
-			const { get_user } = actor;
-			const user = await get_user();
-
-			expect(user.toText()).toEqual(controller.getPrincipal().toText());
 		};
 
 		it(
@@ -142,6 +156,108 @@ describe('Mission control > Upgrade', () => {
 			const settings = await get_settings();
 
 			expect(fromNullable(settings)).toBeUndefined();
+		});
+	});
+
+	describe('v0.14.0 -> v0.1.0', () => {
+		const strategy: CyclesMonitoringStrategy = {
+			BelowThreshold: {
+				min_cycles: 500_000n,
+				fund_cycles: 100_000n
+			}
+		};
+
+		const initMonitoring = async () => {
+			const { update_and_start_monitoring } = actor;
+
+			const config: MonitoringStartConfig = {
+				cycles_config: [
+					{
+						satellites_strategy: toNullable({
+							ids: [satelliteId],
+							strategy
+						}),
+						orbiters_strategy: toNullable({
+							ids: [orbiterId],
+							strategy
+						}),
+						mission_control_strategy: toNullable(strategy)
+					}
+				]
+			};
+
+			await update_and_start_monitoring(config);
+
+			await tick(pic);
+		};
+
+		const testMonitoring = async () => {
+			const { get_settings } = actor;
+
+			const results = await get_settings();
+
+			expect(fromNullable(results)).not.toBeUndefined();
+
+			await testMissionControlMonitoring({
+				expectedEnabled: true,
+				expectedStrategy: strategy,
+				actor
+			});
+
+			await testSatellitesMonitoring({
+				expectedEnabled: true,
+				expectedStrategy: strategy,
+				actor
+			});
+
+			await testOrbiterMonitoring({
+				expectedEnabled: true,
+				expectedStrategy: strategy,
+				actor
+			});
+
+			await testMonitoringHistory({ segmentId: missionControlId, expectedLength: 1, actor });
+
+			await testMonitoringHistory({ segmentId: satelliteId, expectedLength: 1, actor });
+
+			await testMonitoringHistory({ segmentId: orbiterId, expectedLength: 1, actor });
+		};
+
+		beforeEach(async () => {
+			pic = await PocketIc.create(inject('PIC_URL'));
+
+			await init('0.0.14');
+		});
+
+		const upgradeLatest = async () => {
+			await tick(pic);
+
+			await pic.upgradeCanister({
+				canisterId: missionControlId,
+				wasm: MISSION_CONTROL_WASM_PATH,
+				sender: controller.getPrincipal()
+			});
+		};
+
+		it('should preserve heap data as from deprecated archive', async () => {
+			await setModules();
+
+			await testModules();
+			await testUser();
+
+			await initMonitoring();
+
+			await testMonitoring();
+
+			await upgradeLatest();
+
+			actor = pic.createActor<MissionControlActor>(idlFactorMissionControl, missionControlId);
+			actor.setIdentity(controller);
+
+			await testModules();
+			await testUser();
+
+			await testMonitoring();
 		});
 	});
 });

--- a/src/tests/utils/monitoring-tests.utils.ts
+++ b/src/tests/utils/monitoring-tests.utils.ts
@@ -1,0 +1,130 @@
+import type {
+	CyclesMonitoringStrategy,
+	GetMonitoringHistory,
+	_SERVICE as MissionControlActor,
+	Monitoring,
+	MonitoringHistory,
+	MonitoringHistoryKey
+} from '$declarations/mission_control/mission_control.did';
+import type { Principal } from '@dfinity/principal';
+import { assertNonNullish, fromNullable, toNullable } from '@dfinity/utils';
+import type { Actor } from '@hadronous/pic';
+
+const testMonitoring = ({
+	monitoring,
+	expectedEnabled,
+	expectedStrategy
+}: {
+	monitoring: Monitoring | undefined;
+	expectedEnabled: boolean;
+	expectedStrategy: CyclesMonitoringStrategy;
+}) => {
+	const cycles = fromNullable(monitoring?.cycles ?? []);
+	const cyclesStrategy = fromNullable(cycles?.strategy ?? []);
+
+	expect(cycles?.enabled).toBe(expectedEnabled);
+	expect(cyclesStrategy?.BelowThreshold.fund_cycles).toEqual(
+		expectedStrategy.BelowThreshold.fund_cycles
+	);
+	expect(cyclesStrategy?.BelowThreshold.min_cycles).toEqual(
+		expectedStrategy.BelowThreshold.min_cycles
+	);
+};
+
+export const testMissionControlMonitoring = async ({
+	expectedEnabled,
+	expectedStrategy,
+	actor
+}: {
+	expectedEnabled: boolean;
+	expectedStrategy: CyclesMonitoringStrategy;
+	actor: Actor<MissionControlActor>;
+}) => {
+	const { get_settings } = actor;
+
+	const settings = fromNullable(await get_settings());
+	const monitoring = fromNullable(settings?.monitoring ?? []);
+
+	testMonitoring({ monitoring, expectedEnabled, expectedStrategy });
+};
+
+export const testSatellitesMonitoring = async ({
+	expectedEnabled,
+	expectedStrategy,
+	actor
+}: {
+	expectedEnabled: boolean;
+	expectedStrategy: CyclesMonitoringStrategy;
+	actor: Actor<MissionControlActor>;
+}) => {
+	const { list_satellites } = actor;
+
+	const [[_, satellite]] = await list_satellites();
+
+	const settings = fromNullable(satellite.settings);
+	const monitoring = fromNullable(settings?.monitoring ?? []);
+
+	testMonitoring({ monitoring, expectedEnabled, expectedStrategy });
+};
+
+export const testOrbiterMonitoring = async ({
+	expectedEnabled,
+	expectedStrategy,
+	actor
+}: {
+	expectedEnabled: boolean;
+	expectedStrategy: CyclesMonitoringStrategy;
+	actor: Actor<MissionControlActor>;
+}) => {
+	const { list_orbiters } = actor;
+
+	const [[_, orbiter]] = await list_orbiters();
+
+	const settings = fromNullable(orbiter.settings);
+	const monitoring = fromNullable(settings?.monitoring ?? []);
+
+	testMonitoring({ monitoring, expectedEnabled, expectedStrategy });
+};
+
+export const testMonitoringHistory = async ({
+	segmentId,
+	expectedLength,
+	actor
+}: {
+	segmentId: Principal;
+	expectedLength: number;
+	actor: Actor<MissionControlActor>;
+}): Promise<[MonitoringHistoryKey, MonitoringHistory][]> => {
+	const { get_monitoring_history } = actor;
+
+	const filter: GetMonitoringHistory = {
+		segment_id: segmentId,
+		from: toNullable(),
+		to: toNullable()
+	};
+
+	const results = await get_monitoring_history(filter);
+
+	expect(results).toHaveLength(expectedLength);
+
+	results.forEach((result) => {
+		const [key, history] = result;
+
+		expect(key.segment_id.toText()).toEqual(segmentId.toText());
+		expect(key.created_at).toBeGreaterThan(0n);
+
+		const cycles = fromNullable(history.cycles);
+
+		assertNonNullish(cycles);
+
+		expect(cycles.cycles.amount).toBeGreaterThan(0n);
+		expect(cycles.cycles.timestamp).toBeGreaterThan(0n);
+
+		expect(fromNullable(cycles.deposited_cycles)).toBeUndefined();
+	});
+
+	return results.sort(
+		([{ created_at: aCreatedAt }, _], [{ created_at: bCreateAt }, __]) =>
+			Number(aCreatedAt) - Number(bCreateAt)
+	);
+};


### PR DESCRIPTION
# Motivation

We are going to add storage on the heap in #1588. Since we are already there, let's do a cleanup and remove the deprecated "Archive" from the mission control heap.
