### PR TITLE
feat(frontend): style select arrow and padding

### DIFF
--- a/src/frontend/src/lib/components/icons/IconArrowDropDown.svelte
+++ b/src/frontend/src/lib/components/icons/IconArrowDropDown.svelte
@@ -1,4 +1,4 @@
-<!-- Source: https://fonts.google.com/icons?selected=Material%20Symbols%20Sharp%3Aarrow_drop_down%3AFILL%400%3Bwght%40400%3BGRAD%400%3Bopsz%4048 -->
+<!-- Source: https://fonts.google.com/icons?selected=Material+Symbols+Rounded:keyboard_arrow_down:FILL@0;wght@400;GRAD@0;opsz@24&icon.size=24&icon.color=%23e8eaed&icon.query=arrow+down&icon.style=Rounded -->
 <script lang="ts">
 	interface Props {
 		size?: string;
@@ -10,7 +10,10 @@
 <svg
 	fill="currentColor"
 	height={size}
-	viewBox="0 0 48 48"
+	viewBox="0 -960 960 960"
 	width={size}
-	xmlns="http://www.w3.org/2000/svg"><path d="m24 30-10-9.95h20Z" /></svg
+	xmlns="http://www.w3.org/2000/svg"
+	><path
+		d="M480-361q-8 0-15-2.5t-13-8.5L268-556q-11-11-11-28t11-28q11-11 28-11t28 11l156 156 156-156q11-11 28-11t28 11q11 11 11 28t-11 28L508-372q-6 6-13 8.5t-15 2.5Z"
+	/></svg
 >

--- a/src/frontend/src/lib/styles/global/input.scss
+++ b/src/frontend/src/lib/styles/global/input.scss
@@ -85,3 +85,25 @@ textarea {
 		}
 	}
 }
+
+select {
+	line-height: 1;
+	appearance: none;
+
+	background-image: url('data:image/svg+xml;utf8,<svg width="24" height="24" viewBox="0 -960 960 960" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M480-361q-8 0-15-2.5t-13-8.5L268-556q-11-11-11-28t11-28q11-11 28-11t28 11l156 156 156-156q11-11 28-11t28 11q11 11 11 28t-11 28L508-372q-6 6-13 8.5t-15 2.5Z" /></svg>');
+	background-repeat: no-repeat;
+	background-position: right var(--padding-1_5x) center;
+	background-size: 20px;
+
+	cursor: pointer;
+
+	padding: var(--padding) calc(var(--padding-4x) + var(--padding)) var(--padding) var(--padding-2x);
+}
+
+:root {
+	&[theme='dark'] {
+		select {
+			background-image: url('data:image/svg+xml;utf8,<svg width="24" height="24" viewBox="0 -960 960 960" fill="%23ebedf0" xmlns="http://www.w3.org/2000/svg"><path d="M480-361q-8 0-15-2.5t-13-8.5L268-556q-11-11-11-28t11-28q11-11 28-11t28 11l156 156 156-156q11-11 28-11t28 11q11 11 11 28t-11 28L508-372q-6 6-13 8.5t-15 2.5Z" /></svg>');
+		}
+	}
+}


### PR DESCRIPTION
# Motivation

Unfortunatelly did not find any other solution to style the fill color of the inlined svg as duplicating it in dark or light mode.
