### PR TITLE
fix(satellite): serve /_juno/releases on stable

### DIFF
--- a/src/libs/satellite/src/assets/storage/state.rs
+++ b/src/libs/satellite/src/assets/storage/state.rs
@@ -1,3 +1,4 @@
+use crate::assets::constants::{CDN_JUNO_PATH, CDN_JUNO_RELEASES_COLLECTION_KEY};
 use crate::assets::storage::types::state::{
     AssetsStable, ContentChunksStable, StableEncodingChunkKey, StableKey,
 };
@@ -44,6 +45,17 @@ fn get_public_asset_impl(full_path: &FullPath, state: &State) -> (Option<Asset>,
 
     if let Some(stable_asset) = stable_dapp_asset {
         return (Some(stable_asset), Memory::Stable);
+    }
+
+    // If the full_path starts with /_juno/, it's reserved for release assets.
+    if full_path.starts_with(CDN_JUNO_PATH) {
+        let release_asset = get_asset_stable(
+            &CDN_JUNO_RELEASES_COLLECTION_KEY.to_string(),
+            full_path,
+            &state.stable.assets,
+        );
+
+        return (release_asset, Memory::Stable);
     }
 
     // Ultimately, we try to resolve the asset in the custom collections of the dev.


### PR DESCRIPTION
# Motivation

Leftover of #1951. When serving assets from stable, we have to check two collections: dapp and _juno/releases

The later was missing.

This was detected and will be tested by PRs #1960 and #1957
