### PR TITLE
fix(frontend): collapsible

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthConfigAdvancedOptions.svelte
+++ b/src/frontend/src/lib/components/auth/AuthConfigAdvancedOptions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { fromNullable, fromNullishNullable, isEmptyString } from '@dfinity/utils';
-	import { onMount, type SvelteComponent } from 'svelte';
+	import { onMount } from 'svelte';
 	import type { AuthenticationConfig } from '$declarations/satellite/satellite.did';
 	import Collapsible from '$lib/components/ui/Collapsible.svelte';
 	import Input from '$lib/components/ui/Input.svelte';
@@ -26,8 +26,7 @@
 		externalAlternativeOrigins = externalAlternativeOriginsInput;
 	});
 
-	let collapsibleRef: (SvelteComponent & { open: () => void; close: () => void }) | undefined =
-		$state(undefined);
+	let collapsibleRef: Collapsible | undefined = $state(undefined);
 
 	onMount(() => {
 		if (isEmptyString(externalAlternativeOriginsInput)) {
@@ -39,7 +38,9 @@
 </script>
 
 <Collapsible bind:this={collapsibleRef}>
-	<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
+	{#snippet header()}
+		{$i18n.core.advanced_options}
+	{/snippet}
 
 	<div>
 		<Value>

--- a/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
+++ b/src/frontend/src/lib/components/canister/CanisterAdvancedOptions.svelte
@@ -17,7 +17,9 @@
 </script>
 
 <Collapsible>
-	<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
+	{#snippet header()}
+		{$i18n.core.advanced_options}
+	{/snippet}
 
 	<CanisterSubnets bind:subnetId />
 

--- a/src/frontend/src/lib/components/changes/wizard/ChangeOptions.svelte
+++ b/src/frontend/src/lib/components/changes/wizard/ChangeOptions.svelte
@@ -19,7 +19,9 @@
 
 <div class="container">
 	<Collapsible>
-		<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
+		{#snippet header()}
+			{$i18n.core.advanced_options}
+		{/snippet}
 
 		<CheckboxInline bind:checked={clearProposalAssets}>
 			{$i18n.changes.clear_after_apply}

--- a/src/frontend/src/lib/components/cli/CliAdd.svelte
+++ b/src/frontend/src/lib/components/cli/CliAdd.svelte
@@ -181,7 +181,9 @@
 	{#if loadingSegments === 'ready'}
 		<div class="options">
 			<Collapsible>
-				<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
+				{#snippet header()}
+					{$i18n.core.advanced_options}
+				{/snippet}
 
 				<div>
 					<p class="profile-info">{$i18n.cli.profile_info}</p>

--- a/src/frontend/src/lib/components/collections/CollectionEdit.svelte
+++ b/src/frontend/src/lib/components/collections/CollectionEdit.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { fromNullable, isNullish, nonNullish, fromNullishNullable } from '@dfinity/utils';
-	import { type SvelteComponent, getContext } from 'svelte';
+	import { getContext } from 'svelte';
 	import type { RateConfig, Rule, CollectionType } from '$declarations/satellite/satellite.did';
 	import CollectionDelete from '$lib/components/collections/CollectionDelete.svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
@@ -162,8 +162,7 @@
 
 	let disabled = $derived(isNullish(collection) || collection === '');
 
-	let collapsibleRef: (SvelteComponent & { open: () => void; close: () => void }) | undefined =
-		$state(undefined);
+	let collapsibleRef: Collapsible | undefined = $state(undefined);
 
 	const toggle = (toggleOptions: boolean) => {
 		if (!toggleOptions) {
@@ -247,7 +246,9 @@
 		</div>
 
 		<Collapsible bind:this={collapsibleRef}>
-			<svelte:fragment slot="header">{$i18n.collections.options}</svelte:fragment>
+			{#snippet header()}
+				{$i18n.collections.options}
+			{/snippet}
 
 			<div class="options">
 				<div>

--- a/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
@@ -2,7 +2,6 @@
 	import type { Principal } from '@dfinity/principal';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { compare } from 'semver';
-	import type { SvelteComponent } from 'svelte';
 	import type { OrbiterSatelliteFeatures } from '$declarations/orbiter/orbiter.did';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import CheckboxGroup from '$lib/components/ui/CheckboxGroup.svelte';
@@ -42,8 +41,7 @@
 
 	let step: 'init' | 'in_progress' | 'ready' | 'error' = $state('init');
 
-	let collapsibleRef: (SvelteComponent & { open: () => void; close: () => void }) | undefined =
-		$state(undefined);
+	let collapsibleRef: Collapsible | undefined = $state(undefined);
 
 	const openOptions = (features: OrbiterSatelliteFeatures | undefined) => {
 		if (
@@ -196,7 +194,9 @@
 			{#if featuresSupported}
 				<div class="options">
 					<Collapsible bind:this={collapsibleRef}>
-						<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
+						{#snippet header()}
+							{$i18n.core.advanced_options}
+						{/snippet}
 
 						<div class="card-container with-title">
 							<span class="title">{$i18n.analytics.tracked_metrics}</span>

--- a/src/frontend/src/lib/components/ui/Collapsible.svelte
+++ b/src/frontend/src/lib/components/ui/Collapsible.svelte
@@ -1,29 +1,33 @@
-<!-- @migration-task Error while migrating Svelte code: Can't migrate code with afterUpdate. Please migrate by hand. -->
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { afterUpdate } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import IconUnfoldLess from '$lib/components/icons/IconUnfoldLess.svelte';
 	import IconUnfoldMore from '$lib/components/icons/IconUnfoldMore.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { handleKeyPress } from '$lib/utils/keyboard.utils';
 
-	// TODO: migrate to Svelte v5
-	// e.g. afterUpdate cannot be used in runes mode
+	interface Props {
+		id?: string;
+		initiallyExpanded?: boolean;
+		maxContentHeight?: number;
+		wrapHeight?: boolean;
+		expanded: boolean;
+	}
 
-	export let id: string | undefined = undefined;
-	export let initiallyExpanded = false;
-	export let maxContentHeight: number | undefined = undefined;
-
-	export let wrapHeight = false;
+	let {
+		id,
+		initiallyExpanded = false,
+		expanded = $bindable(initiallyExpanded),
+		maxContentHeight,
+		wrapHeight = false
+	}: Props = $props();
 
 	// Minimum height when some part of the text-content is visible (empirical value)
 	const CONTENT_MIN_HEIGHT = 40;
 
-	export let expanded = initiallyExpanded;
-	let container: HTMLDivElement | undefined;
-	let userUpdated = false;
-	let maxHeight: number | undefined;
+	let container = $state<HTMLDivElement | undefined>();
+	let userUpdated = $state(false);
+	let maxHeight = $state<number | undefined>();
 
 	export const close = () => {
 		if (!expanded) {
@@ -73,7 +77,7 @@
 				: 'overflow-y: auto;';
 
 	// recalculate max-height after DOM update
-	afterUpdate(updateMaxHeight);
+	$effect(updateMaxHeight);
 
 	const toggle = () => toggleContent();
 </script>

--- a/src/frontend/src/lib/components/ui/Collapsible.svelte
+++ b/src/frontend/src/lib/components/ui/Collapsible.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import IconUnfoldLess from '$lib/components/icons/IconUnfoldLess.svelte';
 	import IconUnfoldMore from '$lib/components/icons/IconUnfoldMore.svelte';
@@ -11,7 +12,9 @@
 		initiallyExpanded?: boolean;
 		maxContentHeight?: number;
 		wrapHeight?: boolean;
-		expanded: boolean;
+		expanded?: boolean;
+		header: Snippet;
+		children: Snippet;
 	}
 
 	let {
@@ -19,7 +22,9 @@
 		initiallyExpanded = false,
 		expanded = $bindable(initiallyExpanded),
 		maxContentHeight,
-		wrapHeight = false
+		wrapHeight = false,
+		header,
+		children
 	}: Props = $props();
 
 	// Minimum height when some part of the text-content is visible (empirical value)
@@ -45,7 +50,7 @@
 		toggleContent();
 	};
 
-	export const toggleContent = () => {
+	const toggleContent = () => {
 		userUpdated = true;
 		expanded = !expanded;
 	};
@@ -87,8 +92,8 @@
 		id={nonNullish(id) ? `heading${id}` : undefined}
 		role="button"
 		class="header"
-		on:click={toggle}
-		on:keypress={($event) => handleKeyPress({ $event, callback: toggle })}
+		onclick={toggle}
+		onkeypress={($event) => handleKeyPress({ $event, callback: toggle })}
 		tabindex="-1"
 	>
 		<button
@@ -106,7 +111,7 @@
 				<span in:fade class="icon"><IconUnfoldMore size="16px" /></span>
 			{/if}
 		</button>
-		<slot name="header" />
+		{@render header()}
 	</div>
 	<div
 		role="definition"
@@ -121,7 +126,7 @@
 			class:wrapHeight
 			bind:this={container}
 		>
-			<slot />
+			{@render children()}
 		</div>
 	</div>
 </div>

--- a/src/frontend/src/lib/components/upgrade/wizard/CanisterUpgradeOptions.svelte
+++ b/src/frontend/src/lib/components/upgrade/wizard/CanisterUpgradeOptions.svelte
@@ -12,7 +12,9 @@
 
 <div class="container">
 	<Collapsible>
-		<svelte:fragment slot="header">{$i18n.core.advanced_options}</svelte:fragment>
+		{#snippet header()}
+			{$i18n.core.advanced_options}
+		{/snippet}
 
 		<CanisterSnapshotOption bind:takeSnapshot>
 			{$i18n.canisters.snapshot_before_upgrade}


### PR DESCRIPTION
# Motivation

The latest version of Svelte breaks the Collapsible component that needed to be migrated to Svelte v5 anyway.
