### PR TITLE
fix(storage): identity certification

### DIFF
--- a/src/libs/storage/src/certification/impls.rs
+++ b/src/libs/storage/src/certification/impls.rs
@@ -93,7 +93,7 @@ impl CertifiedAssetHashes {
         self.insert_most_important_v1(asset, &full_path);
         self.insert_all_v2(asset, &full_path, config);
     }
-    
+
     // In v1, only the most important encoding is certified.
     fn insert_most_important_v1(&mut self, asset: &Asset, full_path: &FullPath) {
         for encoding_type in ENCODING_CERTIFICATION_ORDER.iter().rev() {
@@ -106,15 +106,13 @@ impl CertifiedAssetHashes {
 
     // In v2, all encoding must be certified.
     fn insert_all_v2(&mut self, asset: &Asset, full_path: &FullPath, config: &StorageConfig) {
-        for encoding_type in ENCODING_CERTIFICATION_ORDER.iter().rev() {
-            if let Some(encoding) = asset.encodings.get(*encoding_type) {
-                self.insert_v2(
-                    &full_path,
-                    &build_headers(asset, encoding, &encoding_type.to_string(), config),
-                    RESPONSE_STATUS_CODE_200,
-                    encoding.sha256,
-                );
-            }
+        for (encoding_type, encoding) in &asset.encodings {
+            self.insert_v2(
+                full_path,
+                &build_headers(asset, encoding, encoding_type, config),
+                RESPONSE_STATUS_CODE_200,
+                encoding.sha256,
+            );
         }
     }
 

--- a/src/tests/specs/satellite/stock/satellite.storage.certification.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.storage.certification.spec.ts
@@ -1,0 +1,116 @@
+import type {
+	HttpRequest,
+	_SERVICE as SatelliteActor
+} from '$declarations/satellite/satellite.did';
+import { idlFactory as idlFactorSatellite } from '$declarations/satellite/satellite.factory.did';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { type Actor, PocketIc } from '@dfinity/pic';
+import type { Principal } from '@dfinity/principal';
+import { toNullable } from '@dfinity/utils';
+import { afterAll, beforeAll, describe, inject } from 'vitest';
+import { assertCertification } from '../../../utils/certification-tests.utils';
+import { uploadAsset } from '../../../utils/satellite-storage-tests.utils';
+import { deleteDefaultIndexHTML } from '../../../utils/satellite-tests.utils';
+import { controllersInitArgs, SATELLITE_WASM_PATH } from '../../../utils/setup-tests.utils';
+
+describe('Satellite > Storage > Certificate', () => {
+	let pic: PocketIc;
+	let canisterId: Principal;
+	let actor: Actor<SatelliteActor>;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	const currentDate = new Date(2021, 6, 10, 0, 0, 0, 0);
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		await pic.setTime(currentDate.getTime());
+
+		const { actor: a, canisterId: c } = await pic.setupCanister<SatelliteActor>({
+			idlFactory: idlFactorSatellite,
+			wasm: SATELLITE_WASM_PATH,
+			arg: controllersInitArgs(controller),
+			sender: controller.getPrincipal()
+		});
+
+		actor = a;
+		canisterId = c;
+
+		await deleteDefaultIndexHTML({ actor, controller });
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	const upload = async (params: {
+		full_path: string;
+		name: string;
+		collection: string;
+		headers?: [string, string][];
+		encoding_type?: [] | [string];
+	}) => {
+		await uploadAsset({
+			...params,
+			actor
+		});
+	};
+
+	const assertResponse = async ({
+		full_path,
+		headers = []
+	}: {
+		full_path: string;
+		headers?: [string, string][];
+	}) => {
+		const { http_request } = actor;
+
+		const request: HttpRequest = {
+			body: [],
+			certificate_version: toNullable(2),
+			headers,
+			method: 'GET',
+			url: full_path
+		};
+
+		const response = await http_request(request);
+
+		await assertCertification({
+			canisterId,
+			pic,
+			request,
+			response,
+			currentDate
+		});
+	};
+
+	it('should provide asset with certificate for identity', async () => {
+		const name = 'hello.html';
+		const full_path = `/${name}`;
+
+		await upload({ full_path, name, collection: '#dapp' });
+
+		await assertResponse({ full_path });
+	});
+
+	it('should provide asset with certificate for gzip', async () => {
+		const name = 'hello2.html';
+		const full_path = `/${name}`;
+
+		await upload({ full_path, name, collection: '#dapp', encoding_type: ['gzip'] });
+
+		await assertResponse({ full_path, headers: [['accept-encoding', 'gzip, deflate, br, zstd']] });
+	});
+
+	it('should provide asset with certificate for identity and gzip', async () => {
+		const name = 'hello3.html';
+		const full_path = `/${name}`;
+
+		await upload({ full_path, name, collection: '#dapp', encoding_type: ['gzip'] });
+		await upload({ full_path, name, collection: '#dapp' });
+
+		await assertResponse({ full_path, headers: [['accept-encoding', 'gzip, deflate, br, zstd']] });
+		await assertResponse({ full_path });
+	});
+});

--- a/src/tests/utils/satellite-storage-tests.utils.ts
+++ b/src/tests/utils/satellite-storage-tests.utils.ts
@@ -10,7 +10,8 @@ export const uploadAsset = async ({
 	collection,
 	actor,
 	headers = [],
-	token
+	token,
+	encoding_type = []
 }: {
 	full_path: string;
 	description?: string;
@@ -19,13 +20,14 @@ export const uploadAsset = async ({
 	actor: Actor<SatelliteActor>;
 	headers?: [string, string][];
 	token?: string;
+	encoding_type?: [] | [string];
 }) => {
 	const { commit_asset_upload, upload_asset_chunk, init_asset_upload } = actor;
 
 	const file = await init_asset_upload({
 		collection,
 		description: toNullable(description),
-		encoding_type: [],
+		encoding_type,
 		full_path,
 		name,
 		token: toNullable(token)


### PR DESCRIPTION
# Motivation

There is a nasty bug in the certification when an is uploaded as gzip and raw (identity). The former gets certified but, not the later. Operatively speaking it's fine because the former is always used but, this is a problem if we want to gzip HTML files because, as I noticed yesterday, some platform (OC, Discord etc.) use identity to fetch social metadata.
