### PR TITLE
feat(satellite): add test IDs for satellite overview actions (Fix #2024)

### DIFF
--- a/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteOverview.svelte
@@ -18,6 +18,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { CanisterSyncData as CanisterSyncDataType } from '$lib/types/canister';
 	import type { SatelliteIdText } from '$lib/types/satellite';
+	import { testId } from '$lib/utils/test.utils';
+    import { testIds } from '$lib/constants/test-ids.constants';
 
 	interface Props {
 		satellite: Satellite;
@@ -64,7 +66,12 @@
 				{#snippet label()}
 					{$i18n.satellites.id}
 				{/snippet}
-				<Identifier identifier={satelliteId} shorten={false} small={false} />
+				<Identifier 
+					identifier={satelliteId} 
+					shorten={false} 
+					small={false} 
+					{...testId(testIds.satelliteOverview.copySatelliteId)}
+				/>
 			</Value>
 
 			<CanisterSubnet canisterId={satellite.satellite_id} />

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -13,6 +13,7 @@ export const testIds: TestIds = {
 		continue: 'btn-continue-overview'
 	},
 	satelliteOverview: {
-		visit: 'link-visit-satellite'
+		visit: 'link-visit-satellite',
+		copySatelliteID: 'btn-copy-satellite-id'
 	}
 };


### PR DESCRIPTION
# Motivation- Fix for #2024

added a test ID to the "copy Satellite ID" action on the satellite overview page. 

Changes:
- Added `copySatelliteID` to the `testIds` constant in `src/frontend/src/lib/constants/test-ids.constants.ts`.
- Applied the new test ID to the `<Identifier>` component in `src/frontend/src/lib/components/satellites/SatelliteOverview.svelte`.
