### PR TITLE
fix(frontend): orbiter version for upgrade workaround

### DIFF
--- a/src/frontend/src/lib/components/modals/OrbiterUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterUpgradeModal.svelte
@@ -6,7 +6,7 @@
 	import CanisterUpgradeModal from '$lib/components/modals/CanisterUpgradeModal.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import type { IgnoreCanUpgradeErrorFn } from '$lib/components/upgrade/wizard/SelectUpgradeVersion.svelte';
-	import { ORBITER_v0_0_8, ORBITER_v0_2_1 } from '$lib/constants/version.constants';
+	import { ORBITER_v0_0_8, ORBITER_v0_2_0 } from '$lib/constants/version.constants';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { reloadOrbiterVersion } from '$lib/services/version/version.orbiter.services';
 	import { authStore } from '$lib/stores/auth.store';
@@ -47,7 +47,7 @@
 	// As a result, checkUpgradeVersion will prevent the upgrade because there is more than one minor version
 	// in between. That is why we are manually allowing this upgrade.
 	const ignoreCanUpgradeError: IgnoreCanUpgradeErrorFn = ({ currentVersion, selectedVersion }) =>
-		compare(currentVersion, ORBITER_v0_0_8) === 0 && compare(selectedVersion, ORBITER_v0_2_1) === 0;
+		compare(currentVersion, ORBITER_v0_0_8) === 0 && compare(selectedVersion, ORBITER_v0_2_0) === 0;
 </script>
 
 {#if nonNullish($orbiterStore)}

--- a/src/frontend/src/lib/constants/version.constants.ts
+++ b/src/frontend/src/lib/constants/version.constants.ts
@@ -20,7 +20,7 @@ const VERSIONS = {
 		v0_0_4: '0.0.4',
 		v0_0_5: '0.0.5',
 		v0_0_8: '0.0.8',
-		v0_2_1: '0.2.1'
+		v0_2_0: '0.2.0'
 	}
 };
 
@@ -46,6 +46,6 @@ export const {
 		v0_0_4: ORBITER_v0_0_4,
 		v0_0_5: ORBITER_v0_0_5,
 		v0_0_8: ORBITER_v0_0_8,
-		v0_2_1: ORBITER_v0_2_1
+		v0_2_0: ORBITER_v0_2_0
 	}
 } = VERSIONS;


### PR DESCRIPTION
# Motivation

Follow-up of #1874. The version to compare is actually v0.2.0. This version is available in the CDN but, was not added in the releases of the Console state.

<img width="2644" height="1918" alt="image" src="https://github.com/user-attachments/assets/f2cadcab-30a5-4a28-8757-cc1f06b457f6" />

