### PR TITLE
feat(console): use crate heap functions

### DIFF
--- a/src/console/src/api/storage.rs
+++ b/src/console/src/api/storage.rs
@@ -104,5 +104,5 @@ fn commit_proposal_many_assets_upload(commits: Vec<CommitBatch>) {
 
 #[query(guard = "caller_is_admin_controller")]
 pub fn list_assets(collection: CollectionKey, filter: ListParams) -> ListResults<AssetNoContent> {
-    junobuild_cdn::storage::heap::list_assets(&CdnHeap, &collection, &filter)
+    crate::cdn::storage::heap::list_assets(&collection, &filter)
 }

--- a/src/console/src/cdn/helpers/heap.rs
+++ b/src/console/src/cdn/helpers/heap.rs
@@ -11,15 +11,15 @@ use junobuild_storage::types::store::Asset;
 // ---------------------------------------------------------
 
 pub fn get_asset(full_path: &FullPath) -> Option<Asset> {
-    junobuild_cdn::storage::heap::get_asset(&CdnHeap, full_path)
+    crate::cdn::storage::heap::get_asset(full_path)
 }
 
 pub fn insert_asset(full_path: &FullPath, asset: &Asset) {
-    junobuild_cdn::storage::heap::insert_asset(&CdnHeap, full_path, asset)
+    crate::cdn::storage::heap::insert_asset(full_path, asset)
 }
 
 pub fn delete_asset(full_path: &FullPath) -> Option<Asset> {
-    junobuild_cdn::storage::heap::delete_asset(&CdnHeap, full_path)
+    crate::cdn::storage::heap::delete_asset(full_path)
 }
 
 // ---------------------------------------------------------

--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -6,7 +6,6 @@ use crate::cdn::helpers::stable::{
     get_asset_stable, insert_asset_encoding_stable, insert_asset_stable,
 };
 use crate::cdn::storage::init_certified_assets;
-use crate::cdn::strategies_impls::cdn::CdnHeap;
 use candid::Principal;
 use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID,
@@ -130,7 +129,7 @@ impl StorageStateStrategy for StorageState {
         full_path: FullPath,
         token: Option<String>,
     ) -> Option<(Asset, Memory)> {
-        junobuild_cdn::storage::heap::get_public_asset(&CdnHeap, full_path, token)
+        crate::cdn::storage::heap::get_public_asset(full_path, token)
     }
 
     fn get_rule(&self, collection: &CollectionKey) -> Result<Rule, String> {


### PR DESCRIPTION
# Motivation

We copied the heap funcitons in the console in #1965. Therefore, we want to use those instead of those of the CDN.
