### PR TITLE
feat: Extend displayed snapshot ID length

### DIFF
--- a/src/frontend/src/lib/components/ui/Identifier.svelte
+++ b/src/frontend/src/lib/components/ui/Identifier.svelte
@@ -13,7 +13,7 @@
 	let { identifier, shorten = true, shortenLength, small = true, what }: Props = $props();
 
 	let shortIdentifier: string = $derived(
-		shorten ? shortenWithMiddleEllipsis({ text: identifier, length: shortenLength }) : identifier
+		shorten ? shortenWithMiddleEllipsis({ text: identifier, startLength: shortenLength, endLength: shortenLength }) : identifier
 	);
 </script>
 

--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -5,14 +5,21 @@
  *
  * @param {Object} params - Parameters object.
  * @param {string} params.text - The original text to shorten.
- * @param {number} [params.length=7] - The number of characters to keep from the start and end of the string.
+ * @param {number} [params.startLength] - The number of characters to keep from the start and end of the string.
+ * @param {number} [params.endLength]
  * @returns {string} The shortened string with a middle ellipsis if applicable.
  */
 export const shortenWithMiddleEllipsis = ({
 	text,
-	length = 7
+	startLength = 9,
+	endLength = 9
 }: {
 	text: string;
-	length?: number;
-}): string =>
-	text.length > length + 2 ? `${text.slice(0, length)}...${text.slice(-1 * length)}` : text;
+	startLength?: number;
+	endLength?: number;
+}): string => {
+	const addedStart = startLength + 2;
+	return text.length > addedStart + endLength + 3
+		? `${text.slice(0, addedStart)}...${text.slice(-endLength)}`
+		: text;
+};


### PR DESCRIPTION
# Motivation

Description:

In the Setup tab, the snapshot section allows users to manage snapshots (create, restore, delete, etc.).

Currently, snapshot IDs are displayed in a shortened format such as 0x00000...1c90101.

This shows only 6 characters at the start and end of the ID. While it helps readability, it’s often too short to reliably identify a snapshot at first glance. For example, the full ID: 0x000000000000000300000000016091c90101 is difficult to distinguish from others when only 6 leading and trailing characters are shown.

Proposed solution:

Extend the visible portion of the snapshot ID to 9 characters before and after the ellipsis (e.g., 0x000000000...091c90101).
Keep the ellipsis in the middle to ensure readability while still providing more context for quick identification.




<img width="1557" height="135" alt="image" src="https://github.com/user-attachments/assets/bca994f1-e5ad-4865-acb9-938d9e5484ea" />



The characters at the start did not seem to respond to the change in length, so I had to do that manually
