### PR TITLE
feat(cdn): order and limit for list_proposals

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -96,8 +96,12 @@ type ListProposalResults = record {
   items : vec record { ProposalKey; Proposal };
   items_length : nat64;
 };
+type ListProposalsOrder = record { desc : bool };
 type ListProposalsPaginate = record { start_after : opt nat; limit : opt nat };
-type ListProposalsParams = record { paginate : opt ListProposalsPaginate };
+type ListProposalsParams = record {
+  order : opt ListProposalsOrder;
+  paginate : opt ListProposalsPaginate;
+};
 type ListResults = record {
   matches_pages : opt nat64;
   matches_length : nat64;

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -124,11 +124,15 @@ export interface ListProposalResults {
 	items: Array<[ProposalKey, Proposal]>;
 	items_length: bigint;
 }
+export interface ListProposalsOrder {
+	desc: boolean;
+}
 export interface ListProposalsPaginate {
 	start_after: [] | [bigint];
 	limit: [] | [bigint];
 }
 export interface ListProposalsParams {
+	order: [] | [ListProposalsOrder];
 	paginate: [] | [ListProposalsPaginate];
 }
 export interface ListResults {

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -218,11 +218,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		block_index_refunded: IDL.Opt(IDL.Nat64)
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -218,11 +218,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		block_index_refunded: IDL.Opt(IDL.Nat64)
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -218,11 +218,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		block_index_refunded: IDL.Opt(IDL.Nat64)
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -143,11 +143,15 @@ export interface ListProposalResults {
 	items: Array<[ProposalKey, Proposal]>;
 	items_length: bigint;
 }
+export interface ListProposalsOrder {
+	desc: boolean;
+}
 export interface ListProposalsPaginate {
 	start_after: [] | [bigint];
 	limit: [] | [bigint];
 }
 export interface ListProposalsParams {
+	order: [] | [ListProposalsOrder];
 	paginate: [] | [ListProposalsPaginate];
 }
 export interface ListResults {

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -246,11 +246,13 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -246,11 +246,13 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -246,11 +246,13 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -143,11 +143,15 @@ export interface ListProposalResults {
 	items: Array<[ProposalKey, Proposal]>;
 	items_length: bigint;
 }
+export interface ListProposalsOrder {
+	desc: boolean;
+}
 export interface ListProposalsPaginate {
 	start_after: [] | [bigint];
 	limit: [] | [bigint];
 }
 export interface ListProposalsParams {
+	order: [] | [ListProposalsOrder];
 	paginate: [] | [ListProposalsPaginate];
 }
 export interface ListResults {

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -246,11 +246,13 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -246,11 +246,13 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/libs/cdn/src/proposals/mod.rs
+++ b/src/libs/cdn/src/proposals/mod.rs
@@ -4,7 +4,8 @@ mod state;
 mod types;
 mod workflows;
 
-pub use state::stable::*;
+pub use state::stable::{count_proposals, get_proposal, insert_proposal};
+pub use state::store::*;
 pub use state::types::*;
 pub use types::*;
 pub use workflows::commit::*;

--- a/src/libs/cdn/src/proposals/state/filter.rs
+++ b/src/libs/cdn/src/proposals/state/filter.rs
@@ -1,31 +1,15 @@
-use crate::proposals::{ListProposalsParams, ProposalKey};
+use crate::proposals::ProposalKey;
 use std::ops::RangeBounds;
 
-const FIRST_PROPOSAL_ID: u128 = 1;
-
 pub fn filter_proposals_range(
-    ListProposalsParams { paginate }: &ListProposalsParams,
+    (start_proposal_id, end_proposal_id): &(u128, u128),
 ) -> impl RangeBounds<ProposalKey> {
     let start_key = ProposalKey {
-        proposal_id: match paginate {
-            Some(paginate) => paginate
-                .start_after
-                .as_ref()
-                .map(|proposal_id| proposal_id.saturating_add(1))
-                .unwrap_or(FIRST_PROPOSAL_ID),
-            None => FIRST_PROPOSAL_ID,
-        },
+        proposal_id: start_proposal_id.clone(),
     };
 
     let end_key = ProposalKey {
-        proposal_id: match paginate {
-            Some(paginate) => paginate
-                .limit
-                .as_ref()
-                .map(|limit| start_key.proposal_id.saturating_add(*limit))
-                .unwrap_or(u128::MAX),
-            None => u128::MAX,
-        },
+        proposal_id: end_proposal_id.clone(),
     };
 
     start_key..end_key

--- a/src/libs/cdn/src/proposals/state/mod.rs
+++ b/src/libs/cdn/src/proposals/state/mod.rs
@@ -1,4 +1,5 @@
 mod filter;
 mod impls;
 pub mod stable;
+pub mod store;
 pub mod types;

--- a/src/libs/cdn/src/proposals/state/stable.rs
+++ b/src/libs/cdn/src/proposals/state/stable.rs
@@ -1,7 +1,5 @@
 use crate::proposals::state::filter::filter_proposals_range;
-use crate::proposals::{
-    ListProposalResults, ListProposalsParams, Proposal, ProposalId, ProposalKey, ProposalsStable,
-};
+use crate::proposals::{ListProposalResults, Proposal, ProposalId, ProposalKey, ProposalsStable};
 use crate::strategies::CdnStableStrategy;
 
 pub fn get_proposal(
@@ -17,17 +15,18 @@ fn get_proposal_impl(proposal_id: &ProposalId, proposals: &ProposalsStable) -> O
 
 pub fn list_proposals(
     cdn_stable: &impl CdnStableStrategy,
-    filters: &ListProposalsParams,
+    filters_key: &(u128, u128),
 ) -> ListProposalResults {
-    cdn_stable.with_proposals(|proposals| list_proposals_impl(filters, proposals))
+    cdn_stable.with_proposals(|proposals| list_proposals_impl(filters_key, proposals))
 }
 
 fn list_proposals_impl(
-    filters: &ListProposalsParams,
+    filters_key: &(u128, u128),
     proposals: &ProposalsStable,
 ) -> ListProposalResults {
-    let items: Vec<(ProposalKey, Proposal)> =
-        proposals.range(filter_proposals_range(filters)).collect();
+    let items: Vec<(ProposalKey, Proposal)> = proposals
+        .range(filter_proposals_range(filters_key))
+        .collect();
 
     let items_length = items.len();
 

--- a/src/libs/cdn/src/proposals/state/store.rs
+++ b/src/libs/cdn/src/proposals/state/store.rs
@@ -24,8 +24,10 @@ pub fn list_proposals(
         }
 
         (None, true) => {
-            let end = u128::try_from(count_proposals(cdn_stable)).unwrap_or(u128::MAX);
-            let start = end.saturating_sub(DEFAULT_MAX_PROPOSALS.saturating_sub(1));
+            let end = u128::try_from(count_proposals(cdn_stable))
+                .unwrap_or(u128::MAX)
+                .saturating_add(1);
+            let start = end.saturating_sub(DEFAULT_MAX_PROPOSALS);
             (start, end)
         }
 
@@ -40,8 +42,12 @@ pub fn list_proposals(
         }
 
         (Some(paginate), true) => {
-            let end = paginate.start_after.unwrap_or(u128::MAX);
-            let start = end.saturating_sub(limit.saturating_sub(1));
+            let end = paginate.start_after.unwrap_or(
+                u128::try_from(count_proposals(cdn_stable))
+                    .unwrap_or(u128::MAX)
+                    .saturating_add(1),
+            );
+            let start = end.saturating_sub(limit);
             (start, end)
         }
     };

--- a/src/libs/cdn/src/proposals/state/store.rs
+++ b/src/libs/cdn/src/proposals/state/store.rs
@@ -1,0 +1,58 @@
+use crate::proposals::state::stable::list_proposals as list_proposals_stable;
+use crate::proposals::{count_proposals, ListProposalResults, ListProposalsParams};
+use crate::strategies::CdnStableStrategy;
+
+const FIRST_PROPOSAL_ID: u128 = 1;
+
+const DEFAULT_MAX_PROPOSALS: u128 = 100;
+
+pub fn list_proposals(
+    cdn_stable: &impl CdnStableStrategy,
+    ListProposalsParams { paginate, order }: &ListProposalsParams,
+) -> ListProposalResults {
+    let desc = order.as_ref().map(|order| order.desc).unwrap_or(false);
+    let limit = paginate
+        .as_ref()
+        .and_then(|p| p.limit)
+        .unwrap_or(DEFAULT_MAX_PROPOSALS);
+
+    let filters = match (paginate, desc) {
+        (None, false) => {
+            let start = FIRST_PROPOSAL_ID;
+            let end = start.saturating_add(DEFAULT_MAX_PROPOSALS);
+            (start, end)
+        }
+
+        (None, true) => {
+            let end = u128::try_from(count_proposals(cdn_stable)).unwrap_or(u128::MAX);
+            let start = end.saturating_sub(DEFAULT_MAX_PROPOSALS.saturating_sub(1));
+            (start, end)
+        }
+
+        (Some(paginate), false) => {
+            let start = paginate
+                .start_after
+                .as_ref()
+                .map(|proposal_id| proposal_id.saturating_add(1))
+                .unwrap_or(FIRST_PROPOSAL_ID);
+            let end = start.saturating_add(limit);
+            (start, end)
+        }
+
+        (Some(paginate), true) => {
+            let end = paginate.start_after.unwrap_or(u128::MAX);
+            let start = end.saturating_sub(limit.saturating_sub(1));
+            (start, end)
+        }
+    };
+
+    let mut proposals = list_proposals_stable(cdn_stable, &filters);
+
+    if desc {
+        proposals
+            .items
+            .sort_by(|a, b| b.0.proposal_id.cmp(&a.0.proposal_id));
+    }
+
+    proposals
+}

--- a/src/libs/cdn/src/proposals/state/types.rs
+++ b/src/libs/cdn/src/proposals/state/types.rs
@@ -59,12 +59,18 @@ pub enum ProposalStatus {
 #[derive(CandidType, Deserialize, Clone)]
 pub struct ListProposalsParams {
     pub paginate: Option<ListProposalsPaginate>,
+    pub order: Option<ListProposalsOrder>,
 }
 
 #[derive(Default, CandidType, Deserialize, Clone)]
 pub struct ListProposalsPaginate {
     pub start_after: Option<ProposalId>,
     pub limit: Option<u128>,
+}
+
+#[derive(Default, CandidType, Deserialize, Clone)]
+pub struct ListProposalsOrder {
+    pub desc: bool,
 }
 
 #[derive(Default, CandidType, Deserialize, Clone)]

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -110,8 +110,12 @@ type ListProposalResults = record {
   items : vec record { ProposalKey; Proposal };
   items_length : nat64;
 };
+type ListProposalsOrder = record { desc : bool };
 type ListProposalsPaginate = record { start_after : opt nat; limit : opt nat };
-type ListProposalsParams = record { paginate : opt ListProposalsPaginate };
+type ListProposalsParams = record {
+  order : opt ListProposalsOrder;
+  paginate : opt ListProposalsPaginate;
+};
 type ListResults = record {
   matches_pages : opt nat64;
   matches_length : nat64;

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -112,8 +112,12 @@ type ListProposalResults = record {
   items : vec record { ProposalKey; Proposal };
   items_length : nat64;
 };
+type ListProposalsOrder = record { desc : bool };
 type ListProposalsPaginate = record { start_after : opt nat; limit : opt nat };
-type ListProposalsParams = record { paginate : opt ListProposalsPaginate };
+type ListProposalsParams = record {
+  order : opt ListProposalsOrder;
+  paginate : opt ListProposalsPaginate;
+};
 type ListResults = record {
   matches_pages : opt nat64;
   matches_length : nat64;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -112,8 +112,12 @@ type ListProposalResults = record {
   items : vec record { ProposalKey; Proposal };
   items_length : nat64;
 };
+type ListProposalsOrder = record { desc : bool };
 type ListProposalsPaginate = record { start_after : opt nat; limit : opt nat };
-type ListProposalsParams = record { paginate : opt ListProposalsPaginate };
+type ListProposalsParams = record {
+  order : opt ListProposalsOrder;
+  paginate : opt ListProposalsPaginate;
+};
 type ListResults = record {
   matches_pages : opt nat64;
   matches_length : nat64;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -143,11 +143,15 @@ export interface ListProposalResults {
 	items: Array<[ProposalKey, Proposal]>;
 	items_length: bigint;
 }
+export interface ListProposalsOrder {
+	desc: boolean;
+}
 export interface ListProposalsPaginate {
 	start_after: [] | [bigint];
 	limit: [] | [bigint];
 }
 export interface ListProposalsParams {
+	order: [] | [ListProposalsOrder];
 	paginate: [] | [ListProposalsPaginate];
 }
 export interface ListResults {

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -247,11 +247,13 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -247,11 +247,13 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
 		items_length: IDL.Nat64
 	});
+	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
 		start_after: IDL.Opt(IDL.Nat),
 		limit: IDL.Opt(IDL.Nat)
 	});
 	const ListProposalsParams = IDL.Record({
+		order: IDL.Opt(ListProposalsOrder),
 		paginate: IDL.Opt(ListProposalsPaginate)
 	});
 	const ProposalKey = IDL.Record({ proposal_id: IDL.Nat });

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -112,8 +112,12 @@ type ListProposalResults = record {
   items : vec record { ProposalKey; Proposal };
   items_length : nat64;
 };
+type ListProposalsOrder = record { desc : bool };
 type ListProposalsPaginate = record { start_after : opt nat; limit : opt nat };
-type ListProposalsParams = record { paginate : opt ListProposalsPaginate };
+type ListProposalsParams = record {
+  order : opt ListProposalsOrder;
+  paginate : opt ListProposalsPaginate;
+};
 type ListResults = record {
   matches_pages : opt nat64;
   matches_length : nat64;

--- a/src/tests/mocks/list.mocks.ts
+++ b/src/tests/mocks/list.mocks.ts
@@ -9,5 +9,6 @@ export const mockListParams: ListParams = {
 };
 
 export const mockListProposalsParams: ListProposalsParams = {
-	paginate: toNullable()
+	paginate: toNullable(),
+	order: toNullable()
 };

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -944,7 +944,7 @@ export const testCdnListProposals = ({
 	actor: () => Actor<SatelliteActor | ConsoleActor>;
 	proposalsLength?: bigint;
 }) => {
-	describe("Asc", () => {
+	describe('Asc', () => {
 		it('should list all proposals', async () => {
 			const { list_proposals } = actor();
 
@@ -1039,13 +1039,13 @@ export const testCdnListProposals = ({
 		});
 	});
 
-	describe("Desc", () => {
+	describe('Desc', () => {
 		const descListProposalsParams = {
 			...mockListProposalsParams,
 			order: toNullable({
 				desc: true
 			})
-		}
+		};
 
 		it('should list all proposals', async () => {
 			const { list_proposals } = actor();
@@ -1139,7 +1139,7 @@ export const testCdnListProposals = ({
 			expect(items_length).toEqual(length);
 			expect(matches_length).toEqual(proposalsLength);
 		});
-	})
+	});
 };
 
 /* eslint-enable */

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -944,98 +944,202 @@ export const testCdnListProposals = ({
 	actor: () => Actor<SatelliteActor | ConsoleActor>;
 	proposalsLength?: bigint;
 }) => {
-	it('should list all proposals', async () => {
-		const { list_proposals } = actor();
+	describe("Asc", () => {
+		it('should list all proposals', async () => {
+			const { list_proposals } = actor();
 
-		const { items, items_length, matches_length } = await list_proposals(mockListProposalsParams);
+			const { items, items_length, matches_length } = await list_proposals(mockListProposalsParams);
 
-		expect(items).toHaveLength(Number(proposalsLength));
-		expect(items_length).toEqual(proposalsLength);
-		expect(matches_length).toEqual(proposalsLength);
-	});
-
-	it('should list start after', async () => {
-		const { list_proposals } = actor();
-
-		const startAfter = 5n;
-
-		const { items, items_length, matches_length } = await list_proposals({
-			...mockListProposalsParams,
-			paginate: toNullable({
-				start_after: toNullable(startAfter),
-				limit: toNullable()
-			})
+			expect(items).toHaveLength(Number(proposalsLength));
+			expect(items_length).toEqual(proposalsLength);
+			expect(matches_length).toEqual(proposalsLength);
 		});
 
-		expect(items).toHaveLength(Number(proposalsLength - startAfter));
-		expect(items_length).toEqual(proposalsLength - startAfter);
-		expect(matches_length).toEqual(proposalsLength);
+		it('should list start after', async () => {
+			const { list_proposals } = actor();
 
-		expect(items[0][0].proposal_id).toEqual(startAfter + 1n);
-	});
+			const startAfter = 5n;
 
-	it('should list limit', async () => {
-		const { list_proposals } = actor();
+			const { items, items_length, matches_length } = await list_proposals({
+				...mockListProposalsParams,
+				paginate: toNullable({
+					start_after: toNullable(startAfter),
+					limit: toNullable()
+				})
+			});
 
-		const limit = 10n;
+			expect(items).toHaveLength(Number(proposalsLength - startAfter));
+			expect(items_length).toEqual(proposalsLength - startAfter);
+			expect(matches_length).toEqual(proposalsLength);
 
-		const { items, items_length, matches_length } = await list_proposals({
-			...mockListProposalsParams,
-			paginate: toNullable({
-				start_after: toNullable(),
-				limit: toNullable(limit)
-			})
+			expect(items[0][0].proposal_id).toEqual(startAfter + 1n);
 		});
 
-		expect(items).toHaveLength(Number(limit));
-		expect(items_length).toEqual(limit);
-		expect(matches_length).toEqual(proposalsLength);
+		it('should list limit', async () => {
+			const { list_proposals } = actor();
 
-		expect(items[0][0].proposal_id).toEqual(1n);
-		expect(items[items.length - 1][0].proposal_id).toEqual(limit);
-	});
+			const limit = 10n;
 
-	it('should list start after and limit', async () => {
-		const { list_proposals } = actor();
+			const { items, items_length, matches_length } = await list_proposals({
+				...mockListProposalsParams,
+				paginate: toNullable({
+					start_after: toNullable(),
+					limit: toNullable(limit)
+				})
+			});
 
-		const startAfter = 5n;
-		const limit = 10n;
+			expect(items).toHaveLength(Number(limit));
+			expect(items_length).toEqual(limit);
+			expect(matches_length).toEqual(proposalsLength);
 
-		const { items, items_length, matches_length } = await list_proposals({
-			...mockListProposalsParams,
-			paginate: toNullable({
-				start_after: toNullable(startAfter),
-				limit: toNullable(limit)
-			})
+			expect(items[0][0].proposal_id).toEqual(1n);
+			expect(items[items.length - 1][0].proposal_id).toEqual(limit);
 		});
 
-		expect(items).toHaveLength(Number(limit));
-		expect(items_length).toEqual(limit);
-		expect(matches_length).toEqual(proposalsLength);
+		it('should list start after and limit', async () => {
+			const { list_proposals } = actor();
 
-		expect(items[0][0].proposal_id).toEqual(startAfter + 1n);
-		expect(items[items.length - 1][0].proposal_id).toEqual(limit + startAfter);
-	});
+			const startAfter = 5n;
+			const limit = 10n;
 
-	it('should list less limit if length is reached', async () => {
-		const { list_proposals } = actor();
+			const { items, items_length, matches_length } = await list_proposals({
+				...mockListProposalsParams,
+				paginate: toNullable({
+					start_after: toNullable(startAfter),
+					limit: toNullable(limit)
+				})
+			});
 
-		const length = 4n;
-		const startAfter = proposalsLength - length;
-		const limit = 10n;
+			expect(items).toHaveLength(Number(limit));
+			expect(items_length).toEqual(limit);
+			expect(matches_length).toEqual(proposalsLength);
 
-		const { items, items_length, matches_length } = await list_proposals({
-			...mockListProposalsParams,
-			paginate: toNullable({
-				start_after: toNullable(startAfter),
-				limit: toNullable(limit)
-			})
+			expect(items[0][0].proposal_id).toEqual(startAfter + 1n);
+			expect(items[items.length - 1][0].proposal_id).toEqual(limit + startAfter);
 		});
 
-		expect(items).toHaveLength(Number(length));
-		expect(items_length).toEqual(length);
-		expect(matches_length).toEqual(proposalsLength);
+		it('should list less limit if length is reached', async () => {
+			const { list_proposals } = actor();
+
+			const length = 4n;
+			const startAfter = proposalsLength - length;
+			const limit = 10n;
+
+			const { items, items_length, matches_length } = await list_proposals({
+				...mockListProposalsParams,
+				paginate: toNullable({
+					start_after: toNullable(startAfter),
+					limit: toNullable(limit)
+				})
+			});
+
+			expect(items).toHaveLength(Number(length));
+			expect(items_length).toEqual(length);
+			expect(matches_length).toEqual(proposalsLength);
+		});
 	});
+
+	describe("Desc", () => {
+		const descListProposalsParams = {
+			...mockListProposalsParams,
+			order: toNullable({
+				desc: true
+			})
+		}
+
+		it('should list all proposals', async () => {
+			const { list_proposals } = actor();
+
+			const { items, items_length, matches_length } = await list_proposals(descListProposalsParams);
+
+			expect(items).toHaveLength(Number(proposalsLength));
+			expect(items_length).toEqual(proposalsLength);
+			expect(matches_length).toEqual(proposalsLength);
+		});
+
+		it('should list start after', async () => {
+			const { list_proposals } = actor();
+
+			const startAfter = 5n;
+
+			const { items, items_length, matches_length } = await list_proposals({
+				...descListProposalsParams,
+				paginate: toNullable({
+					start_after: toNullable(startAfter),
+					limit: toNullable()
+				})
+			});
+
+			expect(items).toHaveLength(Number(startAfter - 1n));
+			expect(items_length).toEqual(startAfter - 1n);
+			expect(matches_length).toEqual(proposalsLength);
+
+			expect(items[0][0].proposal_id).toEqual(startAfter - 1n);
+		});
+
+		it('should list limit', async () => {
+			const { list_proposals } = actor();
+
+			const limit = 10n;
+
+			const { items, items_length, matches_length } = await list_proposals({
+				...descListProposalsParams,
+				paginate: toNullable({
+					start_after: toNullable(),
+					limit: toNullable(limit)
+				})
+			});
+
+			expect(items).toHaveLength(Number(limit));
+			expect(items_length).toEqual(limit);
+			expect(matches_length).toEqual(proposalsLength);
+
+			expect(items[0][0].proposal_id).toEqual(proposalsLength);
+			expect(items[items.length - 1][0].proposal_id).toEqual(proposalsLength + 1n - limit);
+		});
+
+		it('should list start after and limit', async () => {
+			const { list_proposals } = actor();
+
+			const startAfter = 15n;
+			const limit = 10n;
+
+			const { items, items_length, matches_length } = await list_proposals({
+				...descListProposalsParams,
+				paginate: toNullable({
+					start_after: toNullable(startAfter),
+					limit: toNullable(limit)
+				})
+			});
+
+			expect(items).toHaveLength(Number(limit));
+			expect(items_length).toEqual(limit);
+			expect(matches_length).toEqual(proposalsLength);
+
+			expect(items[0][0].proposal_id).toEqual(startAfter - 1n);
+			expect(items[items.length - 1][0].proposal_id).toEqual(startAfter - limit);
+		});
+
+		it('should list less limit if length is reached', async () => {
+			const { list_proposals } = actor();
+
+			const length = 4n;
+			const startAfter = 1n + length;
+			const limit = 10n;
+
+			const { items, items_length, matches_length } = await list_proposals({
+				...descListProposalsParams,
+				paginate: toNullable({
+					start_after: toNullable(startAfter),
+					limit: toNullable(limit)
+				})
+			});
+
+			expect(items).toHaveLength(Number(length));
+			expect(items_length).toEqual(length);
+			expect(matches_length).toEqual(proposalsLength);
+		});
+	})
 };
 
 /* eslint-enable */


### PR DESCRIPTION
# Motivation

I want to avoid two calls - count and list - in the frontend and also want to avoid to take all proposals hence the limit to 100.
