### PR TITLE
docs(repo): add check all step to contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,16 @@ git push -u origin fix/login-bug
 - Run tests locally (see `HACKING.md`).
 - Verify functionality.
 
-### 5. **Submit a Pull Request (PR)**
+### 5. **Run Checks**
+
+Before pushing your branch and creating a PR, ensure your code passes
+formatting, linting, and type checks by running:
+
+```bash
+npm run check:all
+```
+
+### 6. **Submit a Pull Request (PR)**
 
 1. Go to [Juno’s Pull Requests](https://github.com/junobuild/juno/pulls) and click "New PR".
 2. Select **your fork/branch** as the source.

--- a/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
+++ b/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
@@ -21,7 +21,7 @@
 		{#if nonNullish(token)}<span>{formatICP(token.toE8s())} <small>ICP</small></span>{/if}
 
 		{#if nonNullish($icpToUsd) && nonNullish(token)}
-			<span class="usd">{formatICPToUsd({ icp: token, icpToUsd: $icpToUsd })}</span>
+			<span class="usd">{formatICPToUsd({ icp: token.toE8S(), icpToUsd: $icpToUsd })}</span>
 		{/if}
 	</p>
 </Value>

--- a/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
+++ b/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
@@ -2,7 +2,8 @@
 	import { nonNullish, type TokenAmountV2 } from '@dfinity/utils';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { formatICP } from '$lib/utils/icp.utils';
+	import { formatICP, formatICPToUsd } from '$lib/utils/icp.utils';
+	import { icpToUsd } from '$lib/derived/exchange.derived';
 
 	interface Props {
 		token: TokenAmountV2 | undefined;
@@ -18,5 +19,16 @@
 
 	<p>
 		{#if nonNullish(token)}<span>{formatICP(token.toE8s())} <small>ICP</small></span>{/if}
+
+		{#if nonNullish($icpToUsd) && nonNullish(token)}
+			<span class="usd">{formatICPToUsd({ icp: token, icpToUsd: $icpToUsd })}</span>
+		{/if}
 	</p>
 </Value>
+
+<style lang="scss">
+	.usd {
+		display: block;
+		font-size: var(--font-size-small);
+	}
+</style>


### PR DESCRIPTION
### Summary
Added a missing step in CONTRIBUTING.md to remind contributors to run `npm run check:all` before pushing code and opening a PR.

### Changes
- Inserted new Step 5: "Run Checks"
- Described purpose of `npm run check:all` (formatting, linting, type checks)

### Motivation
Ensures contributors validate their changes consistently before submission.

### Related Issue
Closes #2006 
