### PR TITLE
feat: extend displayed snapshot id length

### DIFF
--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -5,14 +5,19 @@
  *
  * @param {Object} params - Parameters object.
  * @param {string} params.text - The original text to shorten.
- * @param {number} [params.length=7] - The number of characters to keep from the start and end of the string.
+ * @param {number} [params.length=9] - The number of characters to keep from the start and end of the string.
  * @returns {string} The shortened string with a middle ellipsis if applicable.
  */
 export const shortenWithMiddleEllipsis = ({
 	text,
-	length = 7
+	length = 9
 }: {
 	text: string;
 	length?: number;
-}): string =>
-	text.length > length + 2 ? `${text.slice(0, length)}...${text.slice(-1 * length)}` : text;
+}): string => {
+	const startLength = length + 2;
+	const endLength = length;
+	return text.length > startLength + endLength + 2
+		? `${text.slice(0, startLength)}...${text.slice(-endLength)}`
+		: text;
+};


### PR DESCRIPTION
# Motivation

Description:

In the Setup tab, the snapshot section allows users to manage snapshots (create, restore, delete, etc.).

Currently, snapshot IDs are displayed in a shortened format such as 0x00000...1c90101.

This shows only 6 characters at the start and end of the ID. While it helps readability, it’s often too short to reliably identify a snapshot at first glance. For example, the full ID: 0x000000000000000300000000016091c90101 is difficult to distinguish from others when only 6 leading and trailing characters are shown.

Proposed solution:

Extend the visible portion of the snapshot ID to 9 characters before and after the ellipsis (e.g., 0x000000000...091c90101).
Keep the ellipsis in the middle to ensure readability while still providing more context for quick identification.


<img width="1557" height="135" alt="image" src="https://github.com/user-attachments/assets/05638900-ecb0-4f5d-9600-bd45029d2dcc" />


closes #2021


