### PR TITLE
feat(satellite): collection #_juno

### DIFF
--- a/src/libs/satellite/src/cdn/constants.rs
+++ b/src/libs/satellite/src/cdn/constants.rs
@@ -2,10 +2,10 @@ use junobuild_collections::types::interface::SetRule;
 use junobuild_collections::types::rules::Memory;
 use junobuild_collections::types::rules::Permission::Controllers;
 
-pub const RELEASES_COLLECTION_KEY: &str = "#releases";
+pub const CDN_JUNO_COLLECTION_KEY: &str = "#_juno";
 
-pub const DEFAULT_RELEASES_COLLECTIONS: [(&str, SetRule); 1] = [(
-    RELEASES_COLLECTION_KEY,
+pub const DEFAULT_CDN_JUNO_COLLECTIONS: [(&str, SetRule); 1] = [(
+    CDN_JUNO_COLLECTION_KEY,
     SetRule {
         read: Controllers,
         write: Controllers,

--- a/src/libs/satellite/src/memory/mod.rs
+++ b/src/libs/satellite/src/memory/mod.rs
@@ -2,3 +2,4 @@ pub mod internal;
 pub mod lifecycle;
 mod manager;
 pub mod utils;
+mod upgrade;

--- a/src/libs/satellite/src/memory/upgrade.rs
+++ b/src/libs/satellite/src/memory/upgrade.rs
@@ -1,0 +1,40 @@
+use ic_cdk::api::time;
+use junobuild_collections::types::interface::SetRule;
+use junobuild_collections::types::rules::{Memory, Rule, Rules};
+use crate::cdn::constants::{CDN_JUNO_COLLECTION_KEY, DEFAULT_CDN_JUNO_COLLECTIONS};
+use crate::memory::internal::STATE;
+
+// TODO: One time upgrade - To be removed.
+
+// Adds the new collection reserved for juno. Useful for the CDN to handle releases.
+pub fn init_juno_collection() {
+    STATE.with(|state| {
+        let rules = &mut state.borrow_mut().heap.storage.rules;
+
+        if !rules.contains_key(CDN_JUNO_COLLECTION_KEY) {
+            init_juno_collection_impl(rules);
+        }
+    });
+}
+
+fn init_juno_collection_impl(rules: &mut Rules) {
+    let now = time();
+
+    let cdn_set_rule: SetRule = DEFAULT_CDN_JUNO_COLLECTIONS[0].1.clone();
+
+    let cdn_rule: Rule = Rule {
+        read: cdn_set_rule.read,
+        write: cdn_set_rule.write,
+        memory: Some(cdn_set_rule.memory.unwrap_or(Memory::Heap)),
+        mutable_permissions: Some(cdn_set_rule.mutable_permissions.unwrap_or(false)),
+        max_size: cdn_set_rule.max_size,
+        max_capacity: cdn_set_rule.max_capacity,
+        max_changes_per_user: cdn_set_rule.max_changes_per_user,
+        created_at: now,
+        updated_at: now,
+        version: cdn_set_rule.version,
+        rate_config: cdn_set_rule.rate_config,
+    };
+
+    rules.insert(CDN_JUNO_COLLECTION_KEY.to_string(), cdn_rule);
+}

--- a/src/libs/satellite/src/memory/utils.rs
+++ b/src/libs/satellite/src/memory/utils.rs
@@ -1,11 +1,11 @@
-use crate::cdn::constants::DEFAULT_RELEASES_COLLECTIONS;
+use crate::cdn::constants::DEFAULT_CDN_JUNO_COLLECTIONS;
 use junobuild_collections::constants::assets::DEFAULT_ASSETS_COLLECTIONS;
 use junobuild_storage::types::state::StorageHeapState;
 
-pub fn init_cdn_storage_heap_state() -> StorageHeapState {
+pub fn init_storage_heap_state() -> StorageHeapState {
     let mut collections = Vec::with_capacity(2);
     collections.extend_from_slice(&DEFAULT_ASSETS_COLLECTIONS);
-    collections.extend_from_slice(&DEFAULT_RELEASES_COLLECTIONS);
+    collections.extend_from_slice(&DEFAULT_CDN_JUNO_COLLECTIONS);
 
     StorageHeapState::new_with_storage_collections(collections)
 }

--- a/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
@@ -117,7 +117,13 @@ describe('Satellite > Cdn', () => {
 			currentDate,
 			canisterId: () => canisterId,
 			caller: () => controller,
-			pic: () => pic
+			pic: () => pic,
+			fullPaths: {
+				assetsUpgrade: '/hello.html',
+				segmentsDeployment: '/_juno/releases/satellite-v0.0.18.wasm.gz',
+				assetsCollection: "#dapp",
+				segmentsCollection: "#_juno"
+			}
 		});
 
 		testCdnGetProposal({
@@ -167,7 +173,9 @@ describe('Satellite > Cdn', () => {
 			expected_proposal_id: 5n,
 			fullPaths: {
 				assetsUpgrade: '/world.html',
-				segmentsDeployment: '/releases/my-satellite-v0.1.1.wasm.gz'
+				segmentsDeployment: '/_juno/releases/my-satellite-v0.1.1.wasm.gz',
+				assetsCollection: "#dapp",
+				segmentsCollection: "#_juno"
 			}
 		});
 

--- a/src/tests/specs/satellite/stock/satellite.upgrade.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.upgrade.spec.ts
@@ -786,7 +786,7 @@ describe('Satellite > Upgrade', () => {
 			);
 		});
 
-		it.only('should create collection #_juno', async () => {
+		it('should create collection #_juno', async () => {
 			await upgrade();
 
 			const { get_rule } = actor;

--- a/src/tests/specs/satellite/stock/satellite.upgrade.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.upgrade.spec.ts
@@ -785,5 +785,27 @@ describe('Satellite > Upgrade', () => {
 				new RegExp("Canister has no query method 'version'.", 'i')
 			);
 		});
+
+		it.only('should create collection #_juno', async () => {
+			await upgrade();
+
+			const { get_rule } = actor;
+
+			const result = await get_rule({ Storage: null }, '#_juno');
+
+			const rule = fromNullable(result);
+
+			assertNonNullish(rule);
+
+			const { updated_at, created_at, memory, mutable_permissions, read, write, version } = rule;
+
+			expect(memory).toEqual(toNullable({ Heap: null }));
+			expect(read).toEqual({ Controllers: null });
+			expect(write).toEqual({ Controllers: null });
+			expect(mutable_permissions).toEqual([false]);
+			expect(created_at).toBeGreaterThan(0n);
+			expect(updated_at).toBeGreaterThan(0n);
+			expect(fromNullable(version)).toBeUndefined();
+		});
 	});
 });

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -220,7 +220,7 @@ export const testControlledCdnMethods = ({
 					satellite_version: ['0.0.18']
 				}
 			} as ProposalType,
-			collection: fullPaths.assetsCollection,
+			collection: fullPaths.segmentsCollection,
 			full_path: fullPaths.segmentsDeployment,
 			expected_proposal_id: expected_proposal_id + 1n
 		}

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -188,7 +188,9 @@ export const testControlledCdnMethods = ({
 	expected_proposal_id = 1n,
 	fullPaths = {
 		assetsUpgrade: '/hello.html',
-		segmentsDeployment: '/releases/satellite-v0.0.18.wasm.gz'
+		segmentsDeployment: '/releases/satellite-v0.0.18.wasm.gz',
+		assetsCollection: '#dapp',
+		segmentsCollection: "#releases"
 	}
 }: {
 	actor: (params?: { requireController: boolean }) => Actor<SatelliteActor | ConsoleActor>;
@@ -197,7 +199,7 @@ export const testControlledCdnMethods = ({
 	canisterId: () => Principal;
 	currentDate: Date;
 	expected_proposal_id?: bigint;
-	fullPaths?: { assetsUpgrade: string; segmentsDeployment: string };
+	fullPaths?: { assetsUpgrade: string; segmentsDeployment: string; assetsCollection: string; segmentsCollection: string };
 }) => {
 	describe.each([
 		{
@@ -206,7 +208,7 @@ export const testControlledCdnMethods = ({
 					clear_existing_assets: toNullable()
 				}
 			} as ProposalType,
-			collection: '#dapp',
+			collection: fullPaths.assetsCollection,
 			full_path: fullPaths.assetsUpgrade,
 			expected_proposal_id
 		},
@@ -218,7 +220,7 @@ export const testControlledCdnMethods = ({
 					satellite_version: ['0.0.18']
 				}
 			} as ProposalType,
-			collection: '#releases',
+			collection: fullPaths.assetsCollection,
 			full_path: fullPaths.segmentsDeployment,
 			expected_proposal_id: expected_proposal_id + 1n
 		}


### PR DESCRIPTION
# Motivation

We want use a reserved pathname `/_juno` in satellite to upload WASM / releases for serverless functions.
