### PR TITLE
feat(factory): create satellite with storage options through mission control and console

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -45,6 +45,12 @@ type CreateCanisterArgs = record {
   subnet_id : opt principal;
   user : principal;
 };
+type CreateSatelliteArgs = record {
+  block_index : opt nat64;
+  subnet_id : opt principal;
+  storage : opt InitStorageArgs;
+  user : principal;
+};
 type CustomDomain = record {
   updated_at : nat64;
   created_at : nat64;
@@ -75,6 +81,8 @@ type InitAssetKey = record {
   encoding_type : opt text;
   full_path : text;
 };
+type InitStorageArgs = record { system_memory : opt InitStorageMemory };
+type InitStorageMemory = variant { Heap; Stable };
 type InitUploadResult = record { batch_id : nat };
 type ListMatcher = record {
   key : opt text;
@@ -229,7 +237,7 @@ service : () -> {
   commit_proposal_many_assets_upload : (vec CommitBatch) -> ();
   count_proposals : () -> (nat64) query;
   create_orbiter : (CreateCanisterArgs) -> (principal);
-  create_satellite : (CreateCanisterArgs) -> (principal);
+  create_satellite : (CreateSatelliteArgs) -> (principal);
   del_controllers : (DeleteControllersArgs) -> ();
   del_custom_domain : (text) -> ();
   delete_proposal_assets : (DeleteProposalAssets) -> ();

--- a/src/console/src/api/factory.rs
+++ b/src/console/src/api/factory.rs
@@ -4,10 +4,10 @@ use candid::Principal;
 use ic_cdk_macros::update;
 use junobuild_shared::ic::api::{caller, id};
 use junobuild_shared::ic::UnwrapOrTrap;
-use junobuild_shared::types::interface::CreateCanisterArgs;
+use junobuild_shared::types::interface::{CreateCanisterArgs, CreateSatelliteArgs};
 
 #[update]
-async fn create_satellite(args: CreateCanisterArgs) -> Principal {
+async fn create_satellite(args: CreateSatelliteArgs) -> Principal {
     let console = id();
     let caller = caller();
 

--- a/src/console/src/factory/utils/wasm.rs
+++ b/src/console/src/factory/utils/wasm.rs
@@ -7,7 +7,7 @@ use candid::Encode;
 use junobuild_shared::mgmt::types::ic::WasmArg;
 use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::interface::{
-    InitMissionControlArgs, InitOrbiterArgs, InitSatelliteArgs,
+    InitMissionControlArgs, InitOrbiterArgs, InitSatelliteArgs, InitStorageArgs,
 };
 use junobuild_shared::types::state::{MissionControlId, UserId};
 use junobuild_storage::constants::ASSET_ENCODING_NO_COMPRESSION;
@@ -49,6 +49,7 @@ pub fn mission_control_wasm_arg(user: &UserId) -> Result<WasmArg, String> {
 pub fn satellite_wasm_arg(
     user: &UserId,
     mission_control_id: &MissionControlId,
+    storage: Option<InitStorageArgs>,
 ) -> Result<WasmArg, String> {
     let latest_version =
         get_latest_satellite_version().ok_or("No satellite versions available.")?;
@@ -56,8 +57,7 @@ pub fn satellite_wasm_arg(
     let wasm: Blob = get_chunks(&full_path)?;
     let install_arg: Vec<u8> = Encode!(&InitSatelliteArgs {
         controllers: user_mission_control_controllers(user, mission_control_id),
-        // TODO: arguments to be implemented
-        storage: None
+        storage
     })
     .map_err(|e| e.to_string())?;
     Ok(WasmArg { wasm, install_arg })

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -32,6 +32,7 @@ use junobuild_shared::ic::call::ManualReply;
 use junobuild_shared::rate::types::RateConfig;
 use junobuild_shared::types::core::DomainName;
 use junobuild_shared::types::domain::CustomDomains;
+use junobuild_shared::types::interface::CreateSatelliteArgs;
 use junobuild_shared::types::interface::{
     AssertMissionControlCenterArgs, CreateCanisterArgs, DeleteControllersArgs,
     GetCreateCanisterFeeArgs, SetControllersArgs,

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -59,6 +59,12 @@ export interface CreateCanisterArgs {
 	subnet_id: [] | [Principal];
 	user: Principal;
 }
+export interface CreateSatelliteArgs {
+	block_index: [] | [bigint];
+	subnet_id: [] | [Principal];
+	storage: [] | [InitStorageArgs];
+	user: Principal;
+}
 export interface CustomDomain {
 	updated_at: bigint;
 	created_at: bigint;
@@ -95,6 +101,10 @@ export interface InitAssetKey {
 	encoding_type: [] | [string];
 	full_path: string;
 }
+export interface InitStorageArgs {
+	system_memory: [] | [InitStorageMemory];
+}
+export type InitStorageMemory = { Heap: null } | { Stable: null };
 export interface InitUploadResult {
 	batch_id: bigint;
 }
@@ -271,7 +281,7 @@ export interface _SERVICE {
 	commit_proposal_many_assets_upload: ActorMethod<[Array<CommitBatch>], undefined>;
 	count_proposals: ActorMethod<[], bigint>;
 	create_orbiter: ActorMethod<[CreateCanisterArgs], Principal>;
-	create_satellite: ActorMethod<[CreateCanisterArgs], Principal>;
+	create_satellite: ActorMethod<[CreateSatelliteArgs], Principal>;
 	del_controllers: ActorMethod<[DeleteControllersArgs], undefined>;
 	del_custom_domain: ActorMethod<[string], undefined>;
 	delete_proposal_assets: ActorMethod<[DeleteProposalAssets], undefined>;

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -19,6 +19,19 @@ export const idlFactory = ({ IDL }) => {
 		subnet_id: IDL.Opt(IDL.Principal),
 		user: IDL.Principal
 	});
+	const InitStorageMemory = IDL.Variant({
+		Heap: IDL.Null,
+		Stable: IDL.Null
+	});
+	const InitStorageArgs = IDL.Record({
+		system_memory: IDL.Opt(InitStorageMemory)
+	});
+	const CreateSatelliteArgs = IDL.Record({
+		block_index: IDL.Opt(IDL.Nat64),
+		subnet_id: IDL.Opt(IDL.Principal),
+		storage: IDL.Opt(InitStorageArgs),
+		user: IDL.Principal
+	});
 	const DeleteControllersArgs = IDL.Record({
 		controllers: IDL.Vec(IDL.Principal)
 	});
@@ -278,7 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),
 		count_proposals: IDL.Func([], [IDL.Nat64], []),
 		create_orbiter: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
-		create_satellite: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
+		create_satellite: IDL.Func([CreateSatelliteArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		delete_proposal_assets: IDL.Func([DeleteProposalAssets], [], []),

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -19,6 +19,19 @@ export const idlFactory = ({ IDL }) => {
 		subnet_id: IDL.Opt(IDL.Principal),
 		user: IDL.Principal
 	});
+	const InitStorageMemory = IDL.Variant({
+		Heap: IDL.Null,
+		Stable: IDL.Null
+	});
+	const InitStorageArgs = IDL.Record({
+		system_memory: IDL.Opt(InitStorageMemory)
+	});
+	const CreateSatelliteArgs = IDL.Record({
+		block_index: IDL.Opt(IDL.Nat64),
+		subnet_id: IDL.Opt(IDL.Principal),
+		storage: IDL.Opt(InitStorageArgs),
+		user: IDL.Principal
+	});
 	const DeleteControllersArgs = IDL.Record({
 		controllers: IDL.Vec(IDL.Principal)
 	});
@@ -278,7 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),
 		count_proposals: IDL.Func([], [IDL.Nat64], ['query']),
 		create_orbiter: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
-		create_satellite: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
+		create_satellite: IDL.Func([CreateSatelliteArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		delete_proposal_assets: IDL.Func([DeleteProposalAssets], [], []),

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -19,6 +19,19 @@ export const idlFactory = ({ IDL }) => {
 		subnet_id: IDL.Opt(IDL.Principal),
 		user: IDL.Principal
 	});
+	const InitStorageMemory = IDL.Variant({
+		Heap: IDL.Null,
+		Stable: IDL.Null
+	});
+	const InitStorageArgs = IDL.Record({
+		system_memory: IDL.Opt(InitStorageMemory)
+	});
+	const CreateSatelliteArgs = IDL.Record({
+		block_index: IDL.Opt(IDL.Nat64),
+		subnet_id: IDL.Opt(IDL.Principal),
+		storage: IDL.Opt(InitStorageArgs),
+		user: IDL.Principal
+	});
 	const DeleteControllersArgs = IDL.Record({
 		controllers: IDL.Vec(IDL.Principal)
 	});
@@ -278,7 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),
 		count_proposals: IDL.Func([], [IDL.Nat64], ['query']),
 		create_orbiter: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
-		create_satellite: IDL.Func([CreateCanisterArgs], [IDL.Principal], []),
+		create_satellite: IDL.Func([CreateSatelliteArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		delete_proposal_assets: IDL.Func([DeleteProposalAssets], [], []),

--- a/src/declarations/mission_control/mission_control.did.d.ts
+++ b/src/declarations/mission_control/mission_control.did.d.ts
@@ -21,6 +21,11 @@ export interface CreateCanisterConfig {
 	subnet_id: [] | [Principal];
 	name: [] | [string];
 }
+export interface CreateSatelliteConfig {
+	subnet_id: [] | [Principal];
+	storage: [] | [InitStorageArgs];
+	name: [] | [string];
+}
 export interface CyclesBalance {
 	timestamp: bigint;
 	amount: bigint;
@@ -78,6 +83,10 @@ export interface GetMonitoringHistory {
 export interface InitMissionControlArgs {
 	user: Principal;
 }
+export interface InitStorageArgs {
+	system_memory: [] | [InitStorageMemory];
+}
+export type InitStorageMemory = { Heap: null } | { Stable: null };
 export interface MissionControlSettings {
 	updated_at: bigint;
 	created_at: bigint;
@@ -193,7 +202,7 @@ export interface _SERVICE {
 	create_orbiter: ActorMethod<[[] | [string]], Orbiter>;
 	create_orbiter_with_config: ActorMethod<[CreateCanisterConfig], Orbiter>;
 	create_satellite: ActorMethod<[string], Satellite>;
-	create_satellite_with_config: ActorMethod<[CreateCanisterConfig], Satellite>;
+	create_satellite_with_config: ActorMethod<[CreateSatelliteConfig], Satellite>;
 	del_mission_control_controllers: ActorMethod<[Array<Principal>], undefined>;
 	del_orbiter: ActorMethod<[Principal, bigint], undefined>;
 	del_orbiters_controllers: ActorMethod<[Array<Principal>, Array<Principal>], undefined>;

--- a/src/declarations/mission_control/mission_control.factory.certified.did.js
+++ b/src/declarations/mission_control/mission_control.factory.certified.did.js
@@ -32,6 +32,18 @@ export const idlFactory = ({ IDL }) => {
 		satellite_id: IDL.Principal,
 		settings: IDL.Opt(Settings)
 	});
+	const InitStorageMemory = IDL.Variant({
+		Heap: IDL.Null,
+		Stable: IDL.Null
+	});
+	const InitStorageArgs = IDL.Record({
+		system_memory: IDL.Opt(InitStorageMemory)
+	});
+	const CreateSatelliteConfig = IDL.Record({
+		subnet_id: IDL.Opt(IDL.Principal),
+		storage: IDL.Opt(InitStorageArgs),
+		name: IDL.Opt(IDL.Text)
+	});
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
@@ -187,7 +199,7 @@ export const idlFactory = ({ IDL }) => {
 		create_orbiter: IDL.Func([IDL.Opt(IDL.Text)], [Orbiter], []),
 		create_orbiter_with_config: IDL.Func([CreateCanisterConfig], [Orbiter], []),
 		create_satellite: IDL.Func([IDL.Text], [Satellite], []),
-		create_satellite_with_config: IDL.Func([CreateCanisterConfig], [Satellite], []),
+		create_satellite_with_config: IDL.Func([CreateSatelliteConfig], [Satellite], []),
 		del_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal)], [], []),
 		del_orbiter: IDL.Func([IDL.Principal, IDL.Nat], [], []),
 		del_orbiters_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),

--- a/src/declarations/mission_control/mission_control.factory.did.js
+++ b/src/declarations/mission_control/mission_control.factory.did.js
@@ -32,6 +32,18 @@ export const idlFactory = ({ IDL }) => {
 		satellite_id: IDL.Principal,
 		settings: IDL.Opt(Settings)
 	});
+	const InitStorageMemory = IDL.Variant({
+		Heap: IDL.Null,
+		Stable: IDL.Null
+	});
+	const InitStorageArgs = IDL.Record({
+		system_memory: IDL.Opt(InitStorageMemory)
+	});
+	const CreateSatelliteConfig = IDL.Record({
+		subnet_id: IDL.Opt(IDL.Principal),
+		storage: IDL.Opt(InitStorageArgs),
+		name: IDL.Opt(IDL.Text)
+	});
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
@@ -187,7 +199,7 @@ export const idlFactory = ({ IDL }) => {
 		create_orbiter: IDL.Func([IDL.Opt(IDL.Text)], [Orbiter], []),
 		create_orbiter_with_config: IDL.Func([CreateCanisterConfig], [Orbiter], []),
 		create_satellite: IDL.Func([IDL.Text], [Satellite], []),
-		create_satellite_with_config: IDL.Func([CreateCanisterConfig], [Satellite], []),
+		create_satellite_with_config: IDL.Func([CreateSatelliteConfig], [Satellite], []),
 		del_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal)], [], []),
 		del_orbiter: IDL.Func([IDL.Principal, IDL.Nat], [], []),
 		del_orbiters_controllers: IDL.Func([IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal)], [], []),

--- a/src/frontend/src/lib/services/satellites.services.ts
+++ b/src/frontend/src/lib/services/satellites.services.ts
@@ -51,7 +51,9 @@ export const createSatelliteWithConfig = async ({
 
 	return create_satellite_with_config({
 		name: toNullable(name),
-		subnet_id: toNullable(subnetId)
+		subnet_id: toNullable(subnetId),
+		// TODO
+		storage: []
 	});
 };
 

--- a/src/libs/shared/src/impls.rs
+++ b/src/libs/shared/src/impls.rs
@@ -1,4 +1,5 @@
 use crate::types::domain::CustomDomain;
+use crate::types::interface::{CreateCanisterArgs, CreateSatelliteArgs};
 use crate::types::state::{OrbiterSatelliteConfig, SegmentKind, Version, Versioned};
 use crate::types::utils::CalendarDate;
 use std::fmt::{Display, Formatter, Result};
@@ -33,5 +34,15 @@ impl Versioned for CustomDomain {
 impl Versioned for &OrbiterSatelliteConfig {
     fn version(&self) -> Option<Version> {
         self.version
+    }
+}
+
+impl From<CreateSatelliteArgs> for CreateCanisterArgs {
+    fn from(args: CreateSatelliteArgs) -> Self {
+        Self {
+            user: args.user,
+            block_index: args.block_index,
+            subnet_id: args.subnet_id,
+        }
     }
 }

--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -139,6 +139,14 @@ pub mod interface {
     }
 
     #[derive(CandidType, Deserialize)]
+    pub struct CreateSatelliteArgs {
+        pub user: UserId,
+        pub block_index: Option<BlockIndex>,
+        pub subnet_id: Option<SubnetId>,
+        pub storage: Option<InitStorageArgs>,
+    }
+
+    #[derive(CandidType, Deserialize)]
     pub struct GetCreateCanisterFeeArgs {
         pub user: UserId,
     }
@@ -159,12 +167,12 @@ pub mod interface {
         pub storage: Option<InitStorageArgs>,
     }
 
-    #[derive(CandidType, Deserialize)]
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct InitStorageArgs {
         pub system_memory: Option<InitStorageMemory>,
     }
 
-    #[derive(CandidType, Deserialize)]
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub enum InitStorageMemory {
         Heap,
         Stable,

--- a/src/mission_control/mission_control.did
+++ b/src/mission_control/mission_control.did
@@ -12,6 +12,11 @@ type CreateCanisterConfig = record {
   subnet_id : opt principal;
   name : opt text;
 };
+type CreateSatelliteConfig = record {
+  subnet_id : opt principal;
+  storage : opt InitStorageArgs;
+  name : opt text;
+};
 type CyclesBalance = record { timestamp : nat64; amount : nat };
 type CyclesMonitoring = record {
   strategy : opt CyclesMonitoringStrategy;
@@ -59,6 +64,8 @@ type GetMonitoringHistory = record {
   segment_id : principal;
 };
 type InitMissionControlArgs = record { user : principal };
+type InitStorageArgs = record { system_memory : opt InitStorageMemory };
+type InitStorageMemory = variant { Heap; Stable };
 type MissionControlSettings = record {
   updated_at : nat64;
   created_at : nat64;
@@ -158,7 +165,7 @@ service : (InitMissionControlArgs) -> {
   create_orbiter : (opt text) -> (Orbiter);
   create_orbiter_with_config : (CreateCanisterConfig) -> (Orbiter);
   create_satellite : (text) -> (Satellite);
-  create_satellite_with_config : (CreateCanisterConfig) -> (Satellite);
+  create_satellite_with_config : (CreateSatelliteConfig) -> (Satellite);
   del_mission_control_controllers : (vec principal) -> ();
   del_orbiter : (principal, nat) -> ();
   del_orbiters_controllers : (vec principal, vec principal) -> ();

--- a/src/mission_control/src/api/satellites.rs
+++ b/src/mission_control/src/api/satellites.rs
@@ -11,7 +11,7 @@ use crate::segments::satellite::{
 use crate::segments::store::{
     get_satellites, set_satellite_metadata as set_satellite_metadata_store,
 };
-use crate::types::interface::CreateCanisterConfig;
+use crate::types::interface::CreateSatelliteConfig;
 use crate::types::state::{Satellite, Satellites};
 use ic_cdk_macros::{query, update};
 use junobuild_shared::ic::UnwrapOrTrap;
@@ -30,7 +30,7 @@ async fn create_satellite(name: String) -> Satellite {
 }
 
 #[update(guard = "caller_is_user_or_admin_controller")]
-async fn create_satellite_with_config(config: CreateCanisterConfig) -> Satellite {
+async fn create_satellite_with_config(config: CreateSatelliteConfig) -> Satellite {
     create_satellite_with_config_console(&config)
         .await
         .unwrap_or_trap()

--- a/src/mission_control/src/impls.rs
+++ b/src/mission_control/src/impls.rs
@@ -1,5 +1,6 @@
 use crate::memory::manager::init_stable_state;
 use crate::types::core::{Segment, SettingsMonitoring};
+use crate::types::interface::{CreateCanisterConfig, CreateSatelliteConfig};
 use crate::types::state::CyclesMonitoringStrategy::BelowThreshold;
 use crate::types::state::{
     Config, CyclesMonitoring, CyclesMonitoringStrategy, HeapState, MissionControlSettings,
@@ -330,4 +331,13 @@ impl Storable for MonitoringHistoryKey {
     }
 
     const BOUND: Bound = Bound::Unbounded;
+}
+
+impl From<&CreateSatelliteConfig> for CreateCanisterConfig {
+    fn from(args: &CreateSatelliteConfig) -> Self {
+        Self {
+            name: args.name.clone(),
+            subnet_id: args.subnet_id,
+        }
+    }
 }

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -13,6 +13,7 @@ mod types;
 mod user;
 
 use crate::types::interface::CreateCanisterConfig;
+use crate::types::interface::CreateSatelliteConfig;
 use crate::types::interface::GetMonitoringHistory;
 use crate::types::interface::MonitoringStartConfig;
 use crate::types::interface::MonitoringStatus;

--- a/src/mission_control/src/segments/satellite.rs
+++ b/src/mission_control/src/segments/satellite.rs
@@ -3,7 +3,7 @@ use crate::segments::msg::SATELLITE_NOT_FOUND;
 use crate::segments::store::{
     add_satellite, delete_satellite as delete_satellite_store, get_satellite,
 };
-use crate::types::interface::CreateCanisterConfig;
+use crate::types::interface::{CreateCanisterConfig, CreateSatelliteConfig};
 use crate::types::state::Satellite;
 use candid::Principal;
 use ic_cdk::api::call::CallResult;
@@ -11,30 +11,45 @@ use ic_cdk::call;
 use ic_ledger_types::BlockIndex;
 use junobuild_shared::env::CONSOLE;
 use junobuild_shared::types::domain::CustomDomains;
-use junobuild_shared::types::interface::CreateCanisterArgs;
+use junobuild_shared::types::interface::CreateSatelliteArgs;
 use junobuild_shared::types::state::{SatelliteId, UserId};
 
+#[deprecated(
+    since = "0.1.1",
+    note = "please use `create_satellite_with_config` instead"
+)]
 pub async fn create_satellite(name: &str) -> Result<Satellite, String> {
-    let config: CreateCanisterConfig = CreateCanisterConfig {
+    let config: CreateSatelliteConfig = CreateSatelliteConfig {
         name: Some(name.to_string()),
         subnet_id: None,
+        storage: None,
     };
+
+    let args: CreateCanisterConfig = (&config).into();
 
     create_canister(
         "get_create_satellite_fee",
-        create_and_save_satellite,
-        &config,
+        move |user, _config, block_index| async move {
+            create_and_save_satellite(user, config.clone(), block_index).await
+        },
+        &args,
     )
     .await
 }
 
 pub async fn create_satellite_with_config(
-    config: &CreateCanisterConfig,
+    config: &CreateSatelliteConfig,
 ) -> Result<Satellite, String> {
+    let satellite_config = config.clone();
+
+    let args: CreateCanisterConfig = (&satellite_config).into();
+
     create_canister(
         "get_create_satellite_fee",
-        create_and_save_satellite,
-        config,
+        move |user, _config, block_index| async move {
+            create_and_save_satellite(user, satellite_config, block_index).await
+        },
+        &args,
     )
     .await
 }
@@ -59,15 +74,20 @@ pub async fn delete_satellite(
 
 async fn create_and_save_satellite(
     user: UserId,
-    CreateCanisterConfig { name, subnet_id }: CreateCanisterConfig,
+    CreateSatelliteConfig {
+        name,
+        subnet_id,
+        storage,
+    }: CreateSatelliteConfig,
     block_index: Option<BlockIndex>,
 ) -> Result<Satellite, String> {
     let console = Principal::from_text(CONSOLE).unwrap();
 
-    let args = CreateCanisterArgs {
+    let args = CreateSatelliteArgs {
         user,
         block_index,
         subnet_id,
+        storage,
     };
 
     let result: CallResult<(SatelliteId,)> = call(console, "create_satellite", (args,)).await;

--- a/src/mission_control/src/types.rs
+++ b/src/mission_control/src/types.rs
@@ -170,6 +170,7 @@ pub mod interface {
     use crate::types::state::CyclesMonitoringStrategy;
     use candid::CandidType;
     use junobuild_shared::mgmt::types::cmc::SubnetId;
+    use junobuild_shared::types::interface::InitStorageArgs;
     use junobuild_shared::types::state::{OrbiterId, SatelliteId, SegmentId, Timestamp};
     use serde::{Deserialize, Serialize};
 
@@ -177,6 +178,13 @@ pub mod interface {
     pub struct CreateCanisterConfig {
         pub name: Option<String>,
         pub subnet_id: Option<SubnetId>,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize, Clone)]
+    pub struct CreateSatelliteConfig {
+        pub name: Option<String>,
+        pub subnet_id: Option<SubnetId>,
+        pub storage: Option<InitStorageArgs>,
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]

--- a/src/tests/specs/console/console.factory.spec.ts
+++ b/src/tests/specs/console/console.factory.spec.ts
@@ -21,10 +21,10 @@ import {
 import { inject } from 'vitest';
 import { CONSOLE_ID } from '../../constants/console-tests.constants';
 import { MEMORIES } from '../../constants/satellite-tests.constants';
-import { deploySegments } from '../../utils/console-tests.utils';
+import { deploySegments, updateRateConfig } from '../../utils/console-tests.utils';
 import { canisterStatus } from '../../utils/ic-management-tests.utils';
-import { CONSOLE_WASM_PATH } from '../../utils/setup-tests.utils';
 import { tick } from '../../utils/pic-tests.utils';
+import { CONSOLE_WASM_PATH } from '../../utils/setup-tests.utils';
 
 describe('Console', () => {
 	let pic: PocketIc;
@@ -180,6 +180,12 @@ describe('Console', () => {
 		describe('satellite', () => {
 			let satelliteId: Principal;
 
+			beforeAll(async () => {
+				actor.setIdentity(controller);
+
+				await updateRateConfig({ actor });
+			});
+
 			describe('Settings', () => {
 				beforeAll(async () => {
 					assertNonNullish(missionControlId);
@@ -243,6 +249,8 @@ describe('Console', () => {
 						);
 						micActor.setIdentity(user);
 
+						await tick(pic);
+
 						const { create_satellite_with_config } = micActor;
 						const { satellite_id } = await create_satellite_with_config({
 							name: toNullable(title),
@@ -273,7 +281,7 @@ describe('Console', () => {
 
 							const ruleMemory = fromNullishNullable(result?.memory);
 
-							expect(ruleMemory).toEqual(memory);
+							expect(ruleMemory).toEqual(memory ?? { Heap: null });
 						}
 					});
 

--- a/src/tests/specs/console/console.upgrade.spec.ts
+++ b/src/tests/specs/console/console.upgrade.spec.ts
@@ -17,6 +17,7 @@ import {
 	initMissionControls,
 	installReleasesWithDeprecatedFlow,
 	testSatelliteExists,
+	updateRateConfig,
 	uploadFileWithProposal
 } from '../../utils/console-tests.utils';
 import { tick } from '../../utils/pic-tests.utils';
@@ -66,23 +67,6 @@ describe('Console > Upgrade', () => {
 				missionControls.find(([key]) => key.toText() === user.getPrincipal().toText())
 			).not.toBeUndefined();
 		}
-	};
-
-	const updateRateConfig = async ({
-		actor
-	}: {
-		actor: Actor<ConsoleActor_0_0_8 | ConsoleActor_0_0_14 | ConsoleActor>;
-	}) => {
-		const { update_rate_config } = actor;
-
-		const config = {
-			max_tokens: 100n,
-			time_per_token_ns: 60n
-		};
-
-		await update_rate_config({ Satellite: null }, config);
-		await update_rate_config({ Orbiter: null }, config);
-		await update_rate_config({ MissionControl: null }, config);
 	};
 
 	const testProposal = async ({

--- a/src/tests/utils/console-tests.utils.ts
+++ b/src/tests/utils/console-tests.utils.ts
@@ -460,3 +460,20 @@ export const assertAssetServed = async ({
 
 	expect(decoder.decode(body as Uint8Array<ArrayBufferLike>)).toEqual(content);
 };
+
+export const updateRateConfig = async ({
+	actor
+}: {
+	actor: Actor<ConsoleActor_0_0_8 | ConsoleActor_0_0_14 | ConsoleActor>;
+}) => {
+	const { update_rate_config } = actor;
+
+	const config = {
+		max_tokens: 100n,
+		time_per_token_ns: 60n
+	};
+
+	await update_rate_config({ Satellite: null }, config);
+	await update_rate_config({ Orbiter: null }, config);
+	await update_rate_config({ MissionControl: null }, config);
+};


### PR DESCRIPTION
# Motivation

Through the console and mission control, we want to be able to create satellite using options, starting with the system collections being on heap or stable.
