### PR TITLE
refactor(satellite): move set and assert config to auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "ic-certification",
  "junobuild-shared",
  "serde",
+ "url",
 ]
 
 [[package]]

--- a/src/libs/auth/Cargo.toml
+++ b/src/libs/auth/Cargo.toml
@@ -21,4 +21,5 @@ candid.workspace = true
 serde.workspace = true
 ic-certification.workspace = true
 ic-canister-sig-creation = "1.3.0"
+url.workspace = true
 junobuild-shared = "0.3.0"

--- a/src/libs/auth/src/lib.rs
+++ b/src/libs/auth/src/lib.rs
@@ -3,5 +3,7 @@ mod state;
 pub mod strategies;
 pub mod types;
 
+pub use state::errors;
 pub use state::heap;
 pub use state::runtime;
+pub use state::store;

--- a/src/libs/auth/src/state/assert.rs
+++ b/src/libs/auth/src/state/assert.rs
@@ -1,6 +1,6 @@
-use crate::errors::auth::JUNO_AUTH_ERROR_INVALID_ORIGIN;
-use junobuild_auth::types::config::AuthenticationConfig;
-use junobuild_auth::types::interface::SetAuthenticationConfig;
+use crate::state::errors::JUNO_AUTH_ERROR_INVALID_ORIGIN;
+use crate::types::config::AuthenticationConfig;
+use crate::types::interface::SetAuthenticationConfig;
 use junobuild_shared::assert::assert_version;
 use junobuild_shared::types::core::DomainName;
 use junobuild_shared::types::state::Version;

--- a/src/libs/auth/src/state/errors.rs
+++ b/src/libs/auth/src/state/errors.rs
@@ -1,0 +1,2 @@
+// Error message indicating that a domain - derivation or external alternative origins - cannot be parsed to a valid URL.
+pub const JUNO_AUTH_ERROR_INVALID_ORIGIN: &str = "juno.auth.error.invalid_origin";

--- a/src/libs/auth/src/state/mod.rs
+++ b/src/libs/auth/src/state/mod.rs
@@ -1,4 +1,7 @@
+mod assert;
+pub mod errors;
 pub mod heap;
 mod memory;
 pub mod runtime;
 pub(crate) mod services;
+pub mod store;

--- a/src/libs/auth/src/state/store.rs
+++ b/src/libs/auth/src/state/store.rs
@@ -1,0 +1,20 @@
+use crate::heap::{get_config, insert_config as insert_state_config};
+use crate::state::assert::assert_set_config;
+use crate::strategies::AuthHeapStrategy;
+use crate::types::config::AuthenticationConfig;
+use crate::types::interface::SetAuthenticationConfig;
+
+pub fn set_config(
+    auth_heap: &impl AuthHeapStrategy,
+    proposed_config: &SetAuthenticationConfig,
+) -> Result<AuthenticationConfig, String> {
+    let current_config = get_config(auth_heap);
+
+    assert_set_config(proposed_config, &current_config)?;
+
+    let config = AuthenticationConfig::prepare(&current_config, proposed_config);
+
+    insert_state_config(auth_heap, &config);
+
+    Ok(config)
+}

--- a/src/libs/satellite/src/auth/alternative_origins.rs
+++ b/src/libs/satellite/src/auth/alternative_origins.rs
@@ -1,7 +1,7 @@
 use crate::assets::storage::store::get_custom_domains_store;
 use crate::assets::storage::strategy_impls::StorageState;
 use crate::certification::strategy_impls::StorageCertificate;
-use crate::errors::auth::JUNO_AUTH_ERROR_INVALID_ORIGIN;
+use junobuild_auth::errors::JUNO_AUTH_ERROR_INVALID_ORIGIN;
 use junobuild_auth::types::config::AuthenticationConfig;
 use junobuild_shared::ic::api::id;
 use junobuild_shared::types::core::DomainName;

--- a/src/libs/satellite/src/auth/assert/mod.rs
+++ b/src/libs/satellite/src/auth/assert/mod.rs
@@ -1,2 +1,1 @@
 pub mod caller;
-pub mod config;

--- a/src/libs/satellite/src/auth/store.rs
+++ b/src/libs/satellite/src/auth/store.rs
@@ -1,10 +1,9 @@
 use crate::auth::alternative_origins::update_alternative_origins;
-use crate::auth::assert::config::assert_set_config;
 use crate::auth::strategy_impls::AuthHeap;
 use junobuild_auth::heap::{
-    get_config as get_state_config, get_salt as get_state_salt,
-    insert_config as insert_state_config, insert_salt,
+    get_config as get_state_config, get_salt as get_state_salt, insert_salt,
 };
+use junobuild_auth::store::set_config as set_store_config;
 use junobuild_auth::types::config::AuthenticationConfig;
 use junobuild_auth::types::interface::SetAuthenticationConfig;
 use junobuild_auth::types::state::Salt;
@@ -12,13 +11,7 @@ use junobuild_auth::types::state::Salt;
 pub fn set_config(
     proposed_config: &SetAuthenticationConfig,
 ) -> Result<AuthenticationConfig, String> {
-    let current_config = get_config();
-
-    assert_set_config(proposed_config, &current_config)?;
-
-    let config = AuthenticationConfig::prepare(&current_config, proposed_config);
-
-    insert_state_config(&AuthHeap, &config);
+    let config = set_store_config(&AuthHeap, &proposed_config)?;
 
     update_alternative_origins(&config)?;
 

--- a/src/libs/satellite/src/errors/auth.rs
+++ b/src/libs/satellite/src/errors/auth.rs
@@ -1,5 +1,3 @@
-// Error message indicating that a domain - derivation or external alternative origins - cannot be parsed to a valid URL.
-pub const JUNO_AUTH_ERROR_INVALID_ORIGIN: &str = "juno.auth.error.invalid_origin";
 // Caller is not an admin controller of the satellite.
 pub const JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER: &str = "juno.auth.error.not_admin_controller";
 // Caller is not an admin or write controller of the satellite.


### PR DESCRIPTION
# Motivation

We want to use the same insert configuration and assertion for the Console.
