### PR TITLE
test(console): assert factory spins expected settings

### DIFF
--- a/src/tests/specs/console/console.factory.spec.ts
+++ b/src/tests/specs/console/console.factory.spec.ts
@@ -1,0 +1,84 @@
+import type { _SERVICE as ConsoleActor } from '$declarations/console/console.did';
+import { idlFactory as idlFactorConsole } from '$declarations/console/console.factory.did';
+import { type Identity } from '@dfinity/agent';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { PocketIc, type Actor } from '@dfinity/pic';
+import { Principal } from '@dfinity/principal';
+import { assertNonNullish, fromNullable } from '@dfinity/utils';
+import { afterEach, beforeEach, describe, inject } from 'vitest';
+import { deploySegments } from '../../utils/console-tests.utils';
+import { canisterStatus } from '../../utils/ic-management-tests.utils';
+import { CONSOLE_WASM_PATH } from '../../utils/setup-tests.utils';
+
+describe('Console', () => {
+	let pic: PocketIc;
+	let actor: Actor<ConsoleActor>;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	beforeEach(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const { actor: c } = await pic.setupCanister<ConsoleActor>({
+			idlFactory: idlFactorConsole,
+			wasm: CONSOLE_WASM_PATH,
+			sender: controller.getPrincipal()
+		});
+
+		actor = c;
+		actor.setIdentity(controller);
+
+		await deploySegments(actor);
+	});
+
+	afterEach(async () => {
+		await pic?.tearDown();
+	});
+
+	describe('User', () => {
+		let user: Identity;
+
+		beforeEach(() => {
+			user = Ed25519KeyIdentity.generate();
+			actor.setIdentity(user);
+		});
+
+		it('should create a mission control with expected default settings', async () => {
+			const { init_user_mission_control_center } = actor;
+
+			const missionControl = await init_user_mission_control_center();
+
+			const missionControlId = fromNullable(missionControl.mission_control_id);
+
+			assertNonNullish(missionControlId);
+
+			const result = await canisterStatus({
+				sender: user,
+				pic,
+				canisterId: missionControlId
+			});
+
+			const settings = result?.settings;
+
+			expect(settings?.controllers).toHaveLength(2);
+			expect(
+				settings?.controllers.find(
+					(controller) => controller.toText() === user.getPrincipal().toText()
+				)
+			).not.toBeUndefined();
+			expect(
+				settings?.controllers.find(
+					(controller) => controller.toText() === missionControlId.toText()
+				)
+			).not.toBeUndefined();
+
+			expect(settings?.freezing_threshold).toEqual(2_592_000n);
+			expect(settings?.wasm_memory_threshold).toEqual(0n);
+			expect(settings?.reserved_cycles_limit).toEqual(5_000_000_000_000n);
+			expect(settings?.log_visibility).toEqual({ controllers: null });
+			expect(settings?.wasm_memory_limit).toEqual(1_073_741_824n);
+			expect(settings?.memory_allocation).toEqual(0n);
+			expect(settings?.compute_allocation).toEqual(0n);
+		});
+	});
+});

--- a/src/tests/specs/console/console.factory.spec.ts
+++ b/src/tests/specs/console/console.factory.spec.ts
@@ -1,11 +1,14 @@
 import type { _SERVICE as ConsoleActor } from '$declarations/console/console.did';
 import { idlFactory as idlFactorConsole } from '$declarations/console/console.factory.did';
+import type { _SERVICE as MissionControlActor } from '$declarations/mission_control/mission_control.did';
+import { idlFactory as idlFactorMissionControl } from '$declarations/mission_control/mission_control.factory.did';
 import { type Identity } from '@dfinity/agent';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { PocketIc, type Actor } from '@dfinity/pic';
 import { Principal } from '@dfinity/principal';
-import { assertNonNullish, fromNullable } from '@dfinity/utils';
-import { afterEach, beforeEach, describe, inject } from 'vitest';
+import { assertNonNullish, fromNullable, nonNullish } from '@dfinity/utils';
+import { describe, inject } from 'vitest';
+import { CONSOLE_ID } from '../../constants/console-tests.constants';
 import { deploySegments } from '../../utils/console-tests.utils';
 import { canisterStatus } from '../../utils/ic-management-tests.utils';
 import { CONSOLE_WASM_PATH } from '../../utils/setup-tests.utils';
@@ -16,13 +19,14 @@ describe('Console', () => {
 
 	const controller = Ed25519KeyIdentity.generate();
 
-	beforeEach(async () => {
+	beforeAll(async () => {
 		pic = await PocketIc.create(inject('PIC_URL'));
 
 		const { actor: c } = await pic.setupCanister<ConsoleActor>({
 			idlFactory: idlFactorConsole,
 			wasm: CONSOLE_WASM_PATH,
-			sender: controller.getPrincipal()
+			sender: controller.getPrincipal(),
+			targetCanisterId: CONSOLE_ID
 		});
 
 		actor = c;
@@ -31,14 +35,54 @@ describe('Console', () => {
 		await deploySegments(actor);
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		await pic?.tearDown();
 	});
 
+	const assertSettings = async ({
+		user,
+		canisterId,
+		missionControlId
+	}: {
+		user: Identity;
+		canisterId: Principal;
+		missionControlId: Principal;
+	}) => {
+		const result = await canisterStatus({
+			sender: user,
+			pic,
+			canisterId
+		});
+
+		const settings = result?.settings;
+
+		expect(settings?.controllers).toHaveLength(2);
+		expect(
+			settings?.controllers.find(
+				(controller) => controller.toText() === user.getPrincipal().toText()
+			)
+		).not.toBeUndefined();
+		expect(
+			settings?.controllers.find(
+				(controller) =>
+					nonNullish(missionControlId) && controller.toText() === missionControlId.toText()
+			)
+		).not.toBeUndefined();
+
+		expect(settings?.freezing_threshold).toEqual(2_592_000n);
+		expect(settings?.wasm_memory_threshold).toEqual(0n);
+		expect(settings?.reserved_cycles_limit).toEqual(5_000_000_000_000n);
+		expect(settings?.log_visibility).toEqual({ controllers: null });
+		expect(settings?.wasm_memory_limit).toEqual(1_073_741_824n);
+		expect(settings?.memory_allocation).toEqual(0n);
+		expect(settings?.compute_allocation).toEqual(0n);
+	};
+
 	describe('User', () => {
 		let user: Identity;
+		let missionControlId: Principal | undefined;
 
-		beforeEach(() => {
+		beforeAll(() => {
 			user = Ed25519KeyIdentity.generate();
 			actor.setIdentity(user);
 		});
@@ -48,37 +92,33 @@ describe('Console', () => {
 
 			const missionControl = await init_user_mission_control_center();
 
-			const missionControlId = fromNullable(missionControl.mission_control_id);
-
+			missionControlId = fromNullable(missionControl.mission_control_id);
 			assertNonNullish(missionControlId);
 
-			const result = await canisterStatus({
-				sender: user,
-				pic,
+			await assertSettings({
+				user,
+				missionControlId,
 				canisterId: missionControlId
 			});
+		});
 
-			const settings = result?.settings;
+		it('should create a satellite with expected default settings', async () => {
+			assertNonNullish(missionControlId);
 
-			expect(settings?.controllers).toHaveLength(2);
-			expect(
-				settings?.controllers.find(
-					(controller) => controller.toText() === user.getPrincipal().toText()
-				)
-			).not.toBeUndefined();
-			expect(
-				settings?.controllers.find(
-					(controller) => controller.toText() === missionControlId.toText()
-				)
-			).not.toBeUndefined();
+			const micActor = pic.createActor<MissionControlActor>(
+				idlFactorMissionControl,
+				missionControlId
+			);
+			micActor.setIdentity(user);
 
-			expect(settings?.freezing_threshold).toEqual(2_592_000n);
-			expect(settings?.wasm_memory_threshold).toEqual(0n);
-			expect(settings?.reserved_cycles_limit).toEqual(5_000_000_000_000n);
-			expect(settings?.log_visibility).toEqual({ controllers: null });
-			expect(settings?.wasm_memory_limit).toEqual(1_073_741_824n);
-			expect(settings?.memory_allocation).toEqual(0n);
-			expect(settings?.compute_allocation).toEqual(0n);
+			const { create_satellite } = micActor;
+			const { satellite_id: satelliteId } = await create_satellite('test');
+
+			await assertSettings({
+				user,
+				missionControlId,
+				canisterId: satelliteId
+			});
 		});
 	});
 });

--- a/src/tests/specs/console/console.factory.spec.ts
+++ b/src/tests/specs/console/console.factory.spec.ts
@@ -120,5 +120,31 @@ describe('Console', () => {
 				canisterId: satelliteId
 			});
 		});
+
+		it('should create an orbiter with expected default settings', async () => {
+			// First we need credits or ICP to spin another module. Let's use the former method.
+			actor.setIdentity(controller);
+
+			const { add_credits } = actor;
+			await add_credits(user.getPrincipal(), { e8s: 100_000_000n });
+
+			// Then we can create the additional module
+			assertNonNullish(missionControlId);
+
+			const micActor = pic.createActor<MissionControlActor>(
+				idlFactorMissionControl,
+				missionControlId
+			);
+			micActor.setIdentity(user);
+
+			const { create_orbiter } = micActor;
+			const { orbiter_id: orbiterId } = await create_orbiter([]);
+
+			await assertSettings({
+				user,
+				missionControlId,
+				canisterId: orbiterId
+			});
+		});
 	});
 });

--- a/src/tests/utils/ic-management-tests.utils.ts
+++ b/src/tests/utils/ic-management-tests.utils.ts
@@ -95,7 +95,7 @@ interface install_chunked_code_args {
 
 // canister_status did
 
-const canister_status_args = IDL.Record({ canister_id: canister_id });
+const canister_status_args = IDL.Record({ canister_id });
 
 const log_visibility = IDL.Variant({
 	controllers: IDL.Null,
@@ -108,7 +108,7 @@ const definite_canister_settings = IDL.Record({
 	wasm_memory_threshold: IDL.Nat,
 	controllers: IDL.Vec(IDL.Principal),
 	reserved_cycles_limit: IDL.Nat,
-	log_visibility: log_visibility,
+	log_visibility,
 	wasm_memory_limit: IDL.Nat,
 	memory_allocation: IDL.Nat,
 	compute_allocation: IDL.Nat


### PR DESCRIPTION
# Motivation

We want to assert that the Console spins modules (mission control, satellites or orbiter) with the expected default settings.
