### PR TITLE
fix(frontend): KongSwap API breaking changes

### DIFF
--- a/src/frontend/src/lib/schemas/kongswap.schema.ts
+++ b/src/frontend/src/lib/schemas/kongswap.schema.ts
@@ -1,10 +1,6 @@
 import { PrincipalTextSchema } from '@dfinity/zod-schemas';
 import * as z from 'zod/v4';
 
-const NumberAsStringSchema = z.string().refine((val) => !isNaN(Number(val)), {
-	message: 'Invalid number string'
-});
-
 const DateTimeSchema = z.string().refine(
 	(val) => {
 		const parsed = new Date(val);
@@ -16,15 +12,17 @@ const DateTimeSchema = z.string().refine(
 );
 
 const KongSwapTokenMetricsSchema = z.object({
-	market_cap: NumberAsStringSchema.nullable(),
-	previous_price: NumberAsStringSchema.nullable(),
-	price: NumberAsStringSchema,
-	price_change_24h: NumberAsStringSchema,
+	price: z.number().nullable(),
 	token_id: z.number(),
-	total_supply: NumberAsStringSchema.nullable(),
-	tvl: NumberAsStringSchema,
-	updated_at: DateTimeSchema,
-	volume_24h: NumberAsStringSchema
+	total_supply: z.number().nullable(),
+	market_cap: z.number().nullable(),
+	updated_at: DateTimeSchema.nullable(),
+	volume_24h: z.number().nullable(),
+	tvl: z.number().nullable(),
+	price_change_24h: z.number().nullable(),
+	previous_price: z.number().nullable(),
+	market_cap_rank: z.number().nullable(),
+	is_verified: z.boolean()
 });
 
 export const KongSwapTokenSchema = z.object({

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -99,12 +99,16 @@ const exchangeRateICPToUsd = async (): Promise<ExchangePrice | undefined> => {
 		metrics: { price, updated_at, market_cap, volume_24h, price_change_24h }
 	} = icp;
 
+	if (isNullish(price)) {
+		return undefined;
+	}
+
 	return {
 		usd: Number(price),
-		usdMarketCap: Number(market_cap),
-		usdVolume24h: Number(volume_24h),
-		usdChange24h: Number(price_change_24h),
-		updatedAt: new Date(updated_at).getTime()
+		...(nonNullish(market_cap) && { usdMarketCap: Number(market_cap) }),
+		...(nonNullish(volume_24h) && { usdVolume24h: Number(volume_24h) }),
+		...(nonNullish(price_change_24h) && { usdChange24h: Number(price_change_24h) }),
+		updatedAt: nonNullish(updated_at) ? new Date(updated_at).getTime() : new Date().getTime()
 	};
 };
 


### PR DESCRIPTION
# Motivation

The KongSwap API - used for fetching ICP<>USD - has been upgraded in production with breaking changes. All metrics are now number instead of strings. As a result, the Console cannot displays anymore dollars value as the response of the API does not comply with the known schema. 
