### PR TITLE
fix(frontend): load auth config when version not set

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthConfig.svelte
+++ b/src/frontend/src/lib/components/auth/AuthConfig.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish, fromNullishNullable } from '@dfinity/utils';
+	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import type { Satellite } from '$declarations/mission_control/mission_control.did';
 	import type { AuthenticationConfig, Rule } from '$declarations/satellite/satellite.did';
@@ -11,10 +12,9 @@
 	import { authStore } from '$lib/stores/auth.store';
 	import { busy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { versionStore } from '$lib/stores/version.store';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
-	import { versionStore } from '$lib/stores/version.store';
-	import { untrack } from 'svelte';
 
 	interface Props {
 		satellite: Satellite;

--- a/src/frontend/src/lib/components/auth/AuthConfig.svelte
+++ b/src/frontend/src/lib/components/auth/AuthConfig.svelte
@@ -13,6 +13,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import { versionStore } from '$lib/stores/version.store';
+	import { untrack } from 'svelte';
 
 	interface Props {
 		satellite: Satellite;
@@ -63,7 +65,11 @@
 	};
 
 	$effect(() => {
-		load();
+		$versionStore;
+
+		untrack(() => {
+			load();
+		});
 	});
 
 	$effect(() => {


### PR DESCRIPTION
# Motivation

On navigation the version is set, therefore the auth config was loaded but, on direct access not.
