### PR TITLE
fix(frontend): add focus-visible style to menu items for accessibility (#2053)

### DIFF
--- a/src/frontend/src/lib/components/core/Navmenu.svelte
+++ b/src/frontend/src/lib/components/core/Navmenu.svelte
@@ -181,7 +181,8 @@
 		color: var(--color-background-contrast);
 
 		&:hover:not(:disabled),
-		&:active:not(:disabled) {
+		&:active:not(:disabled),
+		&:focus-visible:not(:disabled) {
 			background: var(--color-background);
 		}
 	}
@@ -203,7 +204,8 @@
 		@include text.truncate;
 
 		&:hover:not(:disabled),
-		&:active:not(:disabled) {
+		&:active:not(:disabled),
+		&:focus-visible:not(:disabled) {
 			color: var(--color-primary-contrast);
 			font-weight: var(--font-weight-bold);
 		}
@@ -239,7 +241,8 @@
 	@include media.dark-theme {
 		a.link {
 			&:hover:not(:disabled),
-			&:active:not(:disabled) {
+			&:active:not(:disabled),
+			&:focus-visible:not(:disabled) {
 				color: var(--color-card-contrast);
 			}
 		}


### PR DESCRIPTION
## Description

This PR addresses an accessibility issue where menu items in the Console lacked a visible focus state.  
When navigating via keyboard (using the Tab key), users couldn’t see which menu item was currently focused.

### Changes Made
- Added `:focus-visible` selector to `a.link` elements in `Navmenu.svelte`.
- Applied the same visual style used for the hover state to the focus state.
- Updated both light and dark theme sections for consistency.

## Before
- Menu items had hover and active styles only.
- No visible focus indicator for keyboard navigation.

## After
- Focus state now mirrors the hover style.
- Keyboard users can visually identify the focused menu item.

## Type of Change
- [x] Accessibility improvement
- [x] UI enhancement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related Issue
Closes #2053