### PR TITLE
feat(cdn): assert release description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"@junobuild/config": "^0.1.8",
 				"@junobuild/config-loader": "^0.2.1",
 				"@junobuild/console": "^0.1.7",
-				"@junobuild/errors": "^0.0.11-next-2025-05-29",
+				"@junobuild/errors": "^0.0.11-next-2025-06-03.9",
 				"@junobuild/functions": "^0.1.0",
 				"@junobuild/storage": "^0.1.8",
 				"@ltd/j-toml": "^1.38.0",
@@ -1834,9 +1834,9 @@
 			}
 		},
 		"node_modules/@junobuild/errors": {
-			"version": "0.0.11-next-2025-05-29",
-			"resolved": "https://registry.npmjs.org/@junobuild/errors/-/errors-0.0.11-next-2025-05-29.tgz",
-			"integrity": "sha512-R04GzKXuyjALSyaj0cOBT7D5J9LBEBDHcS2tu+IqV7aU7ZqVVjxt/TtWnRjftmKGgWjd+jw7Of0C8lHEiAj1Rw==",
+			"version": "0.0.11-next-2025-06-03.9",
+			"resolved": "https://registry.npmjs.org/@junobuild/errors/-/errors-0.0.11-next-2025-06-03.9.tgz",
+			"integrity": "sha512-9gu6h0X+kZSDPesLaOKSSFxGIowZ9mKHuVv68lYsXpk+1tfHuNcYZ6rQlm5Ugtcec0krwlMsc69PlozcSwKmCQ==",
 			"license": "MIT"
 		},
 		"node_modules/@junobuild/functions": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"@junobuild/config": "^0.1.8",
 		"@junobuild/config-loader": "^0.2.1",
 		"@junobuild/console": "^0.1.7",
-		"@junobuild/errors": "^0.0.11-next-2025-05-29",
+		"@junobuild/errors": "^0.0.11-next-2025-06-03.9",
 		"@junobuild/functions": "^0.1.0",
 		"@junobuild/storage": "^0.1.8",
 		"@ltd/j-toml": "^1.38.0",

--- a/src/console/src/cdn/assert.rs
+++ b/src/console/src/cdn/assert.rs
@@ -1,4 +1,5 @@
 use crate::cdn::constants::{RELEASES_COLLECTION_KEY, RELEASES_COLLECTION_PATH};
+use junobuild_cdn::storage::assert_releases_description;
 use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH,
 };
@@ -9,10 +10,16 @@ use junobuild_storage::types::state::FullPath;
 
 pub fn assert_cdn_asset_keys(
     full_path: &FullPath,
+    description: &Option<String>,
     collection: &CollectionKey,
 ) -> Result<(), String> {
     match collection.as_str() {
-        RELEASES_COLLECTION_KEY => assert_releases_keys(full_path),
+        RELEASES_COLLECTION_KEY => {
+            assert_releases_keys(full_path)?;
+            assert_releases_description(description)?;
+
+            Ok(())
+        }
         _ => {
             if full_path.starts_with(RELEASES_COLLECTION_PATH) {
                 return Err(format!(

--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -31,8 +31,13 @@ use junobuild_storage::utils::clone_asset_encoding_content_chunks;
 pub struct StorageAssertions;
 
 impl StorageAssertionsStrategy for StorageAssertions {
-    fn assert_key(&self, full_path: &FullPath, _description: &Option<String>, collection: &CollectionKey) -> Result<(), String> {
-        assert_cdn_asset_keys(full_path, collection)
+    fn assert_key(
+        &self,
+        full_path: &FullPath,
+        description: &Option<String>,
+        collection: &CollectionKey,
+    ) -> Result<(), String> {
+        assert_cdn_asset_keys(full_path, description, collection)
     }
 
     fn assert_write_on_dapp_collection(

--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -31,7 +31,7 @@ use junobuild_storage::utils::clone_asset_encoding_content_chunks;
 pub struct StorageAssertions;
 
 impl StorageAssertionsStrategy for StorageAssertions {
-    fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
+    fn assert_key(&self, full_path: &FullPath, _description: &Option<String>, collection: &CollectionKey) -> Result<(), String> {
         assert_cdn_asset_keys(full_path, collection)
     }
 

--- a/src/libs/cdn/src/storage/assert.rs
+++ b/src/libs/cdn/src/storage/assert.rs
@@ -1,0 +1,21 @@
+use crate::storage::errors::{
+    JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION,
+    JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION,
+};
+use junobuild_shared::regex::build_regex;
+
+pub fn assert_releases_description(description: &Option<String>) -> Result<(), String> {
+    let desc = description
+        .as_deref()
+        .ok_or_else(|| JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION)?;
+
+    let desc_re = build_regex(r"^change=\d+;version=[^;]+$")?;
+    if !desc_re.is_match(&desc) {
+        return Err(format!(
+            "{} ({})",
+            JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION, desc
+        ));
+    }
+
+    Ok(())
+}

--- a/src/libs/cdn/src/storage/errors.rs
+++ b/src/libs/cdn/src/storage/errors.rs
@@ -13,6 +13,12 @@ pub const JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND: &str =
 pub const JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH: &str =
     "juno.cdn.storage.error.invalid_releases_path";
 
+pub const JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION: &str =
+    "juno.cdn.storage.error.missing_releases_description";
+
+pub const JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION: &str =
+    "juno.cdn.storage.error.invalid_releases_description";
+
 // An asset is uploaded with the CDN prefix but using the #dapp collection
 pub const JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION: &str =
     "juno.cdn.storage.error.invalid_collection";

--- a/src/libs/cdn/src/storage/mod.rs
+++ b/src/libs/cdn/src/storage/mod.rs
@@ -1,8 +1,10 @@
+mod assert;
 mod certified_assets;
 pub mod errors;
 mod state;
 mod store;
 
+pub use assert::*;
 pub use certified_assets::init_certified_assets;
 pub use state::heap;
 pub use state::stable;

--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -1,8 +1,6 @@
 use crate::cdn::constants::{CDN_JUNO_COLLECTION_KEY, CDN_JUNO_COLLECTION_PATH};
 use candid::Principal;
-use junobuild_cdn::storage::errors::{
-    JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH,
-};
+use junobuild_cdn::storage::errors::{JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION};
 use junobuild_collections::assert::stores::{
     assert_create_permission, assert_create_permission_with, assert_permission,
     assert_permission_with,
@@ -19,10 +17,11 @@ use junobuild_storage::types::state::FullPath;
 
 pub fn assert_cdn_asset_keys(
     full_path: &FullPath,
+    description: &Option<String>,
     collection: &CollectionKey,
 ) -> Result<(), String> {
     match collection.as_str() {
-        CDN_JUNO_COLLECTION_KEY => assert_releases_keys(full_path),
+        CDN_JUNO_COLLECTION_KEY => assert_releases_keys(full_path, description),
         _ => {
             if full_path.starts_with(CDN_JUNO_COLLECTION_PATH) {
                 return Err(format!(
@@ -36,13 +35,25 @@ pub fn assert_cdn_asset_keys(
     }
 }
 
-fn assert_releases_keys(full_path: &FullPath) -> Result<(), String> {
-    let re = build_regex(r"^/_juno/releases/satellite[^/]*\.wasm\.gz$")?;
+fn assert_releases_keys(full_path: &FullPath, description: &Option<String>) -> Result<(), String> {
+    let full_path_re = build_regex(r"^/_juno/releases/satellite[^/]*\.wasm\.gz$")?;
 
-    if !re.is_match(full_path) {
+    if !full_path_re.is_match(full_path) {
         return Err(format!(
             "{} ({})",
             JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH, full_path
+        ));
+    }
+
+    let desc = description.as_deref().ok_or_else(|| {
+        JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION
+    })?;
+
+    let desc_re = build_regex(r"^change=\d+;version=[^;]+$")?;
+    if !desc_re.is_match(&desc) {
+        return Err(format!(
+            "{} ({})",
+            JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION, desc
         ));
     }
 

--- a/src/libs/satellite/src/cdn/strategies_impls/storage.rs
+++ b/src/libs/satellite/src/cdn/strategies_impls/storage.rs
@@ -28,7 +28,12 @@ use junobuild_storage::utils::clone_asset_encoding_content_chunks;
 pub struct CdnStorageAssertions;
 
 impl StorageAssertionsStrategy for CdnStorageAssertions {
-    fn assert_key(&self, full_path: &FullPath, description: &Option<String>, collection: &CollectionKey) -> Result<(), String> {
+    fn assert_key(
+        &self,
+        full_path: &FullPath,
+        description: &Option<String>,
+        collection: &CollectionKey,
+    ) -> Result<(), String> {
         assert_cdn_asset_keys(full_path, description, collection)
     }
 

--- a/src/libs/satellite/src/cdn/strategies_impls/storage.rs
+++ b/src/libs/satellite/src/cdn/strategies_impls/storage.rs
@@ -28,8 +28,8 @@ use junobuild_storage::utils::clone_asset_encoding_content_chunks;
 pub struct CdnStorageAssertions;
 
 impl StorageAssertionsStrategy for CdnStorageAssertions {
-    fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
-        assert_cdn_asset_keys(full_path, collection)
+    fn assert_key(&self, full_path: &FullPath, description: &Option<String>, collection: &CollectionKey) -> Result<(), String> {
+        assert_cdn_asset_keys(full_path, description, collection)
     }
 
     fn assert_write_on_dapp_collection(

--- a/src/libs/satellite/src/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/storage/strategy_impls.rs
@@ -26,7 +26,12 @@ use junobuild_storage::types::store::{
 pub struct StorageAssertions;
 
 impl StorageAssertionsStrategy for StorageAssertions {
-    fn assert_key(&self, full_path: &FullPath, description: &Option<String>, collection: &CollectionKey) -> Result<(), String> {
+    fn assert_key(
+        &self,
+        full_path: &FullPath,
+        description: &Option<String>,
+        collection: &CollectionKey,
+    ) -> Result<(), String> {
         assert_cdn_asset_keys(full_path, description, collection)
     }
 

--- a/src/libs/satellite/src/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/storage/strategy_impls.rs
@@ -26,8 +26,8 @@ use junobuild_storage::types::store::{
 pub struct StorageAssertions;
 
 impl StorageAssertionsStrategy for StorageAssertions {
-    fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String> {
-        assert_cdn_asset_keys(full_path, collection)
+    fn assert_key(&self, full_path: &FullPath, description: &Option<String>, collection: &CollectionKey) -> Result<(), String> {
+        assert_cdn_asset_keys(full_path, description, collection)
     }
 
     fn assert_write_on_dapp_collection(

--- a/src/libs/storage/src/assert.rs
+++ b/src/libs/storage/src/assert.rs
@@ -33,6 +33,7 @@ pub fn assert_create_batch(
     assert_key(
         caller,
         &init.full_path,
+        &init.description,
         &init.collection,
         assertions,
         controllers,
@@ -76,6 +77,7 @@ pub fn assert_commit_batch(
     assert_key(
         caller,
         &batch.key.full_path,
+        &batch.key.description,
         &batch.key.collection,
         assertions,
         controllers,
@@ -180,6 +182,7 @@ fn assert_memory_size(config: &StorageConfig) -> Result<(), String> {
 /// # Arguments
 /// * `caller` - The principal trying to upload the asset.
 /// * `full_path` - The full path where the asset is to be stored.
+/// * `description` - The optional description of the asset.
 /// * `collection` - The collection key (e.g., `#dapp`, `user-assets`, etc.).
 /// * `controllers` - A list of principals allowed to control the storage.
 ///
@@ -197,6 +200,7 @@ fn assert_memory_size(config: &StorageConfig) -> Result<(), String> {
 fn assert_key(
     caller: Principal,
     full_path: &FullPath,
+    description: &Option<String>,
     collection: &CollectionKey,
     assertions: &impl StorageAssertionsStrategy,
     controllers: &Controllers,
@@ -234,7 +238,7 @@ fn assert_key(
         return Err(JUNO_STORAGE_ERROR_UPLOAD_PATH_COLLECTION_PREFIX.to_string());
     }
 
-    assertions.assert_key(full_path, collection)?;
+    assertions.assert_key(full_path, description, collection)?;
 
     Ok(())
 }

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -11,7 +11,7 @@ use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
 
 pub trait StorageAssertionsStrategy {
-    fn assert_key(&self, full_path: &FullPath, collection: &CollectionKey) -> Result<(), String>;
+    fn assert_key(&self, full_path: &FullPath, description: &Option<String>, collection: &CollectionKey) -> Result<(), String>;
 
     fn assert_write_on_dapp_collection(&self, caller: Principal, controllers: &Controllers)
         -> bool;

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -11,7 +11,12 @@ use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
 
 pub trait StorageAssertionsStrategy {
-    fn assert_key(&self, full_path: &FullPath, description: &Option<String>, collection: &CollectionKey) -> Result<(), String>;
+    fn assert_key(
+        &self,
+        full_path: &FullPath,
+        description: &Option<String>,
+        collection: &CollectionKey,
+    ) -> Result<(), String>;
 
     fn assert_write_on_dapp_collection(&self, caller: Principal, controllers: &Controllers)
         -> bool;

--- a/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
@@ -8,9 +8,7 @@ import { type Actor, PocketIc } from '@hadronous/pic';
 import {
 	JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER,
 	JUNO_AUTH_ERROR_NOT_CONTROLLER,
-	JUNO_AUTH_ERROR_NOT_WRITE_CONTROLLER, JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION,
-	JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH,
-	JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION,
+	JUNO_AUTH_ERROR_NOT_WRITE_CONTROLLER,
 	JUNO_STORAGE_ERROR_UPLOAD_PATH_COLLECTION_PREFIX
 } from '@junobuild/errors';
 import { beforeAll, describe, expect, inject } from 'vitest';
@@ -214,9 +212,6 @@ describe('Satellite > Cdn', () => {
 			'/_juno/releases/satellite.wasm.gz'
 		];
 
-		const FULL_PATH_PREFIX = '/_juno/releases';
-		const VALID_COLLECTION = '#_juno';
-
 		beforeAll(async () => {
 			actor.setIdentity(controller);
 
@@ -256,61 +251,8 @@ describe('Satellite > Cdn', () => {
 				'orbiter.txt'
 			],
 			validModuleFullPaths,
-			validCollection: VALID_COLLECTION,
-			fullPathPrefix: FULL_PATH_PREFIX
-		});
-
-		describe("Asset requires description", () => {
-			const filename = `satellite-${crypto.randomUUID()}.wasm.gz`;
-			const fullPath = `${FULL_PATH_PREFIX}/${filename}`;
-
-			it('should throw error if description is missing', async () => {
-				const { init_proposal_asset_upload, init_proposal } = actor;
-
-				const [proposalId, _] = await init_proposal({
-					AssetsUpgrade: {
-						clear_existing_assets: toNullable()
-					}
-				});
-
-				await expect(
-					init_proposal_asset_upload(
-						{
-							collection: VALID_COLLECTION,
-							description: toNullable(),
-							encoding_type: [],
-							full_path: fullPath,
-							name: filename,
-							token: toNullable()
-						},
-						proposalId
-					)
-				).rejects.toThrow(JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION);
-			});
-
-			it('should throw error if description is using an invalid pattern', async () => {
-				const { init_proposal_asset_upload, init_proposal } = actor;
-
-				const [proposalId, _] = await init_proposal({
-					AssetsUpgrade: {
-						clear_existing_assets: toNullable()
-					}
-				});
-
-				await expect(
-					init_proposal_asset_upload(
-						{
-							collection: VALID_COLLECTION,
-							description: toNullable("test"),
-							encoding_type: [],
-							full_path: fullPath,
-							name: filename,
-							token: toNullable(),
-						},
-						proposalId
-					)
-				).rejects.toThrow(`${JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION} (test)`);
-			});
+			validCollection: '#_juno',
+			fullPathPrefix: '/_juno/releases'
 		});
 
 		describe.each(validModuleFullPaths)(`Assert upload value path start with %s`, (fullPath) => {
@@ -382,7 +324,7 @@ describe('Satellite > Cdn', () => {
 				canisterId: () => canisterId,
 				caller: () => controllerSubmit,
 				pic: () => pic,
-				expected_proposal_id: 30n,
+				expected_proposal_id: 32n,
 				fullPaths: {
 					assetsUpgrade: '/magic.html',
 					segmentsDeployment: '/_juno/releases/satellite-v2.1.1.wasm.gz',
@@ -394,7 +336,7 @@ describe('Satellite > Cdn', () => {
 			testCdnGetProposal({
 				actor: () => actor,
 				owner: () => controllerSubmit,
-				proposalId: 30n
+				proposalId: 32n
 			});
 
 			testCdnGetProposal({
@@ -414,7 +356,7 @@ describe('Satellite > Cdn', () => {
 					return actor;
 				},
 				owner: () => controllerSubmit,
-				proposalId: 30n
+				proposalId: 32n
 			});
 
 			testCdnGetProposal({
@@ -423,7 +365,7 @@ describe('Satellite > Cdn', () => {
 					return actor;
 				},
 				owner: () => controllerSubmit,
-				proposalId: 30n
+				proposalId: 32n
 			});
 		});
 
@@ -442,7 +384,7 @@ describe('Satellite > Cdn', () => {
 				canisterId: () => canisterId,
 				caller: () => controllerSubmit,
 				pic: () => pic,
-				expected_proposal_id: 36n,
+				expected_proposal_id: 38n,
 				fullPaths: {
 					assetsUpgrade: '/book.html',
 					segmentsDeployment: '/_juno/releases/satellite-v3.1.1.wasm.gz',
@@ -454,7 +396,7 @@ describe('Satellite > Cdn', () => {
 			testCdnGetProposal({
 				actor: () => actor,
 				owner: () => controllerSubmit,
-				proposalId: 30n
+				proposalId: 32n
 			});
 
 			testCdnGetProposal({
@@ -474,7 +416,7 @@ describe('Satellite > Cdn', () => {
 					return actor;
 				},
 				owner: () => controllerSubmit,
-				proposalId: 30n
+				proposalId: 32n
 			});
 
 			testCdnGetProposal({
@@ -483,7 +425,7 @@ describe('Satellite > Cdn', () => {
 					return actor;
 				},
 				owner: () => controllerSubmit,
-				proposalId: 30n
+				proposalId: 32n
 			});
 		});
 
@@ -493,7 +435,7 @@ describe('Satellite > Cdn', () => {
 			await expect(
 				commit_proposal({
 					sha256: Array.from({ length: 32 }).map((_, i) => i),
-					proposal_id: 30n
+					proposal_id: 32n
 				})
 			).rejects.toThrow(JUNO_AUTH_ERROR_NOT_WRITE_CONTROLLER);
 		});
@@ -514,12 +456,12 @@ describe('Satellite > Cdn', () => {
 
 		testCdnListProposals({
 			actor: () => actor,
-			proposalsLength: 41n
+			proposalsLength: 43n
 		});
 
 		testCdnCountProposals({
 			actor: () => actor,
-			proposalsLength: 41n
+			proposalsLength: 43n
 		});
 	});
 });

--- a/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
@@ -144,6 +144,7 @@ describe('Satellite > Cdn', () => {
 			fullPaths: {
 				assetsUpgrade: '/hello.html',
 				segmentsDeployment: '/_juno/releases/satellite-v0.0.18.wasm.gz',
+				segmentsVersion: '0.0.18',
 				assetsCollection: '#dapp',
 				segmentsCollection: '#_juno'
 			}
@@ -187,6 +188,7 @@ describe('Satellite > Cdn', () => {
 			fullPaths: {
 				assetsUpgrade: '/world.html',
 				segmentsDeployment: '/_juno/releases/satellite-v0.1.1.wasm.gz',
+				segmentsVersion: '0.1.1',
 				assetsCollection: '#dapp',
 				segmentsCollection: '#_juno'
 			}
@@ -328,6 +330,7 @@ describe('Satellite > Cdn', () => {
 				fullPaths: {
 					assetsUpgrade: '/magic.html',
 					segmentsDeployment: '/_juno/releases/satellite-v2.1.1.wasm.gz',
+					segmentsVersion: '2.1.1',
 					assetsCollection: '#dapp',
 					segmentsCollection: '#_juno'
 				}
@@ -388,6 +391,7 @@ describe('Satellite > Cdn', () => {
 				fullPaths: {
 					assetsUpgrade: '/book.html',
 					segmentsDeployment: '/_juno/releases/satellite-v3.1.1.wasm.gz',
+					segmentsVersion: '3.1.1',
 					assetsCollection: '#dapp',
 					segmentsCollection: '#_juno'
 				}

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -319,7 +319,7 @@ export const testControlledCdnMethods = ({
 				const file = await init_proposal_asset_upload(
 					{
 						collection,
-						description: toNullable(),
+						description: toNullable(`change=${Number(proposalId)};version=v3.2.0`),
 						encoding_type: [],
 						full_path,
 						name: 'hello.html',

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -31,7 +31,9 @@ import {
 	JUNO_CDN_PROPOSALS_ERROR_EMPTY_ASSETS,
 	JUNO_CDN_PROPOSALS_ERROR_INVALID_HASH,
 	JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION,
+	JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION,
 	JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_PATH,
+	JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION,
 	JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND
 } from '@junobuild/errors';
 import { describe, expect } from 'vitest';
@@ -812,6 +814,56 @@ export const testReleasesProposal = ({
 			});
 		});
 
+		describe.each(validModuleFullPaths)('Asset requires description', (fullPath) => {
+			it('should throw error if description is missing', async () => {
+				const { init_proposal_asset_upload, init_proposal } = actor();
+
+				const [proposalId, _] = await init_proposal({
+					AssetsUpgrade: {
+						clear_existing_assets: toNullable()
+					}
+				});
+
+				await expect(
+					init_proposal_asset_upload(
+						{
+							collection: validCollection,
+							description: toNullable(),
+							encoding_type: [],
+							full_path: fullPath,
+							name: fullPath,
+							token: toNullable()
+						},
+						proposalId
+					)
+				).rejects.toThrow(JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION);
+			});
+
+			it('should throw error if description is using an invalid pattern', async () => {
+				const { init_proposal_asset_upload, init_proposal } = actor();
+
+				const [proposalId, _] = await init_proposal({
+					AssetsUpgrade: {
+						clear_existing_assets: toNullable()
+					}
+				});
+
+				await expect(
+					init_proposal_asset_upload(
+						{
+							collection: validCollection,
+							description: toNullable('test'),
+							encoding_type: [],
+							full_path: fullPath,
+							name: fullPath,
+							token: toNullable()
+						},
+						proposalId
+					)
+				).rejects.toThrow(`${JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION} (test)`);
+			});
+		});
+
 		describe.each(validModuleFullPaths)(`Assert upload value path %s`, (fullPath) => {
 			it('should throw error if collection is #dapp', async () => {
 				const { init_proposal_asset_upload, init_proposal } = actor();
@@ -955,7 +1007,7 @@ export const testCdnGetProposal = ({
 
 export const testCdnCountProposals = ({
 	actor,
-	proposalsLength = 19n
+	proposalsLength = 25n
 }: {
 	actor: () => Actor<SatelliteActor | ConsoleActor>;
 	proposalsLength?: bigint;
@@ -969,7 +1021,7 @@ export const testCdnCountProposals = ({
 
 export const testCdnListProposals = ({
 	actor,
-	proposalsLength = 19n
+	proposalsLength = 25n
 }: {
 	actor: () => Actor<SatelliteActor | ConsoleActor>;
 	proposalsLength?: bigint;

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -224,6 +224,7 @@ export const testControlledCdnMethods = ({
 	fullPaths = {
 		assetsUpgrade: '/hello.html',
 		segmentsDeployment: '/releases/satellite-v0.0.18.wasm.gz',
+		segmentsVersion: '0.0.18',
 		assetsCollection: '#dapp',
 		segmentsCollection: '#releases'
 	}
@@ -237,6 +238,7 @@ export const testControlledCdnMethods = ({
 	fullPaths?: {
 		assetsUpgrade: string;
 		segmentsDeployment: string;
+		segmentsVersion: string;
 		assetsCollection: string;
 		segmentsCollection: string;
 	};
@@ -250,6 +252,7 @@ export const testControlledCdnMethods = ({
 			} as ProposalType,
 			collection: fullPaths.assetsCollection,
 			full_path: fullPaths.assetsUpgrade,
+			version: fullPaths.segmentsVersion,
 			expected_proposal_id
 		},
 		{
@@ -262,11 +265,13 @@ export const testControlledCdnMethods = ({
 			} as ProposalType,
 			collection: fullPaths.segmentsCollection,
 			full_path: fullPaths.segmentsDeployment,
+			description: (proposalId: bigint) =>
+				`change=${proposalId};version=v${fullPaths.segmentsVersion}`,
 			expected_proposal_id: expected_proposal_id + 2n // The proposal committed and the one we reject
 		}
 	])(
 		'Proposal, upload and serve',
-		({ proposal_type, collection, full_path, expected_proposal_id }) => {
+		({ proposal_type, collection, full_path, expected_proposal_id, description }) => {
 			let sha256: [] | [Uint8Array | number[]];
 			let proposalId: bigint;
 
@@ -321,7 +326,7 @@ export const testControlledCdnMethods = ({
 				const file = await init_proposal_asset_upload(
 					{
 						collection,
-						description: toNullable(`change=${Number(proposalId)};version=v3.2.0`),
+						description: toNullable(description?.(proposalId)),
 						encoding_type: [],
 						full_path,
 						name: 'hello.html',

--- a/src/tests/utils/console-tests.utils.ts
+++ b/src/tests/utils/console-tests.utils.ts
@@ -89,7 +89,7 @@ const uploadSegment = async ({
 	const { batch_id: batchId } = await init_proposal_asset_upload(
 		{
 			collection: '#releases',
-			description: toNullable(),
+			description: toNullable(`change=${proposalId};version=v${version}`),
 			encoding_type: ['identity'],
 			full_path: fullPath,
 			name,


### PR DESCRIPTION
# Motivation

We want to pass the change (proposal) number and version within the description field of the asset.

We want to do this for the Satellite and Console, any CDN. This means, that's a "breaking change" or required addition to the current Console implementation.
