### PR TITLE
fix(storage): wildcard rewrite

### DIFF
--- a/src/libs/storage/src/certification/impls.rs
+++ b/src/libs/storage/src/certification/impls.rs
@@ -64,7 +64,7 @@ impl CertifiedAssetHashes {
         let combined_proof = fallback_paths
             .into_iter()
             .fold(absence_proof, |accumulator, path| {
-                let new_proof = self.tree_v2.witness(&[path]);
+                let new_proof = self.tree_v2.witness(&path);
                 merge_hash_trees(accumulator, new_proof)
             });
 

--- a/src/libs/storage/src/certification/tree_utils.rs
+++ b/src/libs/storage/src/certification/tree_utils.rs
@@ -1,6 +1,6 @@
 use crate::certification::constants::{
-    EXACT_MATCH_TERMINATOR, IC_CERTIFICATE_EXPRESSION, IC_CERTIFICATE_EXPRESSION_HEADER,
-    IC_STATUS_CODE_PSEUDO_HEADER, LABEL_HTTP_EXPR, WILDCARD_MATCH_TERMINATOR,
+    IC_CERTIFICATE_EXPRESSION, IC_CERTIFICATE_EXPRESSION_HEADER, IC_STATUS_CODE_PSEUDO_HEADER,
+    LABEL_HTTP_EXPR, WILDCARD_MATCH_TERMINATOR,
 };
 use crate::http::types::{HeaderField, StatusCode};
 use crate::types::state::FullPath;
@@ -41,19 +41,18 @@ pub fn nested_tree_path(full_path: &str, terminator: &str) -> Vec<Blob> {
     segments
 }
 
-pub fn fallback_paths(paths: Vec<Blob>) -> Vec<Blob> {
+pub fn fallback_paths(paths: Vec<Blob>) -> Vec<Vec<Blob>> {
     let mut fallback_paths = Vec::new();
 
-    // starting at 1 because "http_expr" is always the starting element
-    for i in 1..paths.len() {
+    for i in 0..paths.len() {
         let mut without_trailing_slash: Vec<Blob> = paths.as_slice()[0..i].to_vec();
         let mut with_trailing_slash = without_trailing_slash.clone();
-        without_trailing_slash.push(EXACT_MATCH_TERMINATOR.as_bytes().to_vec());
+        without_trailing_slash.push(WILDCARD_MATCH_TERMINATOR.as_bytes().to_vec());
         with_trailing_slash.push("".as_bytes().to_vec());
         with_trailing_slash.push(WILDCARD_MATCH_TERMINATOR.as_bytes().to_vec());
 
-        fallback_paths.extend(without_trailing_slash);
-        fallback_paths.extend(with_trailing_slash);
+        fallback_paths.push(without_trailing_slash);
+        fallback_paths.push(with_trailing_slash);
     }
 
     fallback_paths


### PR DESCRIPTION
# Motivation

I'm not exactly sure why, but when the [agent-js docs](https://github.com/dfinity/agent-js/tree/main/docs) are deployed on a Satellite, the fallback rewrites to the default `index.html` or `404.html` (if available) don't work in certain cases — specifically when a folder contains a large amount of data or something along those lines. What’s certain is that it fails for specific paths. For example:

- ✅ http://jx5yt-yyaaa-aaaal-abzbq-cai.localhost:5987/unknown
- ✅ http://jx5yt-yyaaa-aaaal-abzbq-cai.localhost:5987/unknown/unknown
- ❌ http://jx5yt-yyaaa-aaaal-abzbq-cai.localhost:5987/core/unknown
- ❌ http://jx5yt-yyaaa-aaaal-abzbq-cai.localhost:5987/unknown/core

After some debugging, we discovered that the issue is likely related to the size or structure of the hash tree. It seemed especially large for the failing paths compared to the working ones.

Today, I managed to deploy the same docs on a DFX assets canister, where everything worked as expected. Comparing both implementations revealed that the logic for constructing fallback paths in my code was different (source of DFX canister [here](https://github.com/dfinity/sdk/blob/92e3c4b39dd9cbb4b26d17c8c1a88dcb165f5b70/src/canisters/frontend/ic-certified-assets/src/asset_certification/types/certification.rs#L153)) and therefore had some flow.

Here’s what I fixed:

- The fallback function was flattening the path instead of returning a `Vec<Vec<Blob>>` representing each path that should be proven.
- I was mistakenly appending the exact match terminator (`<$>`) to paths without trailing slashes, where I should have used a wildcard terminator (`<*>`) instead.
- Lastly, I was unnecessarily trimming the first entry of the path segments (`http_expr`) even though it's appended later in the process anyway.

This PR replicates the working behavior of the DFX canister fallback mechanism and resolves the inconsistency.
