### PR TITLE
feat(frontend): listParamsStore.reload()

### DIFF
--- a/src/frontend/src/lib/components/data/DataDelete.svelte
+++ b/src/frontend/src/lib/components/data/DataDelete.svelte
@@ -46,17 +46,13 @@
 				collection
 			});
 
-			listParamsStore.setAll({
-				order: { ...$listParamsStore.order },
-				filter: { ...$listParamsStore.filter }
-			});
+			listParamsStore.reload();
 		} catch (err: unknown) {
 			toasts.error({
 				text: $i18n.errors.data_delete,
 				detail: err
 			});
 		}
-		
 
 		close();
 

--- a/src/frontend/src/lib/stores/list-params.store.ts
+++ b/src/frontend/src/lib/stores/list-params.store.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_LIST_PARAMS } from '$lib/constants/data.constants';
 import type { ListFilter, ListOrder, ListParams } from '$lib/types/list';
 import { getLocalListParams, setLocalStorageItem } from '$lib/utils/local-storage.utils';
 import { type Readable, writable } from 'svelte/store';
@@ -11,8 +10,7 @@ export type ListParamsStoreData = Pick<ListParams, 'order' | 'filter'>;
 export interface ListParamsStore extends Readable<ListParamsStoreData> {
 	setOrder: (order: ListOrder) => void;
 	setFilter: (filter: ListFilter) => void;
-	setAll: (params: ListParamsStoreData) => void;
-	reset: () => void;
+	reload: () => void;
 }
 
 const initListParamsStore = (): ListParamsStore => {
@@ -47,21 +45,10 @@ const initListParamsStore = (): ListParamsStore => {
 			});
 		},
 
-		setAll: (params: ListParamsStoreData) => {
-			// Ensure we create a fresh object so subscribers are notified
-			const next_state: ListParamsStoreData = {
-				order: { ...params.order },
-				filter: { ...params.filter }
-			};
-
-			set(next_state);
-
-			saveListParams(next_state);
-		},
-
-		reset: () => {
-			set(DEFAULT_LIST_PARAMS);
-			saveListParams(DEFAULT_LIST_PARAMS);
+		reload: () => {
+			update((state) => ({
+				...state
+			}));
 		}
 	};
 };


### PR DESCRIPTION
# Motivation

As discussed in #2013, this PR is a follow-up. I tested the solution I suggested, which simplifies the code, and since it worked, I go ahead with it.

This also has advantages, as it does not require updating IndexedDB and involves less object destruction. Therefore, technically speaking, it is more optimized.

Unrelated to the solution, I also cleaned up the reset function, which had become unused.
