### PR TITLE
style(frontend): fix ugly info alignment in upgrade modal

### DIFF
--- a/src/frontend/src/lib/components/ui/Info.svelte
+++ b/src/frontend/src/lib/components/ui/Info.svelte
@@ -9,12 +9,17 @@
 	let { children }: Props = $props();
 </script>
 
-<p><IconInfo size="32px" /> {@render children()}</p>
+<p><span class="icon"><IconInfo size="32px" /></span> <span>{@render children()}</span></p>
 
 <style lang="scss">
 	@use '../../styles/mixins/info';
 
 	p {
 		@include info.info;
+	}
+
+	.icon {
+		display: inline-flex;
+		width: 32px;
 	}
 </style>


### PR DESCRIPTION
# Motivation

Before:

<img width="923" height="1031" alt="Capture d’écran 2025-08-20 à 16 07 08" src="https://github.com/user-attachments/assets/19376b76-a8f6-4098-b9b0-3ba7088c3739" />

After:

<img width="923" height="1031" alt="Capture d’écran 2025-08-20 à 16 07 17" src="https://github.com/user-attachments/assets/395497ec-2516-457a-9a11-c1cd20d2707a" />

