### PR TITLE
refactor(satellite): move asset keys assertion

### DIFF
--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -12,7 +12,7 @@ pub fn assert_cdn_asset_keys(
     full_path: &FullPath,
     collection: &CollectionKey,
 ) -> Result<(), String> {
-    match collection {
+    match collection.as_str() {
         CDN_JUNO_COLLECTION_KEY => assert_releases_keys(full_path),
         _ => {
             if full_path.starts_with(CDN_JUNO_COLLECTION_PATH) {

--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -1,6 +1,9 @@
 use crate::cdn::constants::{CDN_JUNO_COLLECTION_KEY, CDN_JUNO_COLLECTION_PATH};
-use junobuild_cdn::storage::errors::JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION;
+use junobuild_cdn::storage::errors::{
+    JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH,
+};
 use junobuild_collections::types::core::CollectionKey;
+use junobuild_shared::regex::build_regex;
 use junobuild_storage::types::state::FullPath;
 
 // TODO: storage module uses cdn because of this reference. Refactor modules.
@@ -9,10 +12,28 @@ pub fn assert_cdn_asset_keys(
     full_path: &FullPath,
     collection: &CollectionKey,
 ) -> Result<(), String> {
-    if full_path.starts_with(CDN_JUNO_COLLECTION_PATH) && collection != CDN_JUNO_COLLECTION_KEY {
+    match collection {
+        CDN_JUNO_COLLECTION_KEY => assert_releases_keys(full_path),
+        _ => {
+            if full_path.starts_with(CDN_JUNO_COLLECTION_PATH) {
+                return Err(format!(
+                    "{} ({} - {})",
+                    JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, full_path, collection
+                ));
+            }
+
+            Ok(())
+        }
+    }
+}
+
+fn assert_releases_keys(full_path: &FullPath) -> Result<(), String> {
+    let re = build_regex(r"^/_juno/releases/satellite[^/]*\.wasm\.gz$")?;
+
+    if !re.is_match(full_path) {
         return Err(format!(
-            "{} ({} - {})",
-            JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, full_path, collection
+            "{} ({})",
+            JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, full_path
         ));
     }
 

--- a/src/libs/satellite/src/cdn/helpers/store.rs
+++ b/src/libs/satellite/src/cdn/helpers/store.rs
@@ -1,14 +1,10 @@
-use crate::cdn::constants::CDN_JUNO_COLLECTION_KEY;
 use crate::cdn::helpers::stable::get_proposal;
 use crate::cdn::strategies_impls::storage::{CdnStorageAssertions, CdnStorageState};
 use crate::get_controllers;
 use crate::storage::store::get_config_store;
 use candid::Principal;
-use junobuild_cdn::proposals::{Proposal, ProposalId, ProposalType};
-use junobuild_cdn::storage::errors::{
-    JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND,
-};
-use junobuild_shared::regex::build_regex;
+use junobuild_cdn::proposals::ProposalId;
+use junobuild_cdn::storage::errors::JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND;
 use junobuild_storage::store::create_batch;
 use junobuild_storage::types::interface::InitAssetKey;
 use junobuild_storage::types::runtime_state::BatchId;
@@ -27,9 +23,6 @@ pub fn init_asset_upload(
 
     // TODO: hook
 
-    // TODO: move to strategy assertion
-    assert_releases_keys(&proposal, &init)?;
-
     let controllers = get_controllers();
     let config = get_config_store();
 
@@ -42,44 +35,4 @@ pub fn init_asset_upload(
         &CdnStorageAssertions,
         &CdnStorageState,
     )
-}
-
-fn assert_releases_keys(
-    proposal: &Proposal,
-    InitAssetKey {
-        full_path,
-        collection,
-        ..
-    }: &InitAssetKey,
-) -> Result<(), String> {
-    // match &proposal.proposal_type {
-    //     ProposalType::AssetsUpgrade(ref _options) => (),
-    //     ProposalType::SegmentsDeployment(_) => {
-    //         let re = Regex::new(r"^/_juno/releases/satellite[^/]*\.wasm\.gz$")
-    //             .map_err(|e| format!("Invalid regex: {}", e))?;
-    //
-    //         if !re.is_match(full_path) {
-    //             return Err(format!(
-    //                 "{} ({})",
-    //                 JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, full_path
-    //             ));
-    //         }
-    //     }
-    // }
-
-    // TODO: Releases only through releases - also upload asset
-    if collection != CDN_JUNO_COLLECTION_KEY {
-        return Ok(());
-    }
-
-    let re = build_regex(r"^/_juno/releases/satellite[^/]*\.wasm\.gz$")?;
-
-    if !re.is_match(full_path) {
-        return Err(format!(
-            "{} ({})",
-            JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, full_path
-        ));
-    }
-
-    Ok(())
 }

--- a/src/libs/satellite/src/cdn/helpers/store.rs
+++ b/src/libs/satellite/src/cdn/helpers/store.rs
@@ -14,12 +14,14 @@ pub fn init_asset_upload(
     init: InitAssetKey,
     proposal_id: ProposalId,
 ) -> Result<BatchId, String> {
-    let proposal = get_proposal(&proposal_id).ok_or_else(|| {
-        format!(
+    let proposal = get_proposal(&proposal_id);
+
+    if proposal.is_none() {
+        return Err(format!(
             "{} ({})",
             JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND, proposal_id
-        )
-    })?;
+        ));
+    }
 
     // TODO: hook
 


### PR DESCRIPTION
# Motivation

There is now a strategy on which to hook to assert full path and collection on upload.
