### PR TITLE
feat(satellite): allow submit to write into #_juno collection

### DIFF
--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -13,6 +13,7 @@ use junobuild_cdn::storage::errors::{
 };
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::{Memory, Rule};
+use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
@@ -31,6 +32,15 @@ pub struct StorageAssertions;
 impl StorageAssertionsStrategy for StorageAssertions {
     fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
         assert_cdn_asset_keys(full_path, collection)
+    }
+
+    fn assert_write_on_system_collection(
+        &self,
+        caller: Principal,
+        _collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        controller_can_write(caller, controllers)
     }
 
     fn invoke_assert_upload_asset(

--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -48,6 +48,8 @@ pub fn assert_cdn_write_on_system_collection(
     collection: &CollectionKey,
     controllers: &Controllers,
 ) -> bool {
+    // Only controllers with scope "Admin" or "Write" can write in reserved collections starting with #
+    // ...unless the collection is #_juno and the controller is "Submit".
     if collection == CDN_JUNO_COLLECTION_KEY {
         return is_controller(caller, controllers);
     }

--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -1,9 +1,12 @@
 use crate::cdn::constants::{CDN_JUNO_COLLECTION_KEY, CDN_JUNO_COLLECTION_PATH};
+use candid::Principal;
 use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH,
 };
 use junobuild_collections::types::core::CollectionKey;
+use junobuild_shared::controllers::{controller_can_write, is_controller};
 use junobuild_shared::regex::build_regex;
+use junobuild_shared::types::state::Controllers;
 use junobuild_storage::types::state::FullPath;
 
 // TODO: storage module uses cdn because of this reference. Refactor modules.
@@ -38,4 +41,16 @@ fn assert_releases_keys(full_path: &FullPath) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+pub fn assert_cdn_write_on_system_collection(
+    caller: Principal,
+    collection: &CollectionKey,
+    controllers: &Controllers,
+) -> bool {
+    if collection == CDN_JUNO_COLLECTION_KEY {
+        return is_controller(caller, controllers);
+    }
+
+    controller_can_write(caller, controllers)
 }

--- a/src/libs/satellite/src/cdn/strategies_impls/storage.rs
+++ b/src/libs/satellite/src/cdn/strategies_impls/storage.rs
@@ -1,4 +1,4 @@
-use crate::cdn::assert::assert_cdn_asset_keys;
+use crate::cdn::assert::{assert_cdn_asset_keys, assert_cdn_write_on_system_collection};
 use crate::cdn::strategies_impls::cdn::{CdnHeap, CdnStable};
 use crate::storage::store::get_config_store;
 use candid::Principal;
@@ -26,6 +26,15 @@ pub struct CdnStorageAssertions;
 impl StorageAssertionsStrategy for CdnStorageAssertions {
     fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
         assert_cdn_asset_keys(full_path, collection)
+    }
+
+    fn assert_write_on_system_collection(
+        &self,
+        caller: Principal,
+        collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_cdn_write_on_system_collection(caller, collection, controllers)
     }
 
     fn invoke_assert_upload_asset(

--- a/src/libs/satellite/src/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/storage/strategy_impls.rs
@@ -8,6 +8,7 @@ use crate::user::usage::assert::increment_and_assert_storage_usage;
 use candid::Principal;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::{Memory, Rule};
+use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
@@ -25,6 +26,15 @@ pub struct StorageAssertions;
 impl StorageAssertionsStrategy for StorageAssertions {
     fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
         assert_cdn_asset_keys(full_path, collection)
+    }
+
+    fn assert_write_on_system_collection(
+        &self,
+        caller: Principal,
+        _collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        controller_can_write(caller, controllers)
     }
 
     fn invoke_assert_upload_asset(

--- a/src/libs/shared/src/controllers.rs
+++ b/src/libs/shared/src/controllers.rs
@@ -98,6 +98,22 @@ pub fn controller_can_write(caller: UserId, controllers: &Controllers) -> bool {
                 }))
 }
 
+/// Checks if a caller is a controller regardless of its scope (admin, write or submit).
+///
+/// # Arguments
+/// - `caller`: `UserId` of the caller.
+/// - `controllers`: Reference to the current set of controllers.
+///
+/// # Returns
+/// `true` if the caller is a controller (not anonymous, calling itself or one of the known controllers), otherwise `false`.
+pub fn is_controller(caller: UserId, controllers: &Controllers) -> bool {
+    principal_not_anonymous(caller)
+        && (caller_is_self(caller)
+            || controllers
+                .iter()
+                .any(|(&controller_id, _)| principal_equal(controller_id, caller)))
+}
+
 /// Checks if a caller is an admin controller.
 ///
 /// # Arguments

--- a/src/libs/storage/src/assert.rs
+++ b/src/libs/storage/src/assert.rs
@@ -206,9 +206,6 @@ fn assert_key(
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }
 
-    // Only controllers with scope "Admin" or "Write" can write in reserved collections starting with #
-    // ...unless the consumer explicitly allows it
-
     // Whether a controller is allowed to write in reserved collections starting with `#`.
     if is_system_collection(collection)
         && !assertions.assert_write_on_system_collection(caller, collection, controllers)

--- a/src/libs/storage/src/assert.rs
+++ b/src/libs/storage/src/assert.rs
@@ -201,13 +201,18 @@ fn assert_key(
 
     let dapp_collection = DEFAULT_ASSETS_COLLECTIONS[0].0;
 
-    // Only controllers can write in collection #dapp
+    // Only controllers with scope "Admin" or "Write" can write in collection #dapp
     if collection.clone() == *dapp_collection && !controller_can_write(caller, controllers) {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }
 
-    // Only controllers can write in reserved collections starting with #
-    if is_system_collection(collection) && !controller_can_write(caller, controllers) {
+    // Only controllers with scope "Admin" or "Write" can write in reserved collections starting with #
+    // ...unless the consumer explicitly allows it
+
+    // Whether a controller is allowed to write in reserved collections starting with `#`.
+    if is_system_collection(collection)
+        && !assertions.assert_write_on_system_collection(caller, collection, controllers)
+    {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }
 

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -13,6 +13,13 @@ use junobuild_shared::types::state::Controllers;
 pub trait StorageAssertionsStrategy {
     fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String>;
 
+    fn assert_write_on_system_collection(
+        &self,
+        caller: Principal,
+        collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool;
+
     fn invoke_assert_upload_asset(
         &self,
         caller: &Principal,


### PR DESCRIPTION
# Notes

Hard to test without access to the proposal so it will be covered in #1643.

Note that the "Submit" is allowed only if proposals are used.