### PR TITLE
feat(utils): derive common trait for DocDataPrincipal and DocDataBigint

### DIFF
--- a/src/libs/utils/src/serializers/types.rs
+++ b/src/libs/utils/src/serializers/types.rs
@@ -7,6 +7,7 @@ use candid::Principal as CandidPrincipal;
 ///
 /// # Fields
 /// - `value`: The `Principal` this struct wraps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DocDataPrincipal {
     pub value: CandidPrincipal,
 }
@@ -16,6 +17,7 @@ pub struct DocDataPrincipal {
 ///
 /// # Fields
 /// - `value`: A `u64` integer representing the large numeric value encapsulated by this struct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DocDataBigInt {
     pub value: u64,
 }

--- a/src/tests/specs/satellite/stock/satellite.storage.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.storage.spec.ts
@@ -1194,7 +1194,7 @@ describe('Satellite > Storage', () => {
 		describe.each([
 			{
 				memory: { Heap: null },
-				expectMemory: 3_997_696n,
+				expectMemory: 4_063_232n,
 				allowedMemory: maxHeapMemorySize,
 				preUploadCount: 13
 			},


### PR DESCRIPTION
# Motivation

It would be handy to support Clone and since we are already there, makes sense to support the same derives as the value - Principal - encapsulated.
