### PR TITLE
feat(frontend): workers encapsulation

### DIFF
--- a/src/frontend/src/lib/components/hosting/CustomDomain.svelte
+++ b/src/frontend/src/lib/components/hosting/CustomDomain.svelte
@@ -14,7 +14,7 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import {
 		type HostingCallback,
-		initHostingWorker
+		HostingWorker
 	} from '$lib/services/workers/worker.hosting.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CustomDomainRegistrationState } from '$lib/types/custom-domain';
@@ -54,15 +54,7 @@
 
 	let registrationState: Option<CustomDomainRegistrationState> = $state(undefined);
 
-	let worker:
-		| {
-				startCustomDomainRegistrationTimer: (params: {
-					customDomain: CustomDomainType;
-					callback: HostingCallback;
-				}) => void;
-				stopCustomDomainRegistrationTimer: () => void;
-		  }
-		| undefined = $state();
+	let worker = $state<HostingWorker | undefined>();
 
 	const syncState = ({ registrationState: state }: PostMessageDataResponseHosting) => {
 		registrationState = state;
@@ -93,7 +85,7 @@
 		});
 	};
 
-	onMount(async () => (worker = await initHostingWorker()));
+	onMount(async () => (worker = await HostingWorker.init()));
 	onDestroy(() => worker?.stopCustomDomainRegistrationTimer());
 
 	run(() => {

--- a/src/frontend/src/lib/components/hosting/CustomDomain.svelte
+++ b/src/frontend/src/lib/components/hosting/CustomDomain.svelte
@@ -12,10 +12,7 @@
 	import IconSync from '$lib/components/icons/IconSync.svelte';
 	import ButtonTableAction from '$lib/components/ui/ButtonTableAction.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
-	import {
-		type HostingCallback,
-		HostingWorker
-	} from '$lib/services/workers/worker.hosting.services';
+	import { HostingWorker } from '$lib/services/workers/worker.hosting.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CustomDomainRegistrationState } from '$lib/types/custom-domain';
 	import type { PostMessageDataResponseHosting } from '$lib/types/post-message';

--- a/src/frontend/src/lib/components/loaders/CanistersMonitoringLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/CanistersMonitoringLoader.svelte
@@ -8,10 +8,7 @@
 	import { orbiterNotLoaded } from '$lib/derived/orbiter.derived';
 	import { satellitesNotLoaded } from '$lib/derived/satellites.derived';
 	import { missionControlVersion } from '$lib/derived/version.derived';
-	import {
-		initMonitoringWorker,
-		type MonitoringWorker
-	} from '$lib/services/workers/worker.monitoring.services';
+	import { MonitoringWorker } from '$lib/services/workers/worker.monitoring.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toasts } from '$lib/stores/toasts.store';
 	import type { CanisterSegment } from '$lib/types/canister';
@@ -23,9 +20,9 @@
 
 	let { children, segments }: Props = $props();
 
-	let worker: MonitoringWorker | undefined = $state();
+	let worker = $state<MonitoringWorker | undefined>();
 
-	onMount(async () => (worker = await initMonitoringWorker()));
+	onMount(async () => (worker = await MonitoringWorker.init()));
 
 	const debounceStart = debounce(() => {
 		if (isNullish($missionControlIdDerived)) {

--- a/src/frontend/src/lib/components/loaders/CanistersSyncDataLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/CanistersSyncDataLoader.svelte
@@ -5,10 +5,7 @@
 	import type { Satellite } from '$declarations/mission_control/mission_control.did';
 	import { orbiterNotLoaded } from '$lib/derived/orbiter.derived';
 	import { satellitesNotLoaded } from '$lib/derived/satellites.derived';
-	import {
-		type CyclesWorker,
-		initCyclesWorker
-	} from '$lib/services/workers/worker.cycles.services';
+	import { CyclesWorker } from '$lib/services/workers/worker.cycles.services';
 	import type { CanisterSegment } from '$lib/types/canister';
 
 	interface Props {
@@ -19,9 +16,9 @@
 
 	let { children, segments, satellites: _ }: Props = $props();
 
-	let worker: CyclesWorker | undefined = $state(undefined);
+	let worker = $state<CyclesWorker | undefined>(undefined);
 
-	onMount(async () => (worker = await initCyclesWorker()));
+	onMount(async () => (worker = await CyclesWorker.init()));
 
 	const debounceStart = debounce(() =>
 		worker?.startCyclesTimer({

--- a/src/frontend/src/lib/components/loaders/WalletLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/WalletLoader.svelte
@@ -2,10 +2,7 @@
 	import { isNullish } from '@dfinity/utils';
 	import { onDestroy, onMount, type Snippet } from 'svelte';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
-	import {
-		type WalletWorker,
-		initWalletWorker
-	} from '$lib/services/workers/worker.wallet.services';
+	import { WalletWorker } from '$lib/services/workers/worker.wallet.services';
 
 	interface Props {
 		children?: Snippet;
@@ -13,10 +10,10 @@
 
 	let { children }: Props = $props();
 
-	let worker: WalletWorker | undefined = $state();
+	let worker = $state<WalletWorker | undefined>();
 
 	const initWorker = async () => {
-		worker = await initWalletWorker();
+		worker = await WalletWorker.init();
 	};
 
 	$effect(() => {

--- a/src/frontend/src/lib/services/workers/_worker.services.ts
+++ b/src/frontend/src/lib/services/workers/_worker.services.ts
@@ -1,0 +1,12 @@
+export abstract class AppWorker {
+	protected _worker: Worker;
+
+	protected constructor(worker: Worker) {
+		this._worker = worker;
+	}
+
+	static async getInstance(): Promise<Worker> {
+		const Workers = await import('$lib/workers/workers?worker');
+		return new Workers.default();
+	}
+}

--- a/src/frontend/src/lib/services/workers/worker.auth.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.auth.services.ts
@@ -1,34 +1,40 @@
 import { idleSignOut } from '$lib/services/auth/auth.services';
+import { AppWorker } from '$lib/services/workers/_worker.services';
 import { authRemainingTimeStore, type AuthStoreData } from '$lib/stores/auth.store';
 import type { PostMessageDataResponseAuth, PostMessages } from '$lib/types/post-message';
+import { isNullish } from '@dfinity/utils';
 
-export const initAuthWorker = async () => {
-	const AuthWorker = await import('$lib/workers/workers?worker');
-	const authWorker: Worker = new AuthWorker.default();
+export class AuthWorker extends AppWorker {
+	constructor(worker: Worker) {
+		super(worker);
 
-	authWorker.onmessage = async ({ data }: MessageEvent<PostMessages>) => {
-		const { msg } = data;
+		worker.onmessage = async ({ data }: MessageEvent<PostMessages>) => {
+			const { msg } = data;
 
-		switch (msg) {
-			case 'signOutIdleTimer':
-				await idleSignOut();
-				return;
-			case 'delegationRemainingTime':
-				authRemainingTimeStore.set((data.data as PostMessageDataResponseAuth)?.authRemainingTime);
-				return;
-		}
-	};
-
-	return {
-		syncAuthIdle: (auth: AuthStoreData) => {
-			if (!auth.identity) {
-				authWorker.postMessage({ msg: 'stopIdleTimer' });
-				return;
+			switch (msg) {
+				case 'signOutIdleTimer':
+					await idleSignOut();
+					return;
+				case 'delegationRemainingTime':
+					authRemainingTimeStore.set((data.data as PostMessageDataResponseAuth)?.authRemainingTime);
+					return;
 			}
+		};
+	}
 
-			authWorker.postMessage({
-				msg: 'startIdleTimer'
-			});
+	static async init(): Promise<AuthWorker> {
+		const worker = await AppWorker.getInstance();
+		return new AuthWorker(worker);
+	}
+
+	syncAuthIdle = (auth: AuthStoreData) => {
+		if (isNullish(auth.identity)) {
+			this._worker.postMessage({ msg: 'stopIdleTimer' });
+			return;
 		}
+
+		this._worker.postMessage({
+			msg: 'startIdleTimer'
+		});
 	};
-};
+}

--- a/src/frontend/src/lib/services/workers/worker.cycles.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.cycles.services.ts
@@ -10,7 +10,7 @@ import type {
 	PostMessages
 } from '$lib/types/post-message';
 
-class CyclesWorker extends AppWorker {
+export class CyclesWorker extends AppWorker {
 	constructor(worker: Worker) {
 		super(worker);
 
@@ -53,5 +53,3 @@ class CyclesWorker extends AppWorker {
 		});
 	};
 }
-
-export const initCyclesWorker = (): Promise<CyclesWorker> => CyclesWorker.init();

--- a/src/frontend/src/lib/services/workers/worker.cycles.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.cycles.services.ts
@@ -2,6 +2,7 @@ import {
 	syncCanistersSyncData,
 	syncCanisterSyncData
 } from '$lib/services/canisters.loader.services';
+import { AppWorker } from '$lib/services/workers/_worker.services';
 import type { CanisterSegment } from '$lib/types/canister';
 import type {
 	PostMessageDataResponseCanistersSyncData,
@@ -9,46 +10,48 @@ import type {
 	PostMessages
 } from '$lib/types/post-message';
 
-export interface CyclesWorker {
-	startCyclesTimer: (params: { segments: CanisterSegment[] }) => void;
-	stopCyclesTimer: () => void;
-	restartCyclesTimer: (segments: CanisterSegment[]) => void;
+class CyclesWorker extends AppWorker {
+	constructor(worker: Worker) {
+		super(worker);
+
+		worker.onmessage = ({ data }: MessageEvent<PostMessages>) => {
+			const { msg } = data;
+
+			switch (msg) {
+				case 'syncCanister':
+					syncCanisterSyncData(data.data as PostMessageDataResponseCanisterSyncData);
+					return;
+				case 'syncCanisters':
+					syncCanistersSyncData(data.data as PostMessageDataResponseCanistersSyncData);
+					return;
+			}
+		};
+	}
+
+	static async init(): Promise<CyclesWorker> {
+		const worker = await AppWorker.getInstance();
+		return new CyclesWorker(worker);
+	}
+
+	startCyclesTimer = ({ segments }: { segments: CanisterSegment[] }) => {
+		this._worker.postMessage({
+			msg: 'startCyclesTimer',
+			data: { segments }
+		});
+	};
+
+	stopCyclesTimer = () => {
+		this._worker.postMessage({
+			msg: 'stopCyclesTimer'
+		});
+	};
+
+	restartCyclesTimer = (segments: CanisterSegment[]) => {
+		this._worker.postMessage({
+			msg: 'restartCyclesTimer',
+			data: { segments }
+		});
+	};
 }
 
-export const initCyclesWorker = async (): Promise<CyclesWorker> => {
-	const CyclesWorker = await import('$lib/workers/workers?worker');
-	const cyclesWorker: Worker = new CyclesWorker.default();
-
-	cyclesWorker.onmessage = ({ data }: MessageEvent<PostMessages>) => {
-		const { msg } = data;
-
-		switch (msg) {
-			case 'syncCanister':
-				syncCanisterSyncData(data.data as PostMessageDataResponseCanisterSyncData);
-				return;
-			case 'syncCanisters':
-				syncCanistersSyncData(data.data as PostMessageDataResponseCanistersSyncData);
-				return;
-		}
-	};
-
-	return {
-		startCyclesTimer: ({ segments }: { segments: CanisterSegment[] }) => {
-			cyclesWorker.postMessage({
-				msg: 'startCyclesTimer',
-				data: { segments }
-			});
-		},
-		stopCyclesTimer: () => {
-			cyclesWorker.postMessage({
-				msg: 'stopCyclesTimer'
-			});
-		},
-		restartCyclesTimer: (segments) => {
-			cyclesWorker.postMessage({
-				msg: 'restartCyclesTimer',
-				data: { segments }
-			});
-		}
-	};
-};
+export const initCyclesWorker = (): Promise<CyclesWorker> => CyclesWorker.init();

--- a/src/frontend/src/lib/services/workers/worker.hosting.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.hosting.services.ts
@@ -1,43 +1,49 @@
 import type { CustomDomain } from '$declarations/satellite/satellite.did';
+import { AppWorker } from '$lib/services/workers/_worker.services';
 import type { PostMessageDataResponseHosting, PostMessages } from '$lib/types/post-message';
 
 export type HostingCallback = (data: PostMessageDataResponseHosting) => void;
 
-export const initHostingWorker = async () => {
-	const HostingWorker = await import('$lib/workers/workers?worker');
-	const hostingWorker: Worker = new HostingWorker.default();
+export class HostingWorker extends AppWorker {
+	#hostingCallback: HostingCallback | undefined;
 
-	let hostingCallback: HostingCallback | undefined;
+	constructor(worker: Worker) {
+		super(worker);
 
-	hostingWorker.onmessage = ({ data }: MessageEvent<PostMessages>) => {
-		const { msg } = data;
+		worker.onmessage = ({ data }: MessageEvent<PostMessages>) => {
+			const { msg } = data;
 
-		switch (msg) {
-			case 'customDomainRegistrationState':
-				hostingCallback?.(data.data as PostMessageDataResponseHosting);
-				return;
-		}
+			switch (msg) {
+				case 'customDomainRegistrationState':
+					this.#hostingCallback?.(data.data as PostMessageDataResponseHosting);
+					return;
+			}
+		};
+	}
+
+	static async init(): Promise<HostingWorker> {
+		const worker = await AppWorker.getInstance();
+		return new HostingWorker(worker);
+	}
+
+	startCustomDomainRegistrationTimer = ({
+		callback,
+		customDomain
+	}: {
+		customDomain: CustomDomain;
+		callback: HostingCallback;
+	}) => {
+		this.#hostingCallback = callback;
+
+		this._worker.postMessage({
+			msg: 'startCustomDomainRegistrationTimer',
+			data: { customDomain }
+		});
 	};
 
-	return {
-		startCustomDomainRegistrationTimer: ({
-			callback,
-			customDomain
-		}: {
-			customDomain: CustomDomain;
-			callback: HostingCallback;
-		}) => {
-			hostingCallback = callback;
-
-			hostingWorker.postMessage({
-				msg: 'startCustomDomainRegistrationTimer',
-				data: { customDomain }
-			});
-		},
-		stopCustomDomainRegistrationTimer: () => {
-			hostingWorker.postMessage({
-				msg: 'stopCustomDomainRegistrationTimer'
-			});
-		}
+	stopCustomDomainRegistrationTimer = () => {
+		this._worker.postMessage({
+			msg: 'stopCustomDomainRegistrationTimer'
+		});
 	};
-};
+}

--- a/src/frontend/src/lib/services/workers/worker.monitoring.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.monitoring.services.ts
@@ -2,6 +2,7 @@ import {
 	syncCanisterMonitoring,
 	syncCanistersMonitoring
 } from '$lib/services/canisters.loader.services';
+import { AppWorker } from '$lib/services/workers/_worker.services';
 import type { CanisterSegment } from '$lib/types/canister';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type {
@@ -10,53 +11,60 @@ import type {
 	PostMessages
 } from '$lib/types/post-message';
 
-export interface MonitoringWorker {
-	startMonitoringTimer: (params: {
+export class MonitoringWorker extends AppWorker {
+	constructor(worker: Worker) {
+		super(worker);
+
+		worker.onmessage = ({ data }: MessageEvent<PostMessages>) => {
+			const { msg } = data;
+
+			switch (msg) {
+				case 'syncCanister':
+					syncCanisterMonitoring(data.data as PostMessageDataResponseCanisterMonitoring);
+					return;
+				case 'syncCanisters':
+					syncCanistersMonitoring(data.data as PostMessageDataResponseCanistersMonitoring);
+					return;
+			}
+		};
+	}
+
+	static async init(): Promise<MonitoringWorker> {
+		const worker = await AppWorker.getInstance();
+		return new MonitoringWorker(worker);
+	}
+
+	startMonitoringTimer = ({
+		segments,
+		missionControlId,
+		withMonitoringHistory
+	}: {
 		segments: CanisterSegment[];
 		missionControlId: MissionControlId;
 		withMonitoringHistory: boolean;
-	}) => void;
-	stopMonitoringTimer: () => void;
-	restartMonitoringTimer: (params: {
+	}) => {
+		this._worker.postMessage({
+			msg: 'startMonitoringTimer',
+			data: { segments, missionControlId: missionControlId.toText(), withMonitoringHistory }
+		});
+	};
+
+	stopMonitoringTimer = () => {
+		this._worker.postMessage({
+			msg: 'stopMonitoringTimer'
+		});
+	};
+
+	restartMonitoringTimer = ({
+		segments,
+		missionControlId
+	}: {
 		segments: CanisterSegment[];
 		missionControlId: MissionControlId;
-	}) => void;
+	}) => {
+		this._worker.postMessage({
+			msg: 'restartMonitoringTimer',
+			data: { segments, missionControlId: missionControlId.toText() }
+		});
+	};
 }
-
-export const initMonitoringWorker = async (): Promise<MonitoringWorker> => {
-	const MonitoringWorker = await import('$lib/workers/workers?worker');
-	const monitoringWorker: Worker = new MonitoringWorker.default();
-
-	monitoringWorker.onmessage = ({ data }: MessageEvent<PostMessages>) => {
-		const { msg } = data;
-
-		switch (msg) {
-			case 'syncCanister':
-				syncCanisterMonitoring(data.data as PostMessageDataResponseCanisterMonitoring);
-				return;
-			case 'syncCanisters':
-				syncCanistersMonitoring(data.data as PostMessageDataResponseCanistersMonitoring);
-				return;
-		}
-	};
-
-	return {
-		startMonitoringTimer: ({ segments, missionControlId, withMonitoringHistory }) => {
-			monitoringWorker.postMessage({
-				msg: 'startMonitoringTimer',
-				data: { segments, missionControlId: missionControlId.toText(), withMonitoringHistory }
-			});
-		},
-		stopMonitoringTimer: () => {
-			monitoringWorker.postMessage({
-				msg: 'stopMonitoringTimer'
-			});
-		},
-		restartMonitoringTimer: ({ segments, missionControlId }) => {
-			monitoringWorker.postMessage({
-				msg: 'restartMonitoringTimer',
-				data: { segments, missionControlId: missionControlId.toText() }
-			});
-		}
-	};
-};

--- a/src/frontend/src/lib/services/workers/worker.wallet.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.wallet.services.ts
@@ -14,12 +14,6 @@ import type {
 	PostMessages
 } from '$lib/types/post-message';
 
-export interface WalletWorker {
-	start: (params: { missionControlId: MissionControlId }) => void;
-	restart: (params: { missionControlId: MissionControlId }) => void;
-	stop: () => void;
-}
-
 export class WalletWorker extends AppWorker {
 	constructor(worker: Worker) {
 		super(worker);

--- a/src/frontend/src/lib/services/workers/worker.wallet.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.wallet.services.ts
@@ -4,6 +4,7 @@ import {
 	onWalletCleanUp,
 	onWalletError
 } from '$lib/services/wallet/wallet.loader.services';
+import { AppWorker } from '$lib/services/workers/_worker.services';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type {
 	PostMessageDataResponseError,
@@ -19,50 +20,56 @@ export interface WalletWorker {
 	stop: () => void;
 }
 
-export const initWalletWorker = async (): Promise<WalletWorker> => {
-	const WalletWorker = await import('$lib/workers/workers?worker');
-	const worker: Worker = new WalletWorker.default();
+export class WalletWorker extends AppWorker {
+	constructor(worker: Worker) {
+		super(worker);
 
-	worker.onmessage = ({ data }: MessageEvent<PostMessages>) => {
-		const { msg } = data;
+		worker.onmessage = ({ data }: MessageEvent<PostMessages>) => {
+			const { msg } = data;
 
-		switch (msg) {
-			case 'syncWallet':
-				onSyncWallet(data.data as PostMessageDataResponseWallet);
-				return;
-			case 'syncWalletError':
-				onWalletError({
-					error: (data.data as PostMessageDataResponseError).error
-				});
-				return;
-			case 'syncWalletCleanUp':
-				onWalletCleanUp({
-					transactionIds: (data.data as PostMessageDataResponseWalletCleanUp).transactionIds
-				});
-				return;
-			case 'syncExchange':
-				onSyncExchange(data.data as PostMessageDataResponseExchange);
-				return;
-		}
+			switch (msg) {
+				case 'syncWallet':
+					onSyncWallet(data.data as PostMessageDataResponseWallet);
+					return;
+				case 'syncWalletError':
+					onWalletError({
+						error: (data.data as PostMessageDataResponseError).error
+					});
+					return;
+				case 'syncWalletCleanUp':
+					onWalletCleanUp({
+						transactionIds: (data.data as PostMessageDataResponseWalletCleanUp).transactionIds
+					});
+					return;
+				case 'syncExchange':
+					onSyncExchange(data.data as PostMessageDataResponseExchange);
+					return;
+			}
+		};
+	}
+
+	static async init(): Promise<WalletWorker> {
+		const worker = await AppWorker.getInstance();
+		return new WalletWorker(worker);
+	}
+
+	start = ({ missionControlId }: { missionControlId: MissionControlId }) => {
+		this._worker.postMessage({
+			msg: 'startWalletTimer',
+			data: { missionControlId: missionControlId.toText() }
+		});
 	};
 
-	return {
-		start: ({ missionControlId }: { missionControlId: MissionControlId }) => {
-			worker.postMessage({
-				msg: 'startWalletTimer',
-				data: { missionControlId: missionControlId.toText() }
-			});
-		},
-		restart: ({ missionControlId }: { missionControlId: MissionControlId }) => {
-			worker.postMessage({
-				msg: 'restartWalletTimer',
-				data: { missionControlId: missionControlId.toText() }
-			});
-		},
-		stop: () => {
-			worker.postMessage({
-				msg: 'stopWalletTimer'
-			});
-		}
+	restart = ({ missionControlId }: { missionControlId: MissionControlId }) => {
+		this._worker.postMessage({
+			msg: 'restartWalletTimer',
+			data: { missionControlId: missionControlId.toText() }
+		});
 	};
-};
+
+	stop = () => {
+		this._worker.postMessage({
+			msg: 'stopWalletTimer'
+		});
+	};
+}

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -11,8 +11,8 @@
 	import { initMissionControl } from '$lib/services/console.services';
 	import { syncSnapshots } from '$lib/services/snapshots.services';
 	import { syncSubnets } from '$lib/services/subnets.services';
-	import { initAuthWorker } from '$lib/services/workers/worker.auth.services';
-	import { type AuthStoreData, authStore } from '$lib/stores/auth.store';
+	import { AuthWorker } from '$lib/services/workers/worker.auth.services';
+	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import '$lib/styles/global.scss';
 
@@ -43,9 +43,9 @@
 		(async () => await initMissionControl($authStore))();
 	});
 
-	let worker: { syncAuthIdle: (auth: AuthStoreData) => void } | undefined = $state();
+	let worker = $state<AuthWorker | undefined>();
 
-	onMount(async () => (worker = await initAuthWorker()));
+	onMount(async () => (worker = await AuthWorker.init()));
 
 	run(() => {
 		// @ts-expect-error TODO: to be migrated to Svelte v5


### PR DESCRIPTION
# Motivation

As I'll implement a fix that calls terminate of each workers in #1754, I feel like an encapsulation pattern (if that's the appropriate naming) is a bit cleaner to load the workers since they all load the same worker code.
