### PR TITLE
feat(frontend): redo createSatellite with deprecated notice

### DIFF
--- a/src/frontend/src/lib/services/satellites.services.ts
+++ b/src/frontend/src/lib/services/satellites.services.ts
@@ -15,6 +15,28 @@ interface CreateSatelliteConfig {
 	kind: 'website' | 'application';
 }
 
+/**
+ * @deprecated use createSatelliteWithConfig
+ */
+export const createSatellite = async ({
+	identity,
+	missionControlId,
+	config: { name }
+}: {
+	identity: Option<Identity>;
+	missionControlId: Option<Principal>;
+	config: CreateSatelliteConfig;
+}): Promise<Satellite> => {
+	assertNonNullish(missionControlId);
+
+	const { create_satellite } = await getMissionControlActor({
+		missionControlId,
+		identity
+	});
+
+	return create_satellite(name);
+};
+
 export const createSatelliteWithConfig = async ({
 	identity,
 	missionControlId,

--- a/src/frontend/src/lib/services/wizard.services.ts
+++ b/src/frontend/src/lib/services/wizard.services.ts
@@ -18,7 +18,11 @@ import {
 	loadOrbiters
 } from '$lib/services/orbiter/orbiters.services';
 import { execute } from '$lib/services/progress.services';
-import { createSatelliteWithConfig, loadSatellites } from '$lib/services/satellites.services';
+import {
+	createSatellite,
+	createSatelliteWithConfig,
+	loadSatellites
+} from '$lib/services/satellites.services';
 import { waitMissionControlVersionLoaded } from '$lib/services/version/version.mission-control.services';
 import { busy } from '$lib/stores/busy.store';
 import { i18n } from '$lib/stores/i18n.store';
@@ -227,8 +231,13 @@ export const createSatelliteWizard = async ({
 		return { success: 'error' };
 	}
 
-	const createFn = async ({ identity }: { identity: Identity }): Promise<Satellite> =>
-		await createSatelliteWithConfig({
+	const createFn = async ({ identity }: { identity: Identity }): Promise<Satellite> => {
+		const fn =
+			nonNullish(subnetId) || satelliteKind !== 'website'
+				? createSatelliteWithConfig
+				: createSatellite;
+
+		return await fn({
 			identity,
 			missionControlId,
 			config: {
@@ -237,6 +246,7 @@ export const createSatelliteWizard = async ({
 				kind: satelliteKind
 			}
 		});
+	};
 
 	const buildMonitoringFn = (): MonitoringFn<Satellite> | undefined => {
 		if (isNullish(monitoringStrategy)) {


### PR DESCRIPTION
# Motivation

Let's keep `createSatellite` for time being since it is "just" marked as deprecated but, not removed yet.
