### PR TITLE
style(frontend): wider centered popover on desktop

### DIFF
--- a/src/frontend/src/lib/components/core/Spotlight.svelte
+++ b/src/frontend/src/lib/components/core/Spotlight.svelte
@@ -170,9 +170,6 @@
 	@include dialog.edit;
 
 	.container {
-		width: 420px;
-		max-width: calc(100vw - var(--padding-4x));
-
 		padding: 0;
 	}
 
@@ -200,14 +197,14 @@
 	}
 
 	.search {
-		padding: var(--padding-2x) var(--padding-3x) 0 var(--padding-2x);
+		padding: var(--padding-2x) var(--padding-2x) 0 var(--padding-2x);
 
 		background: var(--color-menu);
 	}
 
 	li,
 	.none {
-		padding: 0 var(--padding-2x) 0 var(--padding-2x);
+		padding: 0 var(--padding) 0 var(--padding-2x);
 	}
 
 	.none {

--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -113,7 +113,7 @@
 		}
 
 		&.center {
-			--popover-min-size: 340px;
+			--popover-min-size: 540px;
 		}
 	}
 </style>

--- a/src/frontend/src/lib/styles/mixins/_overlay.scss
+++ b/src/frontend/src/lib/styles/mixins/_overlay.scss
@@ -43,7 +43,10 @@
 
 		cursor: initial;
 
-		--size: min(var(--popover-min-size, 240px), calc(100vw - 0.45rem - var(--popover-right, 0)));
+		--size: min(
+			var(--popover-min-size, 240px),
+			calc(100vw - 0.45rem - var(--popover-right, var(--padding-4x)))
+		);
 
 		min-width: var(--size);
 		max-width: var(--size);


### PR DESCRIPTION
# Motivation

<img width="1536" height="1031" alt="Capture d’écran 2025-09-10 à 13 29 38" src="https://github.com/user-attachments/assets/fca4d680-d39c-43ae-92f7-1fbef718a7e2" />
<img width="1536" height="1031" alt="Capture d’écran 2025-09-10 à 13 29 35" src="https://github.com/user-attachments/assets/b82fa0de-8274-45eb-a183-304137da8ac6" />
<img width="1536" height="1031" alt="Capture d’écran 2025-09-10 à 13 29 30" src="https://github.com/user-attachments/assets/fe4848aa-c0b5-471f-b7ea-b31a8c3b8b75" />
