### PR TITLE
fix(frontend): snippet recursion

### DIFF
--- a/src/frontend/src/lib/components/modals/CanisterUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/CanisterUpgradeModal.svelte
@@ -21,6 +21,7 @@
 		newerReleases,
 		segment,
 		build,
+		intro: introUpgrade,
 		...propsRest
 	}: Props &
 		Omit<
@@ -69,8 +70,8 @@
 				{onclose}
 				onback={() => (step = 'confirm')}
 			>
-				{#snippet intro()}
-					{@render intro?.()}
+				{#snippet title()}
+					{@render introUpgrade?.()}
 				{/snippet}
 			</SelectUpgradeVersion>
 		{/snippet}

--- a/src/frontend/src/lib/components/upgrade/wizard/SelectUpgradeVersion.svelte
+++ b/src/frontend/src/lib/components/upgrade/wizard/SelectUpgradeVersion.svelte
@@ -18,7 +18,7 @@
 		newerReleases: string[];
 		segment: 'satellite' | 'mission_control' | 'orbiter';
 		back?: boolean;
-		intro?: Snippet;
+		title?: Snippet;
 		takeSnapshot: boolean;
 		onclose: () => void;
 		onback: () => void;
@@ -31,7 +31,7 @@
 		segment,
 		back = false,
 		takeSnapshot = $bindable(true),
-		intro,
+		title,
 		onnext,
 		onclose,
 		onback
@@ -104,7 +104,7 @@
 	};
 </script>
 
-{@render intro?.()}
+{@render title?.()}
 
 <form onsubmit={onSubmit}>
 	{#if newerReleases.length > 1}


### PR DESCRIPTION
# Motivation

It looks like there is a snippets recursive issue - Maximum call size exceeded - when snippets name are identitcal and the compiler cannot figure out which snippet is which props.
