### PR TITLE
feat: rename collections' Controllers to Trusted Keys

### DIFF
--- a/src/frontend/src/lib/components/collections/CollectionEdit.svelte
+++ b/src/frontend/src/lib/components/collections/CollectionEdit.svelte
@@ -227,7 +227,7 @@
 					<option value="Public">{$i18n.collections.public}</option>
 					<option value="Private">{$i18n.collections.private}</option>
 					<option value="Managed">{$i18n.collections.managed}</option>
-					<option value="Controllers">{$i18n.collections.controllers}</option>
+					<option value="TrustedKeys">{$i18n.collections.trusted_keys}</option>
 				</select>
 			</Value>
 		</div>
@@ -241,7 +241,7 @@
 					<option value="Public">{$i18n.collections.public}</option>
 					<option value="Private">{$i18n.collections.private}</option>
 					<option value="Managed">{$i18n.collections.managed}</option>
-					<option value="Controllers">{$i18n.collections.controllers}</option>
+					<option value="TrustedKeys">{$i18n.collections.trusted_keys}</option>
 				</select>
 			</Value>
 		</div>

--- a/src/frontend/src/lib/constants/rules.constants.ts
+++ b/src/frontend/src/lib/constants/rules.constants.ts
@@ -12,9 +12,13 @@ export const StorageCollectionType: CollectionType = { Storage: null };
 export const PermissionPublic: Permission = { Public: null };
 export const PermissionPrivate: Permission = { Private: null };
 export const PermissionManaged: Permission = { Managed: null };
-export const PermissionControllers: Permission = { Controllers: null };
 
-export type PermissionText = 'Public' | 'Private' | 'Managed' | 'Controllers';
+// Originally named "Controllers" but later renamed visually — and only visually — to "Trusted Keys",
+// since it includes both "Admin" (controllers) and "Write" keys (which are not controllers).
+const PermissionControllers: Permission = { Controllers: null };
+export const PermissionTrustedKeys = PermissionControllers;
+
+export type PermissionText = 'Public' | 'Private' | 'Managed' | 'TrustedKeys';
 
 export const MemoryHeap: Memory = { Heap: null };
 export const MemoryStable: Memory = { Stable: null };

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -714,7 +714,7 @@
 		"public": "Public",
 		"private": "Private",
 		"managed": "Managed",
-		"controllers": "Controllers",
+		"trusted_keys": "Trusted Keys",
 		"empty": "The collection <strong>{0}</strong> is empty.",
 		"empty_private": "The collection <strong>{0}</strong> read permission is set to private.",
 		"added": "Collection {0} added.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -714,7 +714,7 @@
 		"public": "公开",
 		"private": "私有",
 		"managed": "可管理的",
-		"controllers": "控制者",
+		"trusted_keys": "Trusted Keys",
 		"empty": "你的文档集 <strong>{0}</strong> 为空.",
 		"empty_private": "你的文档集 <strong>{0}</strong> 读权限设置为私有.",
 		"added": "文档集 {0} 已曾加.",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -735,7 +735,7 @@ interface I18nCollections {
 	public: string;
 	private: string;
 	managed: string;
-	controllers: string;
+	trusted_keys: string;
 	empty: string;
 	empty_private: string;
 	added: string;

--- a/src/frontend/src/lib/utils/rules.utils.ts
+++ b/src/frontend/src/lib/utils/rules.utils.ts
@@ -3,11 +3,11 @@ import {
 	MemoryHeap,
 	MemoryStable,
 	type MemoryText,
-	PermissionControllers,
 	PermissionManaged,
 	PermissionPrivate,
 	PermissionPublic,
-	type PermissionText
+	type PermissionText,
+	PermissionTrustedKeys
 } from '$lib/constants/rules.constants';
 
 export const permissionFromText = (text: PermissionText): Permission => {
@@ -19,7 +19,7 @@ export const permissionFromText = (text: PermissionText): Permission => {
 		case 'Managed':
 			return PermissionManaged;
 		default:
-			return PermissionControllers;
+			return PermissionTrustedKeys;
 	}
 };
 
@@ -36,7 +36,7 @@ export const permissionToText = (permission: Permission): PermissionText => {
 		return 'Managed';
 	}
 
-	return 'Controllers';
+	return 'TrustedKeys';
 };
 
 export const memoryFromText = (text: MemoryText): Memory => {


### PR DESCRIPTION
# Motivation

We also want to rename "Controllers" of the collections because it includes both "Admin" (controllers) and "Write" (not controllers) keys.
