### PR TITLE
build(frontend): fix typescript mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
 				"svelte-check": "^4.2.2",
 				"svelte-preprocess": "^6.0.3",
 				"tslib": "^2.8.1",
-				"typescript": "^5.8.3",
+				"typescript": "5.8.3",
 				"vite": "^7.0.4",
 				"vite-plugin-node-polyfills": "^0.24.0",
 				"vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"svelte-check": "^4.2.2",
 		"svelte-preprocess": "^6.0.3",
 		"tslib": "^2.8.1",
-		"typescript": "^5.8.3",
+		"typescript": "5.8.3",
 		"vite": "^7.0.4",
 		"vite-plugin-node-polyfills": "^0.24.0",
 		"vitest": "^3.2.4"


### PR DESCRIPTION
# Motivation

The docker build (see [here](https://github.com/junobuild/juno-docker/actions/runs/16822771477/job/47652856652)) or fresh fork and build of skylab fails because of the famous TypeScript mismatch 

> Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.

As we cannot migrate yet to newer typescript because of eslint, let's pin the version.
