### PR TITLE
refactor(console): move asset keys assertion to strategy

### DIFF
--- a/src/console/src/cdn/assert.rs
+++ b/src/console/src/cdn/assert.rs
@@ -1,17 +1,51 @@
 use crate::cdn::constants::{RELEASES_COLLECTION_KEY, RELEASES_COLLECTION_PATH};
-use junobuild_cdn::storage::errors::JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION;
+use junobuild_cdn::storage::errors::{
+    JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH,
+};
 use junobuild_collections::types::core::CollectionKey;
+use junobuild_shared::regex::build_regex;
 use junobuild_storage::types::state::FullPath;
 
 pub fn assert_cdn_asset_keys(
     full_path: &FullPath,
     collection: &CollectionKey,
 ) -> Result<(), String> {
-    if full_path.starts_with(RELEASES_COLLECTION_PATH) && collection != RELEASES_COLLECTION_KEY {
-        return Err(format!(
-            "{} ({} - {})",
-            JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, full_path, collection
-        ));
+    match collection {
+        RELEASES_COLLECTION_KEY => assert_releases_keys(full_path),
+        _ => {
+            if full_path.starts_with(RELEASES_COLLECTION_PATH) {
+                return Err(format!(
+                    "{} ({} - {})",
+                    JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, full_path, collection
+                ));
+            }
+
+            Ok(())
+        }
+    }
+}
+
+fn assert_releases_keys(full_path: &FullPath) -> Result<(), String> {
+    if full_path == "/releases/metadata.json" {
+        return Err(format!("{} is a reserved asset.", full_path).to_string());
+    }
+
+    if full_path.starts_with("/releases/satellite")
+        || full_path.starts_with("/releases/mission_control")
+        || full_path.starts_with("/releases/orbiter")
+    {
+        let re = build_regex(
+            r"^/releases/(satellite|mission_control|orbiter)-v\d+\.\d+\.\d+\.wasm\.gz$",
+        )?;
+
+        return if re.is_match(full_path) {
+            Ok(())
+        } else {
+            Err(format!(
+                "{} ({})",
+                JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, full_path
+            ))
+        };
     }
 
     Ok(())

--- a/src/console/src/cdn/assert.rs
+++ b/src/console/src/cdn/assert.rs
@@ -10,7 +10,7 @@ pub fn assert_cdn_asset_keys(
     full_path: &FullPath,
     collection: &CollectionKey,
 ) -> Result<(), String> {
-    match collection {
+    match collection.as_str() {
         RELEASES_COLLECTION_KEY => assert_releases_keys(full_path),
         _ => {
             if full_path.starts_with(RELEASES_COLLECTION_PATH) {

--- a/src/console/src/cdn/assert.rs
+++ b/src/console/src/cdn/assert.rs
@@ -4,6 +4,7 @@ use junobuild_cdn::storage::errors::{
 };
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_shared::regex::build_regex;
+use junobuild_storage::errors::JUNO_STORAGE_ERROR_RESERVED_ASSET;
 use junobuild_storage::types::state::FullPath;
 
 pub fn assert_cdn_asset_keys(
@@ -29,7 +30,7 @@ fn assert_releases_keys(full_path: &FullPath) -> Result<(), String> {
     if full_path == "/releases/metadata.json" {
         return Err(format!(
             "{} ({})",
-            JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, full_path
+            JUNO_STORAGE_ERROR_RESERVED_ASSET, full_path
         ));
     }
 

--- a/src/console/src/cdn/helpers/store.rs
+++ b/src/console/src/cdn/helpers/store.rs
@@ -4,10 +4,7 @@ use crate::cdn::strategies_impls::storage::{StorageAssertions, StorageState};
 use crate::store::heap::get_controllers;
 use candid::Principal;
 use junobuild_cdn::proposals::ProposalId;
-use junobuild_cdn::storage::errors::{
-    JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND,
-};
-use junobuild_shared::regex::build_regex;
+use junobuild_cdn::storage::errors::JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND;
 use junobuild_storage::store::create_batch;
 use junobuild_storage::types::interface::InitAssetKey;
 use junobuild_storage::types::runtime_state::BatchId;
@@ -26,9 +23,6 @@ pub fn init_asset_upload(
         ));
     }
 
-    // TODO: move to strategy assertion
-    assert_releases_keys(&init)?;
-
     let controllers = get_controllers();
     let config = get_config();
 
@@ -41,30 +35,4 @@ pub fn init_asset_upload(
         &StorageAssertions,
         &StorageState,
     )
-}
-
-fn assert_releases_keys(InitAssetKey { full_path, .. }: &InitAssetKey) -> Result<(), String> {
-    if full_path == "/releases/metadata.json" {
-        return Err(format!("{} is a reserved asset.", full_path).to_string());
-    }
-
-    if full_path.starts_with("/releases/satellite")
-        || full_path.starts_with("/releases/mission_control")
-        || full_path.starts_with("/releases/orbiter")
-    {
-        let re = build_regex(
-            r"^/releases/(satellite|mission_control|orbiter)-v\d+\.\d+\.\d+\.wasm\.gz$",
-        )?;
-
-        return if re.is_match(full_path) {
-            Ok(())
-        } else {
-            Err(format!(
-                "{} ({})",
-                JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, full_path
-            ))
-        };
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
# Motivation

There is a now a strategy function to assert keys on upload asset.
