### PR TITLE
feat(satellite): allow read memory size for submit

### DIFF
--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -435,7 +435,7 @@ pub async fn deposit_cycles(args: DepositCyclesArgs) {
 }
 
 #[doc(hidden)]
-#[query(guard = "caller_is_controller_with_write")]
+#[query(guard = "caller_is_controller")]
 pub fn memory_size() -> MemorySize {
     junobuild_shared::canister::memory_size()
 }

--- a/src/tests/specs/satellite/stock/satellite.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.spec.ts
@@ -5,6 +5,7 @@ import { assertNonNullish, fromNullable, toNullable } from '@dfinity/utils';
 import { type Actor, PocketIc } from '@hadronous/pic';
 import {
 	JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER,
+	JUNO_AUTH_ERROR_NOT_CONTROLLER,
 	JUNO_AUTH_ERROR_NOT_WRITE_CONTROLLER,
 	JUNO_COLLECTIONS_ERROR_DELETE_PREFIX_RESERVED,
 	JUNO_COLLECTIONS_ERROR_MODIFY_RESERVED_COLLECTION,
@@ -737,7 +738,7 @@ describe('Satellite', () => {
 		it('should throw errors on memory size', async () => {
 			const { memory_size } = actor;
 
-			await expect(memory_size()).rejects.toThrow(JUNO_AUTH_ERROR_NOT_WRITE_CONTROLLER);
+			await expect(memory_size()).rejects.toThrow(JUNO_AUTH_ERROR_NOT_CONTROLLER);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We open "read memory" size for submit as it will be required to use the CLI in automation when such controller is used.
