### PR TITLE
feat(core): stream stable memory on pre_ and post_upgrade

### DIFF
--- a/src/console/src/memory/lifecycle.rs
+++ b/src/console/src/memory/lifecycle.rs
@@ -2,7 +2,7 @@ use crate::cdn::certified_assets::upgrade::defer_init_certified_assets;
 use crate::cdn::lifecycle::init_cdn_storage_heap_state;
 use crate::memory::manager::{get_memory_upgrades, init_stable_state, STATE};
 use crate::types::state::{Fees, HeapState, Rates, ReleasesMetadata, State};
-use ciborium::{from_reader, into_writer};
+use ciborium::into_writer;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use junobuild_shared::controllers::init_admin_controllers;
 use junobuild_shared::ic::api::caller;
@@ -45,9 +45,7 @@ fn pre_upgrade() {
 #[post_upgrade]
 fn post_upgrade() {
     let memory = get_memory_upgrades();
-    let state_bytes = read_post_upgrade(&memory);
-
-    let state: State = from_reader(&*state_bytes)
+    let state = read_post_upgrade(&memory)
         .expect("Failed to decode the state of the console in post_upgrade hook.");
 
     STATE.with(|s| *s.borrow_mut() = state);

--- a/src/console/src/memory/lifecycle.rs
+++ b/src/console/src/memory/lifecycle.rs
@@ -2,7 +2,6 @@ use crate::cdn::certified_assets::upgrade::defer_init_certified_assets;
 use crate::cdn::lifecycle::init_cdn_storage_heap_state;
 use crate::memory::manager::{get_memory_upgrades, init_stable_state, STATE};
 use crate::types::state::{Fees, HeapState, Rates, ReleasesMetadata, State};
-use ciborium::into_writer;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use junobuild_shared::controllers::init_admin_controllers;
 use junobuild_shared::ic::api::caller;
@@ -34,12 +33,10 @@ fn init() {
 
 #[pre_upgrade]
 fn pre_upgrade() {
-    let mut state_bytes = vec![];
-    STATE
-        .with(|s| into_writer(&*s.borrow(), &mut state_bytes))
-        .expect("Failed to encode the state of the console in pre_upgrade hook.");
-
-    write_pre_upgrade(&state_bytes, &mut get_memory_upgrades());
+    STATE.with(|s| {
+        write_pre_upgrade(&*s.borrow(), &mut get_memory_upgrades())
+            .expect("Failed to encode the state of the console in pre_upgrade hook.");
+    });
 }
 
 #[post_upgrade]

--- a/src/libs/satellite/src/memory/lifecycle.rs
+++ b/src/libs/satellite/src/memory/lifecycle.rs
@@ -6,7 +6,7 @@ use crate::memory::internal::{get_memory_for_upgrade, init_stable_state, STATE};
 use crate::memory::utils::init_storage_heap_state;
 use crate::random::init::defer_init_random_seed;
 use crate::types::state::{HeapState, RuntimeState, State};
-use ciborium::{from_reader, into_writer};
+use ciborium::into_writer;
 use junobuild_shared::controllers::init_admin_controllers;
 use junobuild_shared::types::interface::SegmentArgs;
 use junobuild_shared::types::memory::Memory;
@@ -45,10 +45,9 @@ pub fn pre_upgrade() {
 
 pub fn post_upgrade() {
     let memory: Memory = get_memory_for_upgrade();
-    let state_bytes = read_post_upgrade(&memory);
-
-    let state = from_reader(&*state_bytes)
+    let state = read_post_upgrade(&memory)
         .expect("Failed to decode the state of the satellite in post_upgrade hook.");
+
     STATE.with(|s| *s.borrow_mut() = state);
 
     defer_init_certified_assets();

--- a/src/libs/satellite/src/memory/lifecycle.rs
+++ b/src/libs/satellite/src/memory/lifecycle.rs
@@ -6,7 +6,6 @@ use crate::memory::internal::{get_memory_for_upgrade, init_stable_state, STATE};
 use crate::memory::utils::init_storage_heap_state;
 use crate::random::init::defer_init_random_seed;
 use crate::types::state::{HeapState, RuntimeState, State};
-use ciborium::into_writer;
 use junobuild_shared::controllers::init_admin_controllers;
 use junobuild_shared::types::interface::SegmentArgs;
 use junobuild_shared::types::memory::Memory;
@@ -35,12 +34,10 @@ pub fn init(args: SegmentArgs) {
 }
 
 pub fn pre_upgrade() {
-    let mut state_bytes = vec![];
-    STATE
-        .with(|s| into_writer(&*s.borrow(), &mut state_bytes))
-        .expect("Failed to encode the state of the satellite in pre_upgrade hook.");
-
-    write_pre_upgrade(&state_bytes, &mut get_memory_for_upgrade());
+    STATE.with(|s| {
+        write_pre_upgrade(&*s.borrow(), &mut get_memory_for_upgrade())
+            .expect("Failed to encode the state of the satellite in pre_upgrade hook.");
+    });
 }
 
 pub fn post_upgrade() {

--- a/src/libs/shared/src/upgrade.rs
+++ b/src/libs/shared/src/upgrade.rs
@@ -1,26 +1,66 @@
 use crate::types::memory::Memory;
-use ciborium::{de::Error as CborError, from_reader};
-use ic_stable_structures::writer::Writer;
+use ciborium::{de::Error as CborError, from_reader, into_writer};
 #[allow(unused)]
-use ic_stable_structures::{reader::Reader, Memory as _};
-use std::io::{Error, ErrorKind, Read};
-use std::mem;
+use ic_stable_structures::{reader::Reader, writer::Writer, Memory as _};
+use std::io::{Error, ErrorKind, Read, Write};
+use std::mem::size_of;
 
-pub fn write_pre_upgrade(state_bytes: &[u8], memory: &mut Memory) {
-    // Write the length of the serialized bytes to memory, followed by the bytes themselves.
-    let len = state_bytes.len() as u32;
-    let mut writer = Writer::new(memory, 0);
-    writer.write(&len.to_le_bytes()).unwrap();
-    writer.write(state_bytes).unwrap()
+// The memory offset is 4 bytes because that's the length we used in pre_upgrade to store the length of the memory data for the upgrade.
+// https://github.com/dfinity/stable-structures/issues/104
+const OFFSET: usize = size_of::<u32>();
+
+// A custom writer that writes to memory while also counting the number of bytes written.
+// The total is needed to be later stored in the 4-byte length prefix on the memory.
+struct PreUpgradeWriter<W> {
+    inner: W,
+    bytes_length: usize,
+}
+
+impl<W: Write> Write for PreUpgradeWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+        let m = self.inner.write(buf)?;
+        self.bytes_length += m;
+        Ok(m)
+    }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        self.inner.flush()
+    }
+}
+
+pub fn write_pre_upgrade<T: serde::Serialize>(state: &T, memory: &mut Memory) -> Result<(), Error> {
+    // Reserve 4 bytes for the length of the serialized bytes that will be saved
+    let mut header = Writer::new(memory, 0);
+    header.write_all(&[0u8; OFFSET])?;
+
+    let offset: u64 = OFFSET
+        .try_into()
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "Invalid stable memory offset"))?;
+
+    // Write (stream) the state bytes to memory starting at offset 4 while counting the bytes actually saved
+    let payload = Writer::new(memory, offset);
+    let mut writer = PreUpgradeWriter {
+        inner: payload,
+        bytes_length: 0,
+    };
+    into_writer(state, &mut writer).map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?;
+
+    // Save the effective length of the bytes that were saved
+    let len_u32: u32 = writer.bytes_length.try_into().map_err(|_| {
+        Error::new(
+            ErrorKind::InvalidData,
+            "Serialized state exceeds u32 length prefix",
+        )
+    })?;
+    let mut header = Writer::new(memory, 0);
+    header.write_all(&len_u32.to_le_bytes())?;
+
+    Ok(())
 }
 
 pub fn read_post_upgrade<T: serde::de::DeserializeOwned>(
     memory: &Memory,
 ) -> Result<T, CborError<Error>> {
-    // The memory offset is 4 bytes because that's the length we used in pre_upgrade to store the length of the memory data for the upgrade.
-    // https://github.com/dfinity/stable-structures/issues/104
-    const OFFSET: usize = mem::size_of::<u32>();
-
     // Read the length of the state bytes.
     let mut state_len_bytes = [0; OFFSET];
     memory.read(0, &mut state_len_bytes);
@@ -37,7 +77,7 @@ pub fn read_post_upgrade<T: serde::de::DeserializeOwned>(
         )
     })?;
 
-    // Stream the bytes.
+    // Read (stream) the bytes.
     let reader = Reader::new(memory, offset);
     let bounded_reader = reader.take(len);
 

--- a/src/libs/shared/src/upgrade.rs
+++ b/src/libs/shared/src/upgrade.rs
@@ -1,7 +1,9 @@
 use crate::types::memory::Memory;
+use ciborium::{de::Error as CborError, from_reader};
 use ic_stable_structures::writer::Writer;
 #[allow(unused)]
-use ic_stable_structures::Memory as _;
+use ic_stable_structures::{reader::Reader, Memory as _};
+use std::io::{Error, ErrorKind, Read};
 use std::mem;
 
 pub fn write_pre_upgrade(state_bytes: &[u8], memory: &mut Memory) {
@@ -12,7 +14,9 @@ pub fn write_pre_upgrade(state_bytes: &[u8], memory: &mut Memory) {
     writer.write(state_bytes).unwrap()
 }
 
-pub fn read_post_upgrade(memory: &Memory) -> Vec<u8> {
+pub fn read_post_upgrade<T: serde::de::DeserializeOwned>(
+    memory: &Memory,
+) -> Result<T, CborError<Error>> {
     // The memory offset is 4 bytes because that's the length we used in pre_upgrade to store the length of the memory data for the upgrade.
     // https://github.com/dfinity/stable-structures/issues/104
     const OFFSET: usize = mem::size_of::<u32>();
@@ -22,9 +26,20 @@ pub fn read_post_upgrade(memory: &Memory) -> Vec<u8> {
     memory.read(0, &mut state_len_bytes);
     let state_len = u32::from_le_bytes(state_len_bytes) as usize;
 
-    // Read the bytes.
-    let mut state_bytes = vec![0; state_len];
-    memory.read(u64::try_from(OFFSET).unwrap(), &mut state_bytes);
+    let offset: u64 = OFFSET
+        .try_into()
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "Invalid stable memory offset"))?;
 
-    state_bytes
+    let len: u64 = state_len.try_into().map_err(|_| {
+        Error::new(
+            ErrorKind::InvalidData,
+            "Invalid state length in stable memory",
+        )
+    })?;
+
+    // Stream the bytes.
+    let reader = Reader::new(memory, offset);
+    let bounded_reader = reader.take(len);
+
+    from_reader(bounded_reader)
 }

--- a/src/mission_control/src/memory/lifecycle.rs
+++ b/src/mission_control/src/memory/lifecycle.rs
@@ -2,7 +2,6 @@ use crate::memory::manager::{get_memory_upgrades, init_runtime_state, init_stabl
 use crate::monitoring::monitor::defer_restart_monitoring;
 use crate::random::defer_init_random_seed;
 use crate::types::state::{HeapState, State};
-use ciborium::into_writer;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use junobuild_shared::types::interface::MissionControlArgs;
 use junobuild_shared::upgrade::{read_post_upgrade, write_pre_upgrade};
@@ -25,12 +24,10 @@ fn init(args: MissionControlArgs) {
 
 #[pre_upgrade]
 fn pre_upgrade() {
-    let mut state_bytes = vec![];
-    STATE
-        .with(|s| into_writer(&*s.borrow(), &mut state_bytes))
-        .expect("Failed to encode the state of the mission control in pre_upgrade hook.");
-
-    write_pre_upgrade(&state_bytes, &mut get_memory_upgrades());
+    STATE.with(|s| {
+        write_pre_upgrade(&*s.borrow(), &mut get_memory_upgrades())
+            .expect("Failed to encode the state of the mission control in pre_upgrade hook.");
+    });
 }
 
 #[post_upgrade]

--- a/src/mission_control/src/memory/lifecycle.rs
+++ b/src/mission_control/src/memory/lifecycle.rs
@@ -2,7 +2,7 @@ use crate::memory::manager::{get_memory_upgrades, init_runtime_state, init_stabl
 use crate::monitoring::monitor::defer_restart_monitoring;
 use crate::random::defer_init_random_seed;
 use crate::types::state::{HeapState, State};
-use ciborium::{from_reader, into_writer};
+use ciborium::into_writer;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use junobuild_shared::types::interface::MissionControlArgs;
 use junobuild_shared::upgrade::{read_post_upgrade, write_pre_upgrade};
@@ -36,9 +36,7 @@ fn pre_upgrade() {
 #[post_upgrade]
 fn post_upgrade() {
     let memory = get_memory_upgrades();
-    let state_bytes = read_post_upgrade(&memory);
-
-    let state: State = from_reader(&*state_bytes)
+    let state = read_post_upgrade(&memory)
         .expect("Failed to decode the state of the mission control in post_upgrade hook.");
 
     STATE.with(|s| *s.borrow_mut() = state);

--- a/src/observatory/src/memory/lifecycle.rs
+++ b/src/observatory/src/memory/lifecycle.rs
@@ -1,7 +1,6 @@
 use crate::memory::manager::{get_memory_upgrades, init_runtime_state, init_stable_state, STATE};
 use crate::random::defer_init_random_seed;
 use crate::types::state::{HeapState, State};
-use ciborium::into_writer;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use junobuild_shared::controllers::init_admin_controllers;
 use junobuild_shared::ic::api::caller;
@@ -28,12 +27,10 @@ fn init() {
 
 #[pre_upgrade]
 fn pre_upgrade() {
-    let mut state_bytes = vec![];
-    STATE
-        .with(|s| into_writer(&*s.borrow(), &mut state_bytes))
-        .expect("Failed to encode the state of the mission control in pre_upgrade hook.");
-
-    write_pre_upgrade(&state_bytes, &mut get_memory_upgrades());
+    STATE.with(|s| {
+        write_pre_upgrade(&*s.borrow(), &mut get_memory_upgrades())
+            .expect("Failed to encode the state of the mission control in pre_upgrade hook.");
+    });
 }
 
 #[post_upgrade]

--- a/src/observatory/src/memory/lifecycle.rs
+++ b/src/observatory/src/memory/lifecycle.rs
@@ -1,7 +1,7 @@
 use crate::memory::manager::{get_memory_upgrades, init_runtime_state, init_stable_state, STATE};
 use crate::random::defer_init_random_seed;
 use crate::types::state::{HeapState, State};
-use ciborium::{from_reader, into_writer};
+use ciborium::into_writer;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use junobuild_shared::controllers::init_admin_controllers;
 use junobuild_shared::ic::api::caller;
@@ -39,9 +39,7 @@ fn pre_upgrade() {
 #[post_upgrade]
 fn post_upgrade() {
     let memory = get_memory_upgrades();
-    let state_bytes = read_post_upgrade(&memory);
-
-    let state: State = from_reader(&*state_bytes)
+    let state = read_post_upgrade(&memory)
         .expect("Failed to decode the state of the observatory in post_upgrade hook.");
 
     STATE.with(|s| *s.borrow_mut() = state);

--- a/src/orbiter/src/state/memory/lifecycle.rs
+++ b/src/orbiter/src/state/memory/lifecycle.rs
@@ -1,7 +1,7 @@
 use crate::http::upgrade::defer_init_certified_responses;
 use crate::state::memory::manager::{get_memory_upgrades, init_stable_state, STATE};
 use crate::state::types::state::{HeapState, State};
-use ciborium::{from_reader, into_writer};
+use ciborium::into_writer;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use junobuild_shared::controllers::init_admin_controllers;
 use junobuild_shared::types::interface::SegmentArgs;
@@ -40,9 +40,7 @@ fn pre_upgrade() {
 #[post_upgrade]
 fn post_upgrade() {
     let memory: Memory = get_memory_upgrades();
-    let state_bytes = read_post_upgrade(&memory);
-
-    let state: State = from_reader(&*state_bytes)
+    let state = read_post_upgrade(&memory)
         .expect("Failed to decode the state of the orbiter in post_upgrade hook.");
 
     STATE.with(|s| *s.borrow_mut() = state);

--- a/src/orbiter/src/state/memory/lifecycle.rs
+++ b/src/orbiter/src/state/memory/lifecycle.rs
@@ -1,7 +1,6 @@
 use crate::http::upgrade::defer_init_certified_responses;
 use crate::state::memory::manager::{get_memory_upgrades, init_stable_state, STATE};
 use crate::state::types::state::{HeapState, State};
-use ciborium::into_writer;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use junobuild_shared::controllers::init_admin_controllers;
 use junobuild_shared::types::interface::SegmentArgs;
@@ -29,12 +28,10 @@ fn init(args: SegmentArgs) {
 
 #[pre_upgrade]
 fn pre_upgrade() {
-    let mut state_bytes = vec![];
-    STATE
-        .with(|s| into_writer(&*s.borrow(), &mut state_bytes))
-        .expect("Failed to encode the state of the orbiter in pre_upgrade hook.");
-
-    write_pre_upgrade(&state_bytes, &mut get_memory_upgrades());
+    STATE.with(|s| {
+        write_pre_upgrade(&*s.borrow(), &mut get_memory_upgrades())
+            .expect("Failed to encode the state of the orbiter in pre_upgrade hook.");
+    });
 }
 
 #[post_upgrade]


### PR DESCRIPTION
# Motivation

Be able to upgrade Satellite with more than 1GB as we are assuming that right now, we are hitting that limit because we load the all state in memory on post_upgrade.

Resolves #1921

