### PR TITLE
feat(console): copy assets heap functions from cdn

### DIFF
--- a/src/console/src/cdn/storage/heap/mod.rs
+++ b/src/console/src/cdn/storage/heap/mod.rs
@@ -1,0 +1,6 @@
+pub mod state;
+pub mod store;
+
+pub use state::*;
+pub use store::get_public_asset;
+pub use store::list_assets;

--- a/src/console/src/cdn/storage/heap/state.rs
+++ b/src/console/src/cdn/storage/heap/state.rs
@@ -1,0 +1,38 @@
+use crate::store::{with_assets, with_assets_mut};
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_storage::heap_utils::collect_delete_assets_heap;
+use junobuild_storage::types::state::{AssetsHeap, FullPath};
+use junobuild_storage::types::store::Asset;
+
+// ---------------------------------------------------------
+// Assets
+// ---------------------------------------------------------
+
+pub fn get_asset(full_path: &FullPath) -> Option<Asset> {
+    with_assets(|assets| get_asset_impl(full_path, assets))
+}
+
+fn get_asset_impl(full_path: &FullPath, assets: &AssetsHeap) -> Option<Asset> {
+    let value = assets.get(full_path);
+    value.cloned()
+}
+
+pub fn insert_asset(full_path: &FullPath, asset: &Asset) {
+    with_assets_mut(|assets| insert_asset_impl(full_path, asset, assets))
+}
+
+fn insert_asset_impl(full_path: &FullPath, asset: &Asset, assets: &mut AssetsHeap) {
+    assets.insert(full_path.clone(), asset.clone());
+}
+
+pub fn delete_asset(full_path: &FullPath) -> Option<Asset> {
+    with_assets_mut(|assets| delete_asset_impl(full_path, assets))
+}
+
+fn delete_asset_impl(full_path: &FullPath, assets: &mut AssetsHeap) -> Option<Asset> {
+    assets.remove(full_path)
+}
+
+pub fn collect_delete_assets(collection: &CollectionKey) -> Vec<FullPath> {
+    with_assets(|assets| collect_delete_assets_heap(collection, assets))
+}

--- a/src/console/src/cdn/storage/heap/store.rs
+++ b/src/console/src/cdn/storage/heap/store.rs
@@ -1,0 +1,67 @@
+use crate::cdn::storage::heap::{collect_delete_assets, delete_asset, get_asset};
+use crate::store::with_assets;
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::rules::Memory;
+use junobuild_shared::list::list_values;
+use junobuild_shared::types::list::{ListParams, ListResults};
+use junobuild_storage::heap_utils::collect_assets_heap;
+use junobuild_storage::types::interface::AssetNoContent;
+use junobuild_storage::types::state::FullPath;
+use junobuild_storage::types::store::Asset;
+use junobuild_storage::utils::{get_token_protected_asset, map_asset_no_content};
+
+// ---------------------------------------------------------
+// Assets
+// ---------------------------------------------------------
+
+pub fn list_assets(
+    collection: &CollectionKey,
+    filters: &ListParams,
+) -> ListResults<AssetNoContent> {
+    with_assets(|assets| {
+        let assets = collect_assets_heap(collection, assets);
+        list_assets_impl(&assets, filters)
+    })
+}
+
+fn list_assets_impl(
+    assets: &[(&FullPath, &Asset)],
+    filters: &ListParams,
+) -> ListResults<AssetNoContent> {
+    let values = list_values(assets, filters);
+
+    ListResults::<AssetNoContent> {
+        items: values
+            .items
+            .into_iter()
+            .map(|(_, asset)| map_asset_no_content(&asset))
+            .collect(),
+        items_length: values.items_length,
+        items_page: values.items_page,
+        matches_length: values.matches_length,
+        matches_pages: values.matches_pages,
+    }
+}
+
+pub fn get_public_asset(full_path: FullPath, token: Option<String>) -> Option<(Asset, Memory)> {
+    let asset = get_asset(&full_path);
+
+    match asset {
+        None => None,
+        Some(asset) => match &asset.key.token {
+            None => Some((asset.clone(), Memory::Heap)),
+            Some(asset_token) => {
+                let protected_asset = get_token_protected_asset(&asset, asset_token, token);
+                protected_asset.map(|protected_asset| (protected_asset, Memory::Heap))
+            }
+        },
+    }
+}
+
+pub fn delete_assets(collection: &CollectionKey) {
+    let full_paths = collect_delete_assets(collection);
+
+    for full_path in full_paths {
+        delete_asset(&full_path);
+    }
+}

--- a/src/console/src/cdn/storage/mod.rs
+++ b/src/console/src/cdn/storage/mod.rs
@@ -1,3 +1,4 @@
 mod certified_assets;
+pub mod heap;
 
 pub use certified_assets::*;


### PR DESCRIPTION
# Motivation

We want to make the CDN supports assets on stable. The Console does / will not support at the moment this option. That's why, instead of extending the CDN we will move out accessing the assets in the CDN crate and defer this to consumers. This is also more accurate than current implementation.

This PR copies code but, does not use it yet.
