### PR TITLE
feat(wallet): display amount in USD on send review screen

### DIFF
--- a/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
+++ b/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
@@ -21,7 +21,7 @@
 		{#if nonNullish(token)}<span>{formatICP(token.toE8s())} <small>ICP</small></span>{/if}
 
 		{#if nonNullish($icpToUsd) && nonNullish(token)}
-			<span class="usd">{formatICPToUsd({ icp: token, icpToUsd: $icpToUsd })}</span>
+			<span class="usd">{formatICPToUsd({ icp: token.toE8S(), icpToUsd: $icpToUsd })}</span>
 		{/if}
 	</p>
 </Value>

--- a/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
+++ b/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
@@ -21,7 +21,7 @@
 		{#if nonNullish(token)}<span>{formatICP(token.toE8s())} <small>ICP</small></span>{/if}
 
 		{#if nonNullish($icpToUsd) && nonNullish(token)}
-			<span class="usd">{formatICPToUsd({ icp: token.toE8S(), icpToUsd: $icpToUsd })}</span>
+			<span class="usd">{formatICPToUsd({ icp: token.toE8s(), icpToUsd: $icpToUsd })}</span>
 		{/if}
 	</p>
 </Value>

--- a/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
+++ b/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
@@ -2,7 +2,8 @@
 	import { nonNullish, type TokenAmountV2 } from '@dfinity/utils';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { formatICP } from '$lib/utils/icp.utils';
+	import { formatICP, formatICPToUsd } from '$lib/utils/icp.utils';
+	import { icpToUsd } from '$lib/derived/exchange.derived';
 
 	interface Props {
 		token: TokenAmountV2 | undefined;
@@ -18,5 +19,16 @@
 
 	<p>
 		{#if nonNullish(token)}<span>{formatICP(token.toE8s())} <small>ICP</small></span>{/if}
+
+		{#if nonNullish($icpToUsd) && nonNullish(token)}
+			<span class="usd">{formatICPToUsd({ icp: token, icpToUsd: $icpToUsd })}</span>
+		{/if}
 	</p>
 </Value>
+
+<style lang="scss">
+	.usd {
+		display: block;
+		font-size: var(--font-size-small);
+	}
+</style>


### PR DESCRIPTION
# Motivation
- Improves user transparency during the review step.
- Aligns with how the balance is displayed in USD.

## Issue Reference
Closes #1999
<!-- Describe the motivation that lead to the PR -->

# Display Amount in USD on Wallet Send Review Screen

## Description
This PR enhances the **wallet send review screen** by displaying the **amount in USD** in addition to ICP.  
Previously, only the balance was shown in USD. Now, both the **balance** and the **amount being sent** are displayed in dollars, improving user clarity.

## Changes
- Updated `SendTokensAmount.svelte`:
  - Added conditional block to render the amount in USD.
  - Used `formatICPToUsd({ icp: token, icpToUsd: $icpToUsd })` to calculate conversion.
- Styled the USD amount with `.usd` class for consistency with balance display.
