### PR TITLE
style(frontend): remove data and collections header animation

### DIFF
--- a/src/frontend/src/lib/components/data/DataCollectionHeader.svelte
+++ b/src/frontend/src/lib/components/data/DataCollectionHeader.svelte
@@ -23,7 +23,7 @@
 	<span>{@render children()}</span>
 
 	{#if collectionSelected}
-		<div transition:fade>
+		<div>
 			<ListParamsFilter />
 			<DataOrder />
 			<DataActions>

--- a/src/frontend/src/lib/components/data/DataCollectionsHeader.svelte
+++ b/src/frontend/src/lib/components/data/DataCollectionsHeader.svelte
@@ -16,7 +16,7 @@
 	<span>{@render children()}</span>
 
 	{#if nonNullish(actions)}
-		<div transition:fade>
+		<div>
 			<DataActions>
 				{@render actions?.()}
 			</DataActions>

--- a/src/frontend/src/lib/components/data/DataHeader.svelte
+++ b/src/frontend/src/lib/components/data/DataHeader.svelte
@@ -16,7 +16,7 @@
 </script>
 
 {#if nonNullish($store?.data)}
-	<div class="actions" transition:fade>
+	<div class="actions">
 		<span>{@render children()}</span>
 
 		<DataActions>


### PR DESCRIPTION
# Motivation

It used to work smoothly but, someone now the animation lead the UI to briefly displaying two component - i.e. twice the tables. It's annoying so better remove the small fade.
