### PR TITLE
style(frontend): popover padding x and y similar

### DIFF
--- a/src/frontend/src/lib/styles/mixins/_overlay.scss
+++ b/src/frontend/src/lib/styles/mixins/_overlay.scss
@@ -121,6 +121,6 @@
 
 		width: 100%;
 
-		padding: var(--padding) var(--padding-2x);
+		padding: var(--padding);
 	}
 }


### PR DESCRIPTION
# Motivation

<img width="1533" height="1031" alt="Capture d’écran 2025-09-19 à 16 49 57" src="https://github.com/user-attachments/assets/1f99749f-114d-4065-b957-b7ceb721abba" />

