### PR TITLE
feat(satellite): use AssertContext struct instead of plain rule

### DIFF
--- a/src/libs/satellite/src/assets/storage/assert.rs
+++ b/src/libs/satellite/src/assets/storage/assert.rs
@@ -1,5 +1,5 @@
 use crate::hooks::storage::invoke_assert_delete_asset;
-use crate::types::store::StoreContext;
+use crate::types::store::{AssertContext, StoreContext};
 use crate::user::core::assert::{assert_user_is_not_banned, is_known_user};
 use crate::user::usage::assert::increment_and_assert_storage_usage;
 use candid::Principal;
@@ -8,7 +8,7 @@ use junobuild_collections::assert::stores::{
 };
 use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
 use junobuild_collections::types::core::CollectionKey;
-use junobuild_collections::types::rules::{Permission, Rule};
+use junobuild_collections::types::rules::Permission;
 use junobuild_shared::controllers::{controller_can_write, is_controller};
 use junobuild_shared::types::state::Controllers;
 use junobuild_storage::errors::{
@@ -24,7 +24,7 @@ pub fn assert_get_asset(
         controllers,
         collection: _,
     }: &StoreContext,
-    rule: &Rule,
+    &AssertContext { rule }: &AssertContext,
     current_asset: &Asset,
 ) -> Result<(), String> {
     assert_user_is_not_banned(caller, controllers)?;
@@ -66,7 +66,7 @@ pub fn assert_storage_list_permission(
 pub fn assert_create_batch(
     caller: Principal,
     controllers: &Controllers,
-    rule: &Rule,
+    &AssertContext { rule }: &AssertContext,
 ) -> Result<(), String> {
     assert_user_is_not_banned(caller, controllers)?;
 
@@ -82,7 +82,7 @@ pub fn assert_create_batch(
 
 pub fn assert_delete_asset(
     context: &StoreContext,
-    rule: &Rule,
+    &AssertContext { rule }: &AssertContext,
     asset: &Asset,
 ) -> Result<(), String> {
     assert_user_is_not_banned(context.caller, context.controllers)?;

--- a/src/libs/satellite/src/assets/storage/store.rs
+++ b/src/libs/satellite/src/assets/storage/store.rs
@@ -13,7 +13,7 @@ use crate::assets::storage::state::{
 use crate::assets::storage::strategy_impls::{StorageAssertions, StorageState, StorageUpload};
 use crate::controllers::store::get_controllers;
 use crate::memory::internal::STATE;
-use crate::types::store::StoreContext;
+use crate::types::store::{AssertContext, StoreContext};
 use candid::Principal;
 use junobuild_collections::msg::msg_storage_collection_not_empty;
 use junobuild_collections::types::core::CollectionKey;
@@ -247,20 +247,22 @@ fn secure_get_asset_impl(
 ) -> Result<Option<Asset>, String> {
     let rule = get_state_rule(context.collection)?;
 
-    get_asset_impl(context, full_path, &rule)
+    let assert_context = AssertContext { rule: &rule };
+
+    get_asset_impl(context, &assert_context, full_path)
 }
 
 fn get_asset_impl(
     context: &StoreContext,
+    assert_context: &AssertContext,
     full_path: FullPath,
-    rule: &Rule,
 ) -> Result<Option<Asset>, String> {
-    let asset = get_state_asset(context.collection, &full_path, rule);
+    let asset = get_state_asset(context.collection, &full_path, assert_context.rule);
 
     match asset {
         None => Ok(None),
         Some(asset) => {
-            if assert_get_asset(context, rule, &asset).is_err() {
+            if assert_get_asset(context, assert_context, &asset).is_err() {
                 return Ok(None);
             }
 
@@ -390,30 +392,34 @@ fn secure_delete_asset_impl(
 ) -> Result<Option<Asset>, String> {
     let rule = get_state_rule(context.collection)?;
 
-    delete_asset_impl(context, full_path, &rule, config)
+    let assert_context = AssertContext { rule: &rule };
+
+    delete_asset_impl(context, &assert_context, full_path, config)
 }
 
 fn delete_asset_impl(
     context: &StoreContext,
+    assert_context: &AssertContext,
     full_path: FullPath,
-    rule: &Rule,
     config: &StorageConfig,
 ) -> Result<Option<Asset>, String> {
-    let asset = get_state_asset(context.collection, &full_path, rule);
+    let asset = get_state_asset(context.collection, &full_path, assert_context.rule);
 
     match asset {
         None => Err(JUNO_STORAGE_ERROR_ASSET_NOT_FOUND.to_string()),
         Some(asset) => {
-            assert_delete_asset(context, rule, &asset)?;
+            assert_delete_asset(context, assert_context, &asset)?;
 
-            let deleted = delete_state_asset(context.collection, &full_path, rule);
+            let deleted = delete_state_asset(context.collection, &full_path, assert_context.rule);
             delete_runtime_certified_asset(&asset);
 
             // We just removed the rewrite for /404.html in the certification tree therefore if /index.html exists, we want to reintroduce it as rewrite
             if *full_path == *ROOT_404_HTML {
-                if let Some(index_asset) =
-                    get_state_asset(context.collection, &ROOT_INDEX_HTML.to_string(), rule)
-                {
+                if let Some(index_asset) = get_state_asset(
+                    context.collection,
+                    &ROOT_INDEX_HTML.to_string(),
+                    assert_context.rule,
+                ) {
                     update_runtime_certified_asset(&index_asset, config);
                 }
             }
@@ -516,13 +522,20 @@ fn delete_filtered_assets_store_impl(
     assets: &ListResults<AssetNoContent>,
 ) -> Result<Vec<Option<Asset>>, String> {
     let rule = get_state_rule(context.collection)?;
+
+    let assert_context = AssertContext { rule: &rule };
+
     let config = get_config_store();
 
     let mut results: Vec<Option<Asset>> = Vec::new();
 
     for (_, asset) in &assets.items {
-        let deleted_asset =
-            delete_asset_impl(context, asset.key.full_path.clone(), &rule, &config)?;
+        let deleted_asset = delete_asset_impl(
+            context,
+            &assert_context,
+            asset.key.full_path.clone(),
+            &config,
+        )?;
 
         results.push(deleted_asset);
     }
@@ -576,7 +589,9 @@ fn secure_create_batch_impl(
 ) -> Result<BatchId, String> {
     let rule = get_state_rule(&init.collection)?;
 
-    assert_create_batch(caller, controllers, &rule)?;
+    let assert_context = AssertContext { rule: &rule };
+
+    assert_create_batch(caller, controllers, &assert_context)?;
 
     create_batch(
         caller,

--- a/src/libs/satellite/src/db/assert.rs
+++ b/src/libs/satellite/src/db/assert.rs
@@ -3,7 +3,7 @@ use crate::db::types::config::DbConfig;
 use crate::db::types::state::{DocAssertDelete, DocAssertSet, DocContext};
 use crate::errors::db::{JUNO_DATASTORE_ERROR_CANNOT_READ, JUNO_DATASTORE_ERROR_CANNOT_WRITE};
 use crate::hooks::db::{invoke_assert_delete_doc, invoke_assert_set_doc};
-use crate::types::store::StoreContext;
+use crate::types::store::{AssertContext, StoreContext};
 use crate::user::core::assert::{
     assert_user_collection_caller_key, assert_user_collection_data, assert_user_is_not_banned,
     assert_user_write_permission,
@@ -16,7 +16,7 @@ use candid::Principal;
 use junobuild_collections::assert::stores::{
     assert_create_permission, assert_permission, public_permission,
 };
-use junobuild_collections::types::rules::{Permission, Rule};
+use junobuild_collections::types::rules::Permission;
 use junobuild_shared::assert::{assert_description_length, assert_max_memory_size, assert_version};
 use junobuild_shared::types::core::Key;
 use junobuild_shared::types::state::{Controllers, Version};
@@ -27,7 +27,7 @@ pub fn assert_get_doc(
         controllers,
         collection: _,
     }: &StoreContext,
-    rule: &Rule,
+    &AssertContext { rule }: &AssertContext,
     current_doc: &Doc,
 ) -> Result<(), String> {
     assert_user_is_not_banned(caller, controllers)?;
@@ -55,10 +55,10 @@ pub fn assert_set_doc(
         controllers,
         collection,
     }: &StoreContext,
+    &AssertContext { rule }: &AssertContext,
     config: &Option<DbConfig>,
     key: &Key,
     value: &SetDoc,
-    rule: &Rule,
     current_doc: &Option<Doc>,
 ) -> Result<(), String> {
     assert_user_is_not_banned(caller, controllers)?;
@@ -102,9 +102,9 @@ pub fn assert_delete_doc(
         controllers,
         collection,
     }: &StoreContext,
+    &AssertContext { rule }: &AssertContext,
     key: &Key,
     value: &DelDoc,
-    rule: &Rule,
     current_doc: &Option<Doc>,
 ) -> Result<(), String> {
     assert_user_is_not_banned(caller, controllers)?;

--- a/src/libs/satellite/src/db/store.rs
+++ b/src/libs/satellite/src/db/store.rs
@@ -12,7 +12,7 @@ use crate::db::types::interface::{DelDoc, SetDoc};
 use crate::db::types::state::{Doc, DocContext, DocUpsert};
 use crate::db::utils::filter_values;
 use crate::memory::internal::STATE;
-use crate::types::store::StoreContext;
+use crate::types::store::{AssertContext, StoreContext};
 use candid::Principal;
 use junobuild_collections::msg::msg_db_collection_not_empty;
 use junobuild_collections::types::core::CollectionKey;
@@ -94,16 +94,23 @@ pub fn get_doc_store(
 
 fn secure_get_doc(context: &StoreContext, key: Key) -> Result<Option<Doc>, String> {
     let rule = get_state_rule(context.collection)?;
-    get_doc_impl(context, key, &rule)
+
+    let assert_context = AssertContext { rule: &rule };
+
+    get_doc_impl(context, &assert_context, key)
 }
 
-fn get_doc_impl(context: &StoreContext, key: Key, rule: &Rule) -> Result<Option<Doc>, String> {
-    let value = get_state_doc(context.collection, &key, rule)?;
+fn get_doc_impl(
+    context: &StoreContext,
+    assert_context: &AssertContext,
+    key: Key,
+) -> Result<Option<Doc>, String> {
+    let value = get_state_doc(context.collection, &key, assert_context.rule)?;
 
     match value {
         None => Ok(None),
         Some(value) => {
-            if assert_get_doc(context, rule, &value).is_err() {
+            if assert_get_doc(context, assert_context, &value).is_err() {
                 return Ok(None);
             }
 
@@ -165,23 +172,27 @@ fn secure_set_doc(
     value: SetDoc,
 ) -> Result<DocUpsert, String> {
     let rule = get_state_rule(context.collection)?;
-    set_doc_impl(context, config, key, value, &rule)
+
+    let assert_context = AssertContext { rule: &rule };
+
+    set_doc_impl(context, &assert_context, config, key, value)
 }
 
 fn set_doc_impl(
     context: &StoreContext,
+    assert_context: &AssertContext,
     config: &Option<DbConfig>,
     key: Key,
     value: SetDoc,
-    rule: &Rule,
 ) -> Result<DocUpsert, String> {
-    let current_doc = get_state_doc(context.collection, &key, rule)?;
+    let current_doc = get_state_doc(context.collection, &key, assert_context.rule)?;
 
-    assert_set_doc(context, config, &key, &value, rule, &current_doc)?;
+    assert_set_doc(context, assert_context, config, &key, &value, &current_doc)?;
 
     let doc: Doc = Doc::prepare(context.caller, &current_doc, value);
 
-    let (_evicted_doc, after) = insert_state_doc(context.collection, &key, &doc, rule)?;
+    let (_evicted_doc, after) =
+        insert_state_doc(context.collection, &key, &doc, assert_context.rule)?;
 
     Ok(DocUpsert {
         before: current_doc,
@@ -345,20 +356,23 @@ fn secure_delete_doc(
     value: DelDoc,
 ) -> Result<Option<Doc>, String> {
     let rule = get_state_rule(context.collection)?;
-    delete_doc_impl(context, key, value, &rule)
+
+    let assert_context = AssertContext { rule: &rule };
+
+    delete_doc_impl(context, &assert_context, key, value)
 }
 
 fn delete_doc_impl(
     context: &StoreContext,
+    assert_context: &AssertContext,
     key: Key,
     value: DelDoc,
-    rule: &Rule,
 ) -> Result<Option<Doc>, String> {
-    let current_doc = get_state_doc(context.collection, &key, rule)?;
+    let current_doc = get_state_doc(context.collection, &key, assert_context.rule)?;
 
-    assert_delete_doc(context, &key, &value, rule, &current_doc)?;
+    assert_delete_doc(context, assert_context, &key, &value, &current_doc)?;
 
-    delete_state_doc(context.collection, &key, rule)
+    delete_state_doc(context.collection, &key, assert_context.rule)
 }
 
 /// Delete multiple documents from a collection's store.
@@ -479,6 +493,8 @@ fn delete_filtered_docs_store_impl(
 ) -> Result<Vec<DocContext<Option<Doc>>>, String> {
     let rule = get_state_rule(context.collection)?;
 
+    let assert_context = AssertContext { rule: &rule };
+
     let mut results: Vec<DocContext<Option<Doc>>> = Vec::new();
 
     for (key, doc) in &docs.items {
@@ -486,7 +502,7 @@ fn delete_filtered_docs_store_impl(
             version: doc.version,
         };
 
-        let deleted_doc = delete_doc_impl(context, key.clone(), value, &rule)?;
+        let deleted_doc = delete_doc_impl(context, &assert_context, key.clone(), value)?;
 
         let doc_context = DocContext {
             key: key.clone(),

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -78,12 +78,17 @@ pub mod interface {
 
 pub mod store {
     use junobuild_collections::types::core::CollectionKey;
+    use junobuild_collections::types::rules::Rule;
     use junobuild_shared::types::state::{Controllers, UserId};
 
     pub struct StoreContext<'a> {
         pub caller: UserId,
         pub controllers: &'a Controllers,
         pub collection: &'a CollectionKey,
+    }
+
+    pub struct AssertContext<'a> {
+        pub rule: &'a Rule,
     }
 }
 


### PR DESCRIPTION
# Motivation

In #1786 we will have to pass down the auth config. So instead of passing two parameters, let's introduce a struct `AssertContext`. Similar to `StoreContext` but for readonly info for assertions.
