### PR TITLE
fix(frontend): csp for reading wasm

### DIFF
--- a/scripts/build.csp.mjs
+++ b/scripts/build.csp.mjs
@@ -185,7 +185,7 @@ const updateCSP = (indexHtml) => {
         img-src 'self' data:;
         child-src 'self';
         manifest-src 'self';
-        script-src 'strict-dynamic' ${indexHashes.join(' ')} ${JUNO_CDN};
+        script-src 'wasm-unsafe-eval' 'strict-dynamic' ${indexHashes.join(' ')} ${JUNO_CDN};
         base-uri 'self';
         form-action 'none';
         style-src 'self' 'unsafe-inline' ${JUNO_CDN};


### PR DESCRIPTION
# Motivation

Removing `unsafe-eval` in #1853 has for result that the frontend cannot read the custom section of the download WASM, which we need for example to read their dependency tree and version. 

```
const wasmModule = await WebAssembly.compile(wasm);

const pkgSections = WebAssembly.Module.customSections(wasmModule, sectionName);
```

This happens because `compile` requires eval. We can potentially, maybe, use `compileStreaming` or `instantiateStreaming`, but not sure if supported in NodeJS. Therefore, pragmatically and at least for the time being let's (re-)add `wasm-unsafe-eval` to the CSP.

<img width="1536" height="1031" alt="Capture d’écran 2025-08-15 à 06 52 13" src="https://github.com/user-attachments/assets/5c7cf591-cdd0-4a30-943b-bf1390f1393e" />


