### PR TITLE
refactor(console): make a module for the certification strategy impl

### DIFF
--- a/src/console/src/api/cdn.rs
+++ b/src/console/src/api/cdn.rs
@@ -7,7 +7,8 @@ use crate::cdn::proposals::{
     submit_proposal as make_submit_proposal,
 };
 use crate::cdn::strategies_impls::cdn::CdnHeap;
-use crate::cdn::strategies_impls::storage::{StorageCertificate, StorageState};
+use crate::cdn::strategies_impls::certification::StorageCertificate;
+use crate::cdn::strategies_impls::storage::StorageState;
 use crate::guards::caller_is_admin_controller;
 use crate::types::interface::DeleteProposalAssets;
 use ic_cdk_macros::{query, update};
@@ -20,7 +21,6 @@ use junobuild_shared::ic::call::ManualReply;
 use junobuild_shared::ic::UnwrapOrTrap;
 use junobuild_shared::types::core::DomainName;
 use junobuild_shared::types::domain::CustomDomains;
-
 // ---------------------------------------------------------
 // Proposal
 // ---------------------------------------------------------

--- a/src/console/src/api/http.rs
+++ b/src/console/src/api/http.rs
@@ -1,4 +1,5 @@
-use crate::cdn::strategies_impls::storage::{StorageCertificate, StorageState};
+use crate::cdn::strategies_impls::certification::StorageCertificate;
+use crate::cdn::strategies_impls::storage::StorageState;
 use ic_cdk_macros::query;
 use junobuild_storage::http::types::{
     HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken,

--- a/src/console/src/cdn/storage/certified_assets.rs
+++ b/src/console/src/cdn/storage/certified_assets.rs
@@ -1,4 +1,5 @@
-use crate::cdn::strategies_impls::storage::{StorageCertificate, StorageState};
+use crate::cdn::strategies_impls::certification::StorageCertificate;
+use crate::cdn::strategies_impls::storage::StorageState;
 use crate::store::{with_assets, with_config};
 use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
 use junobuild_storage::certified_assets::extend_and_init_certified_assets;

--- a/src/console/src/cdn/strategies_impls/certification.rs
+++ b/src/console/src/cdn/strategies_impls/certification.rs
@@ -1,0 +1,19 @@
+use crate::certification::cert::update_certified_data;
+use ic_certification::HashTree;
+use junobuild_auth::runtime::pruned_labeled_sigs_root_hash_tree;
+use junobuild_storage::strategies::StorageCertificateStrategy;
+
+pub struct StorageCertificate;
+
+impl StorageCertificateStrategy for StorageCertificate {
+    fn update_certified_data(&self) {
+        update_certified_data();
+    }
+
+    // We use this function to access the auth signatures root hash
+    // in the storage crate when we build an HTTP response because the
+    // tree is a fork of both assets and signatures.
+    fn get_pruned_labeled_sigs_root_hash_tree(&self) -> HashTree {
+        pruned_labeled_sigs_root_hash_tree()
+    }
+}

--- a/src/console/src/cdn/strategies_impls/mod.rs
+++ b/src/console/src/cdn/strategies_impls/mod.rs
@@ -1,2 +1,3 @@
 pub mod cdn;
+pub mod certification;
 pub mod storage;

--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -6,10 +6,7 @@ use crate::cdn::helpers::stable::{
     get_asset_stable, insert_asset_encoding_stable, insert_asset_stable,
 };
 use crate::cdn::storage::init_certified_assets;
-use crate::certification::cert::update_certified_data;
 use candid::Principal;
-use ic_certification::HashTree;
-use junobuild_auth::runtime::pruned_labeled_sigs_root_hash_tree;
 use junobuild_cdn::storage::errors::{
     JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID,
     JUNO_CDN_STORAGE_ERROR_CANNOT_INSERT_ASSET_ENCODING_UNKNOWN_REFERENCE_ID,
@@ -23,8 +20,7 @@ use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::domain::CustomDomains;
 use junobuild_shared::types::state::Controllers;
 use junobuild_storage::strategies::{
-    StorageAssertionsStrategy, StorageCertificateStrategy, StorageStateStrategy,
-    StorageUploadStrategy,
+    StorageAssertionsStrategy, StorageStateStrategy, StorageUploadStrategy,
 };
 use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::state::FullPath;
@@ -253,20 +249,5 @@ impl StorageUploadStrategy for StorageUpload {
             }
             None => Err(JUNO_CDN_STORAGE_ERROR_CANNOT_GET_ASSET_UNKNOWN_REFERENCE_ID.to_string()),
         }
-    }
-}
-
-pub struct StorageCertificate;
-
-impl StorageCertificateStrategy for StorageCertificate {
-    fn update_certified_data(&self) {
-        update_certified_data();
-    }
-
-    // We use this function to access the auth signatures root hash
-    // in the storage crate when we build an HTTP response because the
-    // tree is a fork of both assets and signatures.
-    fn get_pruned_labeled_sigs_root_hash_tree(&self) -> HashTree {
-        pruned_labeled_sigs_root_hash_tree()
     }
 }


### PR DESCRIPTION
# Motivation

I rather like to have both auth and storary certification strategy implementation in the same module. Easier to retrieve.
