### PR TITLE
feat(backend): alias certified_data_set as set_certified_data

### DIFF
--- a/src/libs/storage/src/certification/cert.rs
+++ b/src/libs/storage/src/certification/cert.rs
@@ -3,14 +3,14 @@ use crate::certification::tree_utils::response_headers_expression;
 use crate::certification::types::certified::CertifiedAssetHashes;
 use crate::http::types::HeaderField;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use ic_cdk::api::{certified_data_set, data_certificate};
+use ic_cdk::api::{certified_data_set as set_certified_data, data_certificate};
 use junobuild_shared::types::core::Blob;
 use serde::Serialize;
 use serde_cbor::ser::Serializer;
 
 pub fn update_certified_data(asset_hashes: &CertifiedAssetHashes) {
     let prefixed_root_hash = &asset_hashes.root_hash();
-    certified_data_set(&prefixed_root_hash[..]);
+    set_certified_data(&prefixed_root_hash[..]);
 }
 
 pub fn build_asset_certificate_header(

--- a/src/orbiter/src/http/state/store.rs
+++ b/src/orbiter/src/http/state/store.rs
@@ -1,7 +1,7 @@
 use crate::http::state::services::{mutate_state, read_state};
 use crate::http::state::types::{CertifiedHttpResponse, StorageRuntimeState};
 use crate::http::types::request::{HttpRequestMethod, HttpRequestPath};
-use ic_cdk::api::certified_data_set;
+use ic_cdk::api::certified_data_set as set_certified_data;
 use ic_http_certification::{HttpCertification, HttpCertificationPath, HttpCertificationTreeEntry};
 
 pub fn insert_certified_response(
@@ -52,5 +52,5 @@ fn certify_response(
 
     storage.tree.insert(&entry);
 
-    certified_data_set(&storage.tree.root_hash());
+    set_certified_data(&storage.tree.root_hash());
 }


### PR DESCRIPTION
# Motivation

Follow-up of #1865. I cannot remember the new name `certified_data_set`, the "set" as suffix feels weird, so let's alias the functions with their previous name `set_certified_data` as in previous version of the ic_cdk.
