### PR TITLE
fix(emulator): juno.config is now required to spin the emulator

### DIFF
--- a/scripts/emulator.sh
+++ b/scripts/emulator.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-CONTAINER_NAME="juno-console"
-VOLUME="juno_console"
+CONTAINER_NAME="juno-console-3"
+VOLUME="juno_console-3"
 
 RUN_FLAGS="-it"
 START_FLAGS="-i"
@@ -28,6 +28,7 @@ else
     -p 5987:5987 \
     -p 5999:5999 \
     -v "$VOLUME":/juno/.juno \
+    -v "$(pwd)/juno.config.mjs:/juno/juno.config.mjs" \
     -v "$(pwd)/target/deploy:/juno/target/deploy" \
     junobuild/console:latest
 fi


### PR DESCRIPTION
# Motivation

Resolved issue discovered in https://github.com/junobuild/juno/issues/2000#issuecomment-3346347349

The root cause of the issue is the breaking change shipped in Juno Docker [v0.4.0](https://github.com/junobuild/juno-docker/releases/tag/v0.4.0). Passing a `juno.config` to the emulator is now mandatory.
