### PR TITLE
feat(cdn): introduce proposal keyword in asset upload functions

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -193,8 +193,8 @@ service : () -> {
   add_credits : (principal, Tokens) -> ();
   add_invitation_code : (text) -> ();
   assert_mission_control_center : (AssertMissionControlCenterArgs) -> () query;
-  commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
+  commit_proposal_asset_upload : (CommitBatch) -> ();
   create_orbiter : (CreateCanisterArgs) -> (principal);
   create_satellite : (CreateCanisterArgs) -> (principal);
   del_controllers : (DeleteControllersArgs) -> ();
@@ -211,8 +211,8 @@ service : () -> {
   http_request_streaming_callback : (StreamingCallbackToken) -> (
       StreamingCallbackHttpResponse,
     ) query;
-  init_asset_upload : (InitAssetKey, nat) -> (InitUploadResult);
   init_proposal : (ProposalType) -> (nat, Proposal);
+  init_proposal_asset_upload : (InitAssetKey, nat) -> (InitUploadResult);
   init_user_mission_control_center : () -> (MissionControl);
   list_assets : (text, ListParams) -> (ListResults) query;
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
@@ -226,5 +226,5 @@ service : () -> {
   set_storage_config : (StorageConfig) -> ();
   submit_proposal : (nat) -> (nat, Proposal);
   update_rate_config : (SegmentKind, RateConfig) -> ();
-  upload_asset_chunk : (UploadChunk) -> (UploadChunkResult);
+  upload_proposal_asset_chunk : (UploadChunk) -> (UploadChunkResult);
 }

--- a/src/console/src/api/storage.rs
+++ b/src/console/src/api/storage.rs
@@ -20,7 +20,7 @@ use junobuild_storage::types::interface::{
 // ---------------------------------------------------------
 
 #[update(guard = "caller_is_admin_controller")]
-fn init_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadResult {
+fn init_proposal_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadResult {
     let caller = caller();
 
     let result = init_asset_upload_store(caller, init, proposal_id);
@@ -32,7 +32,7 @@ fn init_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadR
 }
 
 #[update(guard = "caller_is_admin_controller")]
-fn upload_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
+fn upload_proposal_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
     let caller = caller();
     let config = junobuild_cdn::storage::heap::get_config(&CdnHeap);
 
@@ -45,7 +45,7 @@ fn upload_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
 }
 
 #[update(guard = "caller_is_admin_controller")]
-fn commit_asset_upload(commit: CommitBatch) {
+fn commit_proposal_asset_upload(commit: CommitBatch) {
     let caller = caller();
 
     let controllers: Controllers = get_controllers();

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -228,8 +228,8 @@ export interface _SERVICE {
 	add_credits: ActorMethod<[Principal, Tokens], undefined>;
 	add_invitation_code: ActorMethod<[string], undefined>;
 	assert_mission_control_center: ActorMethod<[AssertMissionControlCenterArgs], undefined>;
-	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
+	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	create_orbiter: ActorMethod<[CreateCanisterArgs], Principal>;
 	create_satellite: ActorMethod<[CreateCanisterArgs], Principal>;
 	del_controllers: ActorMethod<[DeleteControllersArgs], undefined>;
@@ -247,8 +247,8 @@ export interface _SERVICE {
 		[StreamingCallbackToken],
 		StreamingCallbackHttpResponse
 	>;
-	init_asset_upload: ActorMethod<[InitAssetKey, bigint], InitUploadResult>;
 	init_proposal: ActorMethod<[ProposalType], [bigint, Proposal]>;
+	init_proposal_asset_upload: ActorMethod<[InitAssetKey, bigint], InitUploadResult>;
 	init_user_mission_control_center: ActorMethod<[], MissionControl>;
 	list_assets: ActorMethod<[string, ListParams], ListResults>;
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
@@ -260,7 +260,7 @@ export interface _SERVICE {
 	set_storage_config: ActorMethod<[StorageConfig], undefined>;
 	submit_proposal: ActorMethod<[bigint], [bigint, Proposal]>;
 	update_rate_config: ActorMethod<[SegmentKind, RateConfig], undefined>;
-	upload_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
+	upload_proposal_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -5,14 +5,14 @@ export const idlFactory = ({ IDL }) => {
 		mission_control_id: IDL.Principal,
 		user: IDL.Principal
 	});
+	const CommitProposal = IDL.Record({
+		sha256: IDL.Vec(IDL.Nat8),
+		proposal_id: IDL.Nat
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
-	});
-	const CommitProposal = IDL.Record({
-		sha256: IDL.Vec(IDL.Nat8),
-		proposal_id: IDL.Nat
 	});
 	const CreateCanisterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
@@ -238,8 +238,8 @@ export const idlFactory = ({ IDL }) => {
 		add_credits: IDL.Func([IDL.Principal, Tokens], [], []),
 		add_invitation_code: IDL.Func([IDL.Text], [], []),
 		assert_mission_control_center: IDL.Func([AssertMissionControlCenterArgs], [], []),
-		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		create_orbiter: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
 		create_satellite: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
@@ -258,8 +258,8 @@ export const idlFactory = ({ IDL }) => {
 			[StreamingCallbackHttpResponse],
 			[]
 		),
-		init_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_proposal: IDL.Func([ProposalType], [IDL.Nat, Proposal], []),
+		init_proposal_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_user_mission_control_center: IDL.Func([], [MissionControl], []),
 		list_assets: IDL.Func([IDL.Text, ListParams], [ListResults], []),
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
@@ -275,7 +275,7 @@ export const idlFactory = ({ IDL }) => {
 		set_storage_config: IDL.Func([StorageConfig], [], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		update_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
-		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
+		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
 	});
 };
 // @ts-ignore

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -5,14 +5,14 @@ export const idlFactory = ({ IDL }) => {
 		mission_control_id: IDL.Principal,
 		user: IDL.Principal
 	});
+	const CommitProposal = IDL.Record({
+		sha256: IDL.Vec(IDL.Nat8),
+		proposal_id: IDL.Nat
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
-	});
-	const CommitProposal = IDL.Record({
-		sha256: IDL.Vec(IDL.Nat8),
-		proposal_id: IDL.Nat
 	});
 	const CreateCanisterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
@@ -238,8 +238,8 @@ export const idlFactory = ({ IDL }) => {
 		add_credits: IDL.Func([IDL.Principal, Tokens], [], []),
 		add_invitation_code: IDL.Func([IDL.Text], [], []),
 		assert_mission_control_center: IDL.Func([AssertMissionControlCenterArgs], [], ['query']),
-		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		create_orbiter: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
 		create_satellite: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
@@ -258,8 +258,8 @@ export const idlFactory = ({ IDL }) => {
 			[StreamingCallbackHttpResponse],
 			['query']
 		),
-		init_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_proposal: IDL.Func([ProposalType], [IDL.Nat, Proposal], []),
+		init_proposal_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_user_mission_control_center: IDL.Func([], [MissionControl], []),
 		list_assets: IDL.Func([IDL.Text, ListParams], [ListResults], ['query']),
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
@@ -275,7 +275,7 @@ export const idlFactory = ({ IDL }) => {
 		set_storage_config: IDL.Func([StorageConfig], [], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		update_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
-		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
+		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
 	});
 };
 // @ts-ignore

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -5,14 +5,14 @@ export const idlFactory = ({ IDL }) => {
 		mission_control_id: IDL.Principal,
 		user: IDL.Principal
 	});
+	const CommitProposal = IDL.Record({
+		sha256: IDL.Vec(IDL.Nat8),
+		proposal_id: IDL.Nat
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
-	});
-	const CommitProposal = IDL.Record({
-		sha256: IDL.Vec(IDL.Nat8),
-		proposal_id: IDL.Nat
 	});
 	const CreateCanisterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
@@ -238,8 +238,8 @@ export const idlFactory = ({ IDL }) => {
 		add_credits: IDL.Func([IDL.Principal, Tokens], [], []),
 		add_invitation_code: IDL.Func([IDL.Text], [], []),
 		assert_mission_control_center: IDL.Func([AssertMissionControlCenterArgs], [], ['query']),
-		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		create_orbiter: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
 		create_satellite: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
@@ -258,8 +258,8 @@ export const idlFactory = ({ IDL }) => {
 			[StreamingCallbackHttpResponse],
 			['query']
 		),
-		init_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_proposal: IDL.Func([ProposalType], [IDL.Nat, Proposal], []),
+		init_proposal_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_user_mission_control_center: IDL.Func([], [MissionControl], []),
 		list_assets: IDL.Func([IDL.Text, ListParams], [ListResults], ['query']),
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
@@ -275,7 +275,7 @@ export const idlFactory = ({ IDL }) => {
 		set_storage_config: IDL.Func([StorageConfig], [], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		update_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
-		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
+		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
 	});
 };
 // @ts-ignore

--- a/src/declarations/mission_control/mission_control.did.d.ts
+++ b/src/declarations/mission_control/mission_control.did.d.ts
@@ -357,8 +357,8 @@ export interface User {
 export interface _SERVICE {
 	add_mission_control_controllers: ActorMethod<[Array<Principal>], undefined>;
 	add_satellites_controllers: ActorMethod<[Array<Principal>, Array<Principal>], undefined>;
-	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
+	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	create_orbiter: ActorMethod<[[] | [string]], Orbiter>;
 	create_orbiter_with_config: ActorMethod<[CreateCanisterConfig], Orbiter>;
 	create_satellite: ActorMethod<[string], Satellite>;
@@ -390,8 +390,8 @@ export interface _SERVICE {
 	>;
 	icp_transfer: ActorMethod<[TransferArgs], Result>;
 	icrc_transfer: ActorMethod<[Principal, TransferArg], Result_1>;
-	init_asset_upload: ActorMethod<[InitAssetKey, bigint], InitUploadResult>;
 	init_proposal: ActorMethod<[ProposalType], [bigint, Proposal]>;
+	init_proposal_asset_upload: ActorMethod<[InitAssetKey, bigint], InitUploadResult>;
 	list_assets: ActorMethod<[string, ListParams], ListResults>;
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_mission_control_controllers: ActorMethod<[], Array<[Principal, Controller]>>;
@@ -424,7 +424,7 @@ export interface _SERVICE {
 	unset_satellite: ActorMethod<[Principal], undefined>;
 	update_and_start_monitoring: ActorMethod<[MonitoringStartConfig], undefined>;
 	update_and_stop_monitoring: ActorMethod<[MonitoringStopConfig], undefined>;
-	upload_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
+	upload_proposal_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/mission_control/mission_control.factory.certified.did.js
+++ b/src/declarations/mission_control/mission_control.factory.certified.did.js
@@ -1,13 +1,13 @@
 // @ts-ignore
 export const idlFactory = ({ IDL }) => {
+	const CommitProposal = IDL.Record({
+		sha256: IDL.Vec(IDL.Nat8),
+		proposal_id: IDL.Nat
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
-	});
-	const CommitProposal = IDL.Record({
-		sha256: IDL.Vec(IDL.Nat8),
-		proposal_id: IDL.Nat
 	});
 	const CyclesThreshold = IDL.Record({
 		fund_cycles: IDL.Nat,
@@ -359,8 +359,8 @@ export const idlFactory = ({ IDL }) => {
 	return IDL.Service({
 		add_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal)], [], []),
 		add_satellites_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),
-		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		create_orbiter: IDL.Func([IDL.Opt(IDL.Text)], [Orbiter], []),
 		create_orbiter_with_config: IDL.Func([CreateCanisterConfig], [Orbiter], []),
 		create_satellite: IDL.Func([IDL.Text], [Satellite], []),
@@ -394,8 +394,8 @@ export const idlFactory = ({ IDL }) => {
 		),
 		icp_transfer: IDL.Func([TransferArgs], [Result], []),
 		icrc_transfer: IDL.Func([IDL.Principal, TransferArg], [Result_1], []),
-		init_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_proposal: IDL.Func([ProposalType], [IDL.Nat, Proposal], []),
+		init_proposal_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		list_assets: IDL.Func([IDL.Text, ListParams], [ListResults], []),
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_mission_control_controllers: IDL.Func(
@@ -446,7 +446,7 @@ export const idlFactory = ({ IDL }) => {
 		unset_satellite: IDL.Func([IDL.Principal], [], []),
 		update_and_start_monitoring: IDL.Func([MonitoringStartConfig], [], []),
 		update_and_stop_monitoring: IDL.Func([MonitoringStopConfig], [], []),
-		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
+		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
 	});
 };
 // @ts-ignore

--- a/src/declarations/mission_control/mission_control.factory.did.js
+++ b/src/declarations/mission_control/mission_control.factory.did.js
@@ -1,13 +1,13 @@
 // @ts-ignore
 export const idlFactory = ({ IDL }) => {
+	const CommitProposal = IDL.Record({
+		sha256: IDL.Vec(IDL.Nat8),
+		proposal_id: IDL.Nat
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
-	});
-	const CommitProposal = IDL.Record({
-		sha256: IDL.Vec(IDL.Nat8),
-		proposal_id: IDL.Nat
 	});
 	const CyclesThreshold = IDL.Record({
 		fund_cycles: IDL.Nat,
@@ -359,8 +359,8 @@ export const idlFactory = ({ IDL }) => {
 	return IDL.Service({
 		add_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal)], [], []),
 		add_satellites_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),
-		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		create_orbiter: IDL.Func([IDL.Opt(IDL.Text)], [Orbiter], []),
 		create_orbiter_with_config: IDL.Func([CreateCanisterConfig], [Orbiter], []),
 		create_satellite: IDL.Func([IDL.Text], [Satellite], []),
@@ -394,8 +394,8 @@ export const idlFactory = ({ IDL }) => {
 		),
 		icp_transfer: IDL.Func([TransferArgs], [Result], []),
 		icrc_transfer: IDL.Func([IDL.Principal, TransferArg], [Result_1], []),
-		init_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_proposal: IDL.Func([ProposalType], [IDL.Nat, Proposal], []),
+		init_proposal_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		list_assets: IDL.Func([IDL.Text, ListParams], [ListResults], ['query']),
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_mission_control_controllers: IDL.Func(
@@ -446,7 +446,7 @@ export const idlFactory = ({ IDL }) => {
 		unset_satellite: IDL.Func([IDL.Principal], [], []),
 		update_and_start_monitoring: IDL.Func([MonitoringStartConfig], [], []),
 		update_and_stop_monitoring: IDL.Func([MonitoringStopConfig], [], []),
-		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
+		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
 	});
 };
 // @ts-ignore

--- a/src/mission_control/mission_control.did
+++ b/src/mission_control/mission_control.did
@@ -304,8 +304,8 @@ type User = record {
 service : () -> {
   add_mission_control_controllers : (vec principal) -> ();
   add_satellites_controllers : (vec principal, vec principal) -> ();
-  commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
+  commit_proposal_asset_upload : (CommitBatch) -> ();
   create_orbiter : (opt text) -> (Orbiter);
   create_orbiter_with_config : (CreateCanisterConfig) -> (Orbiter);
   create_satellite : (text) -> (Satellite);
@@ -335,8 +335,8 @@ service : () -> {
     ) query;
   icp_transfer : (TransferArgs) -> (Result);
   icrc_transfer : (principal, TransferArg) -> (Result_1);
-  init_asset_upload : (InitAssetKey, nat) -> (InitUploadResult);
   init_proposal : (ProposalType) -> (nat, Proposal);
+  init_proposal_asset_upload : (InitAssetKey, nat) -> (InitUploadResult);
   list_assets : (text, ListParams) -> (ListResults) query;
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_mission_control_controllers : () -> (
@@ -375,5 +375,5 @@ service : () -> {
   unset_satellite : (principal) -> ();
   update_and_start_monitoring : (MonitoringStartConfig) -> ();
   update_and_stop_monitoring : (MonitoringStopConfig) -> ();
-  upload_asset_chunk : (UploadChunk) -> (UploadChunkResult);
+  upload_proposal_asset_chunk : (UploadChunk) -> (UploadChunkResult);
 }

--- a/src/mission_control/src/api/storage.rs
+++ b/src/mission_control/src/api/storage.rs
@@ -21,7 +21,7 @@ use junobuild_storage::types::interface::{
 // ---------------------------------------------------------
 
 #[update(guard = "caller_is_user_or_controller")]
-fn init_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadResult {
+fn init_proposal_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadResult {
     let caller = caller();
 
     let result = init_asset_upload_store(caller, init, proposal_id);
@@ -33,7 +33,7 @@ fn init_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadR
 }
 
 #[update(guard = "caller_is_user_or_controller")]
-fn upload_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
+fn upload_proposal_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
     let caller = caller();
     let config = get_storage_config();
 
@@ -46,7 +46,7 @@ fn upload_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
 }
 
 #[update(guard = "caller_is_user_or_controller")]
-fn commit_asset_upload(commit: CommitBatch) {
+fn commit_proposal_asset_upload(commit: CommitBatch) {
     let caller = caller();
 
     let controllers: Controllers = get_controllers_with_user();

--- a/src/tests/specs/console/console.cdn.spec.ts
+++ b/src/tests/specs/console/console.cdn.spec.ts
@@ -93,7 +93,7 @@ describe('Console > Cdn', () => {
 				'orbiter.txt'
 			])(`Assert upload %s`, (filename) => {
 				it('should throw error if try to upload without version', async () => {
-					const { init_asset_upload, init_proposal } = actor;
+					const { init_proposal_asset_upload, init_proposal } = actor;
 
 					const [proposalId, _] = await init_proposal({
 						AssetsUpgrade: {
@@ -102,7 +102,7 @@ describe('Console > Cdn', () => {
 					});
 
 					await expect(
-						init_asset_upload(
+						init_proposal_asset_upload(
 							{
 								collection: '#releases',
 								description: toNullable(),
@@ -124,9 +124,9 @@ describe('Console > Cdn', () => {
 				http_request,
 				commit_proposal,
 				submit_proposal,
-				commit_asset_upload,
-				upload_asset_chunk,
-				init_asset_upload
+				commit_proposal_asset_upload,
+				upload_proposal_asset_chunk,
+				init_proposal_asset_upload
 			} = actor;
 
 			const [proposalId, __] = await init_proposal({
@@ -136,7 +136,7 @@ describe('Console > Cdn', () => {
 			});
 
 			const upload = async (gzip: boolean) => {
-				const file = await init_asset_upload(
+				const file = await init_proposal_asset_upload(
 					{
 						collection: '#dapp',
 						description: toNullable(),
@@ -152,13 +152,13 @@ describe('Console > Cdn', () => {
 					type: 'text/javascript; charset=utf-8'
 				});
 
-				const chunk = await upload_asset_chunk({
+				const chunk = await upload_proposal_asset_chunk({
 					batch_id: file.batch_id,
 					content: arrayBufferToUint8Array(await blob.arrayBuffer()),
 					order_id: [0n]
 				});
 
-				await commit_asset_upload({
+				await commit_proposal_asset_upload({
 					batch_id: file.batch_id,
 					chunk_ids: [chunk.chunk_id],
 					headers: []

--- a/src/tests/specs/console/console.metadata.spec.ts
+++ b/src/tests/specs/console/console.metadata.spec.ts
@@ -98,7 +98,7 @@ describe('Console > Metadata', () => {
 		});
 
 		it('should throw error if try to upload metadata.json', async () => {
-			const { init_asset_upload, init_proposal } = actor;
+			const { init_proposal_asset_upload, init_proposal } = actor;
 
 			const [proposalId, _] = await init_proposal({
 				AssetsUpgrade: {
@@ -107,7 +107,7 @@ describe('Console > Metadata', () => {
 			});
 
 			await expect(
-				init_asset_upload(
+				init_proposal_asset_upload(
 					{
 						collection: '#releases',
 						description: toNullable(),

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -37,7 +37,7 @@ export const testNotAllowedCdnMethods = ({
 	errorMsgController?: string;
 }) => {
 	it('should throw errors on init asset upload', async () => {
-		const { init_asset_upload } = actor();
+		const { init_proposal_asset_upload } = actor();
 
 		const key: InitAssetKey = {
 			token: toNullable(),
@@ -48,13 +48,13 @@ export const testNotAllowedCdnMethods = ({
 			full_path: '/hello.html'
 		};
 
-		await expect(init_asset_upload(key, 123n)).rejects.toThrow(
+		await expect(init_proposal_asset_upload(key, 123n)).rejects.toThrow(
 			errorMsgController ?? errorMsgAdminController
 		);
 	});
 
 	it('should throw errors on propose assets upgrade', async () => {
-		const { upload_asset_chunk } = actor();
+		const { upload_proposal_asset_chunk } = actor();
 
 		const chunk: UploadChunk = {
 			content: [1, 2, 3],
@@ -62,13 +62,13 @@ export const testNotAllowedCdnMethods = ({
 			order_id: []
 		};
 
-		await expect(upload_asset_chunk(chunk)).rejects.toThrow(
+		await expect(upload_proposal_asset_chunk(chunk)).rejects.toThrow(
 			errorMsgController ?? errorMsgAdminController
 		);
 	});
 
 	it('should throw errors on commit asset upload', async () => {
-		const { commit_asset_upload } = actor();
+		const { commit_proposal_asset_upload } = actor();
 
 		const batch = {
 			batch_id: 123n,
@@ -76,7 +76,7 @@ export const testNotAllowedCdnMethods = ({
 			chunk_ids: [123n]
 		};
 
-		await expect(commit_asset_upload(batch)).rejects.toThrow(
+		await expect(commit_proposal_asset_upload(batch)).rejects.toThrow(
 			errorMsgController ?? errorMsgAdminController
 		);
 	});
@@ -242,12 +242,12 @@ export const testControlledCdnMethods = ({
 			});
 
 			it('should fail at uploading asset for unknown proposal', async () => {
-				const { init_asset_upload } = actor();
+				const { init_proposal_asset_upload } = actor();
 
 				const unknownProposalId = proposalId + 1n;
 
 				await expect(
-					init_asset_upload(
+					init_proposal_asset_upload(
 						{
 							collection,
 							description: toNullable(),
@@ -262,10 +262,14 @@ export const testControlledCdnMethods = ({
 			});
 
 			it('should upload asset', async () => {
-				const { http_request, commit_asset_upload, upload_asset_chunk, init_asset_upload } =
-					actor();
+				const {
+					http_request,
+					commit_proposal_asset_upload,
+					upload_proposal_asset_chunk,
+					init_proposal_asset_upload
+				} = actor();
 
-				const file = await init_asset_upload(
+				const file = await init_proposal_asset_upload(
 					{
 						collection,
 						description: toNullable(),
@@ -277,13 +281,13 @@ export const testControlledCdnMethods = ({
 					proposalId
 				);
 
-				const chunk = await upload_asset_chunk({
+				const chunk = await upload_proposal_asset_chunk({
 					batch_id: file.batch_id,
 					content: arrayBufferToUint8Array(await mockBlob.arrayBuffer()),
 					order_id: [0n]
 				});
 
-				await commit_asset_upload({
+				await commit_proposal_asset_upload({
 					batch_id: file.batch_id,
 					chunk_ids: [chunk.chunk_id],
 					headers: []

--- a/src/tests/utils/cdn-tests.utils.ts
+++ b/src/tests/utils/cdn-tests.utils.ts
@@ -11,9 +11,10 @@ export const uploadFile = async ({
 	actor: Actor<ConsoleActor | MissionControlActor>;
 	proposalId: bigint;
 }) => {
-	const { init_asset_upload, commit_asset_upload, upload_asset_chunk } = actor;
+	const { init_proposal_asset_upload, commit_proposal_asset_upload, upload_proposal_asset_chunk } =
+		actor;
 
-	const file = await init_asset_upload(
+	const file = await init_proposal_asset_upload(
 		{
 			collection: '#dapp',
 			description: toNullable(),
@@ -25,13 +26,13 @@ export const uploadFile = async ({
 		proposalId
 	);
 
-	const chunk = await upload_asset_chunk({
+	const chunk = await upload_proposal_asset_chunk({
 		batch_id: file.batch_id,
 		content: arrayBufferToUint8Array(await mockBlob.arrayBuffer()),
 		order_id: [0n]
 	});
 
-	await commit_asset_upload({
+	await commit_proposal_asset_upload({
 		batch_id: file.batch_id,
 		chunk_ids: [chunk.chunk_id],
 		headers: []

--- a/src/tests/utils/console-tests.utils.ts
+++ b/src/tests/utils/console-tests.utils.ts
@@ -66,7 +66,8 @@ const uploadSegment = async ({
 	actor: Actor<ConsoleActor>;
 	proposalId: bigint;
 }) => {
-	const { init_asset_upload, upload_asset_chunk, commit_asset_upload } = actor;
+	const { init_proposal_asset_upload, upload_proposal_asset_chunk, commit_proposal_asset_upload } =
+		actor;
 
 	const name = `${segment}-v${version}.wasm.gz`;
 	const fullPath = `/releases/${name}`;
@@ -85,7 +86,7 @@ const uploadSegment = async ({
 
 	const data = new Blob([await readFile(wasmPath)]);
 
-	const { batch_id: batchId } = await init_asset_upload(
+	const { batch_id: batchId } = await init_proposal_asset_upload(
 		{
 			collection: '#releases',
 			description: toNullable(),
@@ -136,7 +137,7 @@ const uploadSegment = async ({
 	}
 
 	const uploadChunk = async ({ batchId, chunk, orderId }: UploadChunk) =>
-		upload_asset_chunk({
+		upload_proposal_asset_chunk({
 			batch_id: batchId,
 			content: new Uint8Array(await chunk.arrayBuffer()),
 			order_id: toNullable(orderId)
@@ -156,7 +157,7 @@ const uploadSegment = async ({
 			? [['Content-Type', data.type]]
 			: undefined;
 
-	await commit_asset_upload({
+	await commit_proposal_asset_upload({
 		batch_id: batchId,
 		chunk_ids: chunkIds.map(({ chunk_id }) => chunk_id),
 		headers: [...headers, ...(contentType ?? [])]

--- a/src/tests/utils/custom-domains-tests.utils.ts
+++ b/src/tests/utils/custom-domains-tests.utils.ts
@@ -177,7 +177,7 @@ export const adminCustomDomainsWithProposalTests = ({
 
 	// eslint-disable-next-line vitest/require-top-level-describe
 	it('should throw error if try to upload ic-domains', async () => {
-		const { init_asset_upload, init_proposal } = actor();
+		const { init_proposal_asset_upload, init_proposal } = actor();
 
 		const [proposalId, _] = await init_proposal({
 			AssetsUpgrade: {
@@ -186,7 +186,7 @@ export const adminCustomDomainsWithProposalTests = ({
 		});
 
 		await expect(
-			init_asset_upload(
+			init_proposal_asset_upload(
 				{
 					collection: '#dapp',
 					description: toNullable(),


### PR DESCRIPTION
# Motivation

We ultimately will add the same functions to the Satellite therefore, if we do not rename the assets upload related function that uses proposal, it will clash. That's we insert the notion of proposal in their names, even though that's a breaking change for the Console.
