### PR TITLE
feat(satellite): add version field to StorageConfig

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -165,10 +165,22 @@ type SetControllersArgs = record {
   controller : SetController;
   controllers : vec principal;
 };
-type StorageConfig = record {
+type SetStorageConfig = record {
   iframe : opt StorageConfigIFrame;
   rewrites : vec record { text; text };
   headers : vec record { text; vec record { text; text } };
+  version : opt nat64;
+  max_memory_size : opt ConfigMaxMemorySize;
+  raw_access : opt StorageConfigRawAccess;
+  redirects : opt vec record { text; StorageConfigRedirect };
+};
+type StorageConfig = record {
+  iframe : opt StorageConfigIFrame;
+  updated_at : opt nat64;
+  rewrites : vec record { text; text };
+  headers : vec record { text; vec record { text; text } };
+  created_at : opt nat64;
+  version : opt nat64;
   max_memory_size : opt ConfigMaxMemorySize;
   raw_access : opt StorageConfigRawAccess;
   redirects : opt vec record { text; StorageConfigRedirect };
@@ -248,7 +260,7 @@ service : () -> {
   set_controllers : (SetControllersArgs) -> ();
   set_custom_domain : (text, opt text) -> ();
   set_fee : (SegmentKind, Tokens) -> ();
-  set_storage_config : (StorageConfig) -> ();
+  set_storage_config : (SetStorageConfig) -> (StorageConfig);
   submit_proposal : (nat) -> (nat, Proposal);
   update_rate_config : (SegmentKind, RateConfig) -> ();
   upload_asset_chunk : (UploadChunk) -> (UploadChunkResult);

--- a/src/console/src/api/config.rs
+++ b/src/console/src/api/config.rs
@@ -2,8 +2,10 @@ use crate::cdn::strategies_impls::cdn::CdnHeap;
 use crate::cdn::strategies_impls::storage::StorageState;
 use crate::guards::caller_is_admin_controller;
 use crate::types::interface::Config;
+use ic_cdk::trap;
 use ic_cdk_macros::{query, update};
 use junobuild_storage::types::config::StorageConfig;
+use junobuild_storage::types::interface::SetStorageConfig;
 
 // ---------------------------------------------------------
 // Config
@@ -20,8 +22,9 @@ pub fn get_config() -> Config {
 // ---------------------------------------------------------
 
 #[update(guard = "caller_is_admin_controller")]
-pub fn set_storage_config(config: StorageConfig) {
-    junobuild_cdn::storage::set_config_store(&CdnHeap, &StorageState, &config);
+pub fn set_storage_config(config: SetStorageConfig) -> StorageConfig {
+    junobuild_cdn::storage::set_config_store(&CdnHeap, &StorageState, &config)
+        .unwrap_or_else(|e| trap(&e))
 }
 
 #[query(guard = "caller_is_admin_controller")]

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -49,6 +49,7 @@ use junobuild_storage::types::interface::AssetNoContent;
 use junobuild_storage::types::interface::CommitBatch;
 use junobuild_storage::types::interface::InitAssetKey;
 use junobuild_storage::types::interface::InitUploadResult;
+use junobuild_storage::types::interface::SetStorageConfig;
 use junobuild_storage::types::interface::UploadChunk;
 use junobuild_storage::types::interface::UploadChunkResult;
 

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -201,10 +201,22 @@ export interface SetControllersArgs {
 	controller: SetController;
 	controllers: Array<Principal>;
 }
-export interface StorageConfig {
+export interface SetStorageConfig {
 	iframe: [] | [StorageConfigIFrame];
 	rewrites: Array<[string, string]>;
 	headers: Array<[string, Array<[string, string]>]>;
+	version: [] | [bigint];
+	max_memory_size: [] | [ConfigMaxMemorySize];
+	raw_access: [] | [StorageConfigRawAccess];
+	redirects: [] | [Array<[string, StorageConfigRedirect]>];
+}
+export interface StorageConfig {
+	iframe: [] | [StorageConfigIFrame];
+	updated_at: [] | [bigint];
+	rewrites: Array<[string, string]>;
+	headers: Array<[string, Array<[string, string]>]>;
+	created_at: [] | [bigint];
+	version: [] | [bigint];
 	max_memory_size: [] | [ConfigMaxMemorySize];
 	raw_access: [] | [StorageConfigRawAccess];
 	redirects: [] | [Array<[string, StorageConfigRedirect]>];
@@ -289,7 +301,7 @@ export interface _SERVICE {
 	set_controllers: ActorMethod<[SetControllersArgs], undefined>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;
 	set_fee: ActorMethod<[SegmentKind, Tokens], undefined>;
-	set_storage_config: ActorMethod<[StorageConfig], undefined>;
+	set_storage_config: ActorMethod<[SetStorageConfig], StorageConfig>;
 	submit_proposal: ActorMethod<[bigint], [bigint, Proposal]>;
 	update_rate_config: ActorMethod<[SegmentKind, RateConfig], undefined>;
 	upload_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -44,8 +44,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -247,6 +250,15 @@ export const idlFactory = ({ IDL }) => {
 		MissionControl: IDL.Null,
 		Satellite: IDL.Null
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const RateConfig = IDL.Record({
 		max_tokens: IDL.Nat64,
 		time_per_token_ns: IDL.Nat64
@@ -301,7 +313,7 @@ export const idlFactory = ({ IDL }) => {
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, Tokens], [], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		update_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -44,8 +44,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -247,6 +250,15 @@ export const idlFactory = ({ IDL }) => {
 		MissionControl: IDL.Null,
 		Satellite: IDL.Null
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const RateConfig = IDL.Record({
 		max_tokens: IDL.Nat64,
 		time_per_token_ns: IDL.Nat64
@@ -301,7 +313,7 @@ export const idlFactory = ({ IDL }) => {
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, Tokens], [], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		update_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -44,8 +44,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -247,6 +250,15 @@ export const idlFactory = ({ IDL }) => {
 		MissionControl: IDL.Null,
 		Satellite: IDL.Null
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const RateConfig = IDL.Record({
 		max_tokens: IDL.Nat64,
 		time_per_token_ns: IDL.Nat64
@@ -301,7 +313,7 @@ export const idlFactory = ({ IDL }) => {
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, Tokens], [], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		update_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -270,10 +270,22 @@ export interface SetRule {
 	write: Permission;
 	max_changes_per_user: [] | [number];
 }
-export interface StorageConfig {
+export interface SetStorageConfig {
 	iframe: [] | [StorageConfigIFrame];
 	rewrites: Array<[string, string]>;
 	headers: Array<[string, Array<[string, string]>]>;
+	version: [] | [bigint];
+	max_memory_size: [] | [ConfigMaxMemorySize];
+	raw_access: [] | [StorageConfigRawAccess];
+	redirects: [] | [Array<[string, StorageConfigRedirect]>];
+}
+export interface StorageConfig {
+	iframe: [] | [StorageConfigIFrame];
+	updated_at: [] | [bigint];
+	rewrites: Array<[string, string]>;
+	headers: Array<[string, Array<[string, string]>]>;
+	created_at: [] | [bigint];
+	version: [] | [bigint];
 	max_memory_size: [] | [ConfigMaxMemorySize];
 	raw_access: [] | [StorageConfigRawAccess];
 	redirects: [] | [Array<[string, StorageConfigRedirect]>];
@@ -371,7 +383,7 @@ export interface _SERVICE {
 	set_doc: ActorMethod<[string, string, SetDoc], Doc>;
 	set_many_docs: ActorMethod<[Array<[string, string, SetDoc]>], Array<[string, Doc]>>;
 	set_rule: ActorMethod<[CollectionType, string, SetRule], Rule>;
-	set_storage_config: ActorMethod<[StorageConfig], undefined>;
+	set_storage_config: ActorMethod<[SetStorageConfig], StorageConfig>;
 	submit_proposal: ActorMethod<[bigint], [bigint, Proposal]>;
 	upload_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
 	upload_proposal_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -119,8 +119,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -305,6 +308,15 @@ export const idlFactory = ({ IDL }) => {
 		write: Permission,
 		max_changes_per_user: IDL.Opt(IDL.Nat32)
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,
@@ -387,7 +399,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_rule: IDL.Func([CollectionType, IDL.Text, SetRule], [Rule], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -119,8 +119,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -305,6 +308,15 @@ export const idlFactory = ({ IDL }) => {
 		write: Permission,
 		max_changes_per_user: IDL.Opt(IDL.Nat32)
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,
@@ -387,7 +399,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_rule: IDL.Func([CollectionType, IDL.Text, SetRule], [Rule], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -119,8 +119,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -305,6 +308,15 @@ export const idlFactory = ({ IDL }) => {
 		write: Permission,
 		max_changes_per_user: IDL.Opt(IDL.Nat32)
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,
@@ -387,7 +399,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_rule: IDL.Func([CollectionType, IDL.Text, SetRule], [Rule], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -270,10 +270,22 @@ export interface SetRule {
 	write: Permission;
 	max_changes_per_user: [] | [number];
 }
-export interface StorageConfig {
+export interface SetStorageConfig {
 	iframe: [] | [StorageConfigIFrame];
 	rewrites: Array<[string, string]>;
 	headers: Array<[string, Array<[string, string]>]>;
+	version: [] | [bigint];
+	max_memory_size: [] | [ConfigMaxMemorySize];
+	raw_access: [] | [StorageConfigRawAccess];
+	redirects: [] | [Array<[string, StorageConfigRedirect]>];
+}
+export interface StorageConfig {
+	iframe: [] | [StorageConfigIFrame];
+	updated_at: [] | [bigint];
+	rewrites: Array<[string, string]>;
+	headers: Array<[string, Array<[string, string]>]>;
+	created_at: [] | [bigint];
+	version: [] | [bigint];
 	max_memory_size: [] | [ConfigMaxMemorySize];
 	raw_access: [] | [StorageConfigRawAccess];
 	redirects: [] | [Array<[string, StorageConfigRedirect]>];
@@ -371,7 +383,7 @@ export interface _SERVICE {
 	set_doc: ActorMethod<[string, string, SetDoc], Doc>;
 	set_many_docs: ActorMethod<[Array<[string, string, SetDoc]>], Array<[string, Doc]>>;
 	set_rule: ActorMethod<[CollectionType, string, SetRule], Rule>;
-	set_storage_config: ActorMethod<[StorageConfig], undefined>;
+	set_storage_config: ActorMethod<[SetStorageConfig], StorageConfig>;
 	submit_proposal: ActorMethod<[bigint], [bigint, Proposal]>;
 	upload_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
 	upload_proposal_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -119,8 +119,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -305,6 +308,15 @@ export const idlFactory = ({ IDL }) => {
 		write: Permission,
 		max_changes_per_user: IDL.Opt(IDL.Nat32)
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,
@@ -387,7 +399,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_rule: IDL.Func([CollectionType, IDL.Text, SetRule], [Rule], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -119,8 +119,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -305,6 +308,15 @@ export const idlFactory = ({ IDL }) => {
 		write: Permission,
 		max_changes_per_user: IDL.Opt(IDL.Nat32)
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,
@@ -387,7 +399,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_rule: IDL.Func([CollectionType, IDL.Text, SetRule], [Rule], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])

--- a/src/libs/cdn/src/storage/assert.rs
+++ b/src/libs/cdn/src/storage/assert.rs
@@ -2,7 +2,10 @@ use crate::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION,
     JUNO_CDN_STORAGE_ERROR_MISSING_RELEASES_DESCRIPTION,
 };
+use junobuild_shared::assert::assert_version;
 use junobuild_shared::regex::build_regex;
+use junobuild_storage::types::config::StorageConfig;
+use junobuild_storage::types::interface::SetStorageConfig;
 
 pub fn assert_releases_description(description: &Option<String>) -> Result<(), String> {
     let desc = description
@@ -15,6 +18,15 @@ pub fn assert_releases_description(description: &Option<String>) -> Result<(), S
             "{JUNO_CDN_STORAGE_ERROR_INVALID_RELEASES_DESCRIPTION} ({desc})"
         ));
     }
+
+    Ok(())
+}
+
+pub fn assert_set_config(
+    proposed_config: &SetStorageConfig,
+    current_config: &StorageConfig,
+) -> Result<(), String> {
+    assert_version(proposed_config.version, current_config.version)?;
 
     Ok(())
 }

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -218,10 +218,22 @@ type SetRule = record {
   write : Permission;
   max_changes_per_user : opt nat32;
 };
-type StorageConfig = record {
+type SetStorageConfig = record {
   iframe : opt StorageConfigIFrame;
   rewrites : vec record { text; text };
   headers : vec record { text; vec record { text; text } };
+  version : opt nat64;
+  max_memory_size : opt ConfigMaxMemorySize;
+  raw_access : opt StorageConfigRawAccess;
+  redirects : opt vec record { text; StorageConfigRedirect };
+};
+type StorageConfig = record {
+  iframe : opt StorageConfigIFrame;
+  updated_at : opt nat64;
+  rewrites : vec record { text; text };
+  headers : vec record { text; vec record { text; text } };
+  created_at : opt nat64;
+  version : opt nat64;
   max_memory_size : opt ConfigMaxMemorySize;
   raw_access : opt StorageConfigRawAccess;
   redirects : opt vec record { text; StorageConfigRedirect };
@@ -324,7 +336,7 @@ service : () -> {
       vec record { text; Doc },
     );
   set_rule : (CollectionType, text, SetRule) -> (Rule);
-  set_storage_config : (StorageConfig) -> ();
+  set_storage_config : (SetStorageConfig) -> (StorageConfig);
   submit_proposal : (nat) -> (nat, Proposal);
   upload_asset_chunk : (UploadChunk) -> (UploadChunkResult);
   upload_proposal_asset_chunk : (UploadChunk) -> (UploadChunkResult);

--- a/src/libs/satellite/src/api/config.rs
+++ b/src/libs/satellite/src/api/config.rs
@@ -13,7 +13,7 @@ use crate::db::types::interface::SetDbConfig;
 use crate::types::interface::Config;
 use ic_cdk::trap;
 use junobuild_storage::types::config::StorageConfig;
-
+use junobuild_storage::types::interface::SetStorageConfig;
 // ---------------------------------------------------------
 // Config
 // ---------------------------------------------------------
@@ -58,8 +58,8 @@ pub fn get_db_config() -> Option<DbConfig> {
 // Storage config
 // ---------------------------------------------------------
 
-pub fn set_storage_config(config: StorageConfig) {
-    set_storage_config_store(&config);
+pub fn set_storage_config(config: SetStorageConfig) -> Result<StorageConfig, String> {
+    set_storage_config_store(&config)
 }
 
 pub fn get_storage_config() -> StorageConfig {

--- a/src/libs/satellite/src/assets/storage/assert.rs
+++ b/src/libs/satellite/src/assets/storage/assert.rs
@@ -10,6 +10,7 @@ use junobuild_collections::assert::stores::{
 use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::Permission;
+use junobuild_shared::assert::assert_version;
 use junobuild_shared::controllers::{controller_can_write, is_controller};
 use junobuild_shared::types::state::Controllers;
 use junobuild_storage::errors::{
@@ -17,6 +18,8 @@ use junobuild_storage::errors::{
     JUNO_STORAGE_ERROR_UPLOAD_NOT_ALLOWED,
 };
 use junobuild_storage::runtime::increment_and_assert_rate as increment_and_assert_rate_runtime;
+use junobuild_storage::types::config::StorageConfig;
+use junobuild_storage::types::interface::SetStorageConfig;
 use junobuild_storage::types::store::Asset;
 
 pub fn assert_get_asset(
@@ -128,6 +131,15 @@ fn assert_read_permission(
     if !assert_permission(rule, current_asset.key.owner, caller, controllers) {
         return Err(JUNO_STORAGE_ERROR_CANNOT_READ_ASSET.to_string());
     }
+
+    Ok(())
+}
+
+pub fn assert_set_config(
+    proposed_config: &SetStorageConfig,
+    current_config: &StorageConfig,
+) -> Result<(), String> {
+    assert_version(proposed_config.version, current_config.version)?;
 
     Ok(())
 }

--- a/src/libs/satellite/src/assets/storage/store.rs
+++ b/src/libs/satellite/src/assets/storage/store.rs
@@ -1,5 +1,6 @@
 use crate::assets::storage::assert::{
     assert_create_batch, assert_delete_asset, assert_get_asset, assert_list_assets,
+    assert_set_config,
 };
 use crate::assets::storage::certified_assets::runtime::init_certified_assets as init_runtime_certified_assets;
 use crate::assets::storage::state::{
@@ -36,7 +37,9 @@ use junobuild_storage::runtime::{
 use junobuild_storage::store::{commit_batch as commit_batch_storage, create_batch, create_chunk};
 use junobuild_storage::strategies::StorageAssertionsStrategy;
 use junobuild_storage::types::config::StorageConfig;
-use junobuild_storage::types::interface::{AssetNoContent, CommitBatch, InitAssetKey, UploadChunk};
+use junobuild_storage::types::interface::{
+    AssetNoContent, CommitBatch, InitAssetKey, SetStorageConfig, UploadChunk,
+};
 use junobuild_storage::types::runtime_state::{BatchId, ChunkId};
 use junobuild_storage::types::state::FullPath;
 use junobuild_storage::types::store::{Asset, AssetEncoding};
@@ -631,10 +634,20 @@ fn secure_create_batch_impl(
 // Config
 // ---------------------------------------------------------
 
-pub fn set_config_store(config: &StorageConfig) {
-    insert_state_config(config);
+// TODO: to be reviewed. Maybe a duplicate of CDN similar features for configuration
+
+pub fn set_config_store(proposed_config: &SetStorageConfig) -> Result<StorageConfig, String> {
+    let current_config = get_config();
+
+    assert_set_config(proposed_config, &current_config)?;
+
+    let config = StorageConfig::prepare(&current_config, proposed_config);
+
+    insert_state_config(&config);
 
     init_runtime_certified_assets();
+
+    Ok(config)
 }
 
 pub fn get_config_store() -> StorageConfig {

--- a/src/libs/satellite/src/assets/storage/store.rs
+++ b/src/libs/satellite/src/assets/storage/store.rs
@@ -634,8 +634,6 @@ fn secure_create_batch_impl(
 // Config
 // ---------------------------------------------------------
 
-// TODO: to be reviewed. Maybe a duplicate of CDN similar features for configuration
-
 pub fn set_config_store(proposed_config: &SetStorageConfig) -> Result<StorageConfig, String> {
     let current_config = get_config();
 

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -50,7 +50,8 @@ use junobuild_storage::http::types::{
 };
 use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::interface::{
-    AssetNoContent, CommitBatch, InitAssetKey, InitUploadResult, UploadChunk, UploadChunkResult,
+    AssetNoContent, CommitBatch, InitAssetKey, InitUploadResult, SetStorageConfig, UploadChunk,
+    UploadChunkResult,
 };
 use junobuild_storage::types::state::FullPath;
 use memory::lifecycle;
@@ -335,8 +336,8 @@ pub fn get_db_config() -> Option<DbConfig> {
 
 #[doc(hidden)]
 #[update(guard = "caller_is_admin_controller")]
-pub fn set_storage_config(config: StorageConfig) {
-    api::config::set_storage_config(config);
+pub fn set_storage_config(config: SetStorageConfig) -> StorageConfig {
+    api::config::set_storage_config(config).unwrap_or_else(|e| trap(&e))
 }
 
 #[doc(hidden)]

--- a/src/libs/shared/src/version.rs
+++ b/src/libs/shared/src/version.rs
@@ -7,18 +7,23 @@ where
 {
     match current {
         None => INITIAL_VERSION,
-        Some(current) => {
-            let version = current.version().unwrap_or_default();
+        Some(current) => next_version_from(current),
+    }
+}
 
-            // We reset to zero if the maximum version (u64::MAX) is reached.
-            // This is really an edge case—it would take an extremely high number of updates
-            // (and therefore a significant amount of cycles) to reach this point.
-            // But you never know.
-            if version == u64::MAX {
-                INITIAL_VERSION
-            } else {
-                version + 1
-            }
-        }
+pub fn next_version_from<T>(current: &T) -> Version
+where
+    T: Versioned,
+{
+    let version = current.version().unwrap_or_default();
+
+    // We reset to zero if the maximum version (u64::MAX) is reached.
+    // This is really an edge case—it would take an extremely high number of updates
+    // (and therefore a significant amount of cycles) to reach this point.
+    // But you never know.
+    if version == u64::MAX {
+        INITIAL_VERSION
+    } else {
+        version + 1
     }
 }

--- a/src/libs/storage/src/types.rs
+++ b/src/libs/storage/src/types.rs
@@ -151,6 +151,10 @@ pub mod interface {
     use serde::Serialize;
 
     use crate::http::types::HeaderField;
+    use crate::types::config::{
+        StorageConfigHeaders, StorageConfigIFrame, StorageConfigMaxMemorySize,
+        StorageConfigRawAccess, StorageConfigRedirects, StorageConfigRewrites,
+    };
     use crate::types::runtime_state::{BatchId, ChunkId};
     use crate::types::state::FullPath;
     use crate::types::store::{AssetKey, EncodingType};
@@ -205,12 +209,24 @@ pub mod interface {
         pub total_length: u128,
         pub sha256: Hash,
     }
+
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
+    pub struct SetStorageConfig {
+        pub headers: StorageConfigHeaders,
+        pub rewrites: StorageConfigRewrites,
+        pub redirects: Option<StorageConfigRedirects>,
+        pub iframe: Option<StorageConfigIFrame>,
+        pub raw_access: Option<StorageConfigRawAccess>,
+        pub max_memory_size: Option<StorageConfigMaxMemorySize>,
+        pub version: Option<Version>,
+    }
 }
 
 pub mod config {
     use crate::http::types::{HeaderField, StatusCode};
     use candid::CandidType;
     use junobuild_shared::types::config::ConfigMaxMemorySize;
+    use junobuild_shared::types::state::{Timestamp, Version};
     use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
 
@@ -241,6 +257,9 @@ pub mod config {
         pub iframe: Option<StorageConfigIFrame>,
         pub raw_access: Option<StorageConfigRawAccess>,
         pub max_memory_size: Option<StorageConfigMaxMemorySize>,
+        pub version: Option<Version>,
+        pub created_at: Option<Timestamp>,
+        pub updated_at: Option<Timestamp>,
     }
 
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -220,10 +220,22 @@ type SetRule = record {
   write : Permission;
   max_changes_per_user : opt nat32;
 };
-type StorageConfig = record {
+type SetStorageConfig = record {
   iframe : opt StorageConfigIFrame;
   rewrites : vec record { text; text };
   headers : vec record { text; vec record { text; text } };
+  version : opt nat64;
+  max_memory_size : opt ConfigMaxMemorySize;
+  raw_access : opt StorageConfigRawAccess;
+  redirects : opt vec record { text; StorageConfigRedirect };
+};
+type StorageConfig = record {
+  iframe : opt StorageConfigIFrame;
+  updated_at : opt nat64;
+  rewrites : vec record { text; text };
+  headers : vec record { text; vec record { text; text } };
+  created_at : opt nat64;
+  version : opt nat64;
   max_memory_size : opt ConfigMaxMemorySize;
   raw_access : opt StorageConfigRawAccess;
   redirects : opt vec record { text; StorageConfigRedirect };
@@ -326,7 +338,7 @@ service : () -> {
       vec record { text; Doc },
     );
   set_rule : (CollectionType, text, SetRule) -> (Rule);
-  set_storage_config : (StorageConfig) -> ();
+  set_storage_config : (SetStorageConfig) -> (StorageConfig);
   submit_proposal : (nat) -> (nat, Proposal);
   upload_asset_chunk : (UploadChunk) -> (UploadChunkResult);
   upload_proposal_asset_chunk : (UploadChunk) -> (UploadChunkResult);

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -220,10 +220,22 @@ type SetRule = record {
   write : Permission;
   max_changes_per_user : opt nat32;
 };
-type StorageConfig = record {
+type SetStorageConfig = record {
   iframe : opt StorageConfigIFrame;
   rewrites : vec record { text; text };
   headers : vec record { text; vec record { text; text } };
+  version : opt nat64;
+  max_memory_size : opt ConfigMaxMemorySize;
+  raw_access : opt StorageConfigRawAccess;
+  redirects : opt vec record { text; StorageConfigRedirect };
+};
+type StorageConfig = record {
+  iframe : opt StorageConfigIFrame;
+  updated_at : opt nat64;
+  rewrites : vec record { text; text };
+  headers : vec record { text; vec record { text; text } };
+  created_at : opt nat64;
+  version : opt nat64;
   max_memory_size : opt ConfigMaxMemorySize;
   raw_access : opt StorageConfigRawAccess;
   redirects : opt vec record { text; StorageConfigRedirect };
@@ -326,7 +338,7 @@ service : () -> {
       vec record { text; Doc },
     );
   set_rule : (CollectionType, text, SetRule) -> (Rule);
-  set_storage_config : (StorageConfig) -> ();
+  set_storage_config : (SetStorageConfig) -> (StorageConfig);
   submit_proposal : (nat) -> (nat, Proposal);
   upload_asset_chunk : (UploadChunk) -> (UploadChunkResult);
   upload_proposal_asset_chunk : (UploadChunk) -> (UploadChunkResult);

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -271,10 +271,22 @@ export interface SetRule {
 	write: Permission;
 	max_changes_per_user: [] | [number];
 }
-export interface StorageConfig {
+export interface SetStorageConfig {
 	iframe: [] | [StorageConfigIFrame];
 	rewrites: Array<[string, string]>;
 	headers: Array<[string, Array<[string, string]>]>;
+	version: [] | [bigint];
+	max_memory_size: [] | [ConfigMaxMemorySize];
+	raw_access: [] | [StorageConfigRawAccess];
+	redirects: [] | [Array<[string, StorageConfigRedirect]>];
+}
+export interface StorageConfig {
+	iframe: [] | [StorageConfigIFrame];
+	updated_at: [] | [bigint];
+	rewrites: Array<[string, string]>;
+	headers: Array<[string, Array<[string, string]>]>;
+	created_at: [] | [bigint];
+	version: [] | [bigint];
 	max_memory_size: [] | [ConfigMaxMemorySize];
 	raw_access: [] | [StorageConfigRawAccess];
 	redirects: [] | [Array<[string, StorageConfigRedirect]>];
@@ -373,7 +385,7 @@ export interface _SERVICE {
 	set_doc: ActorMethod<[string, string, SetDoc], Doc>;
 	set_many_docs: ActorMethod<[Array<[string, string, SetDoc]>], Array<[string, Doc]>>;
 	set_rule: ActorMethod<[CollectionType, string, SetRule], Rule>;
-	set_storage_config: ActorMethod<[StorageConfig], undefined>;
+	set_storage_config: ActorMethod<[SetStorageConfig], StorageConfig>;
 	submit_proposal: ActorMethod<[bigint], [bigint, Proposal]>;
 	upload_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
 	upload_proposal_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -119,8 +119,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -306,6 +309,15 @@ export const idlFactory = ({ IDL }) => {
 		write: Permission,
 		max_changes_per_user: IDL.Opt(IDL.Nat32)
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,
@@ -389,7 +401,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_rule: IDL.Func([CollectionType, IDL.Text, SetRule], [Rule], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -119,8 +119,11 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const StorageConfig = IDL.Record({
 		iframe: IDL.Opt(StorageConfigIFrame),
+		updated_at: IDL.Opt(IDL.Nat64),
 		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
 		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
@@ -306,6 +309,15 @@ export const idlFactory = ({ IDL }) => {
 		write: Permission,
 		max_changes_per_user: IDL.Opt(IDL.Nat32)
 	});
+	const SetStorageConfig = IDL.Record({
+		iframe: IDL.Opt(StorageConfigIFrame),
+		rewrites: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
+		version: IDL.Opt(IDL.Nat64),
+		max_memory_size: IDL.Opt(ConfigMaxMemorySize),
+		raw_access: IDL.Opt(StorageConfigRawAccess),
+		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
+	});
 	const UploadChunk = IDL.Record({
 		content: IDL.Vec(IDL.Nat8),
 		batch_id: IDL.Nat,
@@ -389,7 +401,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_rule: IDL.Func([CollectionType, IDL.Text, SetRule], [Rule], []),
-		set_storage_config: IDL.Func([StorageConfig], [], []),
+		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
 		upload_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -220,10 +220,22 @@ type SetRule = record {
   write : Permission;
   max_changes_per_user : opt nat32;
 };
-type StorageConfig = record {
+type SetStorageConfig = record {
   iframe : opt StorageConfigIFrame;
   rewrites : vec record { text; text };
   headers : vec record { text; vec record { text; text } };
+  version : opt nat64;
+  max_memory_size : opt ConfigMaxMemorySize;
+  raw_access : opt StorageConfigRawAccess;
+  redirects : opt vec record { text; StorageConfigRedirect };
+};
+type StorageConfig = record {
+  iframe : opt StorageConfigIFrame;
+  updated_at : opt nat64;
+  rewrites : vec record { text; text };
+  headers : vec record { text; vec record { text; text } };
+  created_at : opt nat64;
+  version : opt nat64;
   max_memory_size : opt ConfigMaxMemorySize;
   raw_access : opt StorageConfigRawAccess;
   redirects : opt vec record { text; StorageConfigRedirect };
@@ -326,7 +338,7 @@ service : () -> {
       vec record { text; Doc },
     );
   set_rule : (CollectionType, text, SetRule) -> (Rule);
-  set_storage_config : (StorageConfig) -> ();
+  set_storage_config : (SetStorageConfig) -> (StorageConfig);
   submit_proposal : (nat) -> (nat, Proposal);
   upload_asset_chunk : (UploadChunk) -> (UploadChunkResult);
   upload_proposal_asset_chunk : (UploadChunk) -> (UploadChunkResult);

--- a/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.cdn.spec.ts
@@ -235,7 +235,8 @@ describe('Satellite > Cdn', () => {
 		});
 
 		testCdnConfig({
-			actor: () => actor
+			actor: () => actor,
+			configBaseVersion: 2n
 		});
 
 		testReleasesProposal({

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -8,7 +8,7 @@ import type {
 } from '$declarations/console/console.did';
 import type {
 	_SERVICE as SatelliteActor,
-	StorageConfig
+	SetStorageConfig
 } from '$declarations/satellite/satellite.did';
 import type { Identity } from '@dfinity/agent';
 import type { Actor, PocketIc } from '@dfinity/pic';
@@ -113,7 +113,8 @@ export const testNotAllowedCdnMethods = ({
 				redirects: toNullable(),
 				rewrites: [],
 				raw_access: toNullable(),
-				max_memory_size: toNullable()
+				max_memory_size: toNullable(),
+				version: toNullable()
 			})
 		).rejects.toThrow(errorMsgAdminController);
 	});
@@ -197,13 +198,14 @@ export const testCdnConfig = ({ actor }: { actor: () => Actor<SatelliteActor | C
 	it('should set and get config', async () => {
 		const { set_storage_config, get_storage_config } = actor();
 
-		const config: StorageConfig = {
+		const config: SetStorageConfig = {
 			headers: [['*', [['cache-control', 'no-cache']]]],
 			iframe: toNullable({ Deny: null }),
 			redirects: [],
 			rewrites: [],
 			raw_access: toNullable(),
-			max_memory_size: toNullable()
+			max_memory_size: toNullable(),
+			version: toNullable()
 		};
 
 		await set_storage_config(config);

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -196,7 +196,13 @@ export const testGuardedAssetsCdnMethods = ({
 	});
 };
 
-export const testCdnConfig = ({ actor }: { actor: () => Actor<SatelliteActor | ConsoleActor> }) => {
+export const testCdnConfig = ({
+	actor,
+	configBaseVersion = 1n
+}: {
+	actor: () => Actor<SatelliteActor | ConsoleActor>;
+	configBaseVersion?: bigint;
+}) => {
 	it('should set and get config', async () => {
 		const { set_storage_config, get_storage_config } = actor();
 
@@ -207,7 +213,7 @@ export const testCdnConfig = ({ actor }: { actor: () => Actor<SatelliteActor | C
 			rewrites: [],
 			raw_access: toNullable(),
 			max_memory_size: toNullable(),
-			version: toNullable(1n)
+			version: toNullable(configBaseVersion)
 		};
 
 		await set_storage_config(config);
@@ -219,7 +225,7 @@ export const testCdnConfig = ({ actor }: { actor: () => Actor<SatelliteActor | C
 				...config,
 				created_at: [expect.any(BigInt)],
 				updated_at: [expect.any(BigInt)],
-				version: [2n]
+				version: [configBaseVersion + 1n]
 			})
 		);
 


### PR DESCRIPTION
# Motivation

Adding `version` fields to config will allow use to synchronize changes with CLI or in the UI.

Similar to #1703
