### PR TITLE
fix(backend): Rust v1.89.0 warnings

### DIFF
--- a/src/console/src/impls.rs
+++ b/src/console/src/impls.rs
@@ -65,7 +65,7 @@ impl Default for Fees {
 }
 
 impl Storable for MissionControl {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 
@@ -81,7 +81,7 @@ impl Storable for MissionControl {
 }
 
 impl Storable for Payment {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 

--- a/src/libs/cdn/src/proposals/state/impls.rs
+++ b/src/libs/cdn/src/proposals/state/impls.rs
@@ -12,7 +12,7 @@ use junobuild_shared::version::next_version;
 use std::borrow::Cow;
 
 impl Storable for ProposalKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 
@@ -28,7 +28,7 @@ impl Storable for ProposalKey {
 }
 
 impl Storable for Proposal {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 

--- a/src/libs/cdn/src/storage/state/impls.rs
+++ b/src/libs/cdn/src/storage/state/impls.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 
 impl Storable for ProposalAssetKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 
@@ -25,7 +25,7 @@ impl Storable for ProposalAssetKey {
 }
 
 impl Storable for ProposalContentChunkKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 

--- a/src/libs/satellite/src/assets/storage/impls.rs
+++ b/src/libs/satellite/src/assets/storage/impls.rs
@@ -7,7 +7,7 @@ use junobuild_shared::serializers::{
 use std::borrow::Cow;
 
 impl Storable for StableKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 
@@ -23,7 +23,7 @@ impl Storable for StableKey {
 }
 
 impl Storable for StableEncodingChunkKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 

--- a/src/libs/satellite/src/db/impls.rs
+++ b/src/libs/satellite/src/db/impls.rs
@@ -69,7 +69,7 @@ impl Timestamped for Doc {
 }
 
 impl Storable for Doc {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 
@@ -85,7 +85,7 @@ impl Storable for Doc {
 }
 
 impl Storable for StableKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 

--- a/src/libs/shared/src/serializers.rs
+++ b/src/libs/shared/src/serializers.rs
@@ -8,11 +8,11 @@ use std::borrow::Cow;
 /// * `value` - A reference to the value to serialize.
 ///
 /// # Returns
-/// A `Cow<[u8]>` representing the serialized data.
+/// A `Cow<'_, [u8]>` representing the serialized data.
 ///
 /// # Panics
 /// Panics if serialization fails.
-pub fn serialize_to_bytes<T: Serialize>(value: &T) -> Cow<[u8]> {
+pub fn serialize_to_bytes<T: Serialize>(value: &T) -> Cow<'_, [u8]> {
     let mut bytes = vec![];
     into_writer(value, &mut bytes).expect("Failed to serialize to bytes");
     Cow::Owned(bytes)

--- a/src/libs/storage/src/impls.rs
+++ b/src/libs/storage/src/impls.rs
@@ -159,7 +159,7 @@ impl From<&Asset> for AssetNoContent {
 }
 
 impl Storable for Asset {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 

--- a/src/mission_control/src/impls.rs
+++ b/src/mission_control/src/impls.rs
@@ -301,7 +301,7 @@ impl SettingsMonitoring for MissionControlSettings {
 }
 
 impl Storable for MonitoringHistory {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 
@@ -317,7 +317,7 @@ impl Storable for MonitoringHistory {
 }
 
 impl Storable for MonitoringHistoryKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 

--- a/src/observatory/src/impls.rs
+++ b/src/observatory/src/impls.rs
@@ -26,7 +26,7 @@ impl Default for State {
 }
 
 impl Storable for Notification {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 
@@ -42,7 +42,7 @@ impl Storable for Notification {
 }
 
 impl Storable for NotificationKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 

--- a/src/orbiter/src/state/impls.rs
+++ b/src/orbiter/src/state/impls.rs
@@ -36,7 +36,7 @@ impl Default for State {
 }
 
 impl Storable for StoredPageView {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         match self {
             StoredPageView::Unbounded(page_view) => serialize_to_bytes(page_view),
             StoredPageView::Bounded(page_view) => serialize_bounded_page_view_to_bytes(page_view),
@@ -86,7 +86,7 @@ impl Versioned for StoredPageView {
 }
 
 impl Storable for StoredTrackEvent {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         match self {
             StoredTrackEvent::Unbounded(track_event) => serialize_to_bytes(track_event),
             StoredTrackEvent::Bounded(track_event) => {
@@ -142,7 +142,7 @@ impl Versioned for StoredTrackEvent {
 }
 
 impl Storable for PerformanceMetric {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_to_bytes(self)
     }
 
@@ -164,7 +164,7 @@ impl Versioned for PerformanceMetric {
 }
 
 impl Storable for AnalyticKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_bounded_analytic_key_to_bytes(self)
     }
 
@@ -183,7 +183,7 @@ impl Storable for AnalyticKey {
 }
 
 impl Storable for AnalyticSatelliteKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
         serialize_bounded_analytic_satellite_key_to_bytes(self)
     }
 


### PR DESCRIPTION
# Motivation

> warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/libs/satellite/src/db/impls.rs:88:17
   |
88 |     fn to_bytes(&self) -> Cow<[u8]> {
   |                 ^^^^^     --------- the same lifetime is hidden here
   |                 |
   |                 the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
88 |     fn to_bytes(&self) -> Cow<'_, [u8]> {
   |                               +++


