### PR TITLE
feat(cdn): new implementation CdnCommitAssets

### DIFF
--- a/src/console/src/cdn/strategies_impls/cdn.rs
+++ b/src/console/src/cdn/strategies_impls/cdn.rs
@@ -1,12 +1,17 @@
 use crate::cdn::proposals::post_commit_assets;
+use crate::cdn::storage::heap::insert_asset;
+use crate::cdn::storage::heap::store::delete_assets;
 use crate::memory::manager::STATE;
 use junobuild_cdn::proposals::{Proposal, ProposalsStable};
 use junobuild_cdn::storage::{ProposalAssetsStable, ProposalContentChunksStable};
-use junobuild_cdn::strategies::{CdnHeapStrategy, CdnStableStrategy, CdnWorkflowStrategy};
-use junobuild_collections::types::rules::Rules;
+use junobuild_cdn::strategies::{CdnCommitAssetsStrategy, CdnHeapStrategy, CdnStableStrategy, CdnWorkflowStrategy};
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::rules::{Rule, Rules};
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_storage::types::config::StorageConfig;
-use junobuild_storage::types::state::AssetsHeap;
+use junobuild_storage::types::state::{AssetsHeap, FullPath};
+use junobuild_storage::types::store::{Asset, AssetEncoding};
+use junobuild_storage::utils::insert_encoding_into_asset;
 
 pub struct CdnHeap;
 
@@ -119,5 +124,36 @@ impl CdnWorkflowStrategy for CdnWorkflow {
 
     fn post_commit_assets(&self, proposal: &Proposal) -> Result<(), String> {
         post_commit_assets(proposal)
+    }
+}
+
+pub struct CdnCommitAssets;
+
+impl CdnCommitAssetsStrategy for CdnCommitAssets {
+    fn insert_asset(
+        &self,
+        _collection: &CollectionKey,
+        full_path: &FullPath,
+        asset: &Asset,
+        _rule: &Rule,
+    ) {
+        insert_asset(full_path, asset);
+    }
+
+    fn insert_asset_encoding(
+        &self,
+        _full_path: &FullPath,
+        encoding_type: &str,
+        encoding: &AssetEncoding,
+        asset: &mut Asset,
+        _rule: &Rule,
+    ) {
+        insert_encoding_into_asset(encoding_type, encoding, asset)
+    }
+
+    fn delete_assets(&self, collection: &CollectionKey) -> Result<(), String> {
+        delete_assets(collection);
+
+        Ok(())
     }
 }

--- a/src/libs/cdn/src/strategies.rs
+++ b/src/libs/cdn/src/strategies.rs
@@ -1,9 +1,11 @@
 use crate::proposals::{Proposal, ProposalsStable};
 use crate::storage::{ProposalAssetsStable, ProposalContentChunksStable};
-use junobuild_collections::types::rules::Rules;
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::rules::{Rule, Rules};
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_storage::types::config::StorageConfig;
-use junobuild_storage::types::state::AssetsHeap;
+use junobuild_storage::types::state::{AssetsHeap, FullPath};
+use junobuild_storage::types::store::{Asset, AssetEncoding};
 
 pub trait CdnHeapStrategy {
     fn with_assets<R>(&self, f: impl FnOnce(&AssetsHeap) -> R) -> R;
@@ -35,4 +37,25 @@ pub trait CdnStableStrategy {
 pub trait CdnWorkflowStrategy {
     fn pre_commit_assets(&self, proposal: &Proposal) -> Result<(), String>;
     fn post_commit_assets(&self, proposal: &Proposal) -> Result<(), String>;
+}
+
+pub trait CdnCommitAssetsStrategy {
+    fn insert_asset(
+        &self,
+        collection: &CollectionKey,
+        full_path: &FullPath,
+        asset: &Asset,
+        rule: &Rule,
+    );
+
+    fn insert_asset_encoding(
+        &self,
+        full_path: &FullPath,
+        encoding_type: &str,
+        encoding: &AssetEncoding,
+        asset: &mut Asset,
+        rule: &Rule,
+    );
+
+    fn delete_assets(&self, collection: &CollectionKey) -> Result<(), String>;
 }

--- a/src/libs/satellite/src/assets/storage/internal.rs
+++ b/src/libs/satellite/src/assets/storage/internal.rs
@@ -1,8 +1,35 @@
-use crate::assets::storage::state::delete_asset;
+use crate::assets::storage::state::{delete_asset, insert_asset, insert_asset_encoding};
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::Rule;
 use junobuild_storage::types::state::FullPath;
-use junobuild_storage::types::store::Asset;
+use junobuild_storage::types::store::{Asset, AssetEncoding};
+
+/// Insert an asset directly into the state.
+///
+/// ⚠️ **Warning:** This function is for internal use only and does not perform any assertions.
+///
+pub fn unsafe_insert_asset(
+    collection: &CollectionKey,
+    full_path: &FullPath,
+    asset: &Asset,
+    rule: &Rule,
+) {
+    insert_asset(collection, full_path, asset, rule)
+}
+
+/// Insert encoding into the asset or within the stable tree map.
+///
+/// ⚠️ **Warning:** This function is for internal use only and does not perform any assertions.
+///
+pub fn unsafe_insert_asset_encoding(
+    full_path: &FullPath,
+    encoding_type: &str,
+    encoding: &AssetEncoding,
+    asset: &mut Asset,
+    rule: &Rule,
+) {
+    insert_asset_encoding(full_path, encoding_type, encoding, asset, rule)
+}
 
 /// Deletes an asset directly from the state.
 ///


### PR DESCRIPTION
# Motivation

We want the CDN to support heap and stable. That's why we introduce a new implementation `CdnCommitAssets` which will be used to commit the assets when proposal are executed - i.e. an implementation which in the Satellite can be use to commit the assets either on heap or stable and in the Console only on heap.
