### PR TITLE
feat(frontend): added extended display snapshot id lenght

### DIFF
--- a/src/frontend/src/lib/components/snapshot/Snapshots.svelte
+++ b/src/frontend/src/lib/components/snapshot/Snapshots.svelte
@@ -110,7 +110,12 @@
 									onrestore={openRestoreModal}
 								/></td
 							>
-							<td><Identifier identifier={`0x${encodeSnapshotId(snapshot.id)}`} small={false} /></td
+							<td
+								><Identifier
+									identifier={`0x${encodeSnapshotId(snapshot.id)}`}
+									shortenLength={11}
+									small={false}
+								/></td
 							>
 							<td>{formatBytes(Number(snapshot.total_size))}</td>
 							<td>{formatToDate(snapshot.taken_at_timestamp)}</td>


### PR DESCRIPTION
# Motivation

Description:

In the Setup tab, the snapshot section allows users to manage snapshots (create, restore, delete, etc.).

Currently, snapshot IDs are displayed in a shortened format such as 0x00000...1c90101.

This shows only 6 characters at the start and end of the ID. While it helps readability, it’s often too short to reliably identify a snapshot at first glance. For example, the full ID: 0x000000000000000300000000016091c90101 is difficult to distinguish from others when only 6 leading and trailing characters are shown.

Proposed solution:

Extend the visible portion of the snapshot ID to 9 characters before and after the ellipsis (e.g., 0x000000000...091c90101).
Keep the ellipsis in the middle to ensure readability while still providing more context for quick identification.


<img width="1517" height="85" alt="image" src="https://github.com/user-attachments/assets/84ff0496-c42b-4a2e-9d93-fdf1fb5bd3e1" />


closes #2021


