### PR TITLE
feat(orbiter): support for gathering utm campaigns

### DIFF
--- a/src/declarations/orbiter/orbiter.did.d.ts
+++ b/src/declarations/orbiter/orbiter.did.d.ts
@@ -44,6 +44,8 @@ export interface AnalyticsOperatingSystemsPageViews {
 export interface AnalyticsTop10PageViews {
 	referrers: Array<[string, number]>;
 	pages: Array<[string, number]>;
+	utm_campaigns: [] | [Array<[string, number]>];
+	utm_sources: [] | [Array<[string, number]>];
 	time_zones: [] | [Array<[string, number]>];
 }
 export interface AnalyticsTrackEvents {
@@ -127,12 +129,20 @@ export interface PageView {
 	referrer: [] | [string];
 	time_zone: string;
 	session_id: string;
+	campaign: [] | [PageViewCampaign];
 	href: string;
 	created_at: bigint;
 	satellite_id: Principal;
 	device: PageViewDevice;
 	version: [] | [bigint];
 	user_agent: [] | [string];
+}
+export interface PageViewCampaign {
+	utm_content: [] | [string];
+	utm_medium: [] | [string];
+	utm_source: string;
+	utm_term: [] | [string];
+	utm_campaign: [] | [string];
 }
 export interface PageViewClient {
 	os: string;
@@ -182,6 +192,7 @@ export interface SetPageView {
 	referrer: [] | [string];
 	time_zone: string;
 	session_id: string;
+	campaign: [] | [PageViewCampaign];
 	href: string;
 	satellite_id: Principal;
 	device: PageViewDevice;

--- a/src/declarations/orbiter/orbiter.factory.certified.did.js
+++ b/src/declarations/orbiter/orbiter.factory.certified.did.js
@@ -33,6 +33,13 @@ export const idlFactory = ({ IDL }) => {
 		device: IDL.Opt(IDL.Text),
 		browser: IDL.Text
 	});
+	const PageViewCampaign = IDL.Record({
+		utm_content: IDL.Opt(IDL.Text),
+		utm_medium: IDL.Opt(IDL.Text),
+		utm_source: IDL.Text,
+		utm_term: IDL.Opt(IDL.Text),
+		utm_campaign: IDL.Opt(IDL.Text)
+	});
 	const PageViewDevice = IDL.Record({
 		inner_height: IDL.Nat16,
 		screen_height: IDL.Opt(IDL.Nat16),
@@ -46,6 +53,7 @@ export const idlFactory = ({ IDL }) => {
 		referrer: IDL.Opt(IDL.Text),
 		time_zone: IDL.Text,
 		session_id: IDL.Text,
+		campaign: IDL.Opt(PageViewCampaign),
 		href: IDL.Text,
 		created_at: IDL.Nat64,
 		satellite_id: IDL.Principal,
@@ -96,6 +104,8 @@ export const idlFactory = ({ IDL }) => {
 	const AnalyticsTop10PageViews = IDL.Record({
 		referrers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
 		pages: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
+		utm_campaigns: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
+		utm_sources: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
 		time_zones: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)))
 	});
 	const NavigationType = IDL.Variant({
@@ -194,6 +204,7 @@ export const idlFactory = ({ IDL }) => {
 		referrer: IDL.Opt(IDL.Text),
 		time_zone: IDL.Text,
 		session_id: IDL.Text,
+		campaign: IDL.Opt(PageViewCampaign),
 		href: IDL.Text,
 		satellite_id: IDL.Principal,
 		device: PageViewDevice,

--- a/src/declarations/orbiter/orbiter.factory.did.js
+++ b/src/declarations/orbiter/orbiter.factory.did.js
@@ -33,6 +33,13 @@ export const idlFactory = ({ IDL }) => {
 		device: IDL.Opt(IDL.Text),
 		browser: IDL.Text
 	});
+	const PageViewCampaign = IDL.Record({
+		utm_content: IDL.Opt(IDL.Text),
+		utm_medium: IDL.Opt(IDL.Text),
+		utm_source: IDL.Text,
+		utm_term: IDL.Opt(IDL.Text),
+		utm_campaign: IDL.Opt(IDL.Text)
+	});
 	const PageViewDevice = IDL.Record({
 		inner_height: IDL.Nat16,
 		screen_height: IDL.Opt(IDL.Nat16),
@@ -46,6 +53,7 @@ export const idlFactory = ({ IDL }) => {
 		referrer: IDL.Opt(IDL.Text),
 		time_zone: IDL.Text,
 		session_id: IDL.Text,
+		campaign: IDL.Opt(PageViewCampaign),
 		href: IDL.Text,
 		created_at: IDL.Nat64,
 		satellite_id: IDL.Principal,
@@ -96,6 +104,8 @@ export const idlFactory = ({ IDL }) => {
 	const AnalyticsTop10PageViews = IDL.Record({
 		referrers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
 		pages: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
+		utm_campaigns: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
+		utm_sources: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
 		time_zones: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)))
 	});
 	const NavigationType = IDL.Variant({
@@ -194,6 +204,7 @@ export const idlFactory = ({ IDL }) => {
 		referrer: IDL.Opt(IDL.Text),
 		time_zone: IDL.Text,
 		session_id: IDL.Text,
+		campaign: IDL.Opt(PageViewCampaign),
 		href: IDL.Text,
 		satellite_id: IDL.Principal,
 		device: PageViewDevice,

--- a/src/declarations/orbiter/orbiter.factory.did.mjs
+++ b/src/declarations/orbiter/orbiter.factory.did.mjs
@@ -33,6 +33,13 @@ export const idlFactory = ({ IDL }) => {
 		device: IDL.Opt(IDL.Text),
 		browser: IDL.Text
 	});
+	const PageViewCampaign = IDL.Record({
+		utm_content: IDL.Opt(IDL.Text),
+		utm_medium: IDL.Opt(IDL.Text),
+		utm_source: IDL.Text,
+		utm_term: IDL.Opt(IDL.Text),
+		utm_campaign: IDL.Opt(IDL.Text)
+	});
 	const PageViewDevice = IDL.Record({
 		inner_height: IDL.Nat16,
 		screen_height: IDL.Opt(IDL.Nat16),
@@ -46,6 +53,7 @@ export const idlFactory = ({ IDL }) => {
 		referrer: IDL.Opt(IDL.Text),
 		time_zone: IDL.Text,
 		session_id: IDL.Text,
+		campaign: IDL.Opt(PageViewCampaign),
 		href: IDL.Text,
 		created_at: IDL.Nat64,
 		satellite_id: IDL.Principal,
@@ -96,6 +104,8 @@ export const idlFactory = ({ IDL }) => {
 	const AnalyticsTop10PageViews = IDL.Record({
 		referrers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
 		pages: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
+		utm_campaigns: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
+		utm_sources: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
 		time_zones: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)))
 	});
 	const NavigationType = IDL.Variant({
@@ -194,6 +204,7 @@ export const idlFactory = ({ IDL }) => {
 		referrer: IDL.Opt(IDL.Text),
 		time_zone: IDL.Text,
 		session_id: IDL.Text,
+		campaign: IDL.Opt(PageViewCampaign),
 		href: IDL.Text,
 		satellite_id: IDL.Principal,
 		device: PageViewDevice,

--- a/src/frontend/src/lib/services/orbiter/orbiter.pagination.page-views.services.ts
+++ b/src/frontend/src/lib/services/orbiter/orbiter.pagination.page-views.services.ts
@@ -42,14 +42,16 @@ const aggregateTop10 = ({
 }: {
 	periodsMetrics: AnalyticsPageViews[];
 }): Pick<AnalyticsPageViews, 'top10'> => {
-	const { referrers, pages, timeZones } = periodsMetrics
+	const { referrers, pages, timeZones, utmCampaigns, utmSources } = periodsMetrics
 		.map(({ top10 }) => top10)
 		.reduce<{
 			referrers: Record<string, number>;
 			pages: Record<string, number>;
 			timeZones: Record<string, number>;
+			utmSources: Record<string, number>;
+			utmCampaigns: Record<string, number>;
 		}>(
-			(acc, { referrers, pages, time_zones }) => {
+			(acc, { referrers, pages, time_zones, utm_sources, utm_campaigns }) => {
 				const cumulatedReferrers = referrers.map(([referrer, count]) => [
 					referrer,
 					count + (acc.referrers[referrer] ?? 0)
@@ -61,6 +63,15 @@ const aggregateTop10 = ({
 					timeZone,
 					count + (acc.pages[timeZone] ?? 0)
 				]);
+
+				const cumulatedUtmSources = (fromNullable(utm_sources) ?? []).map(([utmSource, count]) => [
+					utmSource,
+					count + (acc.pages[utmSource] ?? 0)
+				]);
+
+				const cumulatedUtmCampaigns = (fromNullable(utm_campaigns) ?? []).map(
+					([utmCampaign, count]) => [utmCampaign, count + (acc.pages[utmCampaign] ?? 0)]
+				);
 
 				return {
 					pages: {
@@ -74,10 +85,18 @@ const aggregateTop10 = ({
 					timeZones: {
 						...acc.timeZones,
 						...Object.fromEntries(cumulatedTimeZones)
+					},
+					utmSources: {
+						...acc.utmSources,
+						...Object.fromEntries(cumulatedUtmSources)
+					},
+					utmCampaigns: {
+						...acc.utmCampaigns,
+						...Object.fromEntries(cumulatedUtmCampaigns)
 					}
 				};
 			},
-			{ referrers: {}, pages: {}, timeZones: {} }
+			{ referrers: {}, pages: {}, timeZones: {}, utmSources: {}, utmCampaigns: {} }
 		);
 
 	const mapTop10 = (records: Record<string, number>): [string, number][] =>
@@ -85,11 +104,18 @@ const aggregateTop10 = ({
 			.sort(([, a], [, b]) => b - a)
 			.slice(0, 10);
 
+	const mapOptionalTop10 = (records: Record<string, number>): [] | [[string, number][]] => {
+		const top10 = mapTop10(records);
+		return toNullable(top10.length === 0 ? undefined : top10);
+	};
+
 	return {
 		top10: {
 			referrers: mapTop10(referrers),
 			pages: mapTop10(pages),
-			time_zones: toNullable(mapTop10(timeZones))
+			time_zones: toNullable(mapTop10(timeZones)),
+			utm_sources: mapOptionalTop10(utmSources),
+			utm_campaigns: mapOptionalTop10(utmCampaigns)
 		}
 	};
 };

--- a/src/frontend/src/lib/services/orbiter/orbiters.deprecated.services.ts
+++ b/src/frontend/src/lib/services/orbiter/orbiters.deprecated.services.ts
@@ -179,7 +179,9 @@ const mapDeprecatedAnalyticsTop10PageViews = (
 	return {
 		referrers: referrersEntries,
 		pages: pagesEntries,
-		time_zones: toNullable()
+		time_zones: toNullable(),
+		utm_sources: toNullable(),
+		utm_campaigns: toNullable()
 	};
 };
 

--- a/src/orbiter/orbiter.did
+++ b/src/orbiter/orbiter.did
@@ -37,6 +37,8 @@ type AnalyticsOperatingSystemsPageViews = record {
 type AnalyticsTop10PageViews = record {
   referrers : vec record { text; nat32 };
   pages : vec record { text; nat32 };
+  utm_campaigns : opt vec record { text; nat32 };
+  utm_sources : opt vec record { text; nat32 };
   time_zones : opt vec record { text; nat32 };
 };
 type AnalyticsTrackEvents = record { total : vec record { text; nat32 } };
@@ -108,12 +110,20 @@ type PageView = record {
   referrer : opt text;
   time_zone : text;
   session_id : text;
+  campaign : opt PageViewCampaign;
   href : text;
   created_at : nat64;
   satellite_id : principal;
   device : PageViewDevice;
   version : opt nat64;
   user_agent : opt text;
+};
+type PageViewCampaign = record {
+  utm_content : opt text;
+  utm_medium : opt text;
+  utm_source : text;
+  utm_term : opt text;
+  utm_campaign : opt text;
 };
 type PageViewClient = record { os : text; device : opt text; browser : text };
 type PageViewDevice = record {
@@ -154,6 +164,7 @@ type SetPageView = record {
   referrer : opt text;
   time_zone : text;
   session_id : text;
+  campaign : opt PageViewCampaign;
   href : text;
   satellite_id : principal;
   device : PageViewDevice;

--- a/src/orbiter/src/analytics.rs
+++ b/src/orbiter/src/analytics.rs
@@ -1,7 +1,4 @@
-use crate::state::types::state::{
-    AnalyticKey, PageView, PageViewClient, PerformanceData, PerformanceMetric,
-    PerformanceMetricName, TrackEvent, WebVitalsMetric,
-};
+use crate::state::types::state::{AnalyticKey, PageView, PageViewCampaign, PageViewClient, PerformanceData, PerformanceMetric, PerformanceMetricName, TrackEvent, WebVitalsMetric};
 use crate::types::interface::{
     AnalyticsBrowsersPageViews, AnalyticsClientsPageViews, AnalyticsDevicesPageViews,
     AnalyticsMetricsPageViews, AnalyticsOperatingSystemsPageViews, AnalyticsTop10PageViews,
@@ -116,13 +113,16 @@ pub fn analytics_page_views_top_10(
     let mut referrers: HashMap<String, u32> = HashMap::new();
     let mut pages: HashMap<String, u32> = HashMap::new();
     let mut time_zones: HashMap<String, u32> = HashMap::new();
-
+    let mut utm_sources: HashMap<String, u32> = HashMap::new();
+    let mut utm_campaigns: HashMap<String, u32> = HashMap::new();
+    
     for (
         _,
         PageView {
             referrer,
             href,
             time_zone,
+            campaign,
             ..
         },
     ) in page_views
@@ -130,6 +130,7 @@ pub fn analytics_page_views_top_10(
         analytics_referrers(referrer, &mut referrers);
         analytics_pages(href, &mut pages);
         analytics_time_zones(time_zone, &mut time_zones);
+        analytics_campaigns(campaign, &mut utm_sources, &mut utm_campaigns);
     }
 
     fn top_10(data: HashMap<String, u32>) -> Vec<(String, u32)> {
@@ -138,10 +139,20 @@ pub fn analytics_page_views_top_10(
         entries.into_iter().take(10).collect()
     }
 
+    fn top_10_optional(data: HashMap<String, u32>) -> Option<Vec<(String, u32)>> {
+        if data.is_empty() {
+            None
+        } else {
+            Some(top_10(data))
+        }
+    }
+
     AnalyticsTop10PageViews {
         referrers: top_10(referrers),
         pages: top_10(pages),
-        time_zones: Some(top_10(time_zones)),
+        time_zones: Some(top_10(time_zones)), // TODO top_10_optional
+        utm_sources: top_10_optional(utm_sources),
+        utm_campaigns: top_10_optional(utm_campaigns),
     }
 }
 
@@ -469,6 +480,16 @@ fn analytics_pages(href: &str, pages: &mut HashMap<String, u32>) {
 
 fn analytics_time_zones(time_zone: &str, time_zones: &mut HashMap<String, u32>) {
     *time_zones.entry(time_zone.to_owned()).or_insert(0) += 1;
+}
+
+fn analytics_campaigns(campaign: &Option<PageViewCampaign>, utm_sources: &mut HashMap<String, u32>, utm_campaigns: &mut HashMap<String, u32>) {
+    if let Some(PageViewCampaign { utm_source, utm_campaign, .. }) = campaign {
+        *utm_sources.entry(utm_source.to_owned()).or_insert(0) += 1;
+
+        if let Some(utm_campaign) = utm_campaign {
+            *utm_campaigns.entry(utm_campaign.to_owned()).or_insert(0) += 1;
+        }
+    }
 }
 
 fn analytics_devices_fallback(

--- a/src/orbiter/src/analytics.rs
+++ b/src/orbiter/src/analytics.rs
@@ -1,4 +1,7 @@
-use crate::state::types::state::{AnalyticKey, PageView, PageViewCampaign, PageViewClient, PerformanceData, PerformanceMetric, PerformanceMetricName, TrackEvent, WebVitalsMetric};
+use crate::state::types::state::{
+    AnalyticKey, PageView, PageViewCampaign, PageViewClient, PerformanceData, PerformanceMetric,
+    PerformanceMetricName, TrackEvent, WebVitalsMetric,
+};
 use crate::types::interface::{
     AnalyticsBrowsersPageViews, AnalyticsClientsPageViews, AnalyticsDevicesPageViews,
     AnalyticsMetricsPageViews, AnalyticsOperatingSystemsPageViews, AnalyticsTop10PageViews,
@@ -115,7 +118,7 @@ pub fn analytics_page_views_top_10(
     let mut time_zones: HashMap<String, u32> = HashMap::new();
     let mut utm_sources: HashMap<String, u32> = HashMap::new();
     let mut utm_campaigns: HashMap<String, u32> = HashMap::new();
-    
+
     for (
         _,
         PageView {
@@ -482,8 +485,17 @@ fn analytics_time_zones(time_zone: &str, time_zones: &mut HashMap<String, u32>) 
     *time_zones.entry(time_zone.to_owned()).or_insert(0) += 1;
 }
 
-fn analytics_campaigns(campaign: &Option<PageViewCampaign>, utm_sources: &mut HashMap<String, u32>, utm_campaigns: &mut HashMap<String, u32>) {
-    if let Some(PageViewCampaign { utm_source, utm_campaign, .. }) = campaign {
+fn analytics_campaigns(
+    campaign: &Option<PageViewCampaign>,
+    utm_sources: &mut HashMap<String, u32>,
+    utm_campaigns: &mut HashMap<String, u32>,
+) {
+    if let Some(PageViewCampaign {
+        utm_source,
+        utm_campaign,
+        ..
+    }) = campaign
+    {
         *utm_sources.entry(utm_source.to_owned()).or_insert(0) += 1;
 
         if let Some(utm_campaign) = utm_campaign {

--- a/src/orbiter/src/assert/constraints.rs
+++ b/src/orbiter/src/assert/constraints.rs
@@ -1,11 +1,10 @@
-use crate::constants::{
-    KEY_MAX_LENGTH, LONG_STRING_MAX_LENGTH, METADATA_MAX_ELEMENTS, SHORT_STRING_MAX_LENGTH,
-    STRING_MAX_LENGTH,
-};
+use crate::constants::{KEY_MAX_LENGTH, LONG_STRING_MAX_LENGTH, METADATA_MAX_ELEMENTS, SHORT_STRING_MAX_LENGTH, STRING_MAX_LENGTH, UTM_MAX_LENGTH};
 use crate::state::types::state::AnalyticKey;
 use crate::types::interface::{SetPageView, SetTrackEvent};
 use junobuild_shared::types::state::SatelliteId;
 use junobuild_shared::utils::principal_not_equal;
+
+// TODO: error key
 
 pub fn assert_analytic_key_length(key: &AnalyticKey) -> Result<(), String> {
     if key.key.len() > KEY_MAX_LENGTH {
@@ -107,6 +106,55 @@ pub fn assert_page_view_length(page_view: &SetPageView) -> Result<(), String> {
         ));
     }
 
+    Ok(())
+}
+
+pub fn assert_page_view_campaign_length(page_view: &SetPageView) -> Result<(), String> {
+    if let Some(campaign) = &page_view.campaign {
+        if campaign.utm_source.len() > UTM_MAX_LENGTH {
+            return Err(format!(
+                "utm_source {} is longer than {}.",
+                campaign.utm_source, UTM_MAX_LENGTH
+            ));
+        }
+
+        if let Some(medium) = &campaign.utm_medium {
+            if medium.len() > UTM_MAX_LENGTH {
+                return Err(format!(
+                    "utm_medium {} is longer than {}.",
+                    medium, UTM_MAX_LENGTH
+                ));
+            }
+        }
+
+        if let Some(campaign_name) = &campaign.utm_campaign {
+            if campaign_name.len() > UTM_MAX_LENGTH {
+                return Err(format!(
+                    "utm_campaign {} is longer than {}.",
+                    campaign_name, UTM_MAX_LENGTH
+                ));
+            }
+        }
+
+        if let Some(term) = &campaign.utm_term {
+            if term.len() > UTM_MAX_LENGTH {
+                return Err(format!(
+                    "utm_term {} is longer than {}.",
+                    term, UTM_MAX_LENGTH
+                ));
+            }
+        }
+
+        if let Some(content) = &campaign.utm_content {
+            if content.len() > UTM_MAX_LENGTH {
+                return Err(format!(
+                    "utm_content {} is longer than {}.",
+                    content, UTM_MAX_LENGTH
+                ));
+            }
+        }
+    }
+    
     Ok(())
 }
 

--- a/src/orbiter/src/assert/constraints.rs
+++ b/src/orbiter/src/assert/constraints.rs
@@ -1,4 +1,7 @@
-use crate::constants::{KEY_MAX_LENGTH, LONG_STRING_MAX_LENGTH, METADATA_MAX_ELEMENTS, SHORT_STRING_MAX_LENGTH, STRING_MAX_LENGTH, UTM_MAX_LENGTH};
+use crate::constants::{
+    KEY_MAX_LENGTH, LONG_STRING_MAX_LENGTH, METADATA_MAX_ELEMENTS, SHORT_STRING_MAX_LENGTH,
+    STRING_MAX_LENGTH, UTM_MAX_LENGTH,
+};
 use crate::state::types::state::AnalyticKey;
 use crate::types::interface::{SetPageView, SetTrackEvent};
 use junobuild_shared::types::state::SatelliteId;
@@ -154,7 +157,7 @@ pub fn assert_page_view_campaign_length(page_view: &SetPageView) -> Result<(), S
             }
         }
     }
-    
+
     Ok(())
 }
 

--- a/src/orbiter/src/constants.rs
+++ b/src/orbiter/src/constants.rs
@@ -3,6 +3,7 @@ pub const STRING_MAX_LENGTH: usize = 1024;
 pub const SHORT_STRING_MAX_LENGTH: usize = 256;
 pub const KEY_MAX_LENGTH: usize = 36; // UUID length
 pub const METADATA_MAX_ELEMENTS: usize = 10;
+pub const UTM_MAX_LENGTH: usize = 100;
 
 pub const SERIALIZED_PRINCIPAL_LENGTH: usize = 30;
 pub const SERIALIZED_LONG_STRING_LENGTH: usize = LONG_STRING_MAX_LENGTH + 1;

--- a/src/orbiter/src/events/store.rs
+++ b/src/orbiter/src/events/store.rs
@@ -1,7 +1,4 @@
-use crate::assert::constraints::{
-    assert_analytic_key_length, assert_page_view_length, assert_satellite_id, assert_session_id,
-    assert_track_event_length,
-};
+use crate::assert::constraints::{assert_analytic_key_length, assert_page_view_campaign_length, assert_page_view_length, assert_satellite_id, assert_session_id, assert_track_event_length};
 use crate::events::filters::{filter_analytics, filter_satellites_analytics};
 use crate::state::memory::STATE;
 use crate::state::types::memory::{StoredPageView, StoredTrackEvent};
@@ -25,6 +22,7 @@ fn insert_page_view_impl(
 ) -> Result<PageView, String> {
     assert_analytic_key_length(&key)?;
     assert_page_view_length(&page_view)?;
+    assert_page_view_campaign_length(&page_view)?;
 
     let current_page_view = state.page_views.get(&key);
 
@@ -99,6 +97,7 @@ fn insert_page_view_impl(
         time_zone: page_view.time_zone,
         satellite_id: page_view.satellite_id,
         session_id,
+        campaign: page_view.campaign,
         created_at,
         updated_at: now,
         version: Some(version),

--- a/src/orbiter/src/events/store.rs
+++ b/src/orbiter/src/events/store.rs
@@ -1,4 +1,7 @@
-use crate::assert::constraints::{assert_analytic_key_length, assert_page_view_campaign_length, assert_page_view_length, assert_satellite_id, assert_session_id, assert_track_event_length};
+use crate::assert::constraints::{
+    assert_analytic_key_length, assert_page_view_campaign_length, assert_page_view_length,
+    assert_satellite_id, assert_session_id, assert_track_event_length,
+};
 use crate::events::filters::{filter_analytics, filter_satellites_analytics};
 use crate::state::memory::STATE;
 use crate::state::types::memory::{StoredPageView, StoredTrackEvent};

--- a/src/orbiter/src/handler/impls.rs
+++ b/src/orbiter/src/handler/impls.rs
@@ -1,5 +1,12 @@
-use crate::state::types::state::{AnalyticKey, PageView, PageViewCampaign, PageViewClient, PageViewDevice, PerformanceMetric, TrackEvent};
-use crate::types::interface::http::{AnalyticKeyPayload, PageViewCampaignPayload, PageViewClientPayload, PageViewDevicePayload, PageViewPayload, PerformanceMetricPayload, SatelliteIdText, SetPageViewPayload, SetPerformanceMetricPayload, SetTrackEventPayload, TrackEventPayload};
+use crate::state::types::state::{
+    AnalyticKey, PageView, PageViewCampaign, PageViewClient, PageViewDevice, PerformanceMetric,
+    TrackEvent,
+};
+use crate::types::interface::http::{
+    AnalyticKeyPayload, PageViewCampaignPayload, PageViewClientPayload, PageViewDevicePayload,
+    PageViewPayload, PerformanceMetricPayload, SatelliteIdText, SetPageViewPayload,
+    SetPerformanceMetricPayload, SetTrackEventPayload, TrackEventPayload,
+};
 use crate::types::interface::{SetPageView, SetPerformanceMetric, SetTrackEvent};
 use candid::types::principal::PrincipalError;
 use candid::Principal;
@@ -82,6 +89,7 @@ impl PageViewPayload {
             client: page_view.client.map(PageViewClientPayload::from_domain),
             time_zone: page_view.time_zone,
             session_id: page_view.session_id,
+            campaign: page_view.campaign.map(PageViewCampaignPayload::from_domain),
             created_at: DocDataBigInt {
                 value: page_view.created_at,
             },
@@ -112,6 +120,18 @@ impl PageViewDevicePayload {
             inner_height: client.inner_height,
             screen_width: client.screen_width,
             screen_height: client.screen_height,
+        }
+    }
+}
+
+impl PageViewCampaignPayload {
+    pub fn from_domain(campaign: PageViewCampaign) -> Self {
+        Self {
+            utm_source: campaign.utm_source,
+            utm_medium: campaign.utm_medium,
+            utm_campaign: campaign.utm_campaign,
+            utm_term: campaign.utm_term,
+            utm_content: campaign.utm_content,
         }
     }
 }

--- a/src/orbiter/src/handler/impls.rs
+++ b/src/orbiter/src/handler/impls.rs
@@ -1,11 +1,5 @@
-use crate::state::types::state::{
-    AnalyticKey, PageView, PageViewClient, PageViewDevice, PerformanceMetric, TrackEvent,
-};
-use crate::types::interface::http::{
-    AnalyticKeyPayload, PageViewClientPayload, PageViewDevicePayload, PageViewPayload,
-    PerformanceMetricPayload, SatelliteIdText, SetPageViewPayload, SetPerformanceMetricPayload,
-    SetTrackEventPayload, TrackEventPayload,
-};
+use crate::state::types::state::{AnalyticKey, PageView, PageViewCampaign, PageViewClient, PageViewDevice, PerformanceMetric, TrackEvent};
+use crate::types::interface::http::{AnalyticKeyPayload, PageViewCampaignPayload, PageViewClientPayload, PageViewDevicePayload, PageViewPayload, PerformanceMetricPayload, SatelliteIdText, SetPageViewPayload, SetPerformanceMetricPayload, SetTrackEventPayload, TrackEventPayload};
 use crate::types::interface::{SetPageView, SetPerformanceMetric, SetTrackEvent};
 use candid::types::principal::PrincipalError;
 use candid::Principal;
@@ -35,6 +29,7 @@ impl SetPageViewPayload {
             client: payload.client.map(PageViewClient::convert_to_setter),
             satellite_id: Principal::from_text(satellite_id)?,
             session_id: payload.session_id,
+            campaign: payload.campaign.map(PageViewCampaign::convert_to_setter),
             updated_at: None,
             version: payload.version.map(|version| version.value),
         };
@@ -60,6 +55,18 @@ impl PageViewDevice {
             inner_height: payload.inner_height,
             screen_width: payload.screen_width,
             screen_height: payload.screen_height,
+        }
+    }
+}
+
+impl PageViewCampaign {
+    pub fn convert_to_setter(payload: PageViewCampaignPayload) -> Self {
+        Self {
+            utm_source: payload.utm_source,
+            utm_medium: payload.utm_medium,
+            utm_campaign: payload.utm_campaign,
+            utm_term: payload.utm_term,
+            utm_content: payload.utm_content,
         }
     }
 }

--- a/src/orbiter/src/serializers/bounded.rs
+++ b/src/orbiter/src/serializers/bounded.rs
@@ -163,6 +163,7 @@ pub fn deserialize_bounded_page_view(bytes: Cow<[u8]>) -> PageView {
         time_zone,
         satellite_id,
         session_id,
+        campaign: None,
         created_at,
         updated_at,
         version: None,

--- a/src/orbiter/src/state/types.rs
+++ b/src/orbiter/src/state/types.rs
@@ -75,6 +75,7 @@ pub mod state {
         pub time_zone: String,
         pub satellite_id: SatelliteId,
         pub session_id: SessionId,
+        pub campaign: Option<PageViewCampaign>,
         pub created_at: Timestamp,
         pub updated_at: Timestamp,
         pub version: Option<Version>,
@@ -94,6 +95,15 @@ pub mod state {
         pub inner_height: u16,
         pub screen_width: Option<u16>,
         pub screen_height: Option<u16>,
+    }
+
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
+    pub struct PageViewCampaign {
+        pub utm_source: String, // The name of the campaign source where you plan to share the link.
+        pub utm_medium: Option<String>, // The name of the channel where the link is placed. e.g. "Email" or "Social".
+        pub utm_campaign: Option<String>, // The name of your individual campaign. e.g. "Black+Friday".
+        pub utm_term: Option<String>, // The name of the keyword for your paid search ad campaign.
+        pub utm_content: Option<String>, // The name of the specific link. You may be having multiple links pointing to the same location. 
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]

--- a/src/orbiter/src/state/types.rs
+++ b/src/orbiter/src/state/types.rs
@@ -103,7 +103,7 @@ pub mod state {
         pub utm_medium: Option<String>, // The name of the channel where the link is placed. e.g. "Email" or "Social".
         pub utm_campaign: Option<String>, // The name of your individual campaign. e.g. "Black+Friday".
         pub utm_term: Option<String>, // The name of the keyword for your paid search ad campaign.
-        pub utm_content: Option<String>, // The name of the specific link. You may be having multiple links pointing to the same location. 
+        pub utm_content: Option<String>, // The name of the specific link. You may be having multiple links pointing to the same location.
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]

--- a/src/orbiter/src/types.rs
+++ b/src/orbiter/src/types.rs
@@ -1,5 +1,8 @@
 pub mod interface {
-    use crate::state::types::state::{PageViewCampaign, PageViewClient, PageViewDevice, PerformanceData, PerformanceMetricName, SessionId};
+    use crate::state::types::state::{
+        PageViewCampaign, PageViewClient, PageViewDevice, PerformanceData, PerformanceMetricName,
+        SessionId,
+    };
     use candid::CandidType;
     use junobuild_shared::types::core::DomainName;
     use junobuild_shared::types::state::{
@@ -277,6 +280,8 @@ pub mod interface {
             pub user_agent: Option<String>,
             #[serde(skip_serializing_if = "Option::is_none")]
             pub client: Option<PageViewClientPayload>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub campaign: Option<PageViewCampaignPayload>,
             pub session_id: SessionId,
             pub created_at: TimestampPayload,
             pub updated_at: TimestampPayload,

--- a/src/orbiter/src/types.rs
+++ b/src/orbiter/src/types.rs
@@ -1,7 +1,5 @@
 pub mod interface {
-    use crate::state::types::state::{
-        PageViewClient, PageViewDevice, PerformanceData, PerformanceMetricName, SessionId,
-    };
+    use crate::state::types::state::{PageViewCampaign, PageViewClient, PageViewDevice, PerformanceData, PerformanceMetricName, SessionId};
     use candid::CandidType;
     use junobuild_shared::types::core::DomainName;
     use junobuild_shared::types::state::{
@@ -22,6 +20,7 @@ pub mod interface {
         pub client: Option<PageViewClient>,
         pub satellite_id: SatelliteId,
         pub session_id: SessionId,
+        pub campaign: Option<PageViewCampaign>,
         #[deprecated(
             since = "0.0.7",
             note = "Support for backwards compatibility. It has been replaced by version for overwrite checks."
@@ -96,6 +95,8 @@ pub mod interface {
         pub referrers: Vec<(String, u32)>,
         pub pages: Vec<(String, u32)>,
         pub time_zones: Option<Vec<(String, u32)>>,
+        pub utm_sources: Option<Vec<(String, u32)>>,
+        pub utm_campaigns: Option<Vec<(String, u32)>>,
     }
 
     #[derive(CandidType, Deserialize, Clone)]
@@ -238,8 +239,10 @@ pub mod interface {
             pub device: PageViewDevicePayload,
             pub time_zone: String,
             pub user_agent: Option<String>,
-            pub client: Option<PageViewClientPayload>,
+            pub client: Option<PageViewClientPayload>, // TODO: Option::is_none
             pub session_id: SessionId,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub campaign: Option<PageViewCampaignPayload>,
             pub version: VersionPayload,
         }
 
@@ -298,6 +301,19 @@ pub mod interface {
             pub screen_width: Option<u16>,
             #[serde(skip_serializing_if = "Option::is_none")]
             pub screen_height: Option<u16>,
+        }
+
+        #[derive(Deserialize, Serialize)]
+        pub struct PageViewCampaignPayload {
+            pub utm_source: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub utm_medium: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub utm_campaign: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub utm_term: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub utm_content: Option<String>,
         }
 
         #[derive(Serialize)]

--- a/src/tests/mocks/analytics.campaign.mocks.json
+++ b/src/tests/mocks/analytics.campaign.mocks.json
@@ -1,0 +1,1082 @@
+[
+	[
+		{
+			"key": "BYqw04gpiIk_cngduuiYv",
+			"collected_at": {
+				"__bigint__": "1742076010671000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076012627551082"
+			},
+			"referrer": ["https://source.com/"],
+			"time_zone": "Asia/Tokyo",
+			"session_id": "S3dH3rVWgwWykbhCRUr96",
+			"href": "https://demo.com/hello/",
+			"created_at": {
+				"__bigint__": "1742076012627551082"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 848,
+				"inner_width": 430
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 18_3_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Mobile/15E148 Safari/604.1"
+			],
+			"campaign": [
+				{
+					"utm_source": "twitter",
+					"utm_medium": ["social"],
+					"utm_campaign": ["product_launch"],
+					"utm_term": ["juno"],
+					"utm_content": ["video"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "pbbX_NWl8cRnCs7ynyO8b",
+			"collected_at": {
+				"__bigint__": "1742076030479000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076031445626195"
+			},
+			"referrer": ["https://source.com/"],
+			"time_zone": "Asia/Tokyo",
+			"session_id": "S3dH3rVWgwWykbhCRUr96",
+			"href": "https://demo.com/coolio/",
+			"created_at": {
+				"__bigint__": "1742076031445626195"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 732,
+				"inner_width": 430
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 18_3_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Mobile/15E148 Safari/604.1"
+			],
+			"campaign": [
+				{
+					"utm_source": "referral",
+					"utm_medium": ["partner"],
+					"utm_campaign": ["partner_promo"],
+					"utm_term": ["affiliate"],
+					"utm_content": ["widget"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "mOKcNyDCi26ScvKmJDZ8A",
+			"collected_at": {
+				"__bigint__": "1742076038442000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076039020550679"
+			},
+			"referrer": ["https://source.com/"],
+			"time_zone": "Asia/Tokyo",
+			"session_id": "S3dH3rVWgwWykbhCRUr96",
+			"href": "https://demo.com/hello/",
+			"created_at": {
+				"__bigint__": "1742076039020550679"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 732,
+				"inner_width": 430
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 18_3_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Mobile/15E148 Safari/604.1"
+			],
+			"campaign": [
+				{
+					"utm_source": "linkedin",
+					"utm_medium": ["social"],
+					"utm_campaign": ["b2b_outreach"],
+					"utm_term": ["cloud"],
+					"utm_content": ["text_post"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "xNFiHDu2SCw7Wm8lo2yWY",
+			"collected_at": {
+				"__bigint__": "1742076039936000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076042335876081"
+			},
+			"referrer": ["https://source.com/"],
+			"time_zone": "Asia/Tokyo",
+			"session_id": "S3dH3rVWgwWykbhCRUr96",
+			"href": "https://demo.com/",
+			"created_at": {
+				"__bigint__": "1742076042335876081"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 732,
+				"inner_width": 430
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 18_3_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Mobile/15E148 Safari/604.1"
+			],
+			"campaign": [
+				{
+					"utm_source": "twitter",
+					"utm_medium": ["social"],
+					"utm_campaign": ["product_launch"],
+					"utm_term": ["juno"],
+					"utm_content": ["video"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "_GDeiM6qpFWIZNZnKCUaQ",
+			"collected_at": {
+				"__bigint__": "1742076093049000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076094836517594"
+			},
+			"referrer": ["android-app://com.twitter.android/"],
+			"time_zone": "Europe/Paris",
+			"session_id": "GM4Dqtf0M4HDraaqZTMHn",
+			"href": "https://demo.com/?extid=2-1l7tleppk7wctk653oryqo2vi",
+			"created_at": {
+				"__bigint__": "1742076094836517594"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 782,
+				"inner_width": 411
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "newsletter",
+					"utm_medium": ["email"],
+					"utm_campaign": ["weekly_update"],
+					"utm_term": ["update"],
+					"utm_content": ["cta_button"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "L52jFtAC_ZKFcwEsIgtY3",
+			"collected_at": {
+				"__bigint__": "1742076129752000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076137381687026"
+			},
+			"referrer": ["https://www.google.com/"],
+			"time_zone": "America/Toronto",
+			"session_id": "DcGnulMQm26Jiu0rdJpVa",
+			"href": "https://demo.com/info/?token=Internet%20Computer&network=ICP",
+			"created_at": {
+				"__bigint__": "1742076137381687026"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 768,
+				"inner_width": 1366
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "google",
+					"utm_medium": ["cpc"],
+					"utm_campaign": ["spring_sale"],
+					"utm_term": ["icp hosting"],
+					"utm_content": ["banner_ad_1"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "fuBCI1IxwXK_VILxwz1ul",
+			"collected_at": {
+				"__bigint__": "1742076165618000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076168360847727"
+			},
+			"referrer": ["https://demo.com/?msg=Logged%2520out.&level=warn"],
+			"time_zone": "Pacific/Auckland",
+			"session_id": "55pd7Y6GNOLO6lwW8ZtH2",
+			"href": "https://demo.com/",
+			"created_at": {
+				"__bigint__": "1742076168360847727"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 662,
+				"inner_width": 1463
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "referral",
+					"utm_medium": ["partner"],
+					"utm_campaign": ["partner_promo"],
+					"utm_term": ["affiliate"],
+					"utm_content": ["widget"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "6nsRQgr1vsAWtPR9iqrlT",
+			"collected_at": {
+				"__bigint__": "1742076176471000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076177576863501"
+			},
+			"referrer": [],
+			"time_zone": "America/Vancouver",
+			"session_id": "vPpVvb-Q0Buw9mkYFdYXF",
+			"href": "https://demo.com/",
+			"created_at": {
+				"__bigint__": "1742076177576863501"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 804,
+				"inner_width": 1398
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "google",
+					"utm_medium": ["cpc"],
+					"utm_campaign": ["spring_sale"],
+					"utm_term": ["icp hosting"],
+					"utm_content": ["banner_ad_1"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "ambMwhBvhtLkqbe8X4ojW",
+			"collected_at": {
+				"__bigint__": "1742076278227000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076281058622624"
+			},
+			"referrer": [],
+			"time_zone": "America/Los_Angeles",
+			"session_id": "CIbzikXQUQiqK4_oL_lO8",
+			"href": "https://demo.com/",
+			"created_at": {
+				"__bigint__": "1742076281058622624"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 775,
+				"inner_width": 1512
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "google",
+					"utm_medium": ["cpc"],
+					"utm_campaign": ["spring_sale"],
+					"utm_term": ["icp hosting"],
+					"utm_content": ["banner_ad_1"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "DP5xGgl81MIo2kPEStSjS",
+			"collected_at": {
+				"__bigint__": "1742076280506000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076282358314045"
+			},
+			"referrer": ["https://source.com/HzUcyKgxkY"],
+			"time_zone": "UTC",
+			"session_id": "jQfZ_aeJ43xnGVzRTl3_5",
+			"href": "https://demo.com/",
+			"created_at": {
+				"__bigint__": "1742076282358314045"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 1294,
+				"inner_width": 2560
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:136.0) Gecko/20100101 Firefox/136.0"
+			],
+			"campaign": [
+				{
+					"utm_source": "referral",
+					"utm_medium": ["partner"],
+					"utm_campaign": ["partner_promo"],
+					"utm_term": ["affiliate"],
+					"utm_content": ["widget"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "rVaFrWRbc1CKFygpwoocQ",
+			"collected_at": {
+				"__bigint__": "1742076294751000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076296704015595"
+			},
+			"referrer": [],
+			"time_zone": "Europe/Lisbon",
+			"session_id": "QPLmiqIeFxoRb6Xn9sqt2",
+			"href": "https://demo.com/?extid=2-7f6e2598fqadm3ldqpa1fdblv",
+			"created_at": {
+				"__bigint__": "1742076296704015595"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 666,
+				"inner_width": 393
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 18_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Mobile/15E148 Safari/604.1"
+			],
+			"campaign": [
+				{
+					"utm_source": "google",
+					"utm_medium": ["cpc"],
+					"utm_campaign": ["spring_sale"],
+					"utm_term": ["icp hosting"],
+					"utm_content": ["banner_ad_1"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "q-OZJNMOC5sYb2xgY0g7L",
+			"collected_at": {
+				"__bigint__": "1742076308714000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076309610662307"
+			},
+			"referrer": ["android-app://com.twitter.android/"],
+			"time_zone": "Europe/London",
+			"session_id": "8iJF08qRk5Y7gSBcUv8i9",
+			"href": "https://demo.com/?extid=2-3gykj3ni9scmbcy5abg5izz5s",
+			"created_at": {
+				"__bigint__": "1742076309610662307"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 766,
+				"inner_width": 406
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "linkedin",
+					"utm_medium": ["social"],
+					"utm_campaign": ["b2b_outreach"],
+					"utm_term": ["cloud"],
+					"utm_content": ["text_post"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "RHYgky05xXR-iAX4v_tot",
+			"collected_at": {
+				"__bigint__": "1742076310310000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076311864957879"
+			},
+			"referrer": ["https://source.com/HzUcyKgxkY"],
+			"time_zone": "America/Chicago",
+			"session_id": "4wiYEuaoI8o9YniCdnELN",
+			"href": "https://demo.com/",
+			"created_at": {
+				"__bigint__": "1742076311864957879"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 723,
+				"inner_width": 1377
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "google",
+					"utm_medium": ["cpc"],
+					"utm_campaign": ["spring_sale"],
+					"utm_term": ["icp hosting"],
+					"utm_content": ["banner_ad_1"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "DsZ7cUr-xH961-C8hu-Za",
+			"collected_at": {
+				"__bigint__": "1742076310948000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076313374360443"
+			},
+			"referrer": ["https://demo.com/?msg=Logged%2520out.&level=warn"],
+			"time_zone": "America/Los_Angeles",
+			"session_id": "92B1dFtyeIfi7yGJVJ7OI",
+			"href": "https://demo.com/hello/",
+			"created_at": {
+				"__bigint__": "1742076313374360443"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 917,
+				"inner_width": 1920
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "newsletter",
+					"utm_medium": ["email"],
+					"utm_campaign": ["weekly_update"],
+					"utm_term": ["update"],
+					"utm_content": ["cta_button"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "q8hdNUJ_rwEaeS7OpBN_6",
+			"collected_at": {
+				"__bigint__": "1742076327532000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076330368635843"
+			},
+			"referrer": ["https://demo.com/hello/?msg=Logged%2520out.&level=warn"],
+			"time_zone": "America/Los_Angeles",
+			"session_id": "MHJcOdjUYya4CLTQDKUwc",
+			"href": "https://demo.com/hello/?msg=Logged%2520out.&level=warn",
+			"created_at": {
+				"__bigint__": "1742076330368635843"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 917,
+				"inner_width": 1920
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "linkedin",
+					"utm_medium": ["social"],
+					"utm_campaign": ["b2b_outreach"],
+					"utm_term": ["cloud"],
+					"utm_content": ["text_post"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "0feQJ2ULIQe_aCl3shbvZ",
+			"collected_at": {
+				"__bigint__": "1742076339782000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076340617870203"
+			},
+			"referrer": ["https://source.com/HzUcyKgxkY"],
+			"time_zone": "America/Chicago",
+			"session_id": "4wiYEuaoI8o9YniCdnELN",
+			"href": "https://demo.com/hello/",
+			"created_at": {
+				"__bigint__": "1742076340617870203"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 723,
+				"inner_width": 1377
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "google",
+					"utm_medium": ["cpc"],
+					"utm_campaign": ["spring_sale"],
+					"utm_term": ["icp hosting"],
+					"utm_content": ["banner_ad_1"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "CcgnIjvhMjFdsBAnzxusL",
+			"collected_at": {
+				"__bigint__": "1742076349753000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076353675772183"
+			},
+			"referrer": [],
+			"time_zone": "Africa/Lagos",
+			"session_id": "J8RnwBz9t5M8yJlB8PZYL",
+			"href": "https://demo.com/?extid=25sug0p49omd08thxjz16smrge",
+			"created_at": {
+				"__bigint__": "1742076353675772183"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 670,
+				"inner_width": 390
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Mobile/15E148 Safari/604.1"
+			],
+			"campaign": [
+				{
+					"utm_source": "linkedin",
+					"utm_medium": ["social"],
+					"utm_campaign": ["b2b_outreach"],
+					"utm_term": ["cloud"],
+					"utm_content": ["text_post"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "xhMdF1AO2_3xTox_pWBSG",
+			"collected_at": {
+				"__bigint__": "1742076369044000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076371059591158"
+			},
+			"referrer": [],
+			"time_zone": "America/Los_Angeles",
+			"session_id": "CIbzikXQUQiqK4_oL_lO8",
+			"href": "https://demo.com/hello/",
+			"created_at": {
+				"__bigint__": "1742076371059591158"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 775,
+				"inner_width": 1512
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "google",
+					"utm_medium": ["cpc"],
+					"utm_campaign": ["spring_sale"],
+					"utm_term": ["icp hosting"],
+					"utm_content": ["banner_ad_1"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "TxNKOD7b8UQNGFuG4DmKN",
+			"collected_at": {
+				"__bigint__": "1742076369893000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076373087219300"
+			},
+			"referrer": [],
+			"time_zone": "America/Los_Angeles",
+			"session_id": "CIbzikXQUQiqK4_oL_lO8",
+			"href": "https://demo.com/explore/",
+			"created_at": {
+				"__bigint__": "1742076373087219300"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 775,
+				"inner_width": 1512
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "newsletter",
+					"utm_medium": ["email"],
+					"utm_campaign": ["weekly_update"],
+					"utm_term": ["update"],
+					"utm_content": ["cta_button"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "N_k_KKxgkKy_M9Y_Ex19J",
+			"collected_at": {
+				"__bigint__": "1742076383563000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076389796028554"
+			},
+			"referrer": ["android-app://com.twitter.android/"],
+			"time_zone": "Europe/Berlin",
+			"session_id": "xBVrzn00RxSut_S71wYGG",
+			"href": "https://demo.com/?extid=2-1xzzr6ps2gxp2hyyblr8raf04",
+			"created_at": {
+				"__bigint__": "1742076389796028554"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 780,
+				"inner_width": 411
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "twitter",
+					"utm_medium": ["social"],
+					"utm_campaign": ["product_launch"],
+					"utm_term": ["juno"],
+					"utm_content": ["video"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "F-QnOyfsJnWTn_ACfYpJ0",
+			"collected_at": {
+				"__bigint__": "1742076587510000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076591720862365"
+			},
+			"referrer": [],
+			"time_zone": "America/New_York",
+			"session_id": "C1CFcWvC-9_cIFfIH133-",
+			"href": "https://demo.com/",
+			"created_at": {
+				"__bigint__": "1742076591720862365"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 1014,
+				"inner_width": 1920
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "twitter",
+					"utm_medium": ["social"],
+					"utm_campaign": ["product_launch"],
+					"utm_term": ["juno"],
+					"utm_content": ["video"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "A_Ai8Yss-Ct7JTAvfh_BS",
+			"collected_at": {
+				"__bigint__": "1742076599448000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076600348153459"
+			},
+			"referrer": ["https://demo.com/?msg=Logged%2520out.&level=warn"],
+			"time_zone": "America/Los_Angeles",
+			"session_id": "DU41zjt95xv3fr4DCtDFT",
+			"href": "https://demo.com/?msg=Logged%2520out.&level=warn",
+			"created_at": {
+				"__bigint__": "1742076600348153459"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 958,
+				"inner_width": 1728
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "linkedin",
+					"utm_medium": ["social"],
+					"utm_campaign": ["b2b_outreach"],
+					"utm_term": ["cloud"],
+					"utm_content": ["text_post"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "EpCcs8wKi3OFsgO6ZGFCm",
+			"collected_at": {
+				"__bigint__": "1742076675288000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076676808207395"
+			},
+			"referrer": [],
+			"time_zone": "Asia/Jakarta",
+			"session_id": "1YsyUYQajjDO3_gcbHUzd",
+			"href": "https://demo.com/?extid=24tpxjow6bxqbf8t5oufhmpl5c",
+			"created_at": {
+				"__bigint__": "1742076676808207395"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 670,
+				"inner_width": 390
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1"
+			],
+			"campaign": [
+				{
+					"utm_source": "google",
+					"utm_medium": ["cpc"],
+					"utm_campaign": ["spring_sale"],
+					"utm_term": ["icp hosting"],
+					"utm_content": ["banner_ad_1"]
+				}
+			]
+		}
+	],
+	[
+		{
+			"key": "dS_8v__TmD4vxaE3dUEBZ",
+			"collected_at": {
+				"__bigint__": "1742076758133000000"
+			}
+		},
+		{
+			"title": "Demo",
+			"updated_at": {
+				"__bigint__": "1742076760573093410"
+			},
+			"referrer": [],
+			"time_zone": "America/New_York",
+			"session_id": "C1CFcWvC-9_cIFfIH133-",
+			"href": "https://demo.com/explore/",
+			"created_at": {
+				"__bigint__": "1742076760573093410"
+			},
+			"satellite_id": {
+				"__principal__": "jx5yt-yyaaa-aaaal-abzbq-cai"
+			},
+			"device": {
+				"inner_height": 1014,
+				"inner_width": 1920
+			},
+			"version": [
+				{
+					"__bigint__": "1"
+				}
+			],
+			"user_agent": [
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+			],
+			"campaign": [
+				{
+					"utm_source": "twitter",
+					"utm_medium": ["social"],
+					"utm_campaign": ["product_launch"],
+					"utm_term": ["juno"],
+					"utm_content": ["video"]
+				}
+			]
+		}
+	]
+]

--- a/src/tests/mocks/orbiter.mocks.ts
+++ b/src/tests/mocks/orbiter.mocks.ts
@@ -166,13 +166,15 @@ export const pageViewMock: SetPageView = {
 			os: 'Mac os'
 		}
 	],
-	campaign: [{
-		utm_source: 'newsletter',
-		utm_medium: ['email'],
-		utm_campaign: ['spring_launch'],
-		utm_term: ['rust-sdk'],
-		utm_content: ['cta-button']
-	}],
+	campaign: [
+		{
+			utm_source: 'newsletter',
+			utm_medium: ['email'],
+			utm_campaign: ['spring_launch'],
+			utm_term: ['rust-sdk'],
+			utm_content: ['cta-button']
+		}
+	],
 	version: [],
 	updated_at: []
 };

--- a/src/tests/mocks/orbiter.mocks.ts
+++ b/src/tests/mocks/orbiter.mocks.ts
@@ -31,6 +31,7 @@ export interface SetPageViewPayload {
 	version?: bigint;
 	user_agent?: string;
 	client?: PageViewClientPayload;
+	campaign?: SetPageViewCampaignPayload;
 }
 
 export interface PageViewDevicePayload {
@@ -38,6 +39,14 @@ export interface PageViewDevicePayload {
 	inner_width: number;
 	screen_height?: number;
 	screen_width?: number;
+}
+
+export interface SetPageViewCampaignPayload {
+	utm_source: string;
+	utm_medium?: string;
+	utm_campaign?: string;
+	utm_term?: string;
+	utm_content?: string;
 }
 
 export interface PageViewClientPayload {
@@ -157,6 +166,13 @@ export const pageViewMock: SetPageView = {
 			os: 'Mac os'
 		}
 	],
+	campaign: [{
+		utm_source: 'newsletter',
+		utm_medium: ['email'],
+		utm_campaign: ['spring_launch'],
+		utm_term: ['rust-sdk'],
+		utm_content: ['cta-button']
+	}],
 	version: [],
 	updated_at: []
 };
@@ -177,6 +193,13 @@ export const pageViewPayloadMock: SetPageViewPayload = {
 		browser: 'Firefox',
 		device: 'desktop',
 		os: 'Mac os'
+	},
+	campaign: {
+		utm_source: 'newsletter',
+		utm_medium: 'email',
+		utm_campaign: 'spring_launch',
+		utm_term: 'rust-sdk',
+		utm_content: 'cta-button'
 	}
 };
 

--- a/src/tests/specs/orbiter/orbiter.analytics.campaign.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.analytics.campaign.spec.ts
@@ -1,0 +1,117 @@
+import type {
+	AnalyticKey,
+	_SERVICE as OrbiterActor,
+	PageView
+} from '$declarations/orbiter/orbiter.did';
+import { idlFactory as idlFactorOrbiter } from '$declarations/orbiter/orbiter.factory.did';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { jsonReviver } from '@dfinity/utils';
+import { type Actor, PocketIc } from '@hadronous/pic';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { inject } from 'vitest';
+import { satelliteIdMock } from '../../mocks/orbiter.mocks';
+import { initOrbiterConfig, uploadPageViews } from '../../utils/orbiter-page-views-tests.utils';
+import { controllersInitArgs, ORBITER_WASM_PATH } from '../../utils/setup-tests.utils';
+
+describe('Orbiter > Analytics > Campaign', () => {
+	let pic: PocketIc;
+	let actor: Actor<OrbiterActor>;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	let pageViewsMock: [AnalyticKey, PageView][];
+
+	const collected_at = 1742076010671000000n;
+
+	const initMock = async () => {
+		const content = await readFile(
+			join(process.cwd(), 'src', 'tests/mocks/analytics.campaign.mocks.json'),
+			'utf-8'
+		);
+		pageViewsMock = JSON.parse(content, jsonReviver);
+	};
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const { actor: c } = await pic.setupCanister<OrbiterActor>({
+			idlFactory: idlFactorOrbiter,
+			wasm: ORBITER_WASM_PATH,
+			arg: controllersInitArgs(controller),
+			sender: controller.getPrincipal()
+		});
+
+		actor = c;
+
+		actor.setIdentity(controller);
+
+		await initOrbiterConfig(actor);
+
+		await initMock();
+
+		await uploadPageViews({ pic, actor, collected_at, pageViewsMock });
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	it('should get the top10 campaigns', async () => {
+		const { get_page_views_analytics_top_10 } = actor;
+
+		const result = await get_page_views_analytics_top_10({
+			satellite_id: [satelliteIdMock],
+			from: [collected_at],
+			to: [collected_at + 1000n]
+		});
+
+		expect(result).toEqual({
+			pages: [
+				['/', 14],
+				['/hello/', 6],
+				['/explore/', 2],
+				['/info/', 1],
+				['/coolio/', 1]
+			],
+			referrers: [
+				['source.com', 7],
+				['demo.com', 4],
+				['com.twitter.android', 3],
+				['www.google.com', 1]
+			],
+			time_zones: [
+				[
+					['America/Los_Angeles', 6],
+					['Asia/Tokyo', 4],
+					['America/Chicago', 2],
+					['America/New_York', 2],
+					['UTC', 1],
+					['Europe/Berlin', 1],
+					['Asia/Jakarta', 1],
+					['Africa/Lagos', 1],
+					['Europe/London', 1],
+					['Europe/Lisbon', 1]
+				]
+			],
+			utm_campaigns: [
+				[
+					['spring_sale', 8],
+					['product_launch', 5],
+					['b2b_outreach', 5],
+					['partner_promo', 3],
+					['weekly_update', 3]
+				]
+			],
+			utm_sources: [
+				[
+					['google', 8],
+					['linkedin', 5],
+					['twitter', 5],
+					['referral', 3],
+					['newsletter', 3]
+				]
+			]
+		});
+	});
+});

--- a/src/tests/specs/orbiter/orbiter.analytics.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.analytics.spec.ts
@@ -166,7 +166,9 @@ describe('Orbiter > Analytics', () => {
 						['Europe/Stockholm', 7],
 						['Asia/Manila', 7]
 					]
-				]
+				],
+				utm_campaigns: [],
+				utm_sources: []
 			});
 		});
 

--- a/src/tests/specs/orbiter/orbiter.analytics.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.analytics.spec.ts
@@ -1,21 +1,17 @@
 import type {
 	AnalyticKey,
 	_SERVICE as OrbiterActor,
-	OrbiterSatelliteFeatures,
-	PageView,
-	PageViewClient,
-	SetPageView
+	PageView
 } from '$declarations/orbiter/orbiter.did';
 import { idlFactory as idlFactorOrbiter } from '$declarations/orbiter/orbiter.factory.did';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
-import { fromNullable, isNullish, jsonReviver, toNullable } from '@dfinity/utils';
+import { jsonReviver, toNullable } from '@dfinity/utils';
 import { type Actor, PocketIc } from '@hadronous/pic';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import UAParser from 'ua-parser-js';
 import { inject } from 'vitest';
 import { satelliteIdMock } from '../../mocks/orbiter.mocks';
-import { tick } from '../../utils/pic-tests.utils';
+import { initOrbiterConfig, uploadPageViews } from '../../utils/orbiter-page-views-tests.utils';
 import { controllersInitArgs, ORBITER_WASM_PATH } from '../../utils/setup-tests.utils';
 
 describe('Orbiter > Analytics', () => {
@@ -36,116 +32,6 @@ describe('Orbiter > Analytics', () => {
 		pageViewsMock = JSON.parse(content, jsonReviver);
 	};
 
-	const initConfig = async () => {
-		const allFeatures: OrbiterSatelliteFeatures = {
-			page_views: true,
-			performance_metrics: true,
-			track_events: true
-		};
-
-		const { set_satellite_configs } = actor;
-
-		await set_satellite_configs([
-			[
-				satelliteIdMock,
-				{
-					version: [],
-					restricted_origin: [],
-					features: [allFeatures]
-				}
-			]
-		]);
-	};
-
-	const uploadPageViews = async ({
-		collected_at,
-		withSizeMock = false,
-		withUAParser = false
-	}: {
-		collected_at: bigint;
-		withSizeMock?: boolean;
-		withUAParser?: boolean;
-	}) => {
-		const screen_width = [575, 991, 1439, 1920];
-
-		const setPageViewsData = pageViewsMock.map<[AnalyticKey, SetPageView]>(
-			(
-				[
-					key,
-					{
-						version: ___,
-						created_at: _,
-						updated_at: __,
-						satellite_id: ____,
-						device,
-						user_agent,
-						...value
-					}
-				],
-				i
-			) => {
-				const parseClient = (): PageViewClient | undefined => {
-					if (!withUAParser) {
-						return undefined;
-					}
-
-					const userAgent = fromNullable(user_agent);
-
-					if (isNullish(userAgent)) {
-						return undefined;
-					}
-
-					const parser = new UAParser(userAgent);
-					const { browser, os, device } = parser.getResult();
-
-					if (isNullish(browser.name) || isNullish(os.name)) {
-						return undefined;
-					}
-
-					return {
-						browser: browser.name,
-						os: os.name,
-						device: toNullable(device?.type)
-					};
-				};
-
-				return [
-					{
-						...key,
-						collected_at
-					},
-					{
-						...value,
-						user_agent,
-						updated_at: [],
-						version: [],
-						client: toNullable(parseClient()),
-						satellite_id: satelliteIdMock,
-						device: {
-							...device,
-							screen_width: withSizeMock ? [screen_width[i % screen_width.length]] : [],
-							screen_height: []
-						}
-					}
-				];
-			}
-		);
-
-		const it = setPageViewsData.values();
-		const chunks: [AnalyticKey, SetPageView][][] = Array.from(it, (val) => [
-			val,
-			...it.take(50 - 1)
-		]);
-
-		const { set_page_views } = actor;
-
-		for (const chunk of chunks) {
-			await set_page_views(chunk);
-
-			await tick(pic);
-		}
-	};
-
 	beforeAll(async () => {
 		pic = await PocketIc.create(inject('PIC_URL'));
 
@@ -160,7 +46,7 @@ describe('Orbiter > Analytics', () => {
 
 		actor.setIdentity(controller);
 
-		await initConfig();
+		await initOrbiterConfig(actor);
 
 		await initMock();
 	});
@@ -173,7 +59,7 @@ describe('Orbiter > Analytics', () => {
 		const collected_at = 1742076030479000000n;
 
 		beforeAll(async () => {
-			await uploadPageViews({ collected_at });
+			await uploadPageViews({ pic, actor, collected_at, pageViewsMock });
 		});
 
 		it('should get page views metrics', async () => {
@@ -317,7 +203,7 @@ describe('Orbiter > Analytics', () => {
 		const collected_at = 1742076030479000000n + ONE_DAY;
 
 		beforeAll(async () => {
-			await uploadPageViews({ collected_at, withSizeMock: true });
+			await uploadPageViews({ pic, actor, collected_at, withSizeMock: true, pageViewsMock });
 		});
 
 		it('should get the clients information', async () => {
@@ -353,7 +239,7 @@ describe('Orbiter > Analytics', () => {
 		const collected_at = 1742076030479000000n + ONE_DAY + ONE_DAY;
 
 		beforeAll(async () => {
-			await uploadPageViews({ collected_at, withUAParser: true });
+			await uploadPageViews({ pic, actor, collected_at, withUAParser: true, pageViewsMock });
 		});
 
 		it('should get the data based on extract ua data', async () => {
@@ -398,7 +284,14 @@ describe('Orbiter > Analytics', () => {
 		const collected_at = 1742076030479000000n + ONE_DAY + ONE_DAY + ONE_DAY;
 
 		beforeAll(async () => {
-			await uploadPageViews({ collected_at, withUAParser: true, withSizeMock: true });
+			await uploadPageViews({
+				pic,
+				actor,
+				collected_at,
+				withUAParser: true,
+				withSizeMock: true,
+				pageViewsMock
+			});
 		});
 
 		it('should get the data based on extract ua data except devices from size', async () => {

--- a/src/tests/specs/orbiter/orbiter.assertions.page-views.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.assertions.page-views.spec.ts
@@ -60,6 +60,7 @@ describe('Orbiter > Assertions > Page Views', () => {
 			{ key: 'x'.repeat(37), collected_at: 123567890n },
 			pageViewMock
 		);
+
 		expect(result).toEqual({ Err: 'An analytic key must not be longer than 36.' });
 	});
 
@@ -73,6 +74,7 @@ describe('Orbiter > Assertions > Page Views', () => {
 				session_id: 'x'.repeat(37)
 			}
 		);
+
 		expect(result).toEqual({ Err: 'An analytic session ID must not be longer than 36.' });
 	});
 
@@ -88,6 +90,7 @@ describe('Orbiter > Assertions > Page Views', () => {
 				title
 			}
 		);
+
 		expect(result).toEqual({ Err: `Page event title ${title} is longer than 1024.` });
 	});
 
@@ -103,6 +106,7 @@ describe('Orbiter > Assertions > Page Views', () => {
 				href
 			}
 		);
+
 		expect(result).toEqual({ Err: `Page event href ${href} is longer than 1024.` });
 	});
 
@@ -118,13 +122,14 @@ describe('Orbiter > Assertions > Page Views', () => {
 				referrer: [referrer]
 			}
 		);
+
 		expect(result).toEqual({ Err: `Page event referrer ${referrer} is longer than 4096.` });
 	});
 
 	it('should not set page view for invalid user agent length', async () => {
 		const { set_page_view } = actor;
 
-		const userAgent = 'x'.repeat(1025)
+		const userAgent = 'x'.repeat(1025);
 
 		const result = await set_page_view(
 			{ key: nanoid(), collected_at: 123567890n },
@@ -133,6 +138,7 @@ describe('Orbiter > Assertions > Page Views', () => {
 				user_agent: [userAgent]
 			}
 		);
+
 		expect(result).toEqual({ Err: `Page event user_agent ${userAgent} is longer than 1024.` });
 	});
 
@@ -148,6 +154,7 @@ describe('Orbiter > Assertions > Page Views', () => {
 				time_zone: timeZone
 			}
 		);
+
 		expect(result).toEqual({ Err: `Page event time_zone ${timeZone} is longer than 256.` });
 	});
 });

--- a/src/tests/specs/orbiter/orbiter.assertions.page-views.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.assertions.page-views.spec.ts
@@ -1,0 +1,153 @@
+import type {
+	_SERVICE as OrbiterActor,
+	OrbiterSatelliteFeatures
+} from '$declarations/orbiter/orbiter.did';
+import { idlFactory as idlFactorOrbiter } from '$declarations/orbiter/orbiter.factory.did';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { type Actor, PocketIc } from '@hadronous/pic';
+import { nanoid } from 'nanoid';
+import { inject } from 'vitest';
+import { pageViewMock, satelliteIdMock } from '../../mocks/orbiter.mocks';
+import { controllersInitArgs, ORBITER_WASM_PATH } from '../../utils/setup-tests.utils';
+
+describe('Orbiter > Assertions > Page Views', () => {
+	let pic: PocketIc;
+	let actor: Actor<OrbiterActor>;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const { actor: c } = await pic.setupCanister<OrbiterActor>({
+			idlFactory: idlFactorOrbiter,
+			wasm: ORBITER_WASM_PATH,
+			arg: controllersInitArgs(controller),
+			sender: controller.getPrincipal()
+		});
+
+		actor = c;
+		actor.setIdentity(controller);
+
+		const allFeatures: OrbiterSatelliteFeatures = {
+			page_views: true,
+			performance_metrics: true,
+			track_events: true
+		};
+
+		const { set_satellite_configs } = actor;
+
+		await set_satellite_configs([
+			[
+				satelliteIdMock,
+				{
+					version: [],
+					restricted_origin: [],
+					features: [allFeatures]
+				}
+			]
+		]);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	it('should not set page view for invalid key length', async () => {
+		const { set_page_view } = actor;
+
+		const result = await set_page_view(
+			{ key: 'x'.repeat(37), collected_at: 123567890n },
+			pageViewMock
+		);
+		expect(result).toEqual({ Err: 'An analytic key must not be longer than 36.' });
+	});
+
+	it('should not set page view for invalid session id length', async () => {
+		const { set_page_view } = actor;
+
+		const result = await set_page_view(
+			{ key: nanoid(), collected_at: 123567890n },
+			{
+				...pageViewMock,
+				session_id: 'x'.repeat(37)
+			}
+		);
+		expect(result).toEqual({ Err: 'An analytic session ID must not be longer than 36.' });
+	});
+
+	it('should not set page view for invalid title length', async () => {
+		const { set_page_view } = actor;
+
+		const title = 'x'.repeat(1025);
+
+		const result = await set_page_view(
+			{ key: nanoid(), collected_at: 123567890n },
+			{
+				...pageViewMock,
+				title
+			}
+		);
+		expect(result).toEqual({ Err: `Page event title ${title} is longer than 1024.` });
+	});
+
+	it('should not set page view for invalid href length', async () => {
+		const { set_page_view } = actor;
+
+		const href = 'x'.repeat(4097);
+
+		const result = await set_page_view(
+			{ key: nanoid(), collected_at: 123567890n },
+			{
+				...pageViewMock,
+				href
+			}
+		);
+		expect(result).toEqual({ Err: `Page event href ${href} is longer than 1024.` });
+	});
+
+	it('should not set page view for invalid referrer length', async () => {
+		const { set_page_view } = actor;
+
+		const referrer = 'x'.repeat(4097);
+
+		const result = await set_page_view(
+			{ key: nanoid(), collected_at: 123567890n },
+			{
+				...pageViewMock,
+				referrer: [referrer]
+			}
+		);
+		expect(result).toEqual({ Err: `Page event referrer ${referrer} is longer than 4096.` });
+	});
+
+	it('should not set page view for invalid user agent length', async () => {
+		const { set_page_view } = actor;
+
+		const userAgent = 'x'.repeat(1025)
+
+		const result = await set_page_view(
+			{ key: nanoid(), collected_at: 123567890n },
+			{
+				...pageViewMock,
+				user_agent: [userAgent]
+			}
+		);
+		expect(result).toEqual({ Err: `Page event user_agent ${userAgent} is longer than 1024.` });
+	});
+
+	it('should not set page view for invalid time zone length', async () => {
+		const { set_page_view } = actor;
+
+		const timeZone = 'x'.repeat(257);
+
+		const result = await set_page_view(
+			{ key: nanoid(), collected_at: 123567890n },
+			{
+				...pageViewMock,
+				time_zone: timeZone
+			}
+		);
+		expect(result).toEqual({ Err: `Page event time_zone ${timeZone} is longer than 256.` });
+	});
+});

--- a/src/tests/specs/orbiter/orbiter.assertions.page-views.spec.ts
+++ b/src/tests/specs/orbiter/orbiter.assertions.page-views.spec.ts
@@ -4,6 +4,7 @@ import type {
 } from '$declarations/orbiter/orbiter.did';
 import { idlFactory as idlFactorOrbiter } from '$declarations/orbiter/orbiter.factory.did';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { toNullable } from '@dfinity/utils';
 import { type Actor, PocketIc } from '@hadronous/pic';
 import { nanoid } from 'nanoid';
 import { inject } from 'vitest';
@@ -156,5 +157,127 @@ describe('Orbiter > Assertions > Page Views', () => {
 		);
 
 		expect(result).toEqual({ Err: `Page event time_zone ${timeZone} is longer than 256.` });
+	});
+
+	describe('Campaign', () => {
+		it('should not set page view for invalid utm_source length', async () => {
+			const { set_page_view } = actor;
+
+			const utm = 'x'.repeat(101);
+
+			const result = await set_page_view(
+				{ key: nanoid(), collected_at: 123567890n },
+				{
+					...pageViewMock,
+					campaign: [
+						{
+							utm_source: utm,
+							utm_medium: toNullable(),
+							utm_content: toNullable(),
+							utm_term: toNullable(),
+							utm_campaign: toNullable()
+						}
+					]
+				}
+			);
+
+			expect(result).toEqual({ Err: `utm_source ${utm} is longer than 100.` });
+		});
+
+		it('should not set page view for invalid utm_medium length', async () => {
+			const { set_page_view } = actor;
+
+			const utm = 'x'.repeat(101);
+
+			const result = await set_page_view(
+				{ key: nanoid(), collected_at: 123567890n },
+				{
+					...pageViewMock,
+					campaign: [
+						{
+							utm_source: 'newsletter',
+							utm_medium: toNullable(utm),
+							utm_content: toNullable(),
+							utm_term: toNullable(),
+							utm_campaign: toNullable()
+						}
+					]
+				}
+			);
+
+			expect(result).toEqual({ Err: `utm_medium ${utm} is longer than 100.` });
+		});
+
+		it('should not set page view for invalid utm_content length', async () => {
+			const { set_page_view } = actor;
+
+			const utm = 'x'.repeat(101);
+
+			const result = await set_page_view(
+				{ key: nanoid(), collected_at: 123567890n },
+				{
+					...pageViewMock,
+					campaign: [
+						{
+							utm_source: 'newsletter',
+							utm_medium: toNullable(),
+							utm_content: toNullable(utm),
+							utm_term: toNullable(),
+							utm_campaign: toNullable()
+						}
+					]
+				}
+			);
+
+			expect(result).toEqual({ Err: `utm_content ${utm} is longer than 100.` });
+		});
+
+		it('should not set page view for invalid utm_term length', async () => {
+			const { set_page_view } = actor;
+
+			const utm = 'x'.repeat(101);
+
+			const result = await set_page_view(
+				{ key: nanoid(), collected_at: 123567890n },
+				{
+					...pageViewMock,
+					campaign: [
+						{
+							utm_source: 'newsletter',
+							utm_medium: toNullable(),
+							utm_content: toNullable(),
+							utm_term: toNullable(utm),
+							utm_campaign: toNullable()
+						}
+					]
+				}
+			);
+
+			expect(result).toEqual({ Err: `utm_term ${utm} is longer than 100.` });
+		});
+
+		it('should not set page view for invalid utm_campaign length', async () => {
+			const { set_page_view } = actor;
+
+			const utm = 'x'.repeat(101);
+
+			const result = await set_page_view(
+				{ key: nanoid(), collected_at: 123567890n },
+				{
+					...pageViewMock,
+					campaign: [
+						{
+							utm_source: 'newsletter',
+							utm_medium: toNullable(),
+							utm_content: toNullable(),
+							utm_term: toNullable(),
+							utm_campaign: toNullable(utm)
+						}
+					]
+				}
+			);
+
+			expect(result).toEqual({ Err: `utm_campaign ${utm} is longer than 100.` });
+		});
 	});
 });

--- a/src/tests/utils/orbiter-page-views-tests.utils.ts
+++ b/src/tests/utils/orbiter-page-views-tests.utils.ts
@@ -61,6 +61,7 @@ export const uploadPageViews = async ({
 					satellite_id: ____,
 					device,
 					user_agent,
+					campaign,
 					...value
 				}
 			],
@@ -107,7 +108,8 @@ export const uploadPageViews = async ({
 						...device,
 						screen_width: withSizeMock ? [screen_width[i % screen_width.length]] : [],
 						screen_height: []
-					}
+					},
+					campaign: campaign ?? []
 				}
 			];
 		}

--- a/src/tests/utils/orbiter-page-views-tests.utils.ts
+++ b/src/tests/utils/orbiter-page-views-tests.utils.ts
@@ -7,7 +7,7 @@ import type {
 	SetPageView
 } from '$declarations/orbiter/orbiter.did';
 import { fromNullable, isNullish, toNullable } from '@dfinity/utils';
-import { type Actor, PocketIc } from '@hadronous/pic';
+import type { Actor, PocketIc } from '@hadronous/pic';
 import UAParser from 'ua-parser-js';
 import { satelliteIdMock } from '../mocks/orbiter.mocks';
 import { tick } from './pic-tests.utils';

--- a/src/tests/utils/orbiter-page-views-tests.utils.ts
+++ b/src/tests/utils/orbiter-page-views-tests.utils.ts
@@ -1,0 +1,126 @@
+import type {
+	AnalyticKey,
+	_SERVICE as OrbiterActor,
+	OrbiterSatelliteFeatures,
+	PageView,
+	PageViewClient,
+	SetPageView
+} from '$declarations/orbiter/orbiter.did';
+import { fromNullable, isNullish, toNullable } from '@dfinity/utils';
+import { type Actor, PocketIc } from '@hadronous/pic';
+import UAParser from 'ua-parser-js';
+import { satelliteIdMock } from '../mocks/orbiter.mocks';
+import { tick } from './pic-tests.utils';
+
+export const initOrbiterConfig = async (actor: Actor<OrbiterActor>) => {
+	const allFeatures: OrbiterSatelliteFeatures = {
+		page_views: true,
+		performance_metrics: true,
+		track_events: true
+	};
+
+	const { set_satellite_configs } = actor;
+
+	await set_satellite_configs([
+		[
+			satelliteIdMock,
+			{
+				version: [],
+				restricted_origin: [],
+				features: [allFeatures]
+			}
+		]
+	]);
+};
+
+export const uploadPageViews = async ({
+	collected_at,
+	withSizeMock = false,
+	withUAParser = false,
+	pageViewsMock,
+	pic,
+	actor
+}: {
+	collected_at: bigint;
+	withSizeMock?: boolean;
+	withUAParser?: boolean;
+	pageViewsMock: [AnalyticKey, PageView][];
+	pic: PocketIc;
+	actor: Actor<OrbiterActor>;
+}) => {
+	const screen_width = [575, 991, 1439, 1920];
+
+	const setPageViewsData = pageViewsMock.map<[AnalyticKey, SetPageView]>(
+		(
+			[
+				key,
+				{
+					version: ___,
+					created_at: _,
+					updated_at: __,
+					satellite_id: ____,
+					device,
+					user_agent,
+					...value
+				}
+			],
+			i
+		) => {
+			const parseClient = (): PageViewClient | undefined => {
+				if (!withUAParser) {
+					return undefined;
+				}
+
+				const userAgent = fromNullable(user_agent);
+
+				if (isNullish(userAgent)) {
+					return undefined;
+				}
+
+				const parser = new UAParser(userAgent);
+				const { browser, os, device } = parser.getResult();
+
+				if (isNullish(browser.name) || isNullish(os.name)) {
+					return undefined;
+				}
+
+				return {
+					browser: browser.name,
+					os: os.name,
+					device: toNullable(device?.type)
+				};
+			};
+
+			return [
+				{
+					...key,
+					collected_at
+				},
+				{
+					...value,
+					user_agent,
+					updated_at: [],
+					version: [],
+					client: toNullable(parseClient()),
+					satellite_id: satelliteIdMock,
+					device: {
+						...device,
+						screen_width: withSizeMock ? [screen_width[i % screen_width.length]] : [],
+						screen_height: []
+					}
+				}
+			];
+		}
+	);
+
+	const it = setPageViewsData.values();
+	const chunks: [AnalyticKey, SetPageView][][] = Array.from(it, (val) => [val, ...it.take(50 - 1)]);
+
+	const { set_page_views } = actor;
+
+	for (const chunk of chunks) {
+		await set_page_views(chunk);
+
+		await tick(pic);
+	}
+};


### PR DESCRIPTION
# Motivation

UTM tags are standardized, at least informally, and widely adopted in marketing, analytics, and ad tracking. That's why, we want to allow developers to gather those information in their Analytics Orbiter to ultimately present the top10 in the UI.
