### PR TITLE
fix(storage): preserve filters after delete reload

### DIFF
--- a/src/frontend/src/lib/components/data/DataDelete.svelte
+++ b/src/frontend/src/lib/components/data/DataDelete.svelte
@@ -46,8 +46,11 @@
 				collection
 			});
 
-			listParamsStore.setFilter($listParamsStore.filter);
-			listParamsStore.setOrder($listParamsStore.order);
+			// Single store update to avoid multiple reloads
+			listParamsStore.setAll({
+				order: { ...$listParamsStore.order },
+				filter: { ...$listParamsStore.filter }
+			});
 		} catch (err: unknown) {
 			toasts.error({
 				text: $i18n.errors.data_delete,

--- a/src/frontend/src/lib/components/data/DataDelete.svelte
+++ b/src/frontend/src/lib/components/data/DataDelete.svelte
@@ -46,7 +46,8 @@
 				collection
 			});
 
-			listParamsStore.reset();
+			listParamsStore.setFilter($listParamsStore.filter);
+			listParamsStore.setOrder($listParamsStore.order);
 		} catch (err: unknown) {
 			toasts.error({
 				text: $i18n.errors.data_delete,

--- a/src/frontend/src/lib/components/data/DataDelete.svelte
+++ b/src/frontend/src/lib/components/data/DataDelete.svelte
@@ -46,7 +46,6 @@
 				collection
 			});
 
-			// Single store update to avoid multiple reloads
 			listParamsStore.setAll({
 				order: { ...$listParamsStore.order },
 				filter: { ...$listParamsStore.filter }

--- a/src/frontend/src/lib/components/data/DataDelete.svelte
+++ b/src/frontend/src/lib/components/data/DataDelete.svelte
@@ -56,6 +56,7 @@
 				detail: err
 			});
 		}
+		
 
 		close();
 

--- a/src/frontend/src/lib/stores/list-params.store.ts
+++ b/src/frontend/src/lib/stores/list-params.store.ts
@@ -11,6 +11,7 @@ export type ListParamsStoreData = Pick<ListParams, 'order' | 'filter'>;
 export interface ListParamsStore extends Readable<ListParamsStoreData> {
 	setOrder: (order: ListOrder) => void;
 	setFilter: (filter: ListFilter) => void;
+	setAll: (params: ListParamsStoreData) => void;
 	reset: () => void;
 }
 
@@ -44,6 +45,18 @@ const initListParamsStore = (): ListParamsStore => {
 
 				return updated_state;
 			});
+		},
+
+		setAll: (params: ListParamsStoreData) => {
+			// Ensure we create a fresh object so subscribers are notified
+			const next_state: ListParamsStoreData = {
+				order: { ...params.order },
+				filter: { ...params.filter }
+			};
+
+			set(next_state);
+
+			saveListParams(next_state);
 		},
 
 		reset: () => {


### PR DESCRIPTION
Motivation
After deleting assets in Storage, the list reloaded with default parameters because listParamsStore.reset() cleared active filters. The UI still displayed the filters, but the subsequent fetch ignored them.

Changes 
1 . In src/frontend/src/lib/components/data/DataDelete.svelte, replaced:
              listParamsStore.reset() with:
              listParamsStore.setFilter($listParamsStore.filter)
             listParamsStore.setOrder($listParamsStore.order)
This preserves active filters and still triggers the reactive reload in Assets.svelte.

Verification
1 . Upload 3 files: test.png, test.txt, next.txt
2 . Apply filter: Matcher = “test”
3 . List shows: test.png + test.txt
4 . Delete test.txt
5 . List shows: test.png (filter still applied)
6 . Filter drawer still shows “test” and show "test.png" 
7 . Clear filter
List shows: test.png + next.txt

Linked issue
Fixes: https://github.com/junobuild/juno/issues/1765#event-20029882960

Checklist
[x] Typecheck/lint/format locally (npm run check:all)
[x] Manual verification as above
