### PR TITLE
fix: revert memory_size endpoint

### DIFF
--- a/src/declarations/orbiter/orbiter.did.d.ts
+++ b/src/declarations/orbiter/orbiter.did.d.ts
@@ -103,6 +103,10 @@ export interface HttpResponse {
 	upgrade: [] | [boolean];
 	status_code: number;
 }
+export interface MemorySize {
+	stable: bigint;
+	heap: bigint;
+}
 export type NavigationType =
 	| { Navigate: null }
 	| { Restore: null }
@@ -256,6 +260,7 @@ export interface _SERVICE {
 	http_request_update: ActorMethod<[HttpRequest], HttpResponse>;
 	list_controllers: ActorMethod<[], Array<[Principal, Controller]>>;
 	list_satellite_configs: ActorMethod<[], Array<[Principal, OrbiterSatelliteConfig]>>;
+	memory_size: ActorMethod<[], MemorySize>;
 	set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
 	set_page_view: ActorMethod<[AnalyticKey, SetPageView], Result>;
 	set_page_views: ActorMethod<[Array<[AnalyticKey, SetPageView]>], Result_1>;

--- a/src/declarations/orbiter/orbiter.factory.certified.did.js
+++ b/src/declarations/orbiter/orbiter.factory.certified.did.js
@@ -188,6 +188,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -273,6 +274,7 @@ export const idlFactory = ({ IDL }) => {
 			[IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
 			[]
 		),
+		memory_size: IDL.Func([], [MemorySize], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/src/declarations/orbiter/orbiter.factory.did.js
+++ b/src/declarations/orbiter/orbiter.factory.did.js
@@ -188,6 +188,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -289,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 			[IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
 			['query']
 		),
+		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/src/declarations/orbiter/orbiter.factory.did.mjs
+++ b/src/declarations/orbiter/orbiter.factory.did.mjs
@@ -188,6 +188,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -289,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 			[IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
 			['query']
 		),
+		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -143,6 +143,10 @@ export interface ListResults_1 {
 	items_length: bigint;
 }
 export type Memory = { Heap: null } | { Stable: null };
+export interface MemorySize {
+	stable: bigint;
+	heap: bigint;
+}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -274,6 +278,7 @@ export interface _SERVICE {
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_docs: ActorMethod<[string, ListParams], ListResults_1>;
 	list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
+	memory_size: ActorMethod<[], MemorySize>;
 	set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
 	set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
+		memory_size: IDL.Func([], [MemorySize], []),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -208,6 +208,7 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -143,6 +143,10 @@ export interface ListResults_1 {
 	items_length: bigint;
 }
 export type Memory = { Heap: null } | { Stable: null };
+export interface MemorySize {
+	stable: bigint;
+	heap: bigint;
+}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -274,6 +278,7 @@ export interface _SERVICE {
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_docs: ActorMethod<[string, ListParams], ListResults_1>;
 	list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
+	memory_size: ActorMethod<[], MemorySize>;
 	set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
 	set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
+		memory_size: IDL.Func([], [MemorySize], []),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -117,6 +117,7 @@ type ListResults_1 = record {
   items_length : nat64;
 };
 type Memory = variant { Heap; Stable };
+type MemorySize = record { stable : nat64; heap : nat64 };
 type Permission = variant { Controllers; Private; Public; Managed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Rule = record {
@@ -242,6 +243,7 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_docs : (text, ListParams) -> (ListResults_1) query;
   list_rules : (CollectionType) -> (vec record { text; Rule }) query;
+  memory_size : () -> (MemorySize) query;
   set_auth_config : (AuthenticationConfig) -> ();
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -31,7 +31,7 @@ use junobuild_shared::types::core::DomainName;
 use junobuild_shared::types::core::{Blob, Key};
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::interface::{
-    DeleteControllersArgs, DepositCyclesArgs, SetControllersArgs,
+    DeleteControllersArgs, DepositCyclesArgs, MemorySize, SetControllersArgs,
 };
 use junobuild_shared::types::list::ListParams;
 use junobuild_shared::types::list::ListResults;
@@ -379,6 +379,12 @@ pub async fn deposit_cycles(args: DepositCyclesArgs) {
     junobuild_shared::mgmt::ic::deposit_cycles(args)
         .await
         .unwrap_or_else(|e| trap(&e))
+}
+
+#[doc(hidden)]
+#[query(guard = "caller_is_controller")]
+pub fn memory_size() -> MemorySize {
+    junobuild_shared::canister::memory_size()
 }
 
 /// Include the stock Juno satellite features into your Juno application.

--- a/src/orbiter/orbiter.did
+++ b/src/orbiter/orbiter.did
@@ -83,6 +83,7 @@ type HttpResponse = record {
   upgrade : opt bool;
   status_code : nat16;
 };
+type MemorySize = record { stable : nat64; heap : nat64 };
 type NavigationType = variant {
   Navigate;
   Restore;
@@ -243,6 +244,7 @@ service : () -> {
   list_satellite_configs : () -> (
       vec record { principal; OrbiterSatelliteConfig },
     ) query;
+  memory_size : () -> (MemorySize) query;
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },
     );

--- a/src/orbiter/src/api/mgmt.rs
+++ b/src/orbiter/src/api/mgmt.rs
@@ -1,12 +1,18 @@
-use crate::guards::caller_is_admin_controller;
+use crate::guards::{caller_is_admin_controller, caller_is_controller};
 use ic_cdk::trap;
-use ic_cdk_macros::update;
+use ic_cdk_macros::{query, update};
+use junobuild_shared::canister::memory_size as canister_memory_size;
 use junobuild_shared::mgmt::ic::deposit_cycles as deposit_cycles_shared;
-use junobuild_shared::types::interface::DepositCyclesArgs;
+use junobuild_shared::types::interface::{DepositCyclesArgs, MemorySize};
 
 #[update(guard = "caller_is_admin_controller")]
 async fn deposit_cycles(args: DepositCyclesArgs) {
     deposit_cycles_shared(args)
         .await
         .unwrap_or_else(|e| trap(&e))
+}
+
+#[query(guard = "caller_is_controller")]
+fn memory_size() -> MemorySize {
+    canister_memory_size()
 }

--- a/src/orbiter/src/lib.rs
+++ b/src/orbiter/src/lib.rs
@@ -36,7 +36,7 @@ use ic_cdk_macros::export_candid;
 use ic_http_certification::HttpRequest;
 use ic_http_certification::HttpResponse;
 use junobuild_shared::types::interface::{
-    DeleteControllersArgs, DepositCyclesArgs, SetControllersArgs,
+    DeleteControllersArgs, DepositCyclesArgs, MemorySize, SetControllersArgs,
 };
 use junobuild_shared::types::state::{Controllers, SatelliteId};
 

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -119,6 +119,7 @@ type ListResults_1 = record {
   items_length : nat64;
 };
 type Memory = variant { Heap; Stable };
+type MemorySize = record { stable : nat64; heap : nat64 };
 type Permission = variant { Controllers; Private; Public; Managed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Rule = record {
@@ -244,6 +245,7 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_docs : (text, ListParams) -> (ListResults_1) query;
   list_rules : (CollectionType) -> (vec record { text; Rule }) query;
+  memory_size : () -> (MemorySize) query;
   set_auth_config : (AuthenticationConfig) -> ();
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -119,6 +119,7 @@ type ListResults_1 = record {
   items_length : nat64;
 };
 type Memory = variant { Heap; Stable };
+type MemorySize = record { stable : nat64; heap : nat64 };
 type Permission = variant { Controllers; Private; Public; Managed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Rule = record {
@@ -244,6 +245,7 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_docs : (text, ListParams) -> (ListResults_1) query;
   list_rules : (CollectionType) -> (vec record { text; Rule }) query;
+  memory_size : () -> (MemorySize) query;
   set_auth_config : (AuthenticationConfig) -> ();
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -143,6 +143,10 @@ export interface ListResults_1 {
 	items_length: bigint;
 }
 export type Memory = { Heap: null } | { Stable: null };
+export interface MemorySize {
+	stable: bigint;
+	heap: bigint;
+}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -276,6 +280,7 @@ export interface _SERVICE {
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_docs: ActorMethod<[string, ListParams], ListResults_1>;
 	list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
+	memory_size: ActorMethod<[], MemorySize>;
 	set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
 	set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -209,6 +209,7 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -292,6 +293,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
+		memory_size: IDL.Func([], [MemorySize], []),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -209,6 +209,7 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -292,6 +293,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
 		list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+		memory_size: IDL.Func([], [MemorySize], ['query']),
 		set_auth_config: IDL.Func([AuthenticationConfig], [], []),
 		set_controllers: IDL.Func(
 			[SetControllersArgs],

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -119,6 +119,7 @@ type ListResults_1 = record {
   items_length : nat64;
 };
 type Memory = variant { Heap; Stable };
+type MemorySize = record { stable : nat64; heap : nat64 };
 type Permission = variant { Controllers; Private; Public; Managed };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Rule = record {
@@ -244,6 +245,7 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_docs : (text, ListParams) -> (ListResults_1) query;
   list_rules : (CollectionType) -> (vec record { text; Rule }) query;
+  memory_size : () -> (MemorySize) query;
   set_auth_config : (AuthenticationConfig) -> ();
   set_controllers : (SetControllersArgs) -> (
       vec record { principal; Controller },


### PR DESCRIPTION
# Motivation

We check the size of the heap/stable memory in the CLI.
We use the CLI in CI Action in which the controller is READ+WRITE.
IC canister_status is reserved to controllers.
So we need custom endpoints.
