### PR TITLE
fix(frontend): upgrade from cdn version comparison

### DIFF
--- a/src/frontend/src/lib/services/upgrade/upgrade.cdn.services.ts
+++ b/src/frontend/src/lib/services/upgrade/upgrade.cdn.services.ts
@@ -60,7 +60,7 @@ export const prepareWasmUpgrade = async ({
 
 		const { current: selectedVersion } = metadata;
 
-		const isDowngrade = compare(currentVersion, selectedVersion) < 0;
+		const isDowngrade = compare(selectedVersion, currentVersion) < 0;
 		if (isDowngrade) {
 			toasts.error({
 				text: get(i18n).errors.invalid_version_cannot_downgrade


### PR DESCRIPTION
# Motivation

Current version: v0.1.0
Serverless functions Satellite version: v0.1.1

<img width="1536" height="1031" alt="Capture d’écran 2025-08-04 à 20 30 32" src="https://github.com/user-attachments/assets/e68ca7d1-642c-498d-a358-2b420c16a3de" />
