### PR TITLE
feat(console): use readable state instead of mutable

### DIFF
--- a/src/console/src/store/stable.rs
+++ b/src/console/src/store/stable.rs
@@ -123,7 +123,7 @@ fn delete_mission_control_impl(user: &UserId, state: &mut StableState) -> Option
 }
 
 pub fn list_mission_controls() -> MissionControls {
-    mutate_stable_state(|stable| list_mission_controls_impl(&mut stable.mission_controls))
+    read_stable_state(|stable| list_mission_controls_impl(&stable.mission_controls))
 }
 
 fn list_mission_controls_impl(mission_controls: &MissionControlsStable) -> MissionControls {


### PR DESCRIPTION
# Motivation

> warning: the function `list_mission_controls_impl` doesn't need a mutable reference
   --> src/console/src/store/stable.rs:126:61
    |
126 |     mutate_stable_state(|stable| list_mission_controls_impl(&mut stable.mission_controls))
    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_mut_passed
    = note: `#[warn(clippy::unnecessary_mut_passed)]` on by default
