### PR TITLE
feat(satellite): prevent headers overwrite and precedence

### DIFF
--- a/src/libs/storage/src/certification/tree_utils.rs
+++ b/src/libs/storage/src/certification/tree_utils.rs
@@ -104,11 +104,16 @@ fn response_hash(headers: &[HeaderField], status_code: StatusCode, body_hash: &H
 }
 
 pub fn response_headers_expression(headers: &[HeaderField]) -> String {
-    let headers = headers
+    let mut header_names: Vec<String> = headers
         .iter()
-        .map(|field: &HeaderField| format!("\"{}\"", field.0))
-        .collect::<Vec<_>>()
-        .join(",");
+        .map(|field| format!("\"{}\"", field.0))
+        .collect();
+
+    // We sort for testing purposes so we can assert the exact certification expression
+    // without needing to manipulate or extract parts of it. This allows us to compare the entire block directly.
+    header_names.sort();
+
+    let headers = header_names.join(",");
 
     IC_CERTIFICATE_EXPRESSION.replace("{headers}", &headers)
 }

--- a/src/libs/storage/src/http/headers.rs
+++ b/src/libs/storage/src/http/headers.rs
@@ -4,6 +4,7 @@ use crate::types::config::{StorageConfig, StorageConfigIFrame};
 use crate::types::store::{Asset, AssetEncoding, EncodingType};
 use crate::url::matching_urls;
 use hex::encode;
+use std::collections::HashMap;
 
 pub fn build_headers(
     asset: &Asset,
@@ -11,39 +12,43 @@ pub fn build_headers(
     encoding_type: &EncodingType,
     config: &StorageConfig,
 ) -> Vec<HeaderField> {
-    let mut headers = asset.headers.clone();
+    let mut headers: HashMap<String, String> = asset
+        .headers
+        .iter()
+        .map(|HeaderField(key, value)| (key.to_lowercase(), value.clone()))
+        .collect();
 
     // The Accept-Ranges HTTP response header is a marker used by the server to advertise its support for partial requests from the client for file downloads.
-    headers.push(HeaderField(
-        "accept-ranges".to_string(),
-        "bytes".to_string(),
-    ));
+    headers.insert("accept-ranges".to_string(), "bytes".to_string());
 
-    headers.push(HeaderField(
+    headers.insert(
         "etag".to_string(),
         format!("\"{}\"", encode(encoding.sha256)),
-    ));
+    );
 
     // Headers for security
-    headers.extend(security_headers());
+    for HeaderField(key, value) in security_headers() {
+        headers.insert(key.to_lowercase(), value);
+    }
 
     // iFrame with default to DENY for security reason
-    if let Some(iframe_header) = iframe_headers(&config.unwrap_iframe()) {
-        headers.push(iframe_header);
+    if let Some(HeaderField(key, value)) = iframe_headers(&config.unwrap_iframe()) {
+        headers.insert(key.to_lowercase(), value);
     }
 
     if encoding_type.clone() != *ASSET_ENCODING_NO_COMPRESSION {
-        headers.push(HeaderField(
-            "Content-Encoding".to_string(),
-            encoding_type.to_string(),
-        ));
+        headers.insert("content-encoding".to_string(), encoding_type.to_string());
     }
 
     // Headers build from the configuration
-    let config_headers = build_config_headers(&asset.key.full_path, config);
-    headers.extend(config_headers);
+    for HeaderField(key, value) in build_config_headers(&asset.key.full_path, config) {
+        headers.insert(key.to_lowercase(), value);
+    }
 
     headers
+        .into_iter()
+        .map(|(key, value)| HeaderField(key, value))
+        .collect()
 }
 
 pub fn build_redirect_headers(location: &str, iframe: &StorageConfigIFrame) -> Vec<HeaderField> {

--- a/src/tests/specs/satellite/stock/satellite.datastore.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.datastore.spec.ts
@@ -789,7 +789,7 @@ describe.each([{ memory: { Heap: null } }, { memory: { Stable: null } }])(
 			describe.each([
 				{
 					memory: { Heap: null },
-					expectMemory: 3_932_160n
+					expectMemory: 3_997_696n
 				},
 				{
 					memory: { Stable: null },

--- a/src/tests/specs/satellite/stock/satellite.storage.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.storage.spec.ts
@@ -1177,7 +1177,7 @@ describe('Satellite > Storage', () => {
 		describe.each([
 			{
 				memory: { Heap: null },
-				expectMemory: 3_997_696n,
+				expectMemory: 4_063_232n,
 				allowedMemory: maxHeapMemorySize,
 				preUploadCount: 13
 			},

--- a/src/tests/specs/satellite/stock/satellite.storage.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.storage.spec.ts
@@ -1377,8 +1377,7 @@ describe('Satellite > Storage', () => {
 						['x-content-type-options', 'test'],
 						['strict-transport-security', 'test'],
 						['referrer-policy', 'test'],
-						['x-frame-options', 'test'],
-						['cache-control', 'no-cache']
+						['x-frame-options', 'test']
 					];
 
 					await upload({ full_path, name, collection, headers: customHeaders });
@@ -1400,6 +1399,34 @@ describe('Satellite > Storage', () => {
 					assertHeaders({
 						headers
 					});
+				});
+
+				it('should user asset headers over configs', async () => {
+					const { http_request } = actor;
+
+					const name = 'hello-665544.html';
+					const full_path = `/${collection}/${name}`;
+
+					const customCacheControl = 'public, max-age=3600';
+
+					const customHeaders: [string, string][] = [['cache-control', customCacheControl]];
+
+					await upload({ full_path, name, collection, headers: customHeaders });
+
+					const request: HttpRequest = {
+						body: [],
+						certificate_version: toNullable(2),
+						headers: [],
+						method: 'GET',
+						url: full_path
+					};
+
+					const response = await http_request(request);
+
+					const { headers } = response;
+
+					const cacheControlHeaderDev = headers.find(([key, _]) => key === 'cache-control');
+					expect(cacheControlHeaderDev?.[1]).toEqual(customCacheControl);
 				});
 			}
 		);

--- a/src/tests/specs/satellite/stock/satellite.storage.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.storage.spec.ts
@@ -32,6 +32,7 @@ import { createUser as createUserUtils } from '../../../utils/satellite-doc-test
 import { uploadAsset } from '../../../utils/satellite-storage-tests.utils';
 import { deleteDefaultIndexHTML } from '../../../utils/satellite-tests.utils';
 import { controllersInitArgs, SATELLITE_WASM_PATH } from '../../../utils/setup-tests.utils';
+import { assertHeaders } from '../../../utils/storage-tests.utils';
 
 describe('Satellite > Storage', () => {
 	let pic: PocketIc;
@@ -173,7 +174,7 @@ describe('Satellite > Storage', () => {
 			const { set_storage_config, get_config } = actor;
 
 			const storage: StorageConfig = {
-				headers: [['*', [['Cache-Control', 'no-cache']]]],
+				headers: [['*', [['cache-control', 'no-cache']]]],
 				iframe: toNullable({ Deny: null }),
 				redirects: [],
 				rewrites: [],
@@ -228,23 +229,9 @@ describe('Satellite > Storage', () => {
 
 			const { headers, body } = response;
 
-			const rest = headers.filter(([header, _]) => header !== 'IC-Certificate');
-
-			/* eslint-disable no-useless-escape */
-			expect(rest).toEqual([
-				['accept-ranges', 'bytes'],
-				['etag', '"03ee66f1452916b4f91a504c1e9babfa201b6d64c26a82b2cf03c3ed49d91585"'],
-				['X-Content-Type-Options', 'nosniff'],
-				['Strict-Transport-Security', 'max-age=31536000 ; includeSubDomains'],
-				['Referrer-Policy', 'same-origin'],
-				['X-Frame-Options', 'DENY'],
-				['Cache-Control', 'no-cache'],
-				[
-					'IC-CertificateExpression',
-					'default_certification(ValidationArgs{certification:Certification{no_request_certification:Empty{},response_certification:ResponseCertification{certified_response_headers:ResponseHeaderList{headers:[\"accept-ranges\",\"etag\",\"X-Content-Type-Options\",\"Strict-Transport-Security\",\"Referrer-Policy\",\"X-Frame-Options\",\"Cache-Control\"]}}}})'
-				]
-			]);
-			/* eslint-enable no-useless-escape */
+			assertHeaders({
+				headers
+			});
 
 			await assertCertification({
 				canisterId,
@@ -374,23 +361,9 @@ describe('Satellite > Storage', () => {
 
 					const { headers, body } = response;
 
-					const rest = headers.filter(([header, _]) => header !== 'IC-Certificate');
-
-					/* eslint-disable no-useless-escape */
-					expect(rest).toEqual([
-						['accept-ranges', 'bytes'],
-						['etag', '"03ee66f1452916b4f91a504c1e9babfa201b6d64c26a82b2cf03c3ed49d91585"'],
-						['X-Content-Type-Options', 'nosniff'],
-						['Strict-Transport-Security', 'max-age=31536000 ; includeSubDomains'],
-						['Referrer-Policy', 'same-origin'],
-						['X-Frame-Options', 'DENY'],
-						['Cache-Control', 'no-cache'],
-						[
-							'IC-CertificateExpression',
-							'default_certification(ValidationArgs{certification:Certification{no_request_certification:Empty{},response_certification:ResponseCertification{certified_response_headers:ResponseHeaderList{headers:[\"accept-ranges\",\"etag\",\"X-Content-Type-Options\",\"Strict-Transport-Security\",\"Referrer-Policy\",\"X-Frame-Options\",\"Cache-Control\"]}}}})'
-						]
-					]);
-					/* eslint-enable no-useless-escape */
+					assertHeaders({
+						headers
+					});
 
 					await assertCertification({
 						canisterId,
@@ -500,7 +473,7 @@ describe('Satellite > Storage', () => {
 				const { set_storage_config, get_config } = actor;
 
 				const storage: StorageConfig = {
-					headers: [['*', [['Cache-Control', 'no-cache']]]],
+					headers: [['*', [['cache-control', 'no-cache']]]],
 					iframe: toNullable({ Deny: null }),
 					redirects: [
 						[
@@ -1263,7 +1236,7 @@ describe('Satellite > Storage', () => {
 				const { set_storage_config } = actor;
 
 				const storage: StorageConfig = {
-					headers: [['*', [['Cache-Control', 'no-cache']]]],
+					headers: [['*', [['cache-control', 'no-cache']]]],
 					iframe: toNullable({ Deny: null }),
 					redirects: [],
 					rewrites: [],

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -745,7 +745,7 @@ export const testCdnStorageSettings = ({
 		});
 
 		expect(
-			headers.find(([key, value]) => key === 'Content-Encoding' && value === 'gzip')
+			headers.find(([key, value]) => key === 'content-encoding' && value === 'gzip')
 		).not.toBeUndefined();
 	});
 };

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -36,6 +36,7 @@ import { uploadFile } from './cdn-tests.utils';
 import { assertCertification } from './certification-tests.utils';
 import { sha256ToBase64String } from './crypto-tests.utils';
 import { tick } from './pic-tests.utils';
+import { assertHeaders } from './storage-tests.utils';
 
 /* eslint-disable vitest/require-top-level-describe */
 
@@ -173,7 +174,7 @@ export const testCdnConfig = ({ actor }: { actor: () => Actor<SatelliteActor | C
 		const { set_storage_config, get_storage_config } = actor();
 
 		const config: StorageConfig = {
-			headers: [['*', [['Cache-Control', 'no-cache']]]],
+			headers: [['*', [['cache-control', 'no-cache']]]],
 			iframe: toNullable({ Deny: null }),
 			redirects: [],
 			rewrites: [],
@@ -463,23 +464,9 @@ export const testControlledCdnMethods = ({
 
 				expect(status_code).toBe(200);
 
-				const rest = headers.filter(([header, _]) => header !== 'IC-Certificate');
-
-				/* eslint-disable no-useless-escape */
-				expect(rest).toEqual([
-					['accept-ranges', 'bytes'],
-					['etag', '"03ee66f1452916b4f91a504c1e9babfa201b6d64c26a82b2cf03c3ed49d91585"'],
-					['X-Content-Type-Options', 'nosniff'],
-					['Strict-Transport-Security', 'max-age=31536000 ; includeSubDomains'],
-					['Referrer-Policy', 'same-origin'],
-					['X-Frame-Options', 'DENY'],
-					['Cache-Control', 'no-cache'],
-					[
-						'IC-CertificateExpression',
-						'default_certification(ValidationArgs{certification:Certification{no_request_certification:Empty{},response_certification:ResponseCertification{certified_response_headers:ResponseHeaderList{headers:[\"accept-ranges\",\"etag\",\"X-Content-Type-Options\",\"Strict-Transport-Security\",\"Referrer-Policy\",\"X-Frame-Options\",\"Cache-Control\"]}}}})'
-					]
-				]);
-				/* eslint-enable no-useless-escape */
+				assertHeaders({
+					headers
+				});
 
 				await assertCertification({
 					canisterId: canisterId(),

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -739,7 +739,7 @@ export const testCdnStorageSettings = ({
 		const { headers } = await http_request({
 			body: [],
 			certificate_version: toNullable(),
-			headers: [['Accept-Encoding', 'gzip, deflate, br']],
+			headers: [['accept-encoding', 'gzip, deflate, br']],
 			method: 'GET',
 			url: '/index.js'
 		});

--- a/src/tests/utils/satellite-storage-tests.utils.ts
+++ b/src/tests/utils/satellite-storage-tests.utils.ts
@@ -8,13 +8,15 @@ export const uploadAsset = async ({
 	description,
 	name,
 	collection,
-	actor
+	actor,
+	headers = []
 }: {
 	full_path: string;
 	description?: string;
 	name: string;
 	collection: string;
 	actor: Actor<SatelliteActor>;
+	headers?: [string, string][];
 }) => {
 	const { commit_asset_upload, upload_asset_chunk, init_asset_upload } = actor;
 
@@ -36,6 +38,6 @@ export const uploadAsset = async ({
 	await commit_asset_upload({
 		batch_id: file.batch_id,
 		chunk_ids: [chunk.chunk_id],
-		headers: []
+		headers
 	});
 };

--- a/src/tests/utils/storage-tests.utils.ts
+++ b/src/tests/utils/storage-tests.utils.ts
@@ -1,0 +1,22 @@
+export const assertHeaders = ({ headers }: { headers: [string, string][] }) => {
+	const rest = headers.filter(([header, _]) => header !== 'IC-Certificate');
+
+	const sortHeaders = (headers: [string, string][]): [string, string][] =>
+		headers.sort((a, b) => a[0].localeCompare(b[0]));
+
+	const expectedHeaders: [string, string][] = [
+		['accept-ranges', 'bytes'],
+		['etag', '"03ee66f1452916b4f91a504c1e9babfa201b6d64c26a82b2cf03c3ed49d91585"'],
+		['x-content-type-options', 'nosniff'],
+		['strict-transport-security', 'max-age=31536000 ; includeSubDomains'],
+		['referrer-policy', 'same-origin'],
+		['x-frame-options', 'DENY'],
+		['cache-control', 'no-cache'],
+		[
+			'IC-CertificateExpression',
+			'default_certification(ValidationArgs{certification:Certification{no_request_certification:Empty{},response_certification:ResponseCertification{certified_response_headers:ResponseHeaderList{headers:[\"accept-ranges\",\"cache-control\",\"etag\",\"referrer-policy\",\"strict-transport-security\",\"x-content-type-options\",\"x-frame-options\"]}}}})'
+		]
+	];
+
+	expect(sortHeaders(rest)).toEqual(sortHeaders(expectedHeaders));
+};


### PR DESCRIPTION
# Motivation

There are certain headers we always want the container to set - i.e. even if the developer set a headers with config or single asset some default headers like security should be more important.

Likewise, a single specific header set to an asset by a developer should be more important that the dev default config.
