### PR TITLE
feat(cdn): use commit assets strategy and support for stable

### DIFF
--- a/src/console/src/cdn/proposals.rs
+++ b/src/console/src/cdn/proposals.rs
@@ -1,4 +1,4 @@
-use crate::cdn::strategies_impls::cdn::{CdnHeap, CdnStable, CdnWorkflow};
+use crate::cdn::strategies_impls::cdn::{CdnCommitAssets, CdnHeap, CdnStable, CdnWorkflow};
 use crate::metadata::update_releases_metadata;
 use candid::Principal;
 use junobuild_cdn::proposals::{
@@ -34,7 +34,13 @@ pub fn reject_proposal(proposition: &RejectProposal) -> Result<(), RejectProposa
 }
 
 pub fn commit_proposal(proposition: &CommitProposal) -> Result<(), CommitProposalError> {
-    junobuild_cdn::proposals::commit_proposal(&CdnHeap, &CdnStable, &CdnWorkflow, proposition)
+    junobuild_cdn::proposals::commit_proposal(
+        &CdnHeap,
+        &CdnCommitAssets,
+        &CdnStable,
+        &CdnWorkflow,
+        proposition,
+    )
 }
 
 pub fn delete_proposal_assets(proposal_ids: &Vec<ProposalId>) -> Result<(), String> {

--- a/src/libs/cdn/src/proposals/workflows/commit.rs
+++ b/src/libs/cdn/src/proposals/workflows/commit.rs
@@ -6,15 +6,20 @@ use crate::proposals::errors::{
 use crate::proposals::workflows::assert::assert_known_proposal_type;
 use crate::proposals::{get_proposal, insert_proposal};
 use crate::proposals::{CommitProposal, CommitProposalError, Proposal, ProposalId, ProposalStatus};
-use crate::storage::heap::insert_asset;
-use crate::storage::heap::store::insert_asset_encoding;
+use crate::storage::heap::get_rule;
 use crate::storage::stable::{get_assets, get_content_chunks};
-use crate::strategies::{CdnHeapStrategy, CdnStableStrategy, CdnWorkflowStrategy};
+use crate::strategies::{
+    CdnCommitAssetsStrategy, CdnHeapStrategy, CdnStableStrategy, CdnWorkflowStrategy,
+};
 use hex::encode;
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::rules::Rule;
 use junobuild_storage::types::store::AssetEncoding;
+use std::collections::HashMap;
 
 pub fn commit_proposal(
     cdn_heap: &impl CdnHeapStrategy,
+    cdn_commit_assets: &impl CdnCommitAssetsStrategy,
     cdn_stable: &impl CdnStableStrategy,
     cdn_workflow: &impl CdnWorkflowStrategy,
     proposition: &CommitProposal,
@@ -26,7 +31,14 @@ pub fn commit_proposal(
         ))
     })?;
 
-    match secure_commit_proposal(cdn_heap, cdn_stable, cdn_workflow, proposition, &proposal) {
+    match secure_commit_proposal(
+        cdn_heap,
+        cdn_commit_assets,
+        cdn_stable,
+        cdn_workflow,
+        proposition,
+        &proposal,
+    ) {
         Ok(_) => {
             let executed_proposal = Proposal::execute(&proposal);
             insert_proposal(cdn_stable, &proposition.proposal_id, &executed_proposal);
@@ -45,6 +57,7 @@ pub fn commit_proposal(
 
 fn secure_commit_proposal(
     cdn_heap: &impl CdnHeapStrategy,
+    cdn_commit_assets: &impl CdnCommitAssetsStrategy,
     cdn_stable: &impl CdnStableStrategy,
     cdn_workflow: &impl CdnWorkflowStrategy,
     commit_proposal: &CommitProposal,
@@ -78,8 +91,13 @@ fn secure_commit_proposal(
         .pre_commit_assets(proposal)
         .map_err(CommitProposalError::PreCommitAssetsIssue)?;
 
-    copy_committed_assets(cdn_heap, cdn_stable, &commit_proposal.proposal_id)
-        .map_err(CommitProposalError::CommitAssetsIssue)?;
+    copy_committed_assets(
+        cdn_heap,
+        cdn_commit_assets,
+        cdn_stable,
+        &commit_proposal.proposal_id,
+    )
+    .map_err(CommitProposalError::CommitAssetsIssue)?;
 
     cdn_workflow
         .post_commit_assets(proposal)
@@ -90,6 +108,7 @@ fn secure_commit_proposal(
 
 fn copy_committed_assets(
     cdn_heap: &impl CdnHeapStrategy,
+    cdn_commit_assets: &impl CdnCommitAssetsStrategy,
     cdn_stable: &impl CdnStableStrategy,
     proposal_id: &ProposalId,
 ) -> Result<(), String> {
@@ -102,10 +121,19 @@ fn copy_committed_assets(
         ));
     }
 
-    for (key, asset) in assets {
-        insert_asset(cdn_heap, &key.full_path, &asset);
+    // We cache the rules for performance. With current implementation
+    // there should be only one rule for all assets.
+    let mut rule_cache: HashMap<CollectionKey, Rule> = HashMap::new();
 
-        for (encoding_type, encoding) in asset.encodings {
+    for (key, mut asset) in assets {
+        let rule = rule_cache
+            .entry(key.collection.clone())
+            .or_insert_with(|| get_rule(cdn_heap, &key.collection).unwrap())
+            .clone();
+
+        let encodings = std::mem::take(&mut asset.encodings);
+
+        for (encoding_type, encoding) in encodings {
             let mut content_chunks = Vec::new();
 
             for (i, _) in encoding.content_chunks.iter().enumerate() {
@@ -129,12 +157,15 @@ fn copy_committed_assets(
                 ..encoding
             };
 
-            insert_asset_encoding(
-                cdn_heap,
+            cdn_commit_assets.insert_asset_encoding(
                 &key.full_path,
                 &encoding_type,
                 &encoding_with_content,
-            )?;
+                &mut asset,
+                &rule,
+            );
+
+            cdn_commit_assets.insert_asset(&key.collection, &key.full_path, &asset, &rule);
         }
     }
 

--- a/src/libs/satellite/src/api/cdn.rs
+++ b/src/libs/satellite/src/api/cdn.rs
@@ -1,6 +1,6 @@
 use crate::assets::cdn::helpers::stable::get_proposal as cdn_get_proposal;
 use crate::assets::cdn::helpers::store::init_asset_upload as init_asset_upload_store;
-use crate::assets::cdn::strategies_impls::cdn::{CdnHeap, CdnStable, CdnWorkflow};
+use crate::assets::cdn::strategies_impls::cdn::{CdnCommitAssets, CdnHeap, CdnStable, CdnWorkflow};
 use crate::assets::cdn::strategies_impls::storage::{
     CdnStorageAssertions, CdnStorageState, CdnStorageUpload,
 };
@@ -61,7 +61,13 @@ pub fn reject_proposal(proposal: &RejectProposal) -> ManualReply<()> {
 }
 
 pub fn commit_proposal(proposal: &CommitProposal) -> ManualReply<()> {
-    match junobuild_cdn::proposals::commit_proposal(&CdnHeap, &CdnStable, &CdnWorkflow, proposal) {
+    match junobuild_cdn::proposals::commit_proposal(
+        &CdnHeap,
+        &CdnCommitAssets,
+        &CdnStable,
+        &CdnWorkflow,
+        proposal,
+    ) {
         Ok(_) => {
             defer_init_certified_assets();
             ManualReply::one(())


### PR DESCRIPTION
# Motivation

We want the CDN to support stable assets, that's why this PR uses the new implementation to commit the assets when a proposal is executed.

In addition, it also implements the logic to support stable assets - i.e. `insert_asset_encoding` first and then `insert_asset`.

We also introduces a cache to resolve the rules even though at the moment, a batch targets always a single collection.
