### PR TITLE
feat(satellite): skip storage hook for /_juno/ collection

### DIFF
--- a/src/libs/satellite/src/cdn/helpers/store.rs
+++ b/src/libs/satellite/src/cdn/helpers/store.rs
@@ -25,8 +25,6 @@ pub fn init_asset_upload(
         )
     })?;
 
-    // TODO: hook
-
     // TODO: move to strategy assertion
     assert_releases_keys(&proposal, &init)?;
 


### PR DESCRIPTION
# Motivation

We don't want to trigger a hook when an asset is uploaded to the /_juno/ path - i.e. on serverless functions cdn upload.
