### PR TITLE
feat(storage): support for saving well-known assets with encoding on stable

### DIFF
--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -27,7 +27,7 @@ use junobuild_storage::types::state::FullPath;
 use junobuild_storage::types::store::{
     Asset, AssetAssertUpload, AssetEncoding, Batch, EncodingType, ReferenceId,
 };
-use junobuild_storage::utils::clone_asset_encoding_content_chunks;
+use junobuild_storage::utils::{clone_asset_encoding_content_chunks, insert_encoding_into_asset};
 
 pub struct StorageAssertions;
 
@@ -161,6 +161,17 @@ impl StorageStateStrategy for StorageState {
         _rule: &Rule,
     ) {
         insert_asset(full_path, asset)
+    }
+
+    fn insert_asset_encoding(
+        &self,
+        _full_path: &FullPath,
+        encoding_type: &str,
+        encoding: &AssetEncoding,
+        asset: &mut Asset,
+        _rule: &Rule,
+    ) {
+        insert_encoding_into_asset(encoding_type, encoding, asset)
     }
 
     fn delete_asset(

--- a/src/console/src/metadata.rs
+++ b/src/console/src/metadata.rs
@@ -4,8 +4,11 @@ use crate::constants::RELEASES_METADATA_JSON;
 use crate::store::heap::{get_releases_metadata, set_releases_metadata};
 use junobuild_cdn::proposals::SegmentsDeploymentOptions;
 use junobuild_shared::ic::api::id;
-use junobuild_storage::types::store::{Asset, AssetKey};
-use junobuild_storage::utils::{create_asset_with_content, map_content_type_headers};
+use junobuild_storage::constants::ASSET_ENCODING_NO_COMPRESSION;
+use junobuild_storage::types::store::{Asset, AssetEncoding, AssetKey};
+use junobuild_storage::utils::{
+    create_asset_with_content, insert_encoding_into_asset, map_content_type_headers,
+};
 use serde_json::to_string;
 
 pub fn update_releases_metadata(options: &SegmentsDeploymentOptions) -> Result<(), String> {
@@ -40,7 +43,10 @@ fn update_releases_metadata_asset() -> Result<(), String> {
 
     let existing_asset = get_asset(&RELEASES_METADATA_JSON.to_string());
 
-    let asset = map_releases_metadata_asset(&json, existing_asset);
+    let (mut asset, encoding) = map_releases_metadata_asset(&json, existing_asset);
+
+    // The metadata json leaves on the heap only.
+    insert_encoding_into_asset(ASSET_ENCODING_NO_COMPRESSION, &encoding, &mut asset);
 
     insert_asset(&RELEASES_METADATA_JSON.to_string(), &asset);
 
@@ -49,7 +55,10 @@ fn update_releases_metadata_asset() -> Result<(), String> {
     Ok(())
 }
 
-fn map_releases_metadata_asset(metadata: &str, existing_asset: Option<Asset>) -> Asset {
+fn map_releases_metadata_asset(
+    metadata: &str,
+    existing_asset: Option<Asset>,
+) -> (Asset, AssetEncoding) {
     let key = AssetKey {
         name: RELEASES_METADATA_JSON.to_string(),
         full_path: RELEASES_METADATA_JSON.to_string(),

--- a/src/libs/cdn/src/storage/state/heap/store.rs
+++ b/src/libs/cdn/src/storage/state/heap/store.rs
@@ -8,7 +8,9 @@ use junobuild_storage::heap_utils::collect_assets_heap;
 use junobuild_storage::types::interface::AssetNoContent;
 use junobuild_storage::types::state::FullPath;
 use junobuild_storage::types::store::{Asset, AssetEncoding, EncodingType};
-use junobuild_storage::utils::{get_token_protected_asset, map_asset_no_content};
+use junobuild_storage::utils::{
+    get_token_protected_asset, insert_encoding_into_asset, map_asset_no_content,
+};
 
 // ---------------------------------------------------------
 // Assets
@@ -74,9 +76,7 @@ pub fn insert_asset_encoding(
         None => return Err(format!("No asset found for {full_path}")),
     };
 
-    asset
-        .encodings
-        .insert(encoding_type.to_owned(), encoding.clone());
+    insert_encoding_into_asset(encoding_type, encoding, &mut asset);
 
     insert_asset(cdn_heap, full_path, &asset);
 

--- a/src/libs/satellite/src/assets/cdn/strategies_impls/storage.rs
+++ b/src/libs/satellite/src/assets/cdn/strategies_impls/storage.rs
@@ -25,7 +25,7 @@ use junobuild_storage::types::state::FullPath;
 use junobuild_storage::types::store::{
     Asset, AssetAssertUpload, AssetEncoding, Batch, EncodingType, ReferenceId,
 };
-use junobuild_storage::utils::clone_asset_encoding_content_chunks;
+use junobuild_storage::utils::{clone_asset_encoding_content_chunks, insert_encoding_into_asset};
 
 pub struct CdnStorageAssertions;
 
@@ -159,6 +159,17 @@ impl StorageStateStrategy for CdnStorageState {
         _rule: &Rule,
     ) {
         junobuild_cdn::storage::heap::insert_asset(&CdnHeap, full_path, asset)
+    }
+
+    fn insert_asset_encoding(
+        &self,
+        _full_path: &FullPath,
+        encoding_type: &str,
+        encoding: &AssetEncoding,
+        asset: &mut Asset,
+        _rule: &Rule,
+    ) {
+        insert_encoding_into_asset(encoding_type, encoding, asset)
     }
 
     fn delete_asset(

--- a/src/libs/satellite/src/assets/storage/state.rs
+++ b/src/libs/satellite/src/assets/storage/state.rs
@@ -16,7 +16,7 @@ use junobuild_storage::stable_utils::insert_asset_encoding_stable;
 use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::state::{AssetsHeap, FullPath, StorageHeapState};
 use junobuild_storage::types::store::{Asset, AssetEncoding};
-use junobuild_storage::utils::clone_asset_encoding_content_chunks;
+use junobuild_storage::utils::{clone_asset_encoding_content_chunks, insert_encoding_into_asset};
 use std::borrow::Cow;
 use std::ops::RangeBounds;
 // ---------------------------------------------------------
@@ -111,11 +111,7 @@ pub fn insert_asset_encoding(
     rule: &Rule,
 ) {
     match rule.mem() {
-        Memory::Heap => {
-            asset
-                .encodings
-                .insert(encoding_type.to_owned(), encoding.clone());
-        }
+        Memory::Heap => insert_encoding_into_asset(encoding_type, encoding, asset),
         Memory::Stable => STATE.with(|state| {
             insert_asset_encoding_stable(
                 full_path,

--- a/src/libs/satellite/src/assets/storage/strategy_impls.rs
+++ b/src/libs/satellite/src/assets/storage/strategy_impls.rs
@@ -154,6 +154,17 @@ impl StorageStateStrategy for StorageState {
         insert_asset(collection, full_path, asset, rule)
     }
 
+    fn insert_asset_encoding(
+        &self,
+        full_path: &FullPath,
+        encoding_type: &str,
+        encoding: &AssetEncoding,
+        asset: &mut Asset,
+        rule: &Rule,
+    ) {
+        insert_asset_encoding(full_path, encoding_type, encoding, asset, rule)
+    }
+
     fn delete_asset(
         &self,
         collection: &CollectionKey,

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -104,6 +104,15 @@ pub trait StorageStateStrategy {
         rule: &Rule,
     );
 
+    fn insert_asset_encoding(
+        &self,
+        full_path: &FullPath,
+        encoding_type: &str,
+        encoding: &AssetEncoding,
+        asset: &mut Asset,
+        rule: &Rule,
+    );
+
     fn delete_asset(
         &self,
         collection: &CollectionKey,

--- a/src/libs/storage/src/utils.rs
+++ b/src/libs/storage/src/utils.rs
@@ -1,6 +1,4 @@
-use crate::constants::{
-    ASSET_ENCODING_NO_COMPRESSION, WELL_KNOWN_CUSTOM_DOMAINS, WELL_KNOWN_II_ALTERNATIVE_ORIGINS,
-};
+use crate::constants::{WELL_KNOWN_CUSTOM_DOMAINS, WELL_KNOWN_II_ALTERNATIVE_ORIGINS};
 use crate::http::types::HeaderField;
 use crate::strategies::StorageAssertionsStrategy;
 use crate::types::interface::AssetNoContent;
@@ -154,18 +152,26 @@ pub fn create_asset_with_content(
     headers: &[HeaderField],
     existing_asset: Option<Asset>,
     key: AssetKey,
-) -> Asset {
-    let mut asset: Asset = Asset::prepare(key, headers.to_vec(), &existing_asset);
+) -> (Asset, AssetEncoding) {
+    let asset: Asset = Asset::prepare(key, headers.to_vec(), &existing_asset);
 
     let encoding = map_content_encoding(&content.as_bytes().to_vec());
 
-    asset
-        .encodings
-        .insert(ASSET_ENCODING_NO_COMPRESSION.to_string(), encoding);
-
-    asset
+    (asset, encoding)
 }
 
 pub fn clone_asset_encoding_content_chunks(encoding: &AssetEncoding, chunk_index: usize) -> Blob {
     encoding.content_chunks[chunk_index].clone()
+}
+
+/// With heap memory the encodings are part of the asset struct.
+/// Using stable, the encoding become a key pointing to another stable tree.
+pub fn insert_encoding_into_asset(
+    encoding_type: &str,
+    encoding: &AssetEncoding,
+    asset: &mut Asset,
+) {
+    asset
+        .encodings
+        .insert(encoding_type.to_owned(), encoding.clone());
 }

--- a/src/libs/storage/src/well_known/utils.rs
+++ b/src/libs/storage/src/well_known/utils.rs
@@ -1,5 +1,5 @@
 use crate::constants::{WELL_KNOWN_CUSTOM_DOMAINS, WELL_KNOWN_II_ALTERNATIVE_ORIGINS};
-use crate::types::store::{Asset, AssetKey};
+use crate::types::store::{Asset, AssetEncoding, AssetKey};
 use crate::utils::{create_asset_with_content, map_content_type_headers};
 use ic_cdk::api::time;
 use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
@@ -8,7 +8,10 @@ use junobuild_shared::types::domain::CustomDomain;
 use junobuild_shared::types::state::Timestamp;
 use junobuild_shared::version::next_version;
 
-pub fn map_custom_domains_asset(custom_domains: &str, existing_asset: Option<Asset>) -> Asset {
+pub fn map_custom_domains_asset(
+    custom_domains: &str,
+    existing_asset: Option<Asset>,
+) -> (Asset, AssetEncoding) {
     let key = AssetKey {
         name: "custom-domains".to_string(),
         full_path: WELL_KNOWN_CUSTOM_DOMAINS.to_string(),
@@ -26,7 +29,7 @@ pub fn map_custom_domains_asset(custom_domains: &str, existing_asset: Option<Ass
 pub fn map_alternative_origins_asset(
     alternative_origins: &str,
     existing_asset: Option<Asset>,
-) -> Asset {
+) -> (Asset, AssetEncoding) {
     let key = AssetKey {
         name: "ii-alternative-origins".to_string(),
         full_path: WELL_KNOWN_II_ALTERNATIVE_ORIGINS.to_string(),


### PR DESCRIPTION
# Motivation

We need this PR to implement #1949 - to allow devs to serve apps from heap or stable. Per extension we want to server .well-known from stable or heap as well (it's a bit everything or nothing, otherwise too much changes and backwards compatibility issue).

The current implementation of generating those files assumed it was always heap so we need to extend it as on stable, the encodings are hold in a separate stable tree map.

In #1949 the test suite will assert if those files are created correctly.
