### PR TITLE
fix(cdn): integrate proposal_id in uploaded chunk

### DIFF
--- a/src/console/src/cdn/helpers/stable.rs
+++ b/src/console/src/cdn/helpers/stable.rs
@@ -17,6 +17,7 @@ pub fn get_asset_stable(
 }
 
 pub fn insert_asset_encoding_stable(
+    proposal_id: &ProposalId,
     full_path: &FullPath,
     encoding_type: &str,
     encoding: &AssetEncoding,
@@ -24,6 +25,7 @@ pub fn insert_asset_encoding_stable(
 ) {
     junobuild_cdn::storage::stable::insert_asset_encoding(
         &CdnStable,
+        proposal_id,
         full_path,
         encoding_type,
         encoding,

--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -9,6 +9,7 @@ use crate::cdn::strategies_impls::cdn::CdnHeap;
 use candid::Principal;
 use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID,
+    JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_ENCODING_UNKNOWN_REFERENCE_ID,
     JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_UNKNOWN_REFERENCE_ID,
 };
 use junobuild_collections::assert::stores::{assert_create_permission, assert_permission};
@@ -177,13 +178,29 @@ pub struct StorageUpload;
 impl StorageUploadStrategy for StorageUpload {
     fn insert_asset_encoding(
         &self,
+        reference_id: &Option<ReferenceId>,
         full_path: &FullPath,
         encoding_type: &EncodingType,
         encoding: &AssetEncoding,
         asset: &mut Asset,
         _rule: &Rule,
-    ) {
-        insert_asset_encoding_stable(full_path, encoding_type, encoding, asset);
+    ) -> Result<(), String> {
+        match reference_id {
+            Some(reference_id) => {
+                insert_asset_encoding_stable(
+                    reference_id,
+                    full_path,
+                    encoding_type,
+                    encoding,
+                    asset,
+                );
+                Ok(())
+            }
+            None => Err(
+                JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_ENCODING_UNKNOWN_REFERENCE_ID
+                    .to_string(),
+            ),
+        }
     }
 
     fn insert_asset(&self, batch: &Batch, asset: &Asset, _rule: &Rule) -> Result<(), String> {

--- a/src/console/src/memory/lifecycle.rs
+++ b/src/console/src/memory/lifecycle.rs
@@ -1,6 +1,6 @@
 use crate::cdn::certified_assets::upgrade::defer_init_certified_assets;
 use crate::cdn::lifecycle::init_cdn_storage_heap_state;
-use crate::memory::manager::{get_memory_upgrades, init_stable_state, STATE};
+use crate::memory::manager::{free_stable_memory, get_memory_upgrades, init_stable_state, STATE};
 use crate::types::state::{Fees, HeapState, Rates, ReleasesMetadata, State};
 use ciborium::{from_reader, into_writer};
 use ic_cdk::caller;
@@ -44,6 +44,12 @@ fn pre_upgrade() {
 
 #[post_upgrade]
 fn post_upgrade() {
+    // ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+    // ⚠️ Clearing memory must be executed before the state is initialized.
+    // ⚠️ e.g. Memory ID might be reused or the types of the data and keys might change.
+    // ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+    free_stable_memory();
+
     let memory = get_memory_upgrades();
     let state_bytes = read_post_upgrade(&memory);
 

--- a/src/console/src/memory/lifecycle.rs
+++ b/src/console/src/memory/lifecycle.rs
@@ -44,6 +44,7 @@ fn pre_upgrade() {
 
 #[post_upgrade]
 fn post_upgrade() {
+    // TODO: To be removed
     // ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
     // ⚠️ Clearing memory must be executed before the state is initialized.
     // ⚠️ e.g. Memory ID might be reused or the types of the data and keys might change.

--- a/src/console/src/memory/manager.rs
+++ b/src/console/src/memory/manager.rs
@@ -53,6 +53,8 @@ pub fn init_stable_state() -> StableState {
     }
 }
 
+// TODO: One time upgrade - To be removed.
+
 // ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
 // ⚠️ The introduction of the CDN requires a breaking change due to how content chunks are handled.
 // ⚠️ Therefore we're starting fresh.

--- a/src/console/src/memory/manager.rs
+++ b/src/console/src/memory/manager.rs
@@ -1,15 +1,15 @@
 use crate::types::state::{StableState, State};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
-use ic_stable_structures::DefaultMemoryImpl;
 use ic_stable_structures::StableBTreeMap;
+use ic_stable_structures::{DefaultMemoryImpl, Memory as _};
 use junobuild_shared::types::memory::Memory;
 use std::cell::RefCell;
 
 const UPGRADES: MemoryId = MemoryId::new(0);
 const MISSION_CONTROLS: MemoryId = MemoryId::new(1);
 const PAYMENTS: MemoryId = MemoryId::new(2);
-const ASSETS: MemoryId = MemoryId::new(3);
-const CONTENT_CHUNKS: MemoryId = MemoryId::new(4);
+const PROPOSAL_ASSETS: MemoryId = MemoryId::new(3);
+const PROPOSAL_CONTENT_CHUNKS: MemoryId = MemoryId::new(4);
 const PROPOSALS: MemoryId = MemoryId::new(5);
 
 thread_local! {
@@ -32,11 +32,11 @@ fn get_memory_payments() -> Memory {
 }
 
 fn get_memory_assets() -> Memory {
-    MEMORY_MANAGER.with(|m| m.borrow().get(ASSETS))
+    MEMORY_MANAGER.with(|m| m.borrow().get(PROPOSAL_ASSETS))
 }
 
 fn get_memory_content_chunks() -> Memory {
-    MEMORY_MANAGER.with(|m| m.borrow().get(CONTENT_CHUNKS))
+    MEMORY_MANAGER.with(|m| m.borrow().get(PROPOSAL_CONTENT_CHUNKS))
 }
 
 fn get_memory_proposals() -> Memory {
@@ -51,4 +51,31 @@ pub fn init_stable_state() -> StableState {
         proposals_content_chunks: StableBTreeMap::init(get_memory_content_chunks()),
         proposals: StableBTreeMap::init(get_memory_proposals()),
     }
+}
+
+// ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+// ⚠️ The introduction of the CDN requires a breaking change due to how content chunks are handled.
+// ⚠️ Therefore we're starting fresh.
+// ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+
+pub fn free_stable_memory() {
+    MEMORY_MANAGER.with(|m| {
+        let memory_manager = m.borrow();
+
+        for memory_id in [PROPOSAL_ASSETS, PROPOSAL_CONTENT_CHUNKS, PROPOSALS] {
+            // This cleans up the memory by writing a single zero byte to the memory id,
+            // this will make the memory id available for reuse in the future.
+            //
+            // This makes sure that if `init` is called on the memory id, it will make sure
+            // it can be reused with a different datatype.
+            let memory = memory_manager.get(memory_id);
+            if memory.size() > 0 {
+                // This marks the memory as unused, this is because the StableBTreeMap
+                // implementation uses the first three bytes of the memory to store the MAGIC value [66, 84, 82]
+                // that indicates that the memory is used by the StableBTreeMap, so adding a single different byte
+                // in those first three bytes will make the memory available for reuse.
+                memory.write(0, &[0]);
+            }
+        }
+    })
 }

--- a/src/declarations/deprecated/console-0-0-14.did.d.ts
+++ b/src/declarations/deprecated/console-0-0-14.did.d.ts
@@ -160,7 +160,7 @@ export interface RateConfig {
 	max_tokens: bigint;
 	time_per_token_ns: bigint;
 }
-export type SegmentKind = { Orbiter: null } | { MissionControl: null } | { Satellite: null };
+export type SegmentType = { Orbiter: null } | { MissionControl: null } | { Satellite: null };
 export interface SegmentsDeploymentOptions {
 	orbiter: [] | [string];
 	mission_control_version: [] | [string];
@@ -228,8 +228,8 @@ export interface _SERVICE {
 	add_credits: ActorMethod<[Principal, Tokens], undefined>;
 	add_invitation_code: ActorMethod<[string], undefined>;
 	assert_mission_control_center: ActorMethod<[AssertMissionControlCenterArgs], undefined>;
+	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
-	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	create_orbiter: ActorMethod<[CreateCanisterArgs], Principal>;
 	create_satellite: ActorMethod<[CreateCanisterArgs], Principal>;
 	del_controllers: ActorMethod<[DeleteControllersArgs], undefined>;
@@ -247,8 +247,8 @@ export interface _SERVICE {
 		[StreamingCallbackToken],
 		StreamingCallbackHttpResponse
 	>;
+	init_asset_upload: ActorMethod<[InitAssetKey, bigint], InitUploadResult>;
 	init_proposal: ActorMethod<[ProposalType], [bigint, Proposal]>;
-	init_proposal_asset_upload: ActorMethod<[InitAssetKey, bigint], InitUploadResult>;
 	init_user_mission_control_center: ActorMethod<[], MissionControl>;
 	list_assets: ActorMethod<[string, ListParams], ListResults>;
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
@@ -256,11 +256,12 @@ export interface _SERVICE {
 	list_user_mission_control_centers: ActorMethod<[], Array<[Principal, MissionControl]>>;
 	set_controllers: ActorMethod<[SetControllersArgs], undefined>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;
-	set_fee: ActorMethod<[SegmentKind, Tokens], undefined>;
+	set_fee: ActorMethod<[SegmentType, Tokens], undefined>;
 	set_storage_config: ActorMethod<[StorageConfig], undefined>;
 	submit_proposal: ActorMethod<[bigint], [bigint, Proposal]>;
-	update_rate_config: ActorMethod<[SegmentKind, RateConfig], undefined>;
-	upload_proposal_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
+	update_rate_config: ActorMethod<[SegmentType, RateConfig], undefined>;
+	upload_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
+	version: ActorMethod<[], string>;
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/deprecated/console-0-0-14.factory.did.js
+++ b/src/declarations/deprecated/console-0-0-14.factory.did.js
@@ -5,14 +5,14 @@ export const idlFactory = ({ IDL }) => {
 		mission_control_id: IDL.Principal,
 		user: IDL.Principal
 	});
-	const CommitProposal = IDL.Record({
-		sha256: IDL.Vec(IDL.Nat8),
-		proposal_id: IDL.Nat
-	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
+	});
+	const CommitProposal = IDL.Record({
+		sha256: IDL.Vec(IDL.Nat8),
+		proposal_id: IDL.Nat
 	});
 	const CreateCanisterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
@@ -219,7 +219,7 @@ export const idlFactory = ({ IDL }) => {
 		controller: SetController,
 		controllers: IDL.Vec(IDL.Principal)
 	});
-	const SegmentKind = IDL.Variant({
+	const SegmentType = IDL.Variant({
 		Orbiter: IDL.Null,
 		MissionControl: IDL.Null,
 		Satellite: IDL.Null
@@ -238,14 +238,14 @@ export const idlFactory = ({ IDL }) => {
 		add_credits: IDL.Func([IDL.Principal, Tokens], [], []),
 		add_invitation_code: IDL.Func([IDL.Text], [], []),
 		assert_mission_control_center: IDL.Func([AssertMissionControlCenterArgs], [], ['query']),
+		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
-		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		create_orbiter: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
 		create_satellite: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		delete_proposal_assets: IDL.Func([DeleteProposalAssets], [], []),
-		get_config: IDL.Func([], [Config], ['query']),
+		get_config: IDL.Func([], [Config], []),
 		get_create_orbiter_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], ['query']),
 		get_create_satellite_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], ['query']),
 		get_credits: IDL.Func([], [Tokens], ['query']),
@@ -258,8 +258,8 @@ export const idlFactory = ({ IDL }) => {
 			[StreamingCallbackHttpResponse],
 			['query']
 		),
+		init_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_proposal: IDL.Func([ProposalType], [IDL.Nat, Proposal], []),
-		init_proposal_asset_upload: IDL.Func([InitAssetKey, IDL.Nat], [InitUploadResult], []),
 		init_user_mission_control_center: IDL.Func([], [MissionControl], []),
 		list_assets: IDL.Func([IDL.Text, ListParams], [ListResults], ['query']),
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
@@ -271,11 +271,12 @@ export const idlFactory = ({ IDL }) => {
 		),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
-		set_fee: IDL.Func([SegmentKind, Tokens], [], []),
+		set_fee: IDL.Func([SegmentType, Tokens], [], []),
 		set_storage_config: IDL.Func([StorageConfig], [], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
-		update_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
-		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
+		update_rate_config: IDL.Func([SegmentType, RateConfig], [], []),
+		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
+		version: IDL.Func([], [IDL.Text], ['query'])
 	});
 };
 // @ts-ignore

--- a/src/libs/cdn/src/storage/errors.rs
+++ b/src/libs/cdn/src/storage/errors.rs
@@ -4,6 +4,9 @@ pub const JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_UNKNOWN_REFERENCE_ID: &str 
 // Cannot get asset with unknown reference / proposal ID.
 pub const JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID: &str =
     "juno.cdn.storage.error.cannot_get_asset_unknown_reference_id";
+// Cannot insert asset encoding with unknown reference / proposal ID.
+pub const JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_ENCODING_UNKNOWN_REFERENCE_ID: &str =
+    "juno.cdn.storage.error.cannot_insert_asset_encoding_unknown_reference_id";
 
 // No proposal found for {}
 pub const JUNO_CDN_STORAGE_ERROR_NO_PROPOSAL_FOUND: &str =

--- a/src/libs/cdn/src/storage/state/types.rs
+++ b/src/libs/cdn/src/storage/state/types.rs
@@ -20,6 +20,7 @@ pub struct ProposalAssetKey {
 
 #[derive(CandidType, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProposalContentChunkKey {
+    pub proposal_id: ProposalId,
     pub full_path: FullPath,
     pub encoding_type: EncodingType,
     pub chunk_index: usize,

--- a/src/libs/satellite/src/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/storage/strategy_impls.rs
@@ -169,13 +169,15 @@ pub struct StorageUpload;
 impl StorageUploadStrategy for StorageUpload {
     fn insert_asset_encoding(
         &self,
+        _reference_id: &Option<ReferenceId>,
         full_path: &FullPath,
         encoding_type: &EncodingType,
         encoding: &AssetEncoding,
         asset: &mut Asset,
         rule: &Rule,
-    ) {
+    ) -> Result<(), String> {
         insert_asset_encoding(full_path, encoding_type, encoding, asset, rule);
+        Ok(())
     }
 
     fn insert_asset(&self, batch: &Batch, asset: &Asset, rule: &Rule) -> Result<(), String> {

--- a/src/libs/storage/src/store.rs
+++ b/src/libs/storage/src/store.rs
@@ -111,6 +111,7 @@ pub fn create_chunk(
     let batch = get_runtime_batch(&batch_id);
 
     match batch {
+        // TODO: error label
         None => Err("Batch not found.".to_string()),
         Some(b) => {
             assert_create_chunk(caller, config, &b)?;
@@ -304,6 +305,7 @@ fn commit_chunks(
         let chunk = get_runtime_chunk(chunk_id);
 
         match chunk {
+            // TODO: error label
             None => {
                 return Err("Chunk does not exist.".to_string());
             }
@@ -328,6 +330,7 @@ fn commit_chunks(
     }
 
     if content_chunks.is_empty() {
+        // TODO: error label
         return Err("No chunk to commit.".to_string());
     }
 
@@ -351,18 +354,20 @@ fn commit_chunks(
         Some(max_size) => {
             if encoding.total_length > max_size {
                 clear_runtime_batch(&batch_id, &chunk_ids);
+                // TODO: error label
                 return Err("Asset exceed max allowed size.".to_string());
             }
         }
     }
 
     storage_upload.insert_asset_encoding(
-        &batch.clone().key.full_path,
+        &batch.reference_id,
+        &batch.key.full_path,
         &encoding_type,
         &encoding,
         &mut asset,
         rule,
-    );
+    )?;
 
     storage_upload.insert_asset(batch, &asset, rule)?;
 

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -115,12 +115,13 @@ pub trait StorageStateStrategy {
 pub trait StorageUploadStrategy {
     fn insert_asset_encoding(
         &self,
+        reference_id: &Option<ReferenceId>,
         full_path: &FullPath,
         encoding_type: &EncodingType,
         encoding: &AssetEncoding,
         asset: &mut Asset,
         rule: &Rule,
-    );
+    ) -> Result<(), String>;
 
     fn insert_asset(&self, batch: &Batch, asset: &Asset, rule: &Rule) -> Result<(), String>;
 

--- a/src/tests/mocks/storage.mocks.ts
+++ b/src/tests/mocks/storage.mocks.ts
@@ -3,3 +3,5 @@ export const mockHtml = '<html><body>Hello</body></html>';
 export const mockBlob = new Blob([mockHtml], {
 	type: 'text/plain; charset=utf-8'
 });
+
+export const mockScript = '<script>console.log(123)</script>';

--- a/src/tests/specs/console/console.upgrade.spec.ts
+++ b/src/tests/specs/console/console.upgrade.spec.ts
@@ -1,9 +1,9 @@
+import type { _SERVICE as ConsoleActor } from '$declarations/console/console.did';
+import { idlFactory as idlFactorConsole } from '$declarations/console/console.factory.did';
 import type { _SERVICE as ConsoleActor_0_0_14 } from '$declarations/deprecated/console-0-0-14.did';
 import { idlFactory as idlFactoryConsole_0_0_14 } from '$declarations/deprecated/console-0-0-14.factory.did';
 import type { _SERVICE as ConsoleActor_0_0_8 } from '$declarations/deprecated/console-0-0-8-patch1.did';
 import { idlFactory as idlFactorConsole_0_0_8 } from '$declarations/deprecated/console-0-0-8-patch1.factory.did';
-import type { _SERVICE as ConsoleActor } from '$declarations/orbiter/orbiter.did';
-import { idlFactory as idlFactorConsole } from '$declarations/orbiter/orbiter.factory.did';
 import type { Identity } from '@dfinity/agent';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Principal } from '@dfinity/principal';
@@ -11,8 +11,9 @@ import { assertNonNullish } from '@dfinity/utils';
 import { PocketIc, type Actor } from '@hadronous/pic';
 import { afterEach, beforeEach, describe, expect, inject } from 'vitest';
 import {
+	deploySegments,
 	initMissionControls,
-	installReleases,
+	installReleasesWithDeprecatedFlow,
 	testSatelliteExists
 } from '../../utils/console-tests.utils';
 import { tick } from '../../utils/pic-tests.utils';
@@ -55,6 +56,43 @@ describe('Console > Upgrade', () => {
 		});
 	};
 
+	const testUsers = async ({
+		actor,
+		users
+	}: {
+		users: Identity[];
+		actor: Actor<ConsoleActor_0_0_8 | ConsoleActor_0_0_14 | ConsoleActor>;
+	}) => {
+		const { list_user_mission_control_centers } = actor;
+
+		const missionControls = await list_user_mission_control_centers();
+
+		expect(missionControls).toHaveLength(users.length);
+
+		for (const user of users) {
+			expect(
+				missionControls.find(([key]) => key.toText() === user.getPrincipal().toText())
+			).not.toBeUndefined();
+		}
+	};
+
+	const updateRateConfig = async ({
+		actor
+	}: {
+		actor: Actor<ConsoleActor_0_0_8 | ConsoleActor_0_0_14 | ConsoleActor>;
+	}) => {
+		const { update_rate_config } = actor;
+
+		const config = {
+			max_tokens: 100n,
+			time_per_token_ns: 60n
+		};
+
+		await update_rate_config({ Satellite: null }, config);
+		await update_rate_config({ Orbiter: null }, config);
+		await update_rate_config({ MissionControl: null }, config);
+	};
+
 	describe('v0.0.8 -> v0.0.9', () => {
 		beforeEach(async () => {
 			pic = await PocketIc.create(inject('PIC_URL'));
@@ -71,37 +109,10 @@ describe('Console > Upgrade', () => {
 			canisterId = cId;
 			actor.setIdentity(controller);
 
-			await installReleases(actor);
+			await installReleasesWithDeprecatedFlow(actor);
 
-			await updateRateConfig();
+			await updateRateConfig({ actor });
 		});
-
-		const updateRateConfig = async () => {
-			const { update_rate_config } = actor;
-
-			const config = {
-				max_tokens: 100n,
-				time_per_token_ns: 60n
-			};
-
-			await update_rate_config({ Satellite: null }, config);
-			await update_rate_config({ Orbiter: null }, config);
-			await update_rate_config({ MissionControl: null }, config);
-		};
-
-		const testUsers = async (users: Identity[]) => {
-			const { list_user_mission_control_centers } = actor;
-
-			const missionControls = await list_user_mission_control_centers();
-
-			expect(missionControls).toHaveLength(users.length);
-
-			for (const user of users) {
-				expect(
-					missionControls.find(([key]) => key.toText() === user.getPrincipal().toText())
-				).not.toBeUndefined();
-			}
-		};
 
 		describe('Heap state', () => {
 			it(
@@ -117,7 +128,7 @@ describe('Console > Upgrade', () => {
 
 					actor.setIdentity(controller);
 
-					await testUsers(originalUsers);
+					await testUsers({ users: originalUsers, actor });
 
 					await testSatelliteExists({
 						users: originalUsers,
@@ -130,7 +141,7 @@ describe('Console > Upgrade', () => {
 					// Moving from 0.0.8 to 0.0.9 we are on purpose deprecating previous ways to hold wasm in memory
 					// await testReleases(actor);
 
-					await testUsers(originalUsers);
+					await testUsers({ users: originalUsers, actor });
 
 					await testSatelliteExists({
 						users: originalUsers,
@@ -160,6 +171,10 @@ describe('Console > Upgrade', () => {
 			actor = c;
 			canisterId = cId;
 			actor.setIdentity(controller);
+
+			await updateRateConfig({ actor });
+
+			await deploySegments(actor);
 		});
 
 		it('should preserve controllers even if scope enum is extended', async () => {
@@ -222,6 +237,44 @@ describe('Console > Upgrade', () => {
 			newActor.setIdentity(controller);
 
 			await assertControllers(newActor);
+		});
+
+		describe('Clear stable memory of proposals', () => {
+			it(
+				'should still list mission controls even if we alterate other memory IDs',
+				{
+					timeout: 120000
+				},
+				async () => {
+					// We need to advance time for the rate limiter
+					await pic.advanceTime(1000);
+
+					const originalUsers = await initMissionControls({ actor, pic, length: 3 });
+
+					actor.setIdentity(controller);
+
+					await testUsers({ users: originalUsers, actor });
+
+					await testSatelliteExists({
+						users: originalUsers,
+						actor,
+						pic
+					});
+
+					await upgrade();
+
+					const newActor = pic.createActor<ConsoleActor>(idlFactorConsole, canisterId);
+					newActor.setIdentity(controller);
+
+					await testUsers({ users: originalUsers, actor: newActor });
+
+					await testSatelliteExists({
+						users: originalUsers,
+						actor,
+						pic
+					});
+				}
+			);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

There is a bug or misconcemption in current CDN solution. If two proposals are uploaded with the same assets (fullPaths), then if assets get deleted in one proposal, the content is removed for the second. That's because the chunks are only indexed by fullPath and not with their respective proposal ID.

We can potentially disallow having more than one proposal open but, that's not good.

Therefore this ⚠️ breaking change ⚠️ which makes the StableTreeMap PROPOSAL_CONTENT_CHUNKS indexed by proposal ID.

⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
⚠️ Because of this change we are clearing the stable memory for the proposals in the console ⚠️
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️