### PR TITLE
feat(satellite): narrow #_juno collection to #_juno/releases

### DIFF
--- a/src/libs/satellite/src/cdn/assert.rs
+++ b/src/libs/satellite/src/cdn/assert.rs
@@ -1,4 +1,4 @@
-use crate::cdn::constants::{CDN_JUNO_COLLECTION_KEY, CDN_JUNO_COLLECTION_PATH};
+use crate::cdn::constants::{CDN_JUNO_PATH, CDN_JUNO_RELEASES_COLLECTION_KEY};
 use candid::Principal;
 use junobuild_cdn::storage::assert_releases_description;
 use junobuild_cdn::storage::errors::{
@@ -24,14 +24,14 @@ pub fn assert_cdn_asset_keys(
     collection: &CollectionKey,
 ) -> Result<(), String> {
     match collection.as_str() {
-        CDN_JUNO_COLLECTION_KEY => {
+        CDN_JUNO_RELEASES_COLLECTION_KEY => {
             assert_releases_keys(full_path)?;
             assert_releases_description(description)?;
 
             Ok(())
         }
         _ => {
-            if full_path.starts_with(CDN_JUNO_COLLECTION_PATH) {
+            if full_path.starts_with(CDN_JUNO_PATH) {
                 return Err(format!(
                     "{} ({} - {})",
                     JUNO_CDN_STORAGE_ERROR_INVALID_COLLECTION, full_path, collection
@@ -68,7 +68,7 @@ pub fn assert_cdn_write_on_system_collection(
 ) -> bool {
     // Only controllers with scope "Admin" or "Write" can write in reserved collections starting with #
     // ...unless the collection is #_juno and the controller is "Submit".
-    if collection == CDN_JUNO_COLLECTION_KEY {
+    if collection == CDN_JUNO_RELEASES_COLLECTION_KEY {
         return is_controller(caller, controllers);
     }
 
@@ -82,7 +82,7 @@ pub fn assert_cdn_create_permission(
     controllers: &Controllers,
 ) -> bool {
     // Through a proposal, any controller - including "Submit" - can provide an asset for the #_juno or #dapp collections.
-    if collection == CDN_JUNO_COLLECTION_KEY || collection == COLLECTION_ASSET_KEY {
+    if collection == CDN_JUNO_RELEASES_COLLECTION_KEY || collection == COLLECTION_ASSET_KEY {
         return assert_create_permission_with(permission, caller, controllers, is_controller);
     }
 
@@ -97,7 +97,7 @@ pub fn assert_cdn_update_permission(
     controllers: &Controllers,
 ) -> bool {
     // Through a proposal, any controller - including "Submit" - can provide an update of an asset for the #_juno or #dapp collections.
-    if collection == CDN_JUNO_COLLECTION_KEY || collection == COLLECTION_ASSET_KEY {
+    if collection == CDN_JUNO_RELEASES_COLLECTION_KEY || collection == COLLECTION_ASSET_KEY {
         return assert_permission_with(permission, owner, caller, controllers, is_controller);
     }
 

--- a/src/libs/satellite/src/cdn/constants.rs
+++ b/src/libs/satellite/src/cdn/constants.rs
@@ -2,12 +2,12 @@ use junobuild_collections::types::interface::SetRule;
 use junobuild_collections::types::rules::Memory;
 use junobuild_collections::types::rules::Permission::Controllers;
 
-pub const CDN_JUNO_COLLECTION_KEY: &str = "#_juno";
+pub const CDN_JUNO_PATH: &str = "/_juno/";
 
-pub const CDN_JUNO_COLLECTION_PATH: &str = "/_juno/";
+pub const CDN_JUNO_RELEASES_COLLECTION_KEY: &str = "#_juno/releases";
 
-pub const DEFAULT_CDN_JUNO_COLLECTIONS: [(&str, SetRule); 1] = [(
-    CDN_JUNO_COLLECTION_KEY,
+pub const DEFAULT_CDN_JUNO_RELEASES_COLLECTIONS: [(&str, SetRule); 1] = [(
+    CDN_JUNO_RELEASES_COLLECTION_KEY,
     SetRule {
         read: Controllers,
         write: Controllers,

--- a/src/libs/satellite/src/hooks/storage.rs
+++ b/src/libs/satellite/src/hooks/storage.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::cdn::constants::CDN_JUNO_COLLECTION_KEY;
+use crate::cdn::constants::CDN_JUNO_RELEASES_COLLECTION_KEY;
 use crate::types::hooks::{
     AssertDeleteAssetContext, AssertUploadAssetContext, OnDeleteAssetContext,
     OnDeleteFilteredAssetsContext, OnDeleteManyAssetsContext, OnUploadAssetContext,
@@ -216,7 +216,7 @@ fn filter_assets(
 
 // We skip system collections for performance reason given that the hook might be called when the developer deploys their frontend dapps or update their serverless functions.
 fn is_system_collection(collection: &CollectionKey) -> bool {
-    collection == COLLECTION_ASSET_KEY || collection == CDN_JUNO_COLLECTION_KEY
+    collection == COLLECTION_ASSET_KEY || collection == CDN_JUNO_RELEASES_COLLECTION_KEY
 }
 
 fn is_not_system_collection(collection: &CollectionKey) -> bool {

--- a/src/libs/satellite/src/memory/upgrade.rs
+++ b/src/libs/satellite/src/memory/upgrade.rs
@@ -1,4 +1,6 @@
-use crate::cdn::constants::{CDN_JUNO_COLLECTION_KEY, DEFAULT_CDN_JUNO_COLLECTIONS};
+use crate::cdn::constants::{
+    CDN_JUNO_RELEASES_COLLECTION_KEY, DEFAULT_CDN_JUNO_RELEASES_COLLECTIONS,
+};
 use crate::memory::internal::STATE;
 use ic_cdk::api::time;
 use junobuild_collections::types::interface::SetRule;
@@ -11,7 +13,7 @@ pub fn init_juno_collection() {
     STATE.with(|state| {
         let rules = &mut state.borrow_mut().heap.storage.rules;
 
-        if !rules.contains_key(CDN_JUNO_COLLECTION_KEY) {
+        if !rules.contains_key(CDN_JUNO_RELEASES_COLLECTION_KEY) {
             init_juno_collection_impl(rules);
         }
     });
@@ -20,7 +22,7 @@ pub fn init_juno_collection() {
 fn init_juno_collection_impl(rules: &mut Rules) {
     let now = time();
 
-    let cdn_set_rule: SetRule = DEFAULT_CDN_JUNO_COLLECTIONS[0].1.clone();
+    let cdn_set_rule: SetRule = DEFAULT_CDN_JUNO_RELEASES_COLLECTIONS[0].1.clone();
 
     let cdn_rule: Rule = Rule {
         read: cdn_set_rule.read,
@@ -36,5 +38,5 @@ fn init_juno_collection_impl(rules: &mut Rules) {
         rate_config: cdn_set_rule.rate_config,
     };
 
-    rules.insert(CDN_JUNO_COLLECTION_KEY.to_string(), cdn_rule);
+    rules.insert(CDN_JUNO_RELEASES_COLLECTION_KEY.to_string(), cdn_rule);
 }

--- a/src/libs/satellite/src/memory/utils.rs
+++ b/src/libs/satellite/src/memory/utils.rs
@@ -1,11 +1,11 @@
-use crate::cdn::constants::DEFAULT_CDN_JUNO_COLLECTIONS;
+use crate::cdn::constants::DEFAULT_CDN_JUNO_RELEASES_COLLECTIONS;
 use junobuild_collections::constants::assets::DEFAULT_ASSETS_COLLECTIONS;
 use junobuild_storage::types::state::StorageHeapState;
 
 pub fn init_storage_heap_state() -> StorageHeapState {
     let mut collections = Vec::with_capacity(2);
     collections.extend_from_slice(&DEFAULT_ASSETS_COLLECTIONS);
-    collections.extend_from_slice(&DEFAULT_CDN_JUNO_COLLECTIONS);
+    collections.extend_from_slice(&DEFAULT_CDN_JUNO_RELEASES_COLLECTIONS);
 
     StorageHeapState::new_with_storage_collections(collections)
 }

--- a/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
@@ -146,7 +146,7 @@ describe('Satellite > Cdn', () => {
 				segmentsDeployment: '/_juno/releases/satellite-v0.0.18.wasm.gz',
 				segmentsVersion: '0.0.18',
 				assetsCollection: '#dapp',
-				segmentsCollection: '#_juno'
+				segmentsCollection: '#_juno/releases'
 			}
 		});
 
@@ -190,7 +190,7 @@ describe('Satellite > Cdn', () => {
 				segmentsDeployment: '/_juno/releases/satellite-v0.1.1.wasm.gz',
 				segmentsVersion: '0.1.1',
 				assetsCollection: '#dapp',
-				segmentsCollection: '#_juno'
+				segmentsCollection: '#_juno/releases'
 			}
 		});
 
@@ -253,7 +253,7 @@ describe('Satellite > Cdn', () => {
 				'orbiter.txt'
 			],
 			validModuleFullPaths,
-			validCollection: '#_juno',
+			validCollection: '#_juno/releases',
 			fullPathPrefix: '/_juno/releases'
 		});
 
@@ -332,7 +332,7 @@ describe('Satellite > Cdn', () => {
 					segmentsDeployment: '/_juno/releases/satellite-v2.1.1.wasm.gz',
 					segmentsVersion: '2.1.1',
 					assetsCollection: '#dapp',
-					segmentsCollection: '#_juno'
+					segmentsCollection: '#_juno/releases'
 				}
 			});
 
@@ -393,7 +393,7 @@ describe('Satellite > Cdn', () => {
 					segmentsDeployment: '/_juno/releases/satellite-v3.1.1.wasm.gz',
 					segmentsVersion: '3.1.1',
 					assetsCollection: '#dapp',
-					segmentsCollection: '#_juno'
+					segmentsCollection: '#_juno/releases'
 				}
 			});
 

--- a/src/tests/specs/satellite/stock/satellite.upgrade.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.upgrade.spec.ts
@@ -786,12 +786,12 @@ describe('Satellite > Upgrade', () => {
 			);
 		});
 
-		it('should create collection #_juno', async () => {
+		it('should create collection #_juno/releases', async () => {
 			await upgrade();
 
 			const { get_rule } = actor;
 
-			const result = await get_rule({ Storage: null }, '#_juno');
+			const result = await get_rule({ Storage: null }, '#_juno/releases');
 
 			const rule = fromNullable(result);
 


### PR DESCRIPTION
# Motivation

To fetch the releases assets, it will be more performant to narrow the collection.
