### PR TITLE
feat(cdn): extend pre_commit_assets with result

### DIFF
--- a/src/console/src/cdn/strategies_impls/cdn.rs
+++ b/src/console/src/cdn/strategies_impls/cdn.rs
@@ -113,8 +113,8 @@ impl CdnStableStrategy for CdnStable {
 pub struct CdnWorkflow;
 
 impl CdnWorkflowStrategy for CdnWorkflow {
-    fn pre_commit_assets(&self, proposal: &Proposal) {
-        junobuild_cdn::proposals::pre_commit_assets(&CdnHeap, proposal);
+    fn pre_commit_assets(&self, proposal: &Proposal) -> Result<(), String> {
+        junobuild_cdn::proposals::pre_commit_assets(&CdnHeap, proposal)
     }
 
     fn post_commit_assets(&self, proposal: &Proposal) -> Result<(), String> {

--- a/src/libs/cdn/src/proposals/impls.rs
+++ b/src/libs/cdn/src/proposals/impls.rs
@@ -9,6 +9,7 @@ impl fmt::Display for CommitProposalError {
             CommitProposalError::ProposalNotOpen(err) => write!(f, "{err}"),
             CommitProposalError::InvalidSha256(err) => write!(f, "{err}"),
             CommitProposalError::InvalidType(err) => write!(f, "{err}"),
+            CommitProposalError::PreCommitAssetsIssue(err) => write!(f, "{err}"),
             CommitProposalError::CommitAssetsIssue(err) => write!(f, "{err}"),
             CommitProposalError::PostCommitAssetsIssue(err) => write!(f, "{err}"),
         }

--- a/src/libs/cdn/src/proposals/types.rs
+++ b/src/libs/cdn/src/proposals/types.rs
@@ -17,6 +17,7 @@ pub enum CommitProposalError {
     ProposalNotOpen(String),
     InvalidSha256(String),
     InvalidType(String),
+    PreCommitAssetsIssue(String),
     CommitAssetsIssue(String),
     PostCommitAssetsIssue(String),
 }

--- a/src/libs/cdn/src/proposals/workflows/pre_commit_assets.rs
+++ b/src/libs/cdn/src/proposals/workflows/pre_commit_assets.rs
@@ -3,7 +3,10 @@ use crate::storage::heap::store::delete_assets;
 use crate::strategies::CdnHeapStrategy;
 use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
 
-pub fn pre_commit_assets(cdn_heap: &impl CdnHeapStrategy, proposal: &Proposal) {
+pub fn pre_commit_assets(
+    cdn_heap: &impl CdnHeapStrategy,
+    proposal: &Proposal,
+) -> Result<(), String> {
     match &proposal.proposal_type {
         ProposalType::AssetsUpgrade(ref options) => {
             // Clear existing assets if required.
@@ -13,4 +16,6 @@ pub fn pre_commit_assets(cdn_heap: &impl CdnHeapStrategy, proposal: &Proposal) {
         }
         ProposalType::SegmentsDeployment(_) => (),
     }
+
+    Ok(())
 }

--- a/src/libs/cdn/src/strategies.rs
+++ b/src/libs/cdn/src/strategies.rs
@@ -33,6 +33,6 @@ pub trait CdnStableStrategy {
 }
 
 pub trait CdnWorkflowStrategy {
-    fn pre_commit_assets(&self, proposal: &Proposal);
+    fn pre_commit_assets(&self, proposal: &Proposal) -> Result<(), String>;
     fn post_commit_assets(&self, proposal: &Proposal) -> Result<(), String>;
 }

--- a/src/libs/satellite/src/assets/cdn/strategies_impls/cdn.rs
+++ b/src/libs/satellite/src/assets/cdn/strategies_impls/cdn.rs
@@ -112,8 +112,8 @@ impl CdnStableStrategy for CdnStable {
 pub struct CdnWorkflow;
 
 impl CdnWorkflowStrategy for CdnWorkflow {
-    fn pre_commit_assets(&self, proposal: &Proposal) {
-        junobuild_cdn::proposals::pre_commit_assets(&CdnHeap, proposal);
+    fn pre_commit_assets(&self, proposal: &Proposal) -> Result<(), String> {
+        junobuild_cdn::proposals::pre_commit_assets(&CdnHeap, proposal)
     }
 
     fn post_commit_assets(&self, _proposal: &Proposal) -> Result<(), String> {


### PR DESCRIPTION
# Motivation

We want to extend the cdn for supporting stable memory. Per extension, it should be able to delete assets on stable, function which may result in error in the satellite. Therefore, we extend the function to support result.
