### PR TITLE
feat(satellite): allow commit chunk into #_juno collection

### DIFF
--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -11,8 +11,9 @@ use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID,
     JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_UNKNOWN_REFERENCE_ID,
 };
+use junobuild_collections::assert::stores::{assert_create_permission, assert_permission};
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_collections::types::rules::{Memory, Rule};
+use junobuild_collections::types::rules::{Memory, Permission, Rule};
 use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::domain::CustomDomains;
@@ -49,6 +50,27 @@ impl StorageAssertionsStrategy for StorageAssertions {
         controllers: &Controllers,
     ) -> bool {
         controller_can_write(caller, controllers)
+    }
+
+    fn assert_create_permission(
+        &self,
+        permission: &Permission,
+        caller: Principal,
+        _collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_create_permission(permission, caller, controllers)
+    }
+
+    fn assert_update_permission(
+        &self,
+        permission: &Permission,
+        owner: Principal,
+        caller: Principal,
+        _collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_permission(permission, caller, owner, controllers)
     }
 
     fn invoke_assert_upload_asset(

--- a/src/libs/collections/src/assert/stores.rs
+++ b/src/libs/collections/src/assert/stores.rs
@@ -1,7 +1,7 @@
 use crate::types::rules::Permission;
 use candid::Principal;
 use junobuild_shared::controllers::controller_can_write;
-use junobuild_shared::types::state::Controllers;
+use junobuild_shared::types::state::{Controllers, UserId};
 use junobuild_shared::utils::{principal_not_anonymous, principal_not_anonymous_and_equal};
 
 pub fn assert_permission(
@@ -10,13 +10,23 @@ pub fn assert_permission(
     caller: Principal,
     controllers: &Controllers,
 ) -> bool {
+    assert_permission_with(permission, owner, caller, controllers, controller_can_write)
+}
+
+pub fn assert_permission_with(
+    permission: &Permission,
+    owner: Principal,
+    caller: Principal,
+    controllers: &Controllers,
+    is_allowed_controller: fn(UserId, &Controllers) -> bool,
+) -> bool {
     match permission {
         Permission::Public => true,
         Permission::Private => assert_caller(caller, owner),
         Permission::Managed => {
             assert_caller(caller, owner) || controller_can_write(caller, controllers)
         }
-        Permission::Controllers => controller_can_write(caller, controllers),
+        Permission::Controllers => is_allowed_controller(caller, controllers),
     }
 }
 
@@ -27,11 +37,20 @@ pub fn assert_create_permission(
     caller: Principal,
     controllers: &Controllers,
 ) -> bool {
+    assert_create_permission_with(permission, caller, controllers, controller_can_write)
+}
+
+pub fn assert_create_permission_with(
+    permission: &Permission,
+    caller: Principal,
+    controllers: &Controllers,
+    is_allowed_controller: fn(UserId, &Controllers) -> bool,
+) -> bool {
     match permission {
         Permission::Public => true,
         Permission::Private => assert_not_anonymous(caller),
         Permission::Managed => assert_not_anonymous(caller),
-        Permission::Controllers => controller_can_write(caller, controllers),
+        Permission::Controllers => is_allowed_controller(caller, controllers),
     }
 }
 

--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -3,7 +3,10 @@ use candid::Principal;
 use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH,
 };
+use junobuild_collections::assert::stores::{assert_create_permission_with, assert_permission_with};
+use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
 use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::rules::Permission;
 use junobuild_shared::controllers::{controller_can_write, is_controller};
 use junobuild_shared::regex::build_regex;
 use junobuild_shared::types::state::Controllers;
@@ -60,4 +63,33 @@ pub fn assert_cdn_write_on_system_collection(
     }
 
     controller_can_write(caller, controllers)
+}
+
+pub fn assert_cdn_create_permission(
+    permission: &Permission,
+    caller: Principal,
+    collection: &CollectionKey,
+    controllers: &Controllers,
+) -> bool {
+    // Through a proposal, any controller - including "Submit" - can provide an asset for the #_juno or #dapp collections.
+    if collection == CDN_JUNO_COLLECTION_KEY || collection == COLLECTION_ASSET_KEY {
+        return assert_create_permission_with(permission, caller, controllers, is_controller);
+    }
+
+    assert_create_permission_with(permission, caller, controllers, controller_can_write)
+}
+
+pub fn assert_cdn_update_permission(
+    permission: &Permission,
+    owner: Principal,
+    caller: Principal,
+    collection: &CollectionKey,
+    controllers: &Controllers,
+) -> bool {
+    // Through a proposal, any controller - including "Submit" - can provide an update of an asset for the #_juno or #dapp collections.
+    if collection == CDN_JUNO_COLLECTION_KEY || collection == COLLECTION_ASSET_KEY {
+        return assert_permission_with(permission, caller, owner, controllers, is_controller);
+    }
+
+    assert_permission_with(permission, caller, owner, controllers, controller_can_write)
 }

--- a/src/libs/satellite/src/cdn/strategies_impls/storage.rs
+++ b/src/libs/satellite/src/cdn/strategies_impls/storage.rs
@@ -1,7 +1,4 @@
-use crate::cdn::assert::{
-    assert_cdn_asset_keys, assert_cdn_write_on_dapp_collection,
-    assert_cdn_write_on_system_collection,
-};
+use crate::cdn::assert::{assert_cdn_asset_keys, assert_cdn_create_permission, assert_cdn_update_permission, assert_cdn_write_on_dapp_collection, assert_cdn_write_on_system_collection};
 use crate::cdn::strategies_impls::cdn::{CdnHeap, CdnStable};
 use crate::storage::store::get_config_store;
 use candid::Principal;
@@ -10,7 +7,7 @@ use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_UNKNOWN_REFERENCE_ID,
 };
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_collections::types::rules::{Memory, Rule};
+use junobuild_collections::types::rules::{Memory, Permission, Rule};
 use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
@@ -46,6 +43,27 @@ impl StorageAssertionsStrategy for CdnStorageAssertions {
         controllers: &Controllers,
     ) -> bool {
         assert_cdn_write_on_system_collection(caller, collection, controllers)
+    }
+
+    fn assert_create_permission(
+        &self,
+        permission: &Permission,
+        caller: Principal,
+        collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_cdn_create_permission(permission, caller, collection, controllers)
+    }
+
+    fn assert_update_permission(
+        &self,
+        permission: &Permission,
+        owner: Principal,
+        caller: Principal,
+        collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_cdn_update_permission(permission, owner, caller, collection, controllers)
     }
 
     fn invoke_assert_upload_asset(

--- a/src/libs/satellite/src/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/storage/strategy_impls.rs
@@ -6,8 +6,9 @@ use crate::storage::state::{
 use crate::storage::store::{get_content_chunks_store, get_public_asset_store};
 use crate::user::usage::assert::increment_and_assert_storage_usage;
 use candid::Principal;
+use junobuild_collections::assert::stores::{assert_create_permission, assert_permission};
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_collections::types::rules::{Memory, Rule};
+use junobuild_collections::types::rules::{Memory, Permission, Rule};
 use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::domain::CustomDomains;
@@ -43,6 +44,27 @@ impl StorageAssertionsStrategy for StorageAssertions {
         controllers: &Controllers,
     ) -> bool {
         controller_can_write(caller, controllers)
+    }
+
+    fn assert_create_permission(
+        &self,
+        permission: &Permission,
+        caller: Principal,
+        _collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_create_permission(permission, caller, controllers)
+    }
+
+    fn assert_update_permission(
+        &self,
+        permission: &Permission,
+        owner: Principal,
+        caller: Principal,
+        _collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_permission(permission, caller, owner, controllers)
     }
 
     fn invoke_assert_upload_asset(

--- a/src/libs/storage/src/store.rs
+++ b/src/libs/storage/src/store.rs
@@ -195,7 +195,7 @@ fn secure_commit_chunks(
 
     match current {
         None => {
-            assert_commit_chunks_new_asset(caller, controllers, config, &rule)?;
+            assert_commit_chunks_new_asset(caller, &batch.key.collection, controllers, config, &rule, assertions)?;
 
             commit_chunks(
                 caller,
@@ -234,7 +234,15 @@ fn secure_commit_chunks_update(
     assertions: &impl StorageAssertionsStrategy,
     storage_upload: &impl StorageUploadStrategy,
 ) -> Result<Asset, String> {
-    assert_commit_chunks_update(caller, controllers, config, batch, &rule, &current)?;
+    assert_commit_chunks_update(
+        caller,
+        controllers,
+        config,
+        batch,
+        &rule,
+        &current,
+        assertions,
+    )?;
 
     commit_chunks(
         caller,

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -5,7 +5,7 @@ use crate::types::store::{
 };
 use candid::Principal;
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_collections::types::rules::{Memory, Rule};
+use junobuild_collections::types::rules::{Memory, Permission, Rule};
 use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
@@ -18,6 +18,23 @@ pub trait StorageAssertionsStrategy {
 
     fn assert_write_on_system_collection(
         &self,
+        caller: Principal,
+        collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool;
+
+    fn assert_create_permission(
+        &self,
+        permission: &Permission,
+        caller: Principal,
+        collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool;
+
+    fn assert_update_permission(
+        &self,
+        permission: &Permission,
+        owner: Principal,
         caller: Principal,
         collection: &CollectionKey,
         controllers: &Controllers,


### PR DESCRIPTION
# Motivation

Similar to #1645 and #1644, we want controller "Submit" to propose chunks in #dapp and #_juno collections through proposal only.

Will be tested in https://github.com/junobuild/juno/pull/1643.
