### PR TITLE
chore(ci): run emulator in headless

### DIFF
--- a/scripts/console.config.utils.mjs
+++ b/scripts/console.config.utils.mjs
@@ -3,6 +3,7 @@ import { nonNullish } from '@dfinity/utils';
 import { assertAnswerCtrlC } from '@junobuild/cli-tools';
 import Conf from 'conf';
 import prompts from 'prompts';
+import { isHeadless } from './utils.mjs';
 
 const askForPassword = async () => {
 	const { encryptionKey } = await prompts([
@@ -25,7 +26,7 @@ const initConfig = async (mainnet) => {
 		return;
 	}
 
-	const encryptionKey = await askForPassword();
+	const encryptionKey = isHeadless() ? false : await askForPassword();
 
 	const projectName = `juno-${mainnet ? '' : 'dev-'}console`;
 

--- a/scripts/emulator.sh
+++ b/scripts/emulator.sh
@@ -3,17 +3,27 @@
 CONTAINER_NAME="juno-console"
 VOLUME="juno_console"
 
+RUN_FLAGS="-it"
+START_FLAGS="-i"
+
+for arg in "$@"; do
+  if [ "$arg" = "--headless" ]; then
+    RUN_FLAGS=""
+    START_FLAGS=""
+  fi
+done
+
 if docker ps -a -q -f name="^/${CONTAINER_NAME}$" | grep -q .; then
   if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" = "true" ]; then
     echo "✋  Container '$CONTAINER_NAME' is already running..."
   else
     echo "▶️  Starting the emulator..."
-    docker start -a -i "$CONTAINER_NAME"
+    docker start -a $START_FLAGS "$CONTAINER_NAME"
   fi
 else
   echo "🚀  Running new emulator..."
 
-  docker run -it \
+  docker run $RUN_FLAGS \
     --name "$CONTAINER_NAME" \
     -p 5987:5987 \
     -p 5999:5999 \

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -4,3 +4,8 @@ export const targetMainnet = () => {
 	const args = process.argv.slice(2);
 	return hasArgs({ args, options: ['--mainnet'] });
 };
+
+export const isHeadless = () => {
+	const args = process.argv.slice(2);
+	return hasArgs({ args, options: ['--headless'] });
+};


### PR DESCRIPTION
# Motivation

This resolves the TTY error when running the emulator for the tests in the CI.
