### PR TITLE
refactor(certification): move update_certified_data from storage to consumer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "ic-cdk",
  "ic-cdk-macros",
  "ic-cdk-timers",
+ "ic-certification",
  "ic-ledger-types",
  "ic-stable-structures 0.7.0",
  "junobuild-cdn",

--- a/src/console/Cargo.toml
+++ b/src/console/Cargo.toml
@@ -14,6 +14,7 @@ ic-cdk-macros.workspace = true
 ic-cdk-timers.workspace = true
 ic-ledger-types.workspace = true
 ic-stable-structures.workspace = true
+ic-certification.workspace = true
 serde.workspace = true
 serde_cbor.workspace = true
 serde_json.workspace = true

--- a/src/console/src/api/cdn.rs
+++ b/src/console/src/api/cdn.rs
@@ -7,7 +7,7 @@ use crate::cdn::proposals::{
     submit_proposal as make_submit_proposal,
 };
 use crate::cdn::strategies_impls::cdn::CdnHeap;
-use crate::cdn::strategies_impls::storage::StorageState;
+use crate::cdn::strategies_impls::storage::{StorageCertificate, StorageState};
 use crate::guards::caller_is_admin_controller;
 use crate::types::interface::DeleteProposalAssets;
 use ic_cdk_macros::{query, update};
@@ -89,12 +89,23 @@ pub fn list_custom_domains() -> CustomDomains {
 
 #[update(guard = "caller_is_admin_controller")]
 pub fn set_custom_domain(domain_name: DomainName, bn_id: Option<String>) {
-    junobuild_cdn::storage::set_domain_store(&CdnHeap, &StorageState, &domain_name, &bn_id)
-        .unwrap_or_trap();
+    junobuild_cdn::storage::set_domain_store(
+        &CdnHeap,
+        &StorageState,
+        &StorageCertificate,
+        &domain_name,
+        &bn_id,
+    )
+    .unwrap_or_trap();
 }
 
 #[update(guard = "caller_is_admin_controller")]
 pub fn del_custom_domain(domain_name: DomainName) {
-    junobuild_cdn::storage::delete_domain_store(&CdnHeap, &StorageState, &domain_name)
-        .unwrap_or_trap();
+    junobuild_cdn::storage::delete_domain_store(
+        &CdnHeap,
+        &StorageState,
+        &StorageCertificate,
+        &domain_name,
+    )
+    .unwrap_or_trap();
 }

--- a/src/console/src/cdn/storage/certified_assets.rs
+++ b/src/console/src/cdn/storage/certified_assets.rs
@@ -1,4 +1,4 @@
-use crate::cdn::strategies_impls::storage::StorageState;
+use crate::cdn::strategies_impls::storage::{StorageCertificate, StorageState};
 use crate::store::{with_assets, with_config};
 use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
 use junobuild_storage::certified_assets::extend_and_init_certified_assets;
@@ -12,7 +12,12 @@ pub fn init_certified_assets() {
                 asset_hashes.insert(asset, config);
             }
 
-            extend_and_init_certified_assets(&mut asset_hashes, config, &StorageState);
+            extend_and_init_certified_assets(
+                &mut asset_hashes,
+                config,
+                &StorageState,
+                &StorageCertificate,
+            );
         });
     });
 }

--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -6,6 +6,7 @@ use crate::cdn::helpers::stable::{
     get_asset_stable, insert_asset_encoding_stable, insert_asset_stable,
 };
 use crate::cdn::storage::init_certified_assets;
+use crate::certification::cert::update_certified_data;
 use candid::Principal;
 use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID,
@@ -20,7 +21,8 @@ use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
 use junobuild_storage::strategies::{
-    StorageAssertionsStrategy, StorageStateStrategy, StorageUploadStrategy,
+    StorageAssertionsStrategy, StorageCertificateStrategy, StorageStateStrategy,
+    StorageUploadStrategy,
 };
 use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::state::FullPath;
@@ -249,5 +251,13 @@ impl StorageUploadStrategy for StorageUpload {
             }
             None => Err(JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID.to_string()),
         }
+    }
+}
+
+pub struct StorageCertificate;
+
+impl StorageCertificateStrategy for StorageCertificate {
+    fn update_certified_data(&self) {
+        update_certified_data();
     }
 }

--- a/src/console/src/certification/cert.rs
+++ b/src/console/src/certification/cert.rs
@@ -1,0 +1,7 @@
+use ic_cdk::api::certified_data_set as set_certified_data;
+use junobuild_storage::runtime::certified_assets_root_hash;
+
+pub fn update_certified_data() {
+    let prefixed_root_hash = &certified_assets_root_hash();
+    set_certified_data(&prefixed_root_hash[..]);
+}

--- a/src/console/src/certification/mod.rs
+++ b/src/console/src/certification/mod.rs
@@ -1,0 +1,1 @@
+pub mod cert;

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod api;
 mod cdn;
+mod certification;
 mod constants;
 mod factory;
 mod guards;

--- a/src/libs/cdn/src/storage/store.rs
+++ b/src/libs/cdn/src/storage/store.rs
@@ -2,7 +2,7 @@ use crate::storage::assert_set_config;
 use crate::storage::heap::{delete_domain, get_config, get_domain, insert_config, insert_domain};
 use crate::strategies::CdnHeapStrategy;
 use junobuild_shared::types::core::DomainName;
-use junobuild_storage::strategies::StorageStateStrategy;
+use junobuild_storage::strategies::{StorageCertificateStrategy, StorageStateStrategy};
 use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::interface::SetStorageConfig;
 use junobuild_storage::well_known::update::update_custom_domains_asset;
@@ -37,12 +37,13 @@ pub fn set_config_store(
 pub fn set_domain_store(
     cdn_heap: &impl CdnHeapStrategy,
     storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
     domain_name: &DomainName,
     bn_id: &Option<String>,
 ) -> Result<(), String> {
     set_state_domain(cdn_heap, domain_name, bn_id);
 
-    update_custom_domains_asset(storage_state)
+    update_custom_domains_asset(storage_state, certificate)
 }
 
 fn set_state_domain(
@@ -60,9 +61,10 @@ fn set_state_domain(
 pub fn delete_domain_store(
     cdn_heap: &impl CdnHeapStrategy,
     storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
     domain_name: &DomainName,
 ) -> Result<(), String> {
     delete_domain(cdn_heap, domain_name);
 
-    update_custom_domains_asset(storage_state)
+    update_custom_domains_asset(storage_state, certificate)
 }

--- a/src/libs/satellite/src/assets/storage/certified_assets/runtime.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/runtime.rs
@@ -1,4 +1,5 @@
 use crate::assets::storage::strategy_impls::StorageState;
+use crate::certification::strategy_impls::StorageCertificate;
 use crate::memory::internal::STATE;
 use crate::types::state::State;
 use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
@@ -21,5 +22,10 @@ fn init_certified_assets_impl(state: &State) {
         asset_hashes.insert(&entry.value(), config);
     }
 
-    extend_and_init_certified_assets(&mut asset_hashes, config, &StorageState)
+    extend_and_init_certified_assets(
+        &mut asset_hashes,
+        config,
+        &StorageState,
+        &StorageCertificate,
+    )
 }

--- a/src/libs/satellite/src/assets/storage/handlers.rs
+++ b/src/libs/satellite/src/assets/storage/handlers.rs
@@ -1,6 +1,7 @@
 use crate::assets::storage::state::{
     get_asset, get_config, get_rule, insert_asset, insert_asset_encoding,
 };
+use crate::certification::strategy_impls::StorageCertificate;
 use crate::controllers::store::get_controllers;
 use junobuild_collections::assert::stores::assert_permission;
 use junobuild_collections::types::rules::Rule;
@@ -84,7 +85,7 @@ fn set_asset_handler_impl(
 
     let config = get_config();
 
-    update_runtime_certified_asset(&asset, &config);
+    update_runtime_certified_asset(&asset, &config, &StorageCertificate);
 
     Ok(())
 }

--- a/src/libs/satellite/src/assets/storage/store.rs
+++ b/src/libs/satellite/src/assets/storage/store.rs
@@ -13,6 +13,7 @@ use crate::assets::storage::state::{
 };
 use crate::assets::storage::strategy_impls::{StorageAssertions, StorageState, StorageUpload};
 use crate::auth::store::get_config as get_auth_config;
+use crate::certification::strategy_impls::StorageCertificate;
 use crate::controllers::store::get_controllers;
 use crate::memory::internal::STATE;
 use crate::types::store::{AssertContext, StoreContext};
@@ -428,8 +429,10 @@ fn delete_asset_impl(
         Some(asset) => {
             assert_delete_asset(context, assert_context, &asset)?;
 
+            let certificate = &StorageCertificate;
+
             let deleted = delete_state_asset(context.collection, &full_path, assert_context.rule);
-            delete_runtime_certified_asset(&asset);
+            delete_runtime_certified_asset(&asset, certificate);
 
             // We just removed the rewrite for /404.html in the certification tree therefore if /index.html exists, we want to reintroduce it as rewrite
             if *full_path == *ROOT_404_HTML {
@@ -438,7 +441,7 @@ fn delete_asset_impl(
                     &ROOT_INDEX_HTML.to_string(),
                     assert_context.rule,
                 ) {
-                    update_runtime_certified_asset(&index_asset, config);
+                    update_runtime_certified_asset(&index_asset, config, certificate);
                 }
             }
 
@@ -458,7 +461,7 @@ fn delete_assets_impl(
         match deleted_asset {
             None => {}
             Some(deleted_asset) => {
-                delete_runtime_certified_asset(&deleted_asset);
+                delete_runtime_certified_asset(&deleted_asset, &StorageCertificate);
             }
         }
     }
@@ -598,7 +601,7 @@ pub fn commit_batch_store(caller: Principal, commit_batch: CommitBatch) -> Resul
 
     let config = get_config();
 
-    update_runtime_certified_asset(&asset, &config);
+    update_runtime_certified_asset(&asset, &config, &StorageCertificate);
 
     Ok(asset)
 }
@@ -671,13 +674,13 @@ pub fn get_custom_domains_store() -> CustomDomains {
 fn delete_domain_impl(domain_name: &DomainName) -> Result<(), String> {
     delete_state_domain(domain_name);
 
-    update_custom_domains_asset(&StorageState)
+    update_custom_domains_asset(&StorageState, &StorageCertificate)
 }
 
 fn set_domain_impl(domain_name: &DomainName, bn_id: &Option<String>) -> Result<(), String> {
     set_state_domain_impl(domain_name, bn_id);
 
-    update_custom_domains_asset(&StorageState)
+    update_custom_domains_asset(&StorageState, &StorageCertificate)
 }
 
 fn set_state_domain_impl(domain_name: &DomainName, bn_id: &Option<String>) {

--- a/src/libs/satellite/src/auth/alternative_origins.rs
+++ b/src/libs/satellite/src/auth/alternative_origins.rs
@@ -1,5 +1,6 @@
 use crate::assets::storage::store::get_custom_domains_store;
 use crate::assets::storage::strategy_impls::StorageState;
+use crate::certification::strategy_impls::StorageCertificate;
 use crate::errors::auth::JUNO_AUTH_ERROR_INVALID_ORIGIN;
 use junobuild_auth::types::config::AuthenticationConfig;
 use junobuild_shared::ic::api::id;
@@ -27,7 +28,7 @@ pub fn update_alternative_origins(config: &AuthenticationConfig) -> Result<(), S
         }
     }
 
-    delete_alternative_origins_asset(&StorageState)
+    delete_alternative_origins_asset(&StorageState, &StorageCertificate)
 }
 
 fn set_alternative_origins(
@@ -62,7 +63,7 @@ fn set_alternative_origins(
     custom_domains.extend(external_domains);
 
     if custom_domains.is_empty() {
-        return delete_alternative_origins_asset(&StorageState);
+        return delete_alternative_origins_asset(&StorageState, &StorageCertificate);
     }
 
     set_alternative_origins_with_custom_domains(&mut custom_domains)
@@ -105,5 +106,5 @@ fn set_alternative_origins_with_custom_domains(
         "Cannot convert custom domains to II alternative origins JSON data.".to_string()
     })?;
 
-    update_alternative_origins_asset(&json, &StorageState)
+    update_alternative_origins_asset(&json, &StorageState, &StorageCertificate)
 }

--- a/src/libs/satellite/src/certification/cert.rs
+++ b/src/libs/satellite/src/certification/cert.rs
@@ -1,0 +1,7 @@
+use ic_cdk::api::certified_data_set as set_certified_data;
+use junobuild_storage::runtime::certified_assets_root_hash;
+
+pub fn update_certified_data() {
+    let prefixed_root_hash = &certified_assets_root_hash();
+    set_certified_data(&prefixed_root_hash[..]);
+}

--- a/src/libs/satellite/src/certification/mod.rs
+++ b/src/libs/satellite/src/certification/mod.rs
@@ -1,0 +1,2 @@
+mod cert;
+pub mod strategy_impls;

--- a/src/libs/satellite/src/certification/strategy_impls.rs
+++ b/src/libs/satellite/src/certification/strategy_impls.rs
@@ -1,0 +1,10 @@
+use crate::certification::cert::update_certified_data;
+use junobuild_storage::strategies::StorageCertificateStrategy;
+
+pub struct StorageCertificate;
+
+impl StorageCertificateStrategy for StorageCertificate {
+    fn update_certified_data(&self) {
+        update_certified_data()
+    }
+}

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -3,6 +3,7 @@
 mod api;
 mod assets;
 mod auth;
+mod certification;
 mod controllers;
 mod db;
 mod errors;

--- a/src/libs/satellite/src/rules/switch_memory.rs
+++ b/src/libs/satellite/src/rules/switch_memory.rs
@@ -4,6 +4,7 @@ use crate::assets::storage::store::assert_assets_collection_empty_store;
 use crate::assets::storage::strategy_impls::StorageState;
 use crate::auth::alternative_origins::update_alternative_origins;
 use crate::auth::store::get_config as get_auth_config;
+use crate::certification::strategy_impls::StorageCertificate;
 use crate::rules::internal::unsafe_set_rule;
 use crate::rules::store::get_rule_storage;
 use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
@@ -48,7 +49,7 @@ pub fn switch_storage_memory() -> Result<(), String> {
     unsafe_set_rule(&releases_collection, &update_releases_rule);
 
     // Redo .well-known/ic-domains but, on the new memory
-    update_custom_domains_asset(&StorageState)?;
+    update_custom_domains_asset(&StorageState, &StorageCertificate)?;
 
     // Redo .well-known/ii-alternative-origins but, on the new memory
     if let Some(auth_config) = get_auth_config() {

--- a/src/libs/storage/src/certification/cert.rs
+++ b/src/libs/storage/src/certification/cert.rs
@@ -3,15 +3,10 @@ use crate::certification::tree_utils::response_headers_expression;
 use crate::certification::types::certified::CertifiedAssetHashes;
 use crate::http::types::HeaderField;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use ic_cdk::api::{certified_data_set as set_certified_data, data_certificate};
+use ic_cdk::api::data_certificate;
 use junobuild_shared::types::core::Blob;
 use serde::Serialize;
 use serde_cbor::ser::Serializer;
-
-pub fn update_certified_data(asset_hashes: &CertifiedAssetHashes) {
-    let prefixed_root_hash = &asset_hashes.root_hash();
-    set_certified_data(&prefixed_root_hash[..]);
-}
 
 pub fn build_asset_certificate_header(
     asset_hashes: &CertifiedAssetHashes,

--- a/src/libs/storage/src/certified_assets.rs
+++ b/src/libs/storage/src/certified_assets.rs
@@ -2,7 +2,7 @@ use crate::certification::types::certified::CertifiedAssetHashes;
 use crate::rewrites::rewrite_source_to_path;
 use crate::routing::get_routing;
 use crate::runtime::init_certified_assets;
-use crate::strategies::StorageStateStrategy;
+use crate::strategies::{StorageCertificateStrategy, StorageStateStrategy};
 use crate::types::config::StorageConfig;
 use crate::types::http_request::{Routing, RoutingDefault};
 
@@ -10,6 +10,7 @@ pub fn extend_and_init_certified_assets(
     asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
 ) {
     for (source, destination) in config.rewrites.clone() {
         if let Ok(Routing::Default(RoutingDefault { url: _, asset })) =
@@ -32,5 +33,5 @@ pub fn extend_and_init_certified_assets(
         );
     }
 
-    init_certified_assets(asset_hashes);
+    init_certified_assets(asset_hashes, certificate);
 }

--- a/src/libs/storage/src/strategies.rs
+++ b/src/libs/storage/src/strategies.rs
@@ -144,3 +144,7 @@ pub trait StorageUploadStrategy {
         rule: &Rule,
     ) -> Result<Option<Asset>, String>;
 }
+
+pub trait StorageCertificateStrategy {
+    fn update_certified_data(&self);
+}

--- a/src/libs/storage/src/well_known/update.rs
+++ b/src/libs/storage/src/well_known/update.rs
@@ -4,7 +4,7 @@ use crate::constants::{
 use crate::runtime::{
     delete_certified_asset, update_certified_asset as update_runtime_certified_asset,
 };
-use crate::strategies::StorageStateStrategy;
+use crate::strategies::{StorageCertificateStrategy, StorageStateStrategy};
 use crate::well_known::types::PrepareWellKnownAssetFn;
 use crate::well_known::utils::{map_alternative_origins_asset, map_custom_domains_asset};
 use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
@@ -13,6 +13,7 @@ use junobuild_shared::types::core::DomainName;
 pub fn update_alternative_origins_asset(
     alternative_origins: &str,
     storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
 ) -> Result<(), String> {
     let full_path = WELL_KNOWN_II_ALTERNATIVE_ORIGINS.to_string();
 
@@ -20,19 +21,21 @@ pub fn update_alternative_origins_asset(
         &full_path,
         alternative_origins,
         storage_state,
+        certificate,
         &map_alternative_origins_asset,
     )
 }
 
 pub fn update_custom_domains_asset(
     storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
 ) -> Result<(), String> {
     let full_path = WELL_KNOWN_CUSTOM_DOMAINS.to_string();
 
     let custom_domains = storage_state.get_domains();
 
     if custom_domains.is_empty() {
-        return delete_asset(&full_path, storage_state);
+        return delete_asset(&full_path, storage_state, certificate);
     }
 
     let concat_custom_domains = custom_domains
@@ -44,22 +47,25 @@ pub fn update_custom_domains_asset(
         &full_path,
         &concat_custom_domains,
         storage_state,
+        certificate,
         &map_custom_domains_asset,
     )
 }
 
 pub fn delete_alternative_origins_asset(
     storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
 ) -> Result<(), String> {
     let full_path = WELL_KNOWN_II_ALTERNATIVE_ORIGINS.to_string();
 
-    delete_asset(&full_path, storage_state)
+    delete_asset(&full_path, storage_state, certificate)
 }
 
 fn update_asset(
     full_path: &String,
     content: &str,
     storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
     f: &PrepareWellKnownAssetFn,
 ) -> Result<(), String> {
     let collection = COLLECTION_ASSET_KEY.to_string();
@@ -83,7 +89,7 @@ fn update_asset(
 
     let config = storage_state.get_config();
 
-    update_runtime_certified_asset(&asset, &config);
+    update_runtime_certified_asset(&asset, &config, certificate);
 
     Ok(())
 }
@@ -91,6 +97,7 @@ fn update_asset(
 fn delete_asset(
     full_path: &String,
     storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
 ) -> Result<(), String> {
     let collection = COLLECTION_ASSET_KEY.to_string();
 
@@ -100,7 +107,7 @@ fn delete_asset(
     let asset = storage_state.delete_asset(&collection, full_path, &rule);
 
     if let Some(asset) = asset {
-        delete_certified_asset(&asset);
+        delete_certified_asset(&asset, certificate);
     }
 
     Ok(())


### PR DESCRIPTION
# Motivation

We want to extend the certification tree with signatures. Those will be handled in the new `junobuild_auth` crate. Given that the assets root hash finds place in `junobuild_storage`, we need to move the function that updates the certified data (`set_certified_data`) to the consumers (Console and Satellite) as we do not want to create a direct dependency between the two libs.
