### PR TITLE
refactor: rename controller_can_write for write scope

### DIFF
--- a/src/libs/collections/src/assert/stores.rs
+++ b/src/libs/collections/src/assert/stores.rs
@@ -1,6 +1,6 @@
 use crate::types::rules::Permission;
 use candid::Principal;
-use junobuild_shared::controllers::is_controller;
+use junobuild_shared::controllers::is_write_controller;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::{principal_not_anonymous, principal_not_anonymous_and_equal};
 
@@ -13,8 +13,10 @@ pub fn assert_permission(
     match permission {
         Permission::Public => true,
         Permission::Private => assert_caller(caller, owner),
-        Permission::Managed => assert_caller(caller, owner) || is_controller(caller, controllers),
-        Permission::Controllers => is_controller(caller, controllers),
+        Permission::Managed => {
+            assert_caller(caller, owner) || is_write_controller(caller, controllers)
+        }
+        Permission::Controllers => is_write_controller(caller, controllers),
     }
 }
 
@@ -29,7 +31,7 @@ pub fn assert_create_permission(
         Permission::Public => true,
         Permission::Private => assert_not_anonymous(caller),
         Permission::Managed => assert_not_anonymous(caller),
-        Permission::Controllers => is_controller(caller, controllers),
+        Permission::Controllers => is_write_controller(caller, controllers),
     }
 }
 

--- a/src/libs/collections/src/assert/stores.rs
+++ b/src/libs/collections/src/assert/stores.rs
@@ -1,6 +1,6 @@
 use crate::types::rules::Permission;
 use candid::Principal;
-use junobuild_shared::controllers::is_write_controller;
+use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::{principal_not_anonymous, principal_not_anonymous_and_equal};
 
@@ -14,9 +14,9 @@ pub fn assert_permission(
         Permission::Public => true,
         Permission::Private => assert_caller(caller, owner),
         Permission::Managed => {
-            assert_caller(caller, owner) || is_write_controller(caller, controllers)
+            assert_caller(caller, owner) || controller_can_write(caller, controllers)
         }
-        Permission::Controllers => is_write_controller(caller, controllers),
+        Permission::Controllers => controller_can_write(caller, controllers),
     }
 }
 
@@ -31,7 +31,7 @@ pub fn assert_create_permission(
         Permission::Public => true,
         Permission::Private => assert_not_anonymous(caller),
         Permission::Managed => assert_not_anonymous(caller),
-        Permission::Controllers => is_write_controller(caller, controllers),
+        Permission::Controllers => controller_can_write(caller, controllers),
     }
 }
 

--- a/src/libs/satellite/src/guards.rs
+++ b/src/libs/satellite/src/guards.rs
@@ -1,7 +1,7 @@
 use crate::controllers::store::get_controllers;
 use crate::errors::auth::{JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER, JUNO_AUTH_ERROR_NOT_CONTROLLER};
 use ic_cdk::caller;
-use junobuild_shared::controllers::{is_admin_controller, is_write_controller};
+use junobuild_shared::controllers::{is_admin_controller, controller_can_write};
 use junobuild_shared::types::state::Controllers;
 
 pub fn caller_is_admin_controller() -> Result<(), String> {
@@ -19,7 +19,7 @@ pub fn caller_is_controller() -> Result<(), String> {
     let caller = caller();
     let controllers: Controllers = get_controllers();
 
-    if is_write_controller(caller, &controllers) {
+    if controller_can_write(caller, &controllers) {
         Ok(())
     } else {
         Err(JUNO_AUTH_ERROR_NOT_CONTROLLER.to_string())

--- a/src/libs/satellite/src/guards.rs
+++ b/src/libs/satellite/src/guards.rs
@@ -1,7 +1,7 @@
 use crate::controllers::store::get_controllers;
 use crate::errors::auth::{JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER, JUNO_AUTH_ERROR_NOT_CONTROLLER};
 use ic_cdk::caller;
-use junobuild_shared::controllers::{is_admin_controller, is_controller};
+use junobuild_shared::controllers::{is_admin_controller, is_write_controller};
 use junobuild_shared::types::state::Controllers;
 
 pub fn caller_is_admin_controller() -> Result<(), String> {
@@ -19,7 +19,7 @@ pub fn caller_is_controller() -> Result<(), String> {
     let caller = caller();
     let controllers: Controllers = get_controllers();
 
-    if is_controller(caller, &controllers) {
+    if is_write_controller(caller, &controllers) {
         Ok(())
     } else {
         Err(JUNO_AUTH_ERROR_NOT_CONTROLLER.to_string())

--- a/src/libs/satellite/src/storage/assert.rs
+++ b/src/libs/satellite/src/storage/assert.rs
@@ -5,7 +5,7 @@ use crate::user::usage::assert::increment_and_assert_storage_usage;
 use candid::Principal;
 use junobuild_collections::assert::stores::{assert_permission, public_permission};
 use junobuild_collections::types::rules::{Permission, Rule};
-use junobuild_shared::controllers::is_controller;
+use junobuild_shared::controllers::is_write_controller;
 use junobuild_shared::types::state::Controllers;
 use junobuild_storage::errors::{
     JUNO_STORAGE_ERROR_ASSET_NOT_FOUND, JUNO_STORAGE_ERROR_CANNOT_READ_ASSET,
@@ -51,7 +51,7 @@ pub fn assert_create_batch(
 
     if !(public_permission(&rule.write)
         || is_known_user(caller)
-        || is_controller(caller, controllers))
+        || is_write_controller(caller, controllers))
     {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }

--- a/src/libs/satellite/src/storage/assert.rs
+++ b/src/libs/satellite/src/storage/assert.rs
@@ -5,7 +5,7 @@ use crate::user::usage::assert::increment_and_assert_storage_usage;
 use candid::Principal;
 use junobuild_collections::assert::stores::{assert_permission, public_permission};
 use junobuild_collections::types::rules::{Permission, Rule};
-use junobuild_shared::controllers::is_write_controller;
+use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::state::Controllers;
 use junobuild_storage::errors::{
     JUNO_STORAGE_ERROR_ASSET_NOT_FOUND, JUNO_STORAGE_ERROR_CANNOT_READ_ASSET,
@@ -51,7 +51,7 @@ pub fn assert_create_batch(
 
     if !(public_permission(&rule.write)
         || is_known_user(caller)
-        || is_write_controller(caller, controllers))
+        || controller_can_write(caller, controllers))
     {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }

--- a/src/libs/satellite/src/user/core/assert.rs
+++ b/src/libs/satellite/src/user/core/assert.rs
@@ -9,7 +9,7 @@ use candid::Principal;
 use ic_cdk::id;
 use junobuild_collections::constants::db::COLLECTION_USER_KEY;
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_shared::controllers::is_write_controller;
+use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::core::Key;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_not_equal;
@@ -69,7 +69,7 @@ pub fn assert_user_write_permission(
         return Ok(());
     }
 
-    if is_write_controller(caller, controllers) {
+    if controller_can_write(caller, controllers) {
         return Ok(());
     }
 
@@ -87,7 +87,7 @@ pub fn assert_user_is_not_banned(
     controllers: &Controllers,
 ) -> Result<(), String> {
     // This way we spare loading the user for controllers calls and, we for example allow controllers to delete banned users
-    if is_write_controller(caller, controllers) {
+    if controller_can_write(caller, controllers) {
         return Ok(());
     }
 

--- a/src/libs/satellite/src/user/core/assert.rs
+++ b/src/libs/satellite/src/user/core/assert.rs
@@ -9,7 +9,7 @@ use candid::Principal;
 use ic_cdk::id;
 use junobuild_collections::constants::db::COLLECTION_USER_KEY;
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_shared::controllers::is_controller;
+use junobuild_shared::controllers::is_write_controller;
 use junobuild_shared::types::core::Key;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_not_equal;
@@ -69,7 +69,7 @@ pub fn assert_user_write_permission(
         return Ok(());
     }
 
-    if is_controller(caller, controllers) {
+    if is_write_controller(caller, controllers) {
         return Ok(());
     }
 
@@ -87,7 +87,7 @@ pub fn assert_user_is_not_banned(
     controllers: &Controllers,
 ) -> Result<(), String> {
     // This way we spare loading the user for controllers calls and, we for example allow controllers to delete banned users
-    if is_controller(caller, controllers) {
+    if is_write_controller(caller, controllers) {
         return Ok(());
     }
 

--- a/src/libs/satellite/src/user/usage/assert.rs
+++ b/src/libs/satellite/src/user/usage/assert.rs
@@ -9,7 +9,7 @@ use crate::SetDoc;
 use junobuild_collections::assert::collection::is_system_collection;
 use junobuild_collections::constants::db::COLLECTION_USER_USAGE_KEY;
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_shared::controllers::is_write_controller;
+use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::state::{Controllers, UserId};
 use junobuild_utils::decode_doc_data;
 // ---------------------------------------------------------
@@ -59,7 +59,7 @@ fn increment_and_assert_usage(
     }
 
     // We only collect usage for users
-    if is_write_controller(caller, controllers) {
+    if controller_can_write(caller, controllers) {
         return Ok(());
     }
 

--- a/src/libs/satellite/src/user/usage/assert.rs
+++ b/src/libs/satellite/src/user/usage/assert.rs
@@ -9,7 +9,7 @@ use crate::SetDoc;
 use junobuild_collections::assert::collection::is_system_collection;
 use junobuild_collections::constants::db::COLLECTION_USER_USAGE_KEY;
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_shared::controllers::is_controller;
+use junobuild_shared::controllers::is_write_controller;
 use junobuild_shared::types::state::{Controllers, UserId};
 use junobuild_utils::decode_doc_data;
 // ---------------------------------------------------------
@@ -59,7 +59,7 @@ fn increment_and_assert_usage(
     }
 
     // We only collect usage for users
-    if is_controller(caller, controllers) {
+    if is_write_controller(caller, controllers) {
         return Ok(());
     }
 

--- a/src/libs/shared/src/controllers.rs
+++ b/src/libs/shared/src/controllers.rs
@@ -79,8 +79,7 @@ pub fn delete_controllers(remove_controllers: &[UserId], controllers: &mut Contr
     }
 }
 
-// TODO: rename to is_write_controller
-/// Checks if a caller is a controller.
+/// Checks if a caller is a controller with write scope (permissions).
 ///
 /// # Arguments
 /// - `caller`: `UserId` of the caller.
@@ -88,7 +87,7 @@ pub fn delete_controllers(remove_controllers: &[UserId], controllers: &mut Contr
 ///
 /// # Returns
 /// `true` if the caller is a controller (not anonymous, calling itself or one of the known controllers), otherwise `false`.
-pub fn is_controller(caller: UserId, controllers: &Controllers) -> bool {
+pub fn is_write_controller(caller: UserId, controllers: &Controllers) -> bool {
     principal_not_anonymous(caller)
         && (caller_is_self(caller)
             || controllers

--- a/src/libs/shared/src/controllers.rs
+++ b/src/libs/shared/src/controllers.rs
@@ -79,7 +79,7 @@ pub fn delete_controllers(remove_controllers: &[UserId], controllers: &mut Contr
     }
 }
 
-/// Checks if a caller is a controller with write scope (permissions).
+/// Checks if a caller is a controller with admin or write scope (permissions).
 ///
 /// # Arguments
 /// - `caller`: `UserId` of the caller.
@@ -87,7 +87,7 @@ pub fn delete_controllers(remove_controllers: &[UserId], controllers: &mut Contr
 ///
 /// # Returns
 /// `true` if the caller is a controller (not anonymous, calling itself or one of the known controllers), otherwise `false`.
-pub fn is_write_controller(caller: UserId, controllers: &Controllers) -> bool {
+pub fn controller_can_write(caller: UserId, controllers: &Controllers) -> bool {
     principal_not_anonymous(caller)
         && (caller_is_self(caller)
             || controllers

--- a/src/libs/storage/src/assert.rs
+++ b/src/libs/storage/src/assert.rs
@@ -17,7 +17,7 @@ use junobuild_collections::constants::core::SYS_COLLECTION_PREFIX;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::Rule;
 use junobuild_shared::assert::{assert_description_length, assert_max_memory_size};
-use junobuild_shared::controllers::is_controller;
+use junobuild_shared::controllers::is_write_controller;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_not_equal;
 
@@ -202,12 +202,12 @@ fn assert_key(
     let dapp_collection = DEFAULT_ASSETS_COLLECTIONS[0].0;
 
     // Only controllers can write in collection #dapp
-    if collection.clone() == *dapp_collection && !is_controller(caller, controllers) {
+    if collection.clone() == *dapp_collection && !is_write_controller(caller, controllers) {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }
 
     // Only controllers can write in reserved collections starting with #
-    if is_system_collection(collection) && !is_controller(caller, controllers) {
+    if is_system_collection(collection) && !is_write_controller(caller, controllers) {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }
 

--- a/src/libs/storage/src/assert.rs
+++ b/src/libs/storage/src/assert.rs
@@ -17,7 +17,7 @@ use junobuild_collections::constants::core::SYS_COLLECTION_PREFIX;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::Rule;
 use junobuild_shared::assert::{assert_description_length, assert_max_memory_size};
-use junobuild_shared::controllers::is_write_controller;
+use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_not_equal;
 
@@ -202,12 +202,12 @@ fn assert_key(
     let dapp_collection = DEFAULT_ASSETS_COLLECTIONS[0].0;
 
     // Only controllers can write in collection #dapp
-    if collection.clone() == *dapp_collection && !is_write_controller(caller, controllers) {
+    if collection.clone() == *dapp_collection && !controller_can_write(caller, controllers) {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }
 
     // Only controllers can write in reserved collections starting with #
-    if is_system_collection(collection) && !is_write_controller(caller, controllers) {
+    if is_system_collection(collection) && !controller_can_write(caller, controllers) {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }
 

--- a/src/orbiter/src/guards.rs
+++ b/src/orbiter/src/guards.rs
@@ -1,6 +1,6 @@
 use crate::state::memory::manager::STATE;
 use ic_cdk::caller;
-use junobuild_shared::controllers::{is_admin_controller, is_write_controller};
+use junobuild_shared::controllers::{is_admin_controller, controller_can_write};
 use junobuild_shared::types::state::Controllers;
 
 pub fn caller_is_admin_controller() -> Result<(), String> {
@@ -18,7 +18,7 @@ pub fn caller_is_controller() -> Result<(), String> {
     let caller = caller();
     let controllers: Controllers = STATE.with(|state| state.borrow().heap.controllers.clone());
 
-    if is_write_controller(caller, &controllers) {
+    if controller_can_write(caller, &controllers) {
         Ok(())
     } else {
         Err("Caller is not a controller of the orbiter.".to_string())

--- a/src/orbiter/src/guards.rs
+++ b/src/orbiter/src/guards.rs
@@ -1,6 +1,6 @@
 use crate::state::memory::manager::STATE;
 use ic_cdk::caller;
-use junobuild_shared::controllers::{is_admin_controller, is_controller};
+use junobuild_shared::controllers::{is_admin_controller, is_write_controller};
 use junobuild_shared::types::state::Controllers;
 
 pub fn caller_is_admin_controller() -> Result<(), String> {
@@ -18,7 +18,7 @@ pub fn caller_is_controller() -> Result<(), String> {
     let caller = caller();
     let controllers: Controllers = STATE.with(|state| state.borrow().heap.controllers.clone());
 
-    if is_controller(caller, &controllers) {
+    if is_write_controller(caller, &controllers) {
         Ok(())
     } else {
         Err("Caller is not a controller of the orbiter.".to_string())

--- a/src/sputnik/src/hooks/js/sdk/controllers.rs
+++ b/src/sputnik/src/hooks/js/sdk/controllers.rs
@@ -3,7 +3,7 @@ use junobuild_satellite::{
     get_admin_controllers as get_admin_controllers_sdk, get_controllers as get_controllers_sdk,
 };
 use junobuild_shared::controllers::{
-    is_admin_controller as is_admin_controller_sdk, is_controller as is_controller_sdk,
+    is_admin_controller as is_admin_controller_sdk, is_write_controller as is_controller_sdk,
 };
 use rquickjs::{Ctx, Error as JsError, Result as JsResult};
 

--- a/src/sputnik/src/hooks/js/sdk/controllers.rs
+++ b/src/sputnik/src/hooks/js/sdk/controllers.rs
@@ -3,7 +3,7 @@ use junobuild_satellite::{
     get_admin_controllers as get_admin_controllers_sdk, get_controllers as get_controllers_sdk,
 };
 use junobuild_shared::controllers::{
-    is_admin_controller as is_admin_controller_sdk, is_write_controller as is_controller_sdk,
+    is_admin_controller as is_admin_controller_sdk, controller_can_write as is_controller_sdk,
 };
 use rquickjs::{Ctx, Error as JsError, Result as JsResult};
 


### PR DESCRIPTION
# Motivation

"Submit" controllers were introduced. For backwards compatibility, those should not be identified yet as controller unless they are used, that's why the function `is_controller` returns false if they are used and why we rename the function.
