### PR TITLE
feat(frontend): notifications tabs

### DIFF
--- a/src/frontend/src/lib/components/notifications/Notifications.svelte
+++ b/src/frontend/src/lib/components/notifications/Notifications.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { setContext } from 'svelte';
+	import { writable } from 'svelte/store';
 	import IconAnalytics from '$lib/components/icons/IconAnalytics.svelte';
 	import IconMissionControl from '$lib/components/icons/IconMissionControl.svelte';
 	import IconNotifications from '$lib/components/icons/IconNotifications.svelte';
@@ -8,13 +10,21 @@
 	import NotificationsUpgrade from '$lib/components/notifications/NotificationsUpgrade.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import Popover from '$lib/components/ui/Popover.svelte';
+	import TabsSegment from '$lib/components/ui/TabsSegment.svelte';
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { satelliteStore } from '$lib/derived/satellite.derived';
 	import { versionsLoaded, versionsUpgradeWarning } from '$lib/derived/version.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CanisterData } from '$lib/types/canister';
+	import {
+		type Tab,
+		TABS_CONTEXT_KEY,
+		type TabsContext,
+		type TabsData
+	} from '$lib/types/tabs.context';
 	import { overviewLink } from '$lib/utils/nav.utils';
+	import { initTabId } from '$lib/utils/tabs.utils';
 
 	let button: HTMLButtonElement | undefined = $state();
 	let visible: boolean = $state(false);
@@ -55,6 +65,26 @@
 		missionControlWarnings || orbiterWarnings || satelliteWarnings || hasUpgradeWarning
 	);
 	let noNotifications = $derived(!hasNotifications);
+
+	const tabs: Tab[] = [
+		{
+			id: Symbol('1'),
+			labelKey: 'notifications.alerts'
+		},
+		{
+			id: Symbol('2'),
+			labelKey: 'notifications.inbox'
+		}
+	];
+
+	const store = writable<TabsData>({
+		tabId: initTabId(tabs),
+		tabs
+	});
+
+	setContext<TabsContext>(TABS_CONTEXT_KEY, {
+		store
+	});
 </script>
 
 <ButtonIcon {onclick} {level} bind:button>
@@ -88,47 +118,51 @@
 
 <Popover bind:visible anchor={button} direction="rtl" --popover-min-size="340px">
 	<div class="container">
-		<span class="title">{$i18n.notifications.title}:</span>
+		<TabsSegment>
+			{#if $store.tabId === $store.tabs[0].id}
+				{#if noNotifications}
+					{$i18n.notifications.no_alerts}
+				{:else}
+					{#if hasCanisterNotifications}
+						<NotificationsCanister
+							href="/mission-control"
+							segment="mission_control"
+							{close}
+							data={missionControlCanisterData}
+							heapWarning={missionControlHeapWarning}
+							cyclesWarning={missionControlCyclesWarning}
+							cyclesIcon={IconMissionControl}
+						/>
 
-		{#if noNotifications}
-			{$i18n.notifications.none}
-		{:else}
-			{#if hasCanisterNotifications}
-				<NotificationsCanister
-					href="/mission-control"
-					segment="mission_control"
-					{close}
-					data={missionControlCanisterData}
-					heapWarning={missionControlHeapWarning}
-					cyclesWarning={missionControlCyclesWarning}
-					cyclesIcon={IconMissionControl}
-				/>
+						<NotificationsCanister
+							href="/analytics/?tab=overview"
+							segment="orbiter"
+							{close}
+							data={orbiterCanisterData}
+							heapWarning={orbiterHeapWarning}
+							cyclesWarning={orbiterCyclesWarning}
+							cyclesIcon={IconAnalytics}
+						/>
 
-				<NotificationsCanister
-					href="/analytics/?tab=overview"
-					segment="orbiter"
-					{close}
-					data={orbiterCanisterData}
-					heapWarning={orbiterHeapWarning}
-					cyclesWarning={orbiterCyclesWarning}
-					cyclesIcon={IconAnalytics}
-				/>
+						<NotificationsCanister
+							href={overviewLink($satelliteStore?.satellite_id)}
+							segment="satellite"
+							{close}
+							data={satelliteCanisterData}
+							heapWarning={satelliteHeapWarning}
+							cyclesWarning={satelliteCyclesWarning}
+							cyclesIcon={IconSatellite}
+						/>
+					{/if}
 
-				<NotificationsCanister
-					href={overviewLink($satelliteStore?.satellite_id)}
-					segment="satellite"
-					{close}
-					data={satelliteCanisterData}
-					heapWarning={satelliteHeapWarning}
-					cyclesWarning={satelliteCyclesWarning}
-					cyclesIcon={IconSatellite}
-				/>
+					{#if hasUpgradeWarning}
+						<NotificationsUpgrade {close} />
+					{/if}
+				{/if}
+			{:else if $store.tabId === $store.tabs[1].id}
+				{$i18n.notifications.no_notifications}
 			{/if}
-
-			{#if hasUpgradeWarning}
-				<NotificationsUpgrade {close} />
-			{/if}
-		{/if}
+		</TabsSegment>
 	</div>
 </Popover>
 
@@ -136,10 +170,6 @@
 	@use '../../styles/mixins/overlay';
 
 	@include overlay.popover-container;
-
-	.title {
-		font-weight: var(--font-weight-bold);
-	}
 
 	.container {
 		font-size: var(--font-size-small);

--- a/src/frontend/src/lib/components/satellites/SatelliteOverviewActions.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteOverviewActions.svelte
@@ -4,7 +4,6 @@
 	import SatelliteEditName from '$lib/components/satellites/SatelliteEditName.svelte';
 	import SatelliteVisit from '$lib/components/satellites/SatelliteVisit.svelte';
 	import SegmentActions from '$lib/components/segments/SegmentActions.svelte';
-	import type { CanisterSyncData as CanisterSyncDataType } from '$lib/types/canister';
 
 	interface Props {
 		satellite: Satellite;

--- a/src/frontend/src/lib/components/ui/Tabs.svelte
+++ b/src/frontend/src/lib/components/ui/Tabs.svelte
@@ -69,59 +69,13 @@
 {@render children()}
 
 <style lang="scss">
-	@mixin button {
-		position: relative;
-
-		text-decoration: none;
-
-		margin: 0 var(--padding-2x) 0 0;
-		padding: 1px var(--padding);
-
-		color: var(--label-color);
-
-		border-radius: var(--border-radius);
-
-		transition: all var(--animation-time) ease-out;
-	}
-
-	@mixin hover {
-		background: var(--color-primary);
-		color: var(--color-primary-contrast);
-	}
+	@use '../../styles/mixins/tabs';
 
 	.tabs {
-		display: flex;
-		align-items: center;
-		flex-wrap: wrap;
-		gap: var(--padding);
-
-		margin: var(--padding) 0 var(--padding-1_5x);
-
-		:global(a:not(.tab)) {
-			@include button;
-			border-radius: var(--border-radius);
-			margin: 0;
-
-			&:hover,
-			&:focus {
-				@include hover;
-			}
-		}
+		@include tabs.tabs;
 	}
 
 	.tab {
-		@include button;
-
-		&:hover,
-		&:focus {
-			@include hover;
-		}
-
-		&:not(:focus):not(:hover) {
-			&.selected {
-				background: var(--color-secondary);
-				color: var(--color-secondary-contrast);
-			}
-		}
+		@include tabs.tab;
 	}
 </style>

--- a/src/frontend/src/lib/components/ui/TabsSegment.svelte
+++ b/src/frontend/src/lib/components/ui/TabsSegment.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { getContext, type Snippet } from 'svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { TABS_CONTEXT_KEY, type TabsContext } from '$lib/types/tabs.context';
+	import { keyOf } from '$lib/utils/utils';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	const { store }: TabsContext = getContext<TabsContext>(TABS_CONTEXT_KEY);
+
+	const selectTab = (tabId: symbol) => store.update((data) => ({ ...data, tabId }));
+</script>
+
+<div class="tabs">
+	{#each $store.tabs as { labelKey, id } (id)}
+		{@const [group, key] = labelKey.split('.')}
+		{@const obj = keyOf({ obj: $i18n, key: group })}
+		{@const text = keyOf({ obj, key })}
+
+		<button class="text tab" class:selected={$store.tabId === id} onclick={() => selectTab(id)}
+			>{text}</button
+		>
+	{/each}
+</div>
+
+{@render children()}
+
+<style lang="scss">
+	@use '../../styles/mixins/tabs';
+
+	.tabs {
+		@include tabs.tabs;
+	}
+
+	.tab {
+		--tab-selected-background: var(--color-tertiary);
+		--tab-selected-color: var(--color-tertiary-contrast);
+
+		@include tabs.tab;
+	}
+</style>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -907,7 +907,10 @@
 	},
 	"notifications": {
 		"title": "Notifications",
-		"none": "No notifications at the moment.",
+		"alerts": "Alerts",
+		"inbox": "Inbox",
+		"no_alerts": "All clear. No action required at this time.",
+		"no_notifications": "No notifications at the moment.",
 		"low_cycles": "Your {0} requires action: Low cycles detected.",
 		"heap": "Your {0} requires action: Heap memory is approaching 1 GB.",
 		"upgrade_available": "New upgrades available. Visit the Upgrade Dock to check them out."

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -907,7 +907,10 @@
 	},
 	"notifications": {
 		"title": "Notifications",
-		"none": "No notifications at the moment.",
+		"alerts": "Alerts",
+		"inbox": "Inbox",
+		"no_alerts": "All clear. No action required at this time.",
+		"no_notifications": "No notifications at the moment.",
 		"low_cycles": "Your {0} requires action: Low cycles detected.",
 		"heap": "Your {0} requires action: Heap memory is approaching 1 GB.",
 		"upgrade_available": "New upgrades available. Visit the Upgrade Dock to check them out."

--- a/src/frontend/src/lib/styles/mixins/_tabs.scss
+++ b/src/frontend/src/lib/styles/mixins/_tabs.scss
@@ -1,0 +1,55 @@
+@mixin _tab-button {
+	position: relative;
+
+	text-decoration: none;
+
+	margin: 0 var(--padding-2x) 0 0;
+	padding: 1px var(--padding);
+
+	color: var(--label-color);
+
+	border-radius: var(--border-radius);
+
+	transition: all var(--animation-time) ease-out;
+}
+
+@mixin _tab-hover {
+	background: var(--color-primary);
+	color: var(--color-primary-contrast);
+}
+
+@mixin tabs {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: var(--padding);
+
+	margin: var(--padding) 0 var(--padding-1_5x);
+
+	:global(a:not(.tab)) {
+		@include _tab-button;
+		border-radius: var(--border-radius);
+		margin: 0;
+
+		&:hover,
+		&:focus {
+			@include _tab-hover;
+		}
+	}
+}
+
+@mixin tab {
+	@include _tab-button;
+
+	&:hover,
+	&:focus {
+		@include _tab-hover;
+	}
+
+	&:not(:focus):not(:hover) {
+		&.selected {
+			background: var(--tab-selected-background, var(--color-secondary));
+			color: var(--tab-selected-color, var(--color-secondary-contrast));
+		}
+	}
+}

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -938,7 +938,10 @@ interface I18nCdn {
 
 interface I18nNotifications {
 	title: string;
-	none: string;
+	alerts: string;
+	inbox: string;
+	no_alerts: string;
+	no_notifications: string;
 	low_cycles: string;
 	heap: string;
 	upgrade_available: string;


### PR DESCRIPTION
# Motivation

We want to display alerts but also tips/info/suggestions in the notifications pane.

<img width="1536" height="1031" alt="Capture d’écran 2025-07-22 à 08 03 50" src="https://github.com/user-attachments/assets/ed3cdd5a-a0a5-4538-b8fa-ec94b3e78a87" />
<img width="1536" height="1031" alt="Capture d’écran 2025-07-22 à 08 03 52" src="https://github.com/user-attachments/assets/5fc0adb2-8c5d-4463-a9bc-821715f19f17" />

