### PR TITLE
feat(console): deploy script with junobuild/cdn lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
 				"@junobuild/cli-tools": "^0.2.1",
 				"@junobuild/config": "^0.1.8",
 				"@junobuild/config-loader": "^0.2.1",
-				"@junobuild/console": "^0.1.7",
 				"@junobuild/errors": "^0.1.0",
 				"@junobuild/functions": "^0.1.1",
 				"@ltd/j-toml": "^1.38.0",
@@ -1837,24 +1836,6 @@
 				"@babel/plugin-transform-modules-commonjs": "^7.26.3",
 				"@babel/preset-typescript": "^7.26.0",
 				"@junobuild/config": "*"
-			}
-		},
-		"node_modules/@junobuild/console": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/@junobuild/console/-/console-0.1.7.tgz",
-			"integrity": "sha512-SZ4nvfY4/K5GMmbAHz9yYSphz22thmN+1OcT35fZdsbhzXWdhWlf+fMARWVCB293uuG+ySQWw6bQrwRcvU40wQ==",
-			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"@dfinity/agent": "^2.3.0",
-				"@dfinity/candid": "^2.3.0",
-				"@dfinity/identity": "^2.3.0",
-				"@dfinity/principal": "^2.3.0",
-				"@dfinity/utils": "^2",
-				"@junobuild/config": "*",
-				"@junobuild/storage": "*",
-				"semver": "7.*"
 			}
 		},
 		"node_modules/@junobuild/core": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
 		"@junobuild/cli-tools": "^0.2.1",
 		"@junobuild/config": "^0.1.8",
 		"@junobuild/config-loader": "^0.2.1",
-		"@junobuild/console": "^0.1.7",
 		"@junobuild/errors": "^0.1.0",
 		"@junobuild/functions": "^0.1.1",
 		"@ltd/j-toml": "^1.38.0",

--- a/scripts/console.deploy.assets.mjs
+++ b/scripts/console.deploy.assets.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { toNullable } from '@dfinity/utils';
+import { uploadAssetWithProposal } from '@junobuild/cdn';
 import { deploy as cliDeploy, hasArgs } from '@junobuild/cli-tools';
-import { uploadAsset } from '@junobuild/console';
 import { consoleActor } from './actor.mjs';
 import { deployWithProposal } from './console.deploy.services.mjs';
 import { deployConsole, readJunoConfig } from './console.deploy.utils.mjs';
@@ -91,10 +91,12 @@ const config = await readJunoConfig();
 
 const deployWithCli = async (proposalId) => {
 	const upload = async (asset) => {
-		await uploadAsset({
+		await uploadAssetWithProposal({
 			asset,
 			proposalId,
-			console: await deployConsole()
+			cdn: {
+				console: await deployConsole()
+			}
 		});
 	};
 

--- a/scripts/console.deploy.segments.mjs
+++ b/scripts/console.deploy.segments.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { assertNonNullish, toNullable } from '@dfinity/utils';
+import { uploadAssetWithProposal } from '@junobuild/cdn';
 import { fileExists } from '@junobuild/cli-tools';
-import { uploadAsset } from '@junobuild/console';
 import { parse } from '@ltd/j-toml';
 import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
@@ -10,6 +10,12 @@ import { join } from 'node:path';
 import { deployWithProposal } from './console.deploy.services.mjs';
 import { deployConsole, readJunoConfig } from './console.deploy.utils.mjs';
 import { targetMainnet } from './utils.mjs';
+
+const config = await readJunoConfig();
+
+const consoleUrl = targetMainnet()
+	? `https://console.juno.build`
+	: `http://${config.id}.localhost:5987`;
 
 const readVersion = (segment) => {
 	const tomlFile = readFileSync(join(process.cwd(), 'src', segment, 'Cargo.toml'));
@@ -62,14 +68,17 @@ const deploy = async (proposalId) => {
 			encoding: 'identity',
 			filename: destinationFilename,
 			fullPath,
-			headers: [],
-			data: new Blob([await readFile(source)])
+			headers: [['Access-Control-Allow-Origin', consoleUrl]],
+			data: new Blob([await readFile(source)]),
+			description: `change=${proposalId};version=${version}`
 		};
 
-		await uploadAsset({
+		await uploadAssetWithProposal({
 			asset,
 			proposalId,
-			console: await deployConsole()
+			cdn: {
+				console: await deployConsole()
+			}
 		});
 
 		console.log(`✅  ${source} uploaded to ${fullPath}`);
@@ -79,8 +88,15 @@ const deploy = async (proposalId) => {
 
 	const results = await Promise.all(Object.entries(segments).map(upload));
 
+	const files = results.filter(({ uploaded }) => uploaded).map(({ sourceFile }) => sourceFile);
+
+	if (files.length === 0) {
+		return { result: 'skipped' };
+	}
+
 	return {
-		sourceFiles: results.filter(({ uploaded }) => uploaded).map(({ sourceFile }) => sourceFile)
+		result: 'deployed',
+		files
 	};
 };
 
@@ -88,11 +104,5 @@ await deployWithProposal({
 	proposal_type,
 	deploy
 });
-
-const config = await readJunoConfig();
-
-const consoleUrl = targetMainnet()
-	? `https://console.juno.build`
-	: `http://${config.id}.localhost:5987`;
 
 console.log(`\n✅ Segments uploaded. Metadata: ${consoleUrl}/releases/metadata.json`);

--- a/scripts/console.deploy.services.mjs
+++ b/scripts/console.deploy.services.mjs
@@ -1,22 +1,32 @@
 import { fromNullable, uint8ArrayToHexString } from '@dfinity/utils';
-import { commitProposal, initProposal, submitProposal } from '@junobuild/console';
+import { commitProposal, initProposal, submitProposal } from '@junobuild/cdn';
 import { deployConsole } from './console.deploy.utils.mjs';
 
 export const deployWithProposal = async ({ proposal_type, deploy }) => {
 	const [proposalId, _] = await initProposal({
 		proposalType: proposal_type,
-		console: await deployConsole()
+		cdn: {
+			console: await deployConsole()
+		}
 	});
 
-	const { sourceFiles } = await deploy(proposalId);
+	const result = await deploy(proposalId);
 
-	if (sourceFiles.length === 0) {
+	if (result.result === 'skipped') {
+		process.exit(0);
+	}
+
+	const { files } = result;
+
+	if (files.length === 0) {
 		process.exit(0);
 	}
 
 	const [__, { sha256, status }] = await submitProposal({
 		proposalId,
-		console: await deployConsole()
+		cdn: {
+			console: await deployConsole()
+		}
 	});
 
 	console.log('\nProposal submitted.\n');
@@ -25,10 +35,12 @@ export const deployWithProposal = async ({ proposal_type, deploy }) => {
 	console.log('⏳ ', status);
 
 	await commitProposal({
-		commitProposal: {
+		proposal: {
 			proposal_id: proposalId,
 			sha256: fromNullable(sha256)
 		},
-		console: await deployConsole()
+		cdn: {
+			console: await deployConsole()
+		}
 	});
 };


### PR DESCRIPTION
# Motivation

After we upgrade the Console, we should start using `@junobuild/cdn` for the scripts to update the frontend or upload assets.
