### PR TITLE
feat(satellite): aaguid in user data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 				"@junobuild/cli-tools": "^0.6.5",
 				"@junobuild/config": "^2.1.0",
 				"@junobuild/config-loader": "^0.4.2",
-				"@junobuild/errors": "^0.1.2-next-2025-08-27.2",
+				"@junobuild/errors": "^0.1.2-next-2025-09-01",
 				"@junobuild/functions": "^0.2.7",
 				"@ltd/j-toml": "^1.38.0",
 				"@playwright/test": "^1.54.2",
@@ -1867,9 +1867,9 @@
 			}
 		},
 		"node_modules/@junobuild/errors": {
-			"version": "0.1.2-next-2025-08-27.2",
-			"resolved": "https://registry.npmjs.org/@junobuild/errors/-/errors-0.1.2-next-2025-08-27.2.tgz",
-			"integrity": "sha512-SlNZ0o7dfBDVw5OfWgFPUuIqwA5LRLztPkJctAYsXUvrgqw1c8pMOp7Zd9/vUx/WjSqpgkgYenczHEMpTCfFZA==",
+			"version": "0.1.2-next-2025-09-01",
+			"resolved": "https://registry.npmjs.org/@junobuild/errors/-/errors-0.1.2-next-2025-09-01.tgz",
+			"integrity": "sha512-9cxGzuYn4MdhOK6l/4NFz9Un+vVZ+C2CUn44F8hzMwFJOhsGGTwNCNwshMTiNuym/1ti5LiAkifNaJl1xOfzCw==",
 			"license": "MIT"
 		},
 		"node_modules/@junobuild/functions": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"@junobuild/cli-tools": "^0.6.5",
 		"@junobuild/config": "^2.1.0",
 		"@junobuild/config-loader": "^0.4.2",
-		"@junobuild/errors": "^0.1.2-next-2025-08-27.2",
+		"@junobuild/errors": "^0.1.2-next-2025-09-01",
 		"@junobuild/functions": "^0.2.7",
 		"@ltd/j-toml": "^1.38.0",
 		"@playwright/test": "^1.54.2",

--- a/src/libs/satellite/src/errors/user.rs
+++ b/src/libs/satellite/src/errors/user.rs
@@ -7,6 +7,13 @@ pub const JUNO_DATASTORE_ERROR_USER_KEY_NO_PRINCIPAL: &str =
     "juno.datastore.error.user.key_no_principal";
 // Banned
 pub const JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED: &str = "juno.datastore.error.user.not_allowed";
+// The AAGUID (Authenticator Attestation GUID) must be exactly 16 bytes.
+pub const JUNO_DATASTORE_ERROR_USER_AAGUID_INVALID_LENGTH: &str =
+    "juno.datastore.error.user.webauthn.aaguid_invalid_length";
+pub const JUNO_DATASTORE_ERROR_USER_PROVIDER_INVALID_DATA: &str =
+    "juno.datastore.error.user.webauthn.provider_invalid_data";
+pub const JUNO_DATASTORE_ERROR_USER_PROVIDER_WEBAUTHN_INVALID_DATA: &str =
+    "juno.datastore.error.user.webauthn.provider_webauthn_invalid_data";
 
 // Change limit reached.
 pub const JUNO_DATASTORE_ERROR_USER_USAGE_CHANGE_LIMIT_REACHED: &str =
@@ -22,6 +29,3 @@ pub const JUNO_DATASTORE_ERROR_USER_WEBAUTHN_INVALID_DATA: &str =
 // Caller and public key must match. Only the user can create their webauthn entry.
 pub const JUNO_DATASTORE_ERROR_USER_WEBAUTHN_CALLER_KEY: &str =
     "juno.datastore.error.user.webauthn.caller_key";
-// The AAGUID (Authenticator Attestation GUID) must be exactly 16 bytes.
-pub const JUNO_DATASTORE_ERROR_USER_WEBAUTHN_AAGUID_INVALID_LENGTH: &str =
-    "juno.datastore.error.user.webauthn.aaguid_invalid_length";

--- a/src/libs/satellite/src/user/core/types.rs
+++ b/src/libs/satellite/src/user/core/types.rs
@@ -6,6 +6,7 @@ pub mod state {
     pub struct UserData {
         pub provider: Option<AuthProvider>,
         pub banned: Option<BannedReason>,
+        pub provider_data: Option<ProviderData>,
     }
 
     #[derive(Serialize, Deserialize)]
@@ -21,5 +22,17 @@ pub mod state {
     #[serde(rename_all = "snake_case")]
     pub enum BannedReason {
         Indefinite,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ProviderData {
+        WebAuthn(WebAuthnData),
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case", deny_unknown_fields)]
+    pub struct WebAuthnData {
+        pub aaguid: Option<[u8; 16]>,
     }
 }

--- a/src/libs/satellite/src/user/core/types.rs
+++ b/src/libs/satellite/src/user/core/types.rs
@@ -27,12 +27,13 @@ pub mod state {
     #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "snake_case")]
     pub enum ProviderData {
+        #[serde(rename = "webauthn")]
         WebAuthn(WebAuthnData),
     }
 
     #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct WebAuthnData {
-        pub aaguid: Option<[u8; 16]>,
+        pub aaguid: Option<Vec<u8>>,
     }
 }

--- a/src/libs/satellite/src/user/core/types.rs
+++ b/src/libs/satellite/src/user/core/types.rs
@@ -2,7 +2,7 @@ pub mod state {
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
+    #[serde(deny_unknown_fields, rename_all = "camelCase")]
     pub struct UserData {
         pub provider: Option<AuthProvider>,
         pub banned: Option<BannedReason>,
@@ -31,7 +31,7 @@ pub mod state {
     }
 
     #[derive(Serialize, Deserialize)]
-    #[serde(rename_all = "snake_case", deny_unknown_fields)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct WebAuthnData {
         pub aaguid: Option<[u8; 16]>,
     }

--- a/src/libs/satellite/src/user/webauthn/assert.rs
+++ b/src/libs/satellite/src/user/webauthn/assert.rs
@@ -1,5 +1,4 @@
 use crate::errors::user::{
-    JUNO_DATASTORE_ERROR_USER_WEBAUTHN_AAGUID_INVALID_LENGTH,
     JUNO_DATASTORE_ERROR_USER_WEBAUTHN_CALLER_KEY,
     JUNO_DATASTORE_ERROR_USER_WEBAUTHN_CANNOT_UPDATE,
     JUNO_DATASTORE_ERROR_USER_WEBAUTHN_INVALID_DATA,
@@ -25,14 +24,6 @@ pub fn assert_user_webauthn_collection_data(
 
     let data = decode_doc_data::<UserWebAuthnData>(&doc.data)
         .map_err(|err| format!("{JUNO_DATASTORE_ERROR_USER_WEBAUTHN_INVALID_DATA}: {err}"))?;
-
-    if let Some(aaguid) = data.aaguid.as_ref() {
-        // The AAGUID (Authenticator Attestation GUID) must be exactly 16 bytes.
-        // For simplicity, no further validation is performed here; additional checks are deferred to the frontends for display only.
-        if aaguid.len() != 16 {
-            return Err(JUNO_DATASTORE_ERROR_USER_WEBAUTHN_AAGUID_INVALID_LENGTH.to_string());
-        }
-    }
 
     let public_key = Principal::self_authenticating(&data.public_key.value);
 

--- a/src/libs/satellite/src/user/webauthn/types.rs
+++ b/src/libs/satellite/src/user/webauthn/types.rs
@@ -9,7 +9,6 @@ pub mod state {
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct UserWebAuthnData {
         pub public_key: DocDataUint8Array,
-        pub aaguid: Option<Vec<u8>>,
     }
 
     #[derive(Serialize, Deserialize)]

--- a/src/tests/specs/satellite/stock/satellite.user-webauthn.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.user-webauthn.spec.ts
@@ -11,7 +11,6 @@ import {
 	toNullable
 } from '@dfinity/utils';
 import {
-	JUNO_DATASTORE_ERROR_USER_WEBAUTHN_AAGUID_INVALID_LENGTH,
 	JUNO_DATASTORE_ERROR_USER_WEBAUTHN_CALLER_KEY,
 	JUNO_DATASTORE_ERROR_USER_WEBAUTHN_CANNOT_UPDATE,
 	JUNO_DATASTORE_ERROR_USER_WEBAUTHN_INVALID_DATA
@@ -151,85 +150,6 @@ describe('Satellite > User Webauthn', () => {
 						version: toNullable(1n)
 					})
 				).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_WEBAUTHN_CANNOT_UPDATE);
-			});
-
-			describe('AAGUID', () => {
-				const AAGUID_ZERO = new Array(16).fill(0);
-
-				// deadbeef-0001-0203-0405-060708090a0b
-				const AAGUID = [
-					0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
-					0x0b
-				];
-
-				const INVALID_AAGUID_LEN_15 = new Array(15).fill(0);
-				const INVALID_AAGUID_LEN_17 = new Array(17).fill(0);
-
-				it('should create user-webauthn with valid aaguid', async () => {
-					await createUserWebAuthn({ publicKey: userPublicKey, credentialId, aaguid: AAGUID });
-
-					const { get_doc } = actor;
-
-					const doc = fromNullable(await get_doc('#user-webauthn', credentialId));
-
-					expect(doc).not.toBeUndefined();
-
-					const data = await fromArray(doc?.data ?? []);
-
-					expect((data as { aaguid: number[] }).aaguid).toEqual(AAGUID);
-				});
-
-				it('should create user-webauthn with aaguid zero (some providers intentionally set it to zero)', async () => {
-					await createUserWebAuthn({ publicKey: userPublicKey, credentialId, aaguid: AAGUID_ZERO });
-
-					const { get_doc } = actor;
-
-					const doc = fromNullable(await get_doc('#user-webauthn', credentialId));
-
-					expect(doc).not.toBeUndefined();
-
-					const data = await fromArray(doc?.data ?? []);
-
-					expect((data as { aaguid: number[] }).aaguid).toEqual(AAGUID_ZERO);
-				});
-
-				it('should not create a user-webauthn with aaguid too short', async () => {
-					const { set_doc } = actor;
-
-					const data = await toArray({
-						publicKey: userPublicKey,
-						aaguid: INVALID_AAGUID_LEN_15
-					});
-
-					await expect(
-						set_doc('#user-webauthn', credentialId, {
-							data,
-							description: toNullable(),
-							version: toNullable()
-						})
-					).rejects.toThrow(
-						new RegExp(JUNO_DATASTORE_ERROR_USER_WEBAUTHN_AAGUID_INVALID_LENGTH, 'i')
-					);
-				});
-
-				it('should not create a user-webauthn with aaguid too long', async () => {
-					const { set_doc } = actor;
-
-					const data = await toArray({
-						publicKey: userPublicKey,
-						aaguid: INVALID_AAGUID_LEN_17
-					});
-
-					await expect(
-						set_doc('#user-webauthn', credentialId, {
-							data,
-							description: toNullable(),
-							version: toNullable()
-						})
-					).rejects.toThrow(
-						new RegExp(JUNO_DATASTORE_ERROR_USER_WEBAUTHN_AAGUID_INVALID_LENGTH, 'i')
-					);
-				});
 			});
 		});
 

--- a/src/tests/specs/satellite/stock/satellite.user.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.user.spec.ts
@@ -6,11 +6,14 @@ import { type Actor, PocketIc } from '@dfinity/pic';
 import { assertNonNullish, fromNullable, toNullable } from '@dfinity/utils';
 import {
 	JUNO_DATASTORE_ERROR_CANNOT_WRITE,
+	JUNO_DATASTORE_ERROR_USER_AAGUID_INVALID_LENGTH,
 	JUNO_DATASTORE_ERROR_USER_CALLER_KEY,
 	JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE,
 	JUNO_DATASTORE_ERROR_USER_INVALID_DATA,
 	JUNO_DATASTORE_ERROR_USER_KEY_NO_PRINCIPAL,
-	JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED
+	JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED,
+	JUNO_DATASTORE_ERROR_USER_PROVIDER_INVALID_DATA,
+	JUNO_DATASTORE_ERROR_USER_PROVIDER_WEBAUTHN_INVALID_DATA
 } from '@junobuild/errors';
 import { fromArray, toArray } from '@junobuild/utils';
 import { inject } from 'vitest';
@@ -40,52 +43,66 @@ describe('Satellite > User', () => {
 	});
 
 	describe('user', () => {
-		describe('success', () => {
-			let user: Identity;
+		let user: Identity;
+		interface ProviderData {
+			webauthn: { aaguid?: number[] };
+		}
 
-			beforeEach(() => {
-				user = Ed25519KeyIdentity.generate();
-				actor.setIdentity(user);
+		const assertCreateUser = async ({
+			provider,
+			providerData
+		}: {
+			provider: string;
+			providerData?: ProviderData;
+		}) => {
+			const { set_doc, list_docs } = actor;
+
+			await set_doc('#user', user.getPrincipal().toText(), {
+				data: await toArray({
+					provider,
+					providerData
+				}),
+				description: toNullable(),
+				version: toNullable()
 			});
 
-			const assertCreateUser = async ({ provider }: { provider: string }) => {
-				const { set_doc, list_docs } = actor;
+			const { items: users } = await list_docs('#user', {
+				matcher: toNullable(),
+				order: toNullable(),
+				owner: toNullable(),
+				paginate: toNullable()
+			});
 
-				await set_doc('#user', user.getPrincipal().toText(), {
-					data: await toArray({
-						provider
-					}),
-					description: toNullable(),
-					version: toNullable()
-				});
+			expect(users).toHaveLength(1);
 
-				const { items: users } = await list_docs('#user', {
-					matcher: toNullable(),
-					order: toNullable(),
-					owner: toNullable(),
-					paginate: toNullable()
-				});
+			const updatedUser = users.find(([key]) => key === user.getPrincipal().toText());
+			assertNonNullish(updatedUser);
 
-				expect(users).toHaveLength(1);
+			const [key, doc] = updatedUser;
 
-				const updatedUser = users.find(([key]) => key === user.getPrincipal().toText());
-				assertNonNullish(updatedUser);
+			const data = await fromArray(doc.data);
 
-				const [key, doc] = updatedUser;
+			expect(key).toEqual(user.getPrincipal().toText());
+			expect((data as { provider: string }).provider).toEqual(provider);
+			expect((data as { banned: boolean }).banned).toBeFalsy();
+		};
 
-				const data = await fromArray(doc.data);
+		beforeEach(() => {
+			user = Ed25519KeyIdentity.generate();
+			actor.setIdentity(user);
+		});
 
-				expect(key).toEqual(user.getPrincipal().toText());
-				expect((data as { provider: string }).provider).toEqual(provider);
-				expect((data as { banned: boolean }).banned).toBeFalsy();
-			};
-
-			it.each([['internet_identity'], ['nfid'], ['webauthn']])(
+		describe('success', () => {
+			it.each([['internet_identity'], ['nfid']])(
 				'should create a user for provider %s',
 				async (provider) => {
 					await assertCreateUser({ provider });
 				}
 			);
+
+			it('should create a user for provider webauthn', async () => {
+				await assertCreateUser({ provider: 'webauthn', providerData: { webauthn: {} } });
+			});
 
 			it('should create a user without provider because this is optional', async () => {
 				const { set_doc } = actor;
@@ -139,13 +156,6 @@ describe('Satellite > User', () => {
 		});
 
 		describe('error', () => {
-			let user: Identity;
-
-			beforeEach(() => {
-				user = Ed25519KeyIdentity.generate();
-				actor.setIdentity(user);
-			});
-
 			it('should not update a user because only controller can update', async () => {
 				const { set_doc, get_doc } = actor;
 
@@ -202,6 +212,169 @@ describe('Satellite > User', () => {
 						version: bannedUser.version ?? []
 					})
 				).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_NOT_ALLOWED);
+			});
+		});
+
+		describe('Provider data', () => {
+			// deadbeef-0001-0203-0405-060708090a0b
+			const AAGUID = [
+				0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+				0x0b
+			];
+
+			describe('WebAuthn', () => {
+				const AAGUID_ZERO = new Array(16).fill(0);
+
+				const INVALID_AAGUID_LEN_15 = new Array(15).fill(0);
+				const INVALID_AAGUID_LEN_17 = new Array(17).fill(0);
+
+				it('should create user with valid aaguid', async () => {
+					await assertCreateUser({
+						provider: 'webauthn',
+						providerData: { webauthn: { aaguid: AAGUID } }
+					});
+
+					const { get_doc } = actor;
+
+					const doc = fromNullable(await get_doc('#user', user.getPrincipal().toText()));
+
+					expect(doc).not.toBeUndefined();
+
+					const data = await fromArray(doc?.data ?? []);
+
+					expect((data as { providerData: ProviderData }).providerData.webauthn.aaguid).toEqual(
+						AAGUID
+					);
+				});
+
+				it('should not create user without providerData', async () => {
+					const data = await toArray({
+						provider: 'webauthn'
+					});
+
+					const { set_doc } = actor;
+
+					await expect(
+						set_doc('#user', user.getPrincipal().toText(), {
+							data,
+							description: toNullable(),
+							version: toNullable()
+						})
+					).rejects.toThrow(
+						new RegExp(JUNO_DATASTORE_ERROR_USER_PROVIDER_WEBAUTHN_INVALID_DATA, 'i')
+					);
+				});
+
+				it('should not create webauthn user with unknown providerData', async () => {
+					const data = await toArray({
+						provider: 'webauthn',
+						providerData: { test: null } // does not exist
+					});
+
+					const { set_doc } = actor;
+
+					await expect(
+						set_doc('#user', user.getPrincipal().toText(), {
+							data,
+							description: toNullable(),
+							version: toNullable()
+						})
+					).rejects.toThrow(
+						new RegExp(
+							`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown variant \`test\`, expected \`webauthn\` at line 1 column 45.`,
+							'i'
+						)
+					);
+				});
+
+				it('should create user with aaguid zero (some providers intentionally set it to zero)', async () => {
+					await assertCreateUser({
+						provider: 'webauthn',
+						providerData: { webauthn: { aaguid: AAGUID_ZERO } }
+					});
+
+					const { get_doc } = actor;
+
+					const doc = fromNullable(await get_doc('#user', user.getPrincipal().toText()));
+
+					expect(doc).not.toBeUndefined();
+
+					const data = await fromArray(doc?.data ?? []);
+
+					expect((data as { providerData: ProviderData }).providerData.webauthn.aaguid).toEqual(
+						AAGUID_ZERO
+					);
+				});
+
+				it('should not create a user with aaguid too short', async () => {
+					const { set_doc } = actor;
+
+					const data = await toArray({
+						provider: 'webauthn',
+						providerData: { webauthn: { aaguid: INVALID_AAGUID_LEN_15 } }
+					});
+
+					await expect(
+						set_doc('#user', user.getPrincipal().toText(), {
+							data,
+							description: toNullable(),
+							version: toNullable()
+						})
+					).rejects.toThrow(new RegExp(JUNO_DATASTORE_ERROR_USER_AAGUID_INVALID_LENGTH, 'i'));
+				});
+
+				it('should not create a user-webauthn with aaguid too long', async () => {
+					const { set_doc } = actor;
+
+					const data = await toArray({
+						provider: 'webauthn',
+						providerData: { webauthn: { aaguid: INVALID_AAGUID_LEN_17 } }
+					});
+
+					await expect(
+						set_doc('#user', user.getPrincipal().toText(), {
+							data,
+							description: toNullable(),
+							version: toNullable()
+						})
+					).rejects.toThrow(new RegExp(JUNO_DATASTORE_ERROR_USER_AAGUID_INVALID_LENGTH, 'i'));
+				});
+			});
+
+			describe('Others', () => {
+				it('should not create user with unexpected providerData', async () => {
+					const data = await toArray({
+						provider: 'internet_identity',
+						providerData: { webauthn: {} }
+					});
+
+					const { set_doc } = actor;
+
+					await expect(
+						set_doc('#user', user.getPrincipal().toText(), {
+							data,
+							description: toNullable(),
+							version: toNullable()
+						})
+					).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_PROVIDER_INVALID_DATA);
+				});
+
+				it('should not create user with unexpected providerData webauthn', async () => {
+					const data = await toArray({
+						provider: 'internet_identity',
+						providerData: { webauthn: { aaguid: AAGUID } }
+					});
+
+					const { set_doc } = actor;
+
+					await expect(
+						set_doc('#user', user.getPrincipal().toText(), {
+							data,
+							description: toNullable(),
+							version: toNullable()
+						})
+					).rejects.toThrow(JUNO_DATASTORE_ERROR_USER_PROVIDER_INVALID_DATA);
+				});
 			});
 		});
 	});
@@ -523,6 +696,28 @@ describe('Satellite > User', () => {
 			);
 		});
 
+		it('should not create user with unknown providerData', async () => {
+			const data = await toArray({
+				provider: 'internet_identity',
+				providerData: { test: null } // does not exist
+			});
+
+			const { set_doc } = actor;
+
+			await expect(
+				set_doc('#user', user.getPrincipal().toText(), {
+					data,
+					description: toNullable(),
+					version: toNullable()
+				})
+			).rejects.toThrow(
+				new RegExp(
+					`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown variant \`test\`, expected \`webauthn\` at line 1 column 54.`,
+					'i'
+				)
+			);
+		});
+
 		it('should not create a user with invalid additional data fields', async () => {
 			const { set_doc } = actor;
 
@@ -539,7 +734,7 @@ describe('Satellite > User', () => {
 				})
 			).rejects.toThrow(
 				new RegExp(
-					`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown field \`unknown\`, expected \`provider\` or \`banned\` at line 1 column 41.`,
+					`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown field \`unknown\`, expected one of \`provider\`, \`banned\`, \`providerData\` at line 1 column 41.`,
 					'i'
 				)
 			);


### PR DESCRIPTION
# Motivation

Don't know what I thougt. `#user-webauthn` is read public therefore it should not contains any other information that those that are public and `aaguid` isn't one. Therefore we extend the `#user` data with an optional `provider_data` field (null for internet identity and nfid) which can contains such information. 
