### PR TITLE
build(tools): bump candid-extractor

### DIFF
--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -53,7 +53,7 @@ install_tool() {
 
 install_tool ic-wasm 0.8.5
 install_tool wasi2ic 0.2.15
-install_tool candid-extractor 0.1.4
+install_tool candid-extractor 0.1.6
 install_tool junobuild-didc 0.1.0
 
 # make sure the packages are actually installed (rustup waits for the first invoke to lazyload)


### PR DESCRIPTION
# Motivation

The latest `candid-extractor` seems to be required to generate did files with the ic_cdk v0.18

> warning: `console` (lib) generated 7 warnings (run `cargo fix --lib -p console` to apply 1 suggestion)
>    Finished `release` profile [optimized] target(s) in 14.55s
>
> 👉 ./target/deploy/console.wasm.gz
>
> Error: unknown import: `ic0::canister_liquid_cycle_balance128` has not been defined
