### PR TITLE
feat(frontend): analytics filters default to -2 weeks

### DIFF
--- a/src/frontend/src/lib/stores/analytics-filters.store.ts
+++ b/src/frontend/src/lib/stores/analytics-filters.store.ts
@@ -11,7 +11,7 @@ export interface AnalyticsFiltersStore extends Readable<PageViewsFilters> {
 export const initAnalyticsFiltersStore = (): AnalyticsFiltersStore => {
 	const { subscribe, update } = writable<PageViewsFilters>({
 		...getLocalStorageAnalyticsPeriodicity(),
-		from: addWeeks(new Date(), -1)
+		from: addWeeks(new Date(), -2)
 	});
 
 	return {

--- a/src/frontend/src/lib/stores/analytics-filters.store.ts
+++ b/src/frontend/src/lib/stores/analytics-filters.store.ts
@@ -1,6 +1,6 @@
 import type { AnalyticsPeriodicity, PageViewsFilters } from '$lib/types/orbiter';
 import { getLocalStorageAnalyticsPeriodicity } from '$lib/utils/local-storage.utils';
-import { addMonths } from 'date-fns';
+import { addWeeks } from 'date-fns';
 import { type Readable, writable } from 'svelte/store';
 
 export interface AnalyticsFiltersStore extends Readable<PageViewsFilters> {
@@ -11,7 +11,7 @@ export interface AnalyticsFiltersStore extends Readable<PageViewsFilters> {
 export const initAnalyticsFiltersStore = (): AnalyticsFiltersStore => {
 	const { subscribe, update } = writable<PageViewsFilters>({
 		...getLocalStorageAnalyticsPeriodicity(),
-		from: addMonths(new Date(), -1)
+		from: addWeeks(new Date(), -1)
 	});
 
 	return {


### PR DESCRIPTION
# Motivation

From my experience it feels more handy to use a narrower default period for the default analytics filter than a month.
