### PR TITLE
chore(e2e): testIds enabled for Skylab

### DIFF
--- a/src/frontend/src/lib/utils/test.utils.ts
+++ b/src/frontend/src/lib/utils/test.utils.ts
@@ -1,7 +1,7 @@
-import { isDev, isNotSkylab } from '$lib/env/app.env';
+import { isDev } from '$lib/env/app.env';
 import type { TestId } from '$lib/types/test-id';
 import { nonNullish } from '@dfinity/utils';
 
 export const testId = (testId: TestId | undefined): { ['data-tid']?: string } => ({
-	...(isDev() && isNotSkylab() && nonNullish(testId) && { 'data-tid': testId })
+	...(isDev() && nonNullish(testId) && { 'data-tid': testId })
 });


### PR DESCRIPTION
# Motivation

We want to enable `data-tid` selector for Skylab as well. This way devs, or other projects of Juno such as the CLI, can also automate tests easily using that container.
