### PR TITLE
feat(frontend): rename Authorized Users into Allowed Callers

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthConfig.svelte
+++ b/src/frontend/src/lib/components/auth/AuthConfig.svelte
@@ -155,7 +155,7 @@
 				<div in:fade>
 					<Value>
 						{#snippet label()}
-							{$i18n.authentication.authorized_users}
+							{$i18n.authentication.allowed_callers}
 						{/snippet}
 
 						{#if isNullish(allowedCallers) || allowedCallers.length === 0}

--- a/src/frontend/src/lib/components/auth/AuthConfigForm.svelte
+++ b/src/frontend/src/lib/components/auth/AuthConfigForm.svelte
@@ -150,11 +150,11 @@
 		<div>
 			<Value>
 				{#snippet label()}
-					{$i18n.authentication.authorized_users}
+					{$i18n.authentication.allowed_callers}
 				{/snippet}
 
 				<textarea
-					placeholder={$i18n.authentication.authorized_users_placeholder}
+					placeholder={$i18n.authentication.allowed_callers_placeholder}
 					rows="5"
 					bind:value={allowedCallersInput}
 				></textarea>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -349,8 +349,8 @@
 		"main_domain_warn": "You are about to change your primary domain. Please ensure this is the desired action, as all existing users will no longer be recognized by your app.",
 		"external_alternative_origins": "External alternative origins",
 		"external_alternative_origins_placeholder": "A comma-separated list of external domains to allow for derivation",
-		"authorized_users": "Authorized Users",
-		"authorized_users_placeholder": "Identities (user key format), comma-separated or one per line. Leave empty for no restrictions.",
+		"allowed_callers": "Allowed Callers",
+		"allowed_callers_placeholder": "Identities (user key format), comma-separated or one per line. Leave empty for no restrictions.",
 		"no_restrictions": "No restrictions",
 		"one_identity": "1 identity",
 		"identities": "{0} identities"

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -349,8 +349,8 @@
 		"main_domain_warn": "You are about to change your primary domain. Please ensure this is the desired action, as all existing users will no longer be recognized by your app.",
 		"external_alternative_origins": "外部 alternative origins",
 		"external_alternative_origins_placeholder": "以逗号分隔的用于派生的外部域名列表",
-		"authorized_users": "Authorized Users",
-		"authorized_users_placeholder": "Identities (user key format), comma-separated or one per line. Leave empty for no restrictions.",
+		"allowed_callers": "Allowed Callers",
+		"allowed_callers_placeholder": "Identities (user key format), comma-separated or one per line. Leave empty for no restrictions.",
 		"no_restrictions": "No restrictions",
 		"one_identity": "1 identity",
 		"identities": "{0} identities"

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -358,8 +358,8 @@ interface I18nAuthentication {
 	main_domain_warn: string;
 	external_alternative_origins: string;
 	external_alternative_origins_placeholder: string;
-	authorized_users: string;
-	authorized_users_placeholder: string;
+	allowed_callers: string;
+	allowed_callers_placeholder: string;
 	no_restrictions: string;
 	one_identity: string;
 	identities: string;


### PR DESCRIPTION
# Motivation

Ultimately, for consistency reasons, I'm renaming "Authorized Users" to "Allowed Callers".

It's more technical - because the field is named that way in the Satellite - but, generally speaking we use the same term visually than it's technical representation. Therefore it makes sense to be consistent with this field as well.

Relates to #1525.
