### PR TITLE
feat(satellite): allow submit to write into #dapp collection on proposal

### DIFF
--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -34,6 +34,14 @@ impl StorageAssertionsStrategy for StorageAssertions {
         assert_cdn_asset_keys(full_path, collection)
     }
 
+    fn assert_write_on_dapp_collection(
+        &self,
+        caller: Principal,
+        controllers: &Controllers,
+    ) -> bool {
+        controller_can_write(caller, controllers)
+    }
+
     fn assert_write_on_system_collection(
         &self,
         caller: Principal,

--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -43,6 +43,11 @@ fn assert_releases_keys(full_path: &FullPath) -> Result<(), String> {
     Ok(())
 }
 
+pub fn assert_cdn_write_on_dapp_collection(caller: Principal, controllers: &Controllers) -> bool {
+    // When using proposals, we allow any controllers to upload - submit - an asset to be served from #dapp collection
+    is_controller(caller, controllers)
+}
+
 pub fn assert_cdn_write_on_system_collection(
     caller: Principal,
     collection: &CollectionKey,

--- a/src/libs/satellite/src/cdn/strategies_impls/storage.rs
+++ b/src/libs/satellite/src/cdn/strategies_impls/storage.rs
@@ -1,4 +1,7 @@
-use crate::cdn::assert::{assert_cdn_asset_keys, assert_cdn_write_on_system_collection};
+use crate::cdn::assert::{
+    assert_cdn_asset_keys, assert_cdn_write_on_dapp_collection,
+    assert_cdn_write_on_system_collection,
+};
 use crate::cdn::strategies_impls::cdn::{CdnHeap, CdnStable};
 use crate::storage::store::get_config_store;
 use candid::Principal;
@@ -26,6 +29,14 @@ pub struct CdnStorageAssertions;
 impl StorageAssertionsStrategy for CdnStorageAssertions {
     fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
         assert_cdn_asset_keys(full_path, collection)
+    }
+
+    fn assert_write_on_dapp_collection(
+        &self,
+        caller: Principal,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_cdn_write_on_dapp_collection(caller, controllers)
     }
 
     fn assert_write_on_system_collection(

--- a/src/libs/satellite/src/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/storage/strategy_impls.rs
@@ -28,6 +28,14 @@ impl StorageAssertionsStrategy for StorageAssertions {
         assert_cdn_asset_keys(full_path, collection)
     }
 
+    fn assert_write_on_dapp_collection(
+        &self,
+        caller: Principal,
+        controllers: &Controllers,
+    ) -> bool {
+        controller_can_write(caller, controllers)
+    }
+
     fn assert_write_on_system_collection(
         &self,
         caller: Principal,

--- a/src/libs/storage/src/assert.rs
+++ b/src/libs/storage/src/assert.rs
@@ -17,7 +17,6 @@ use junobuild_collections::constants::core::SYS_COLLECTION_PREFIX;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::Rule;
 use junobuild_shared::assert::{assert_description_length, assert_max_memory_size};
-use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_not_equal;
 
@@ -201,12 +200,14 @@ fn assert_key(
 
     let dapp_collection = DEFAULT_ASSETS_COLLECTIONS[0].0;
 
-    // Only controllers with scope "Admin" or "Write" can write in collection #dapp
-    if collection.clone() == *dapp_collection && !controller_can_write(caller, controllers) {
+    // Whether a caller is allowed to write in reserved collections `#dapp`.
+    if collection.clone() == *dapp_collection
+        && !assertions.assert_write_on_dapp_collection(caller, controllers)
+    {
         return Err(JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED.to_string());
     }
 
-    // Whether a controller is allowed to write in reserved collections starting with `#`.
+    // Whether a caller is allowed to write in reserved collections starting with `#`.
     if is_system_collection(collection)
         && !assertions.assert_write_on_system_collection(caller, collection, controllers)
     {

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -13,6 +13,9 @@ use junobuild_shared::types::state::Controllers;
 pub trait StorageAssertionsStrategy {
     fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String>;
 
+    fn assert_write_on_dapp_collection(&self, caller: Principal, controllers: &Controllers)
+        -> bool;
+
     fn assert_write_on_system_collection(
         &self,
         caller: Principal,


### PR DESCRIPTION
# Motivation

Same as #1644 but for #dapp collection - i.e. allow controller "Submit" to upload to the collection ONLY if provided with a cdn proposal.

Will be tested in #1643 as we need proposal for assertions.
