### PR TITLE
fix: max for cycles topup

### DIFF
--- a/src/frontend/src/lib/components/canister/CanisterTopUpForm.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterTopUpForm.svelte
@@ -96,7 +96,7 @@
 {:else}
 	<form onsubmit={onSubmit}>
 		<div class="columns">
-			<InputIcp bind:amount={icp} {balance} />
+			<InputIcp bind:amount={icp} {balance} fee={TOP_UP_NETWORK_FEES} />
 
 			<GridArrow small />
 

--- a/src/frontend/src/lib/components/core/InputIcp.svelte
+++ b/src/frontend/src/lib/components/core/InputIcp.svelte
@@ -12,9 +12,10 @@
 	interface Props {
 		balance: bigint | undefined;
 		amount: string | undefined;
+		fee?: bigint;
 	}
 
-	let { amount = $bindable(), balance }: Props = $props();
+	let { amount = $bindable(), balance, fee }: Props = $props();
 
 	let token: TokenAmountV2 | undefined = $derived(amountToICPToken(amount));
 
@@ -53,7 +54,7 @@
 			footer={withUsd ? footer : undefined}
 		>
 			{#snippet end()}
-				<SendTokensMax {balance} onmax={(value) => (amount = value)} />
+				<SendTokensMax {balance} onmax={(value) => (amount = value)} {fee} />
 			{/snippet}
 		</Input>
 	</Value>

--- a/src/frontend/src/lib/components/tokens/SendTokensMax.svelte
+++ b/src/frontend/src/lib/components/tokens/SendTokensMax.svelte
@@ -8,9 +8,10 @@
 	interface Props {
 		balance: bigint | undefined;
 		onmax: (max: string) => void;
+		fee?: bigint;
 	}
 
-	let { onmax, balance }: Props = $props();
+	let { onmax, balance, fee }: Props = $props();
 
 	const calculateMax = ($event: MouseEvent | TouchEvent) => {
 		$event.preventDefault();
@@ -20,7 +21,8 @@
 			return;
 		}
 
-		const amount = balance - IC_TRANSACTION_FEE_ICP;
+		const appliedFee = fee ?? IC_TRANSACTION_FEE_ICP;
+		const amount = balance - appliedFee;
 
 		onmax(formatICP(amount));
 	};


### PR DESCRIPTION
The component now checks for a fee prop and falls back to `IC_TRANSACTION_FEE_ICP` if not provided.

https://github.com/user-attachments/assets/5fefb610-e18c-4517-9ce6-b97f4b846667

Please let me know if any changes are required. 

Fixes #1688 