### PR TITLE
feat(frontend): view transitions

### DIFF
--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -11,3 +11,4 @@
 @use 'global/card';
 @use 'global/theme';
 @use 'global/text';
+@use 'global/transition';

--- a/src/frontend/src/lib/styles/global/transition.scss
+++ b/src/frontend/src/lib/styles/global/transition.scss
@@ -1,0 +1,4 @@
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation-duration: 150ms;
+}

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { onMount, type Snippet } from 'svelte';
 	import { run } from 'svelte/legacy';
 	import { browser } from '$app/environment';
+	import { onNavigate } from '$app/navigation';
 	import Overlays from '$lib/components/core/Overlays.svelte';
 	import Spinner from '$lib/components/ui/Spinner.svelte';
 	import { layoutNavigationTitle } from '$lib/derived/layout-navigation.derived';
@@ -56,6 +57,20 @@
 	$effect(() => {
 		$layoutNavigationTitle;
 		debounceSetNavTitle();
+	});
+
+	// Source: https://svelte.dev/blog/view-transitions
+	onNavigate((navigation) => {
+		if (!document.startViewTransition) {
+			return;
+		}
+
+		return new Promise((resolve) => {
+			document.startViewTransition(async () => {
+				resolve();
+				await navigation.complete;
+			});
+		});
 	});
 </script>
 


### PR DESCRIPTION
- https://svelte.dev/blog/view-transitions
- https://developer.chrome.com/docs/web-platform/view-transitions
- https://developer.mozilla.org/en-US/docs/Web/CSS/::view-transition


PS:

For some reason

```
@view-transition {
  navigation: auto;
}
```

Did not work out and add to use the JS navigation.