### PR TITLE
feat: added dollar sign to amount in top up

### DIFF
--- a/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
+++ b/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
@@ -18,10 +18,10 @@
 
 	<p>
 		{#if nonNullish(token)}<span>{formatICP(token.toE8s())} <small>ICP</small></span>{/if}
-				{#if nonNullish($icpToUsd)}
+				{#if nonNullish($icpToUsd) && nonNullish(token)}
 			<span class="usd">
 				{formatICPToUsd({
-					icp: token?.toUlps() ?? BigInt(0),
+					icp: token?.toE8s() ?? BigInt(0),
 					icpToUsd: $icpToUsd
 				})}</span
 			>

--- a/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
+++ b/src/frontend/src/lib/components/tokens/SendTokensAmount.svelte
@@ -2,8 +2,8 @@
 	import { nonNullish, type TokenAmountV2 } from '@dfinity/utils';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { formatICP } from '$lib/utils/icp.utils';
-
+	import { formatICP, formatICPToUsd } from '$lib/utils/icp.utils';
+	import { icpToUsd } from '$lib/derived/exchange.derived';
 	interface Props {
 		token: TokenAmountV2 | undefined;
 	}
@@ -18,5 +18,20 @@
 
 	<p>
 		{#if nonNullish(token)}<span>{formatICP(token.toE8s())} <small>ICP</small></span>{/if}
+				{#if nonNullish($icpToUsd)}
+			<span class="usd">
+				{formatICPToUsd({
+					icp: token?.toUlps() ?? BigInt(0),
+					icpToUsd: $icpToUsd
+				})}</span
+			>
+		{/if}
 	</p>
 </Value>
+
+<style>
+	.usd {
+		display: block;
+		font-size: var(--font-size-small);
+	}
+</style>


### PR DESCRIPTION
# Motivation
<!--In addition to displaying the ‘Balance’ in dollars on the review screen of the top-up wizard, I think it would also be interesting to display it for the ‘Amount’. -->

link: (closes #1994)


screenshot:
<img width="1422" height="816" alt="image" src="https://github.com/user-attachments/assets/1af1aa05-d738-4d91-be68-919f12e1c7b7" />
