### PR TITLE
chore(frontend): disable SvelteKit fallback

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -21,7 +21,6 @@ const config = {
 	}),
 	kit: {
 		adapter: adapter({
-			fallback: 'index.html',
 			precompress: false
 		}),
 		files: {


### PR DESCRIPTION
# Motivation

SvelteKit fallback is badly documented. If I get it right from the code, it automatically generates a fallback page if set, which is not what we want.

https://github.com/sveltejs/kit/blob/b2f6a4136de20e25f9c3b2d6880b0c20fae7ee9d/packages/adapter-static/index.js#L69
