### PR TITLE
feat: assert full_path matches cdn collection

### DIFF
--- a/src/console/src/cdn/assert.rs
+++ b/src/console/src/cdn/assert.rs
@@ -1,0 +1,18 @@
+use crate::cdn::constants::{RELEASES_COLLECTION_KEY, RELEASES_COLLECTION_PATH};
+use junobuild_cdn::storage::errors::JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION;
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_storage::types::state::FullPath;
+
+pub fn assert_cdn_asset_keys(
+    full_path: &FullPath,
+    collection: &CollectionKey,
+) -> Result<(), String> {
+    if full_path.starts_with(RELEASES_COLLECTION_PATH) && collection != RELEASES_COLLECTION_KEY {
+        return Err(format!(
+            "{} ({} - {})",
+            JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, full_path, collection
+        ));
+    }
+
+    Ok(())
+}

--- a/src/console/src/cdn/constants.rs
+++ b/src/console/src/cdn/constants.rs
@@ -4,6 +4,8 @@ use junobuild_collections::types::rules::Permission::Controllers;
 
 pub const RELEASES_COLLECTION_KEY: &str = "#releases";
 
+pub const RELEASES_COLLECTION_PATH: &str = "/releases/";
+
 pub const DEFAULT_RELEASES_COLLECTIONS: [(&str, SetRule); 1] = [(
     RELEASES_COLLECTION_KEY,
     SetRule {

--- a/src/console/src/cdn/helpers/store.rs
+++ b/src/console/src/cdn/helpers/store.rs
@@ -1,6 +1,6 @@
 use crate::cdn::helpers::heap::get_config;
 use crate::cdn::helpers::stable::get_proposal;
-use crate::cdn::strategies_impls::storage::StorageState;
+use crate::cdn::strategies_impls::storage::{StorageAssertions, StorageState};
 use crate::store::heap::get_controllers;
 use candid::Principal;
 use junobuild_cdn::proposals::ProposalId;
@@ -26,6 +26,7 @@ pub fn init_asset_upload(
         ));
     }
 
+    // TODO: move to strategy assertion
     assert_releases_keys(&init)?;
 
     let controllers = get_controllers();
@@ -37,6 +38,7 @@ pub fn init_asset_upload(
         &config,
         init,
         Some(proposal_id),
+        &StorageAssertions,
         &StorageState,
     )
 }

--- a/src/console/src/cdn/mod.rs
+++ b/src/console/src/cdn/mod.rs
@@ -1,3 +1,4 @@
+mod assert;
 pub mod certified_assets;
 pub mod constants;
 pub mod helpers;

--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -1,3 +1,4 @@
+use crate::cdn::assert::assert_cdn_asset_keys;
 use crate::cdn::helpers::heap::{
     delete_asset, get_asset, get_config, get_domains, get_rule, insert_asset,
 };
@@ -28,6 +29,10 @@ use junobuild_storage::utils::clone_asset_encoding_content_chunks;
 pub struct StorageAssertions;
 
 impl StorageAssertionsStrategy for StorageAssertions {
+    fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
+        assert_cdn_asset_keys(full_path, collection)
+    }
+
     fn invoke_assert_upload_asset(
         &self,
         _caller: &Principal,

--- a/src/libs/cdn/src/storage/errors.rs
+++ b/src/libs/cdn/src/storage/errors.rs
@@ -12,3 +12,7 @@ pub const JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND: &str =
 // {} does not match the required pattern.
 pub const JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH: &str =
     "juno.cdn.storage.error.invalid_releases_path";
+
+// An asset is uploaded with the CDN prefix but using the #dapp collection
+pub const JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION: &str =
+    "juno.cdn.storage.error.invalid_collection";

--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -1,0 +1,20 @@
+use crate::cdn::constants::{CDN_JUNO_COLLECTION_KEY, CDN_JUNO_COLLECTION_PATH};
+use junobuild_cdn::storage::errors::JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION;
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_storage::types::state::FullPath;
+
+// TODO: storage module uses cdn because of this reference. Refactor modules.
+
+pub fn assert_cdn_asset_keys(
+    full_path: &FullPath,
+    collection: &CollectionKey,
+) -> Result<(), String> {
+    if full_path.starts_with(CDN_JUNO_COLLECTION_PATH) && collection != CDN_JUNO_COLLECTION_KEY {
+        return Err(format!(
+            "{} ({} - {})",
+            JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, full_path, collection
+        ));
+    }
+
+    Ok(())
+}

--- a/src/libs/satellite/src/cdn/constants.rs
+++ b/src/libs/satellite/src/cdn/constants.rs
@@ -4,6 +4,8 @@ use junobuild_collections::types::rules::Permission::Controllers;
 
 pub const CDN_JUNO_COLLECTION_KEY: &str = "#_juno";
 
+pub const CDN_JUNO_COLLECTION_PATH: &str = "/_juno/";
+
 pub const DEFAULT_CDN_JUNO_COLLECTIONS: [(&str, SetRule); 1] = [(
     CDN_JUNO_COLLECTION_KEY,
     SetRule {

--- a/src/libs/satellite/src/cdn/helpers/store.rs
+++ b/src/libs/satellite/src/cdn/helpers/store.rs
@@ -1,6 +1,6 @@
 use crate::cdn::constants::CDN_JUNO_COLLECTION_KEY;
 use crate::cdn::helpers::stable::get_proposal;
-use crate::cdn::strategies_impls::storage::CdnStorageState;
+use crate::cdn::strategies_impls::storage::{CdnStorageAssertions, CdnStorageState};
 use crate::get_controllers;
 use crate::storage::store::get_config_store;
 use candid::Principal;
@@ -25,6 +25,9 @@ pub fn init_asset_upload(
         )
     })?;
 
+    // TODO: hook
+
+    // TODO: move to strategy assertion
     assert_releases_keys(&proposal, &init)?;
 
     let controllers = get_controllers();
@@ -36,6 +39,7 @@ pub fn init_asset_upload(
         &config,
         init,
         Some(proposal_id),
+        &CdnStorageAssertions,
         &CdnStorageState,
     )
 }

--- a/src/libs/satellite/src/cdn/mod.rs
+++ b/src/libs/satellite/src/cdn/mod.rs
@@ -1,3 +1,4 @@
+pub mod assert;
 pub mod constants;
 pub mod helpers;
 pub mod strategies_impls;

--- a/src/libs/satellite/src/cdn/strategies_impls/storage.rs
+++ b/src/libs/satellite/src/cdn/strategies_impls/storage.rs
@@ -1,3 +1,4 @@
+use crate::cdn::assert::assert_cdn_asset_keys;
 use crate::cdn::strategies_impls::cdn::{CdnHeap, CdnStable};
 use crate::storage::store::get_config_store;
 use candid::Principal;
@@ -23,6 +24,10 @@ use junobuild_storage::utils::clone_asset_encoding_content_chunks;
 pub struct CdnStorageAssertions;
 
 impl StorageAssertionsStrategy for CdnStorageAssertions {
+    fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
+        assert_cdn_asset_keys(full_path, collection)
+    }
+
     fn invoke_assert_upload_asset(
         &self,
         _caller: &Principal,

--- a/src/libs/satellite/src/storage/store.rs
+++ b/src/libs/satellite/src/storage/store.rs
@@ -575,7 +575,15 @@ fn secure_create_batch_impl(
 
     assert_create_batch(caller, controllers, &rule)?;
 
-    create_batch(caller, controllers, config, init, None, &StorageState)
+    create_batch(
+        caller,
+        controllers,
+        config,
+        init,
+        None,
+        &StorageAssertions,
+        &StorageState,
+    )
 }
 
 // ---------------------------------------------------------

--- a/src/libs/satellite/src/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/storage/strategy_impls.rs
@@ -1,3 +1,4 @@
+use crate::cdn::assert::assert_cdn_asset_keys;
 use crate::hooks::storage::invoke_assert_upload_asset;
 use crate::storage::state::{
     delete_asset, get_asset, get_config, get_domains, get_rule, insert_asset, insert_asset_encoding,
@@ -22,6 +23,10 @@ use junobuild_storage::types::store::{
 pub struct StorageAssertions;
 
 impl StorageAssertionsStrategy for StorageAssertions {
+    fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
+        assert_cdn_asset_keys(full_path, collection)
+    }
+
     fn invoke_assert_upload_asset(
         &self,
         caller: &Principal,

--- a/src/libs/storage/src/store.rs
+++ b/src/libs/storage/src/store.rs
@@ -39,9 +39,17 @@ pub fn create_batch(
     config: &StorageConfig,
     init: InitAssetKey,
     reference_id: Option<ReferenceId>,
+    assertions: &impl StorageAssertionsStrategy,
     storage_state: &impl StorageStateStrategy,
 ) -> Result<BatchId, String> {
-    assert_create_batch(caller, controllers, config, &init, storage_state)?;
+    assert_create_batch(
+        caller,
+        controllers,
+        config,
+        &init,
+        assertions,
+        storage_state,
+    )?;
 
     // Assert supported encoding type
     get_encoding_type(&init.encoding_type)?;
@@ -176,7 +184,7 @@ fn secure_commit_chunks(
     storage_state: &impl StorageStateStrategy,
     storage_upload: &impl StorageUploadStrategy,
 ) -> Result<Asset, String> {
-    let rule = assert_commit_batch(caller, controllers, batch, storage_state)?;
+    let rule = assert_commit_batch(caller, controllers, batch, assertions, storage_state)?;
 
     let current = storage_upload.get_asset(
         &batch.reference_id,

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -11,6 +11,8 @@ use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
 
 pub trait StorageAssertionsStrategy {
+    fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String>;
+
     fn invoke_assert_upload_asset(
         &self,
         caller: &Principal,

--- a/src/tests/specs/satellite/stock/satellite.storage.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.storage.spec.ts
@@ -14,6 +14,7 @@ import { type Actor, PocketIc } from '@hadronous/pic';
 import {
 	JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER,
 	JUNO_AUTH_ERROR_NOT_CONTROLLER,
+	JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION,
 	JUNO_COLLECTIONS_ERROR_COLLECTION_NOT_EMPTY,
 	JUNO_COLLECTIONS_ERROR_COLLECTION_NOT_FOUND,
 	JUNO_ERROR_MEMORY_HEAP_EXCEEDED,
@@ -276,6 +277,25 @@ describe('Satellite > Storage', () => {
 				});
 			}
 		);
+
+		describe('Cdn', () => {
+			it(`should throw errors on upload to _juno`, async () => {
+				const { init_asset_upload } = actor;
+
+				await expect(
+					init_asset_upload({
+						collection: '#dapp',
+						description: toNullable(),
+						encoding_type: [],
+						full_path: '/_juno/something.txt',
+						name: 'something.txt',
+						token: toNullable()
+					})
+				).rejects.toThrow(
+					`${JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION} (/_juno/something.txt - #dapp)`
+				);
+			});
+		});
 
 		describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 			'With collection',


### PR DESCRIPTION
# Motivation

We want to prevent assets to be uploaded under path `/_juno` using the collection `#dapp`.
