### PR TITLE
feat(frontend): add test IDs for wallet and get ICP buttons

### DIFF
--- a/src/frontend/src/lib/components/core/NavbarWallet.svelte
+++ b/src/frontend/src/lib/components/core/NavbarWallet.svelte
@@ -7,9 +7,11 @@
 	import WalletActions from '$lib/components/wallet/WalletActions.svelte';
 	import WalletIds from '$lib/components/wallet/WalletIds.svelte';
 	import WalletInlineBalance from '$lib/components/wallet/WalletInlineBalance.svelte';
+	import { testIds } from '$lib/constants/test-ids.constants';
 	import { balance } from '$lib/derived/balance.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
+	import { testId } from '$lib/utils/test.utils';
 
 	interface Props {
 		missionControlId: MissionControlId;
@@ -30,7 +32,7 @@
 	};
 </script>
 
-<ButtonIcon {onclick} bind:button>
+<ButtonIcon {onclick} bind:button {...testId(testIds.wallet.button)}>
 	{#snippet icon()}
 		<IconWallet size="16px" />
 	{/snippet}

--- a/src/frontend/src/lib/components/wallet/WalletGetICP.svelte
+++ b/src/frontend/src/lib/components/wallet/WalletGetICP.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import ConfettiSpread from '$lib/components/ui/ConfettiSpread.svelte';
+	import { testIds } from '$lib/constants/test-ids.constants';
 	import { isDev } from '$lib/env/app.env';
 	import { emulatorLedgerTransfer } from '$lib/rest/emulator.rest';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import { emit } from '$lib/utils/events.utils';
+	import { testId } from '$lib/utils/test.utils';
 
 	interface Props {
 		missionControlId: MissionControlId;
@@ -30,5 +32,5 @@
 		<ConfettiSpread />
 	{/if}
 
-	<button onclick={onClick}>{$i18n.emulator.get_icp}</button>
+	<button onclick={onClick} {...testId(testIds.wallet.getIcp)}>{$i18n.emulator.get_icp}</button>
 {/if}

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -13,7 +13,8 @@ export const testIds: TestIds = {
 		continue: 'btn-continue-overview'
 	},
 	satelliteOverview: {
-		visit: 'link-visit-satellite'
+		visit: 'link-visit-satellite',
+		copySatelliteId: 'btn-copy-satellite-id'
 	},
 	wallet: {
 		button: 'btn-wallet',

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -1,4 +1,4 @@
-import type { TestIds } from '$lib/types/test-id';
+import type { TestIds } from '../types/test-id';
 
 export const testIds: TestIds = {
 	auth: {
@@ -14,5 +14,9 @@ export const testIds: TestIds = {
 	},
 	satelliteOverview: {
 		visit: 'link-visit-satellite'
+	},
+	wallet: {
+		button: 'btn-wallet',
+		getIcp: 'btn-get-icp'
 	}
 };

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -1,4 +1,4 @@
-import type { TestIds } from '../types/test-id';
+import type { TestIds } from '$lib/types/test-id';
 
 export const testIds: TestIds = {
 	auth: {


### PR DESCRIPTION
## Changes
- Added test IDs for E2E testing as per issue #2025
- Implemented test IDs for:
  - Navbar Wallet button (`btn-wallet`)
  - Get ICP button (`btn-get-icp`)

## Implementation Details
- Added new wallet section to [test-ids.constants.ts](cci:7://file:///c:/Users/HP/Desktop/juno/juno/src/frontend/src/lib/constants/test-ids.constants.ts:0:0-0:0)
- Updated [NavbarWallet.svelte](cci:7://file:///c:/Users/HP/Desktop/juno/juno/src/frontend/src/lib/components/core/NavbarWallet.svelte:0:0-0:0) with test ID for wallet button
- Updated [WalletGetICP.svelte](cci:7://file:///c:/Users/HP/Desktop/juno/juno/src/frontend/src/lib/components/wallet/WalletGetICP.svelte:0:0-0:0) with test ID for Get ICP button
- Used existing [testId](cci:1://file:///c:/Users/HP/Desktop/juno/juno/src/frontend/src/lib/utils/test.utils.ts:4:0-6:3) utility to conditionally add `data-tid` attributes in development mode

## Testing
- Verified test IDs are correctly added in development environment
- Confirmed no impact on production build
- Test IDs follow the existing pattern in the codebase

