### PR TITLE
feat(satellite): allow submit controller to list assets

### DIFF
--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -73,6 +73,17 @@ impl StorageAssertionsStrategy for StorageAssertions {
         assert_permission(permission, owner, caller, controllers)
     }
 
+    fn assert_list_permission(
+        &self,
+        permission: &Permission,
+        owner: Principal,
+        caller: Principal,
+        _collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_permission(permission, owner, caller, controllers)
+    }
+
     fn invoke_assert_upload_asset(
         &self,
         _caller: &Principal,

--- a/src/libs/satellite/src/cdn/strategies_impls/storage.rs
+++ b/src/libs/satellite/src/cdn/strategies_impls/storage.rs
@@ -9,6 +9,7 @@ use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID,
     JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_UNKNOWN_REFERENCE_ID,
 };
+use junobuild_collections::assert::stores::assert_permission;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::{Memory, Permission, Rule};
 use junobuild_shared::types::core::Blob;
@@ -67,6 +68,17 @@ impl StorageAssertionsStrategy for CdnStorageAssertions {
         controllers: &Controllers,
     ) -> bool {
         assert_cdn_update_permission(permission, owner, caller, collection, controllers)
+    }
+
+    fn assert_list_permission(
+        &self,
+        permission: &Permission,
+        owner: Principal,
+        caller: Principal,
+        _collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_permission(permission, owner, caller, controllers)
     }
 
     fn invoke_assert_upload_asset(

--- a/src/libs/satellite/src/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/storage/strategy_impls.rs
@@ -1,5 +1,6 @@
 use crate::cdn::assert::assert_cdn_asset_keys;
 use crate::hooks::storage::invoke_assert_upload_asset;
+use crate::storage::assert::assert_storage_list_permission;
 use crate::storage::state::{
     delete_asset, get_asset, get_config, get_domains, get_rule, insert_asset, insert_asset_encoding,
 };
@@ -65,6 +66,17 @@ impl StorageAssertionsStrategy for StorageAssertions {
         controllers: &Controllers,
     ) -> bool {
         assert_permission(permission, owner, caller, controllers)
+    }
+
+    fn assert_list_permission(
+        &self,
+        permission: &Permission,
+        owner: Principal,
+        caller: Principal,
+        collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool {
+        assert_storage_list_permission(permission, owner, caller, collection, controllers)
     }
 
     fn invoke_assert_upload_asset(

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -40,6 +40,15 @@ pub trait StorageAssertionsStrategy {
         controllers: &Controllers,
     ) -> bool;
 
+    fn assert_list_permission(
+        &self,
+        permission: &Permission,
+        owner: Principal,
+        caller: Principal,
+        collection: &CollectionKey,
+        controllers: &Controllers,
+    ) -> bool;
+
     fn invoke_assert_upload_asset(
         &self,
         caller: &Principal,

--- a/src/libs/storage/src/utils.rs
+++ b/src/libs/storage/src/utils.rs
@@ -2,11 +2,11 @@ use crate::constants::{
     ASSET_ENCODING_NO_COMPRESSION, WELL_KNOWN_CUSTOM_DOMAINS, WELL_KNOWN_II_ALTERNATIVE_ORIGINS,
 };
 use crate::http::types::HeaderField;
+use crate::strategies::StorageAssertionsStrategy;
 use crate::types::interface::AssetNoContent;
 use crate::types::state::FullPath;
 use crate::types::store::{Asset, AssetEncoding, AssetKey};
 use candid::Principal;
-use junobuild_collections::assert::stores::assert_permission;
 use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::Permission;
@@ -23,7 +23,7 @@ pub fn map_asset_no_content(asset: &Asset) -> (FullPath, AssetNoContent) {
 pub fn filter_values<'a>(
     caller: Principal,
     controllers: &'a Controllers,
-    rule: &'a Permission,
+    permission: &'a Permission,
     collection: CollectionKey,
     ListParams {
         matcher,
@@ -32,6 +32,7 @@ pub fn filter_values<'a>(
         owner,
     }: &'a ListParams,
     assets: &'a [(&'a FullPath, &'a Asset)],
+    assertions: &impl StorageAssertionsStrategy,
 ) -> Result<Vec<(&'a FullPath, &'a Asset)>, String> {
     let (regex_key, regex_description) = matcher_regex(matcher)?;
 
@@ -43,7 +44,13 @@ pub fn filter_values<'a>(
                 && filter_description(&regex_description, asset)
                 && filter_owner(*owner, asset)
                 && filter_timestamps(matcher, *asset)
-                && assert_permission(rule, asset.key.owner, caller, controllers)
+                && assertions.assert_list_permission(
+                    permission,
+                    asset.key.owner,
+                    caller,
+                    &collection,
+                    controllers,
+                )
             {
                 Some((*key, *asset))
             } else {

--- a/src/tests/specs/satellite/stock/satellite.controllers.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.controllers.spec.ts
@@ -1,0 +1,97 @@
+import type { _SERVICE as SatelliteActor } from '$declarations/satellite/satellite.did';
+import { idlFactory as idlFactorSatellite } from '$declarations/satellite/satellite.factory.did';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Principal } from '@dfinity/principal';
+import { type Actor, PocketIc } from '@hadronous/pic';
+import { beforeAll, describe, inject } from 'vitest';
+import { mockListParams } from '../../../mocks/list.mocks';
+import { uploadAsset } from '../../../utils/satellite-storage-tests.utils';
+import { controllersInitArgs, SATELLITE_WASM_PATH } from '../../../utils/setup-tests.utils';
+import { isNullish } from '@dfinity/utils';
+
+describe('Satellite > Controllers', () => {
+	let pic: PocketIc;
+	let actor: Actor<SatelliteActor>;
+
+	let canisterId: Principal;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	const currentDate = new Date(2021, 6, 10, 0, 0, 0, 0);
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		await pic.setTime(currentDate.getTime());
+
+		const { actor: c, canisterId: cId } = await pic.setupCanister<SatelliteActor>({
+			idlFactory: idlFactorSatellite,
+			wasm: SATELLITE_WASM_PATH,
+			arg: controllersInitArgs(controller),
+			sender: controller.getPrincipal()
+		});
+
+		actor = c;
+		actor.setIdentity(controller);
+
+		canisterId = cId;
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	describe('Submit', () => {
+		const controllerSubmit = Ed25519KeyIdentity.generate();
+
+		const COLLECTION_DAPP = '#dapp';
+		const ITEMS = Array.from({ length: 5 });
+
+		const upload = async ({ index }: { index: number }) => {
+			const name = `hello-${index}.html`;
+			const full_path = `/hello/${name}`;
+
+			await uploadAsset({
+				full_path,
+				name,
+				collection: COLLECTION_DAPP,
+				actor
+			});
+		};
+
+		beforeAll(async () => {
+			actor.setIdentity(controller);
+
+			const { set_controllers } = actor;
+
+			await set_controllers({
+				controller: {
+					scope: { Submit: null },
+					metadata: [],
+					expires_at: []
+				},
+				controllers: [controllerSubmit.getPrincipal()]
+			});
+
+			await Promise.all(ITEMS.map(async (_, index) => await upload({ index })));
+
+			actor.setIdentity(controllerSubmit);
+		});
+
+		it('should list assets of collection #dapp', async () => {
+			const { list_assets } = actor;
+
+			const { items_length, items } = await list_assets(COLLECTION_DAPP, mockListParams);
+
+			// Items + default index.html
+			expect(items_length).toEqual(BigInt(ITEMS.length) + 1n);
+
+			expect(items.find(([fullPath, _]) => fullPath === '/index.html')).not.toBeUndefined();
+
+			for (let i = 0; i < ITEMS.length; i++) {
+				const asset = items.find(([fullPath, _]) => fullPath === `/hello/hello-${i}.html`);
+				expect(asset).not.toBeUndefined();
+			}
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We need this exception for the CLI in GH Action with Controller "Submit" to be able to list assets and only submit/propose those that requires to be uploaded - only the modified.
