### PR TITLE
feat(storage): deprecated proposal_many_assets

### DIFF
--- a/src/console/src/api/storage.rs
+++ b/src/console/src/api/storage.rs
@@ -20,6 +20,7 @@ use junobuild_storage::types::state::FullPath;
 // Storage
 // ---------------------------------------------------------
 
+#[deprecated(note = "Use init_proposal_many_assets_upload instead")]
 #[update(guard = "caller_is_admin_controller")]
 fn init_proposal_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadResult {
     let caller = caller();
@@ -66,6 +67,7 @@ fn upload_proposal_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
     }
 }
 
+#[deprecated(note = "Use commit_proposal_many_assets_upload instead")]
 #[update(guard = "caller_is_admin_controller")]
 fn commit_proposal_asset_upload(commit: CommitBatch) {
     let caller = caller();

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -261,6 +261,7 @@ pub fn delete_proposal_assets(params: DeleteProposalAssets) {
 // ---------------------------------------------------------
 
 #[doc(hidden)]
+#[deprecated(note = "Use init_proposal_many_assets_upload instead")]
 #[update(guard = "caller_is_controller")]
 pub fn init_proposal_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadResult {
     api::cdn::init_proposal_asset_upload(init, proposal_id)
@@ -282,6 +283,7 @@ pub fn upload_proposal_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
 }
 
 #[doc(hidden)]
+#[deprecated(note = "Use commit_proposal_many_assets_upload instead")]
 #[update(guard = "caller_is_controller")]
 pub fn commit_proposal_asset_upload(commit: CommitBatch) {
     api::cdn::commit_proposal_asset_upload(commit)


### PR DESCRIPTION
# Motivation

Since we are moving towards usind a batch init and commit for assets with proposals, we can mark as deprecated the original "single shot" functions.

Follow-up of #1848
