### PR TITLE
feat(console): add to heap and expose authentication config

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -24,13 +24,28 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
+type AuthenticationConfig = record {
+  updated_at : opt nat64;
+  created_at : opt nat64;
+  version : opt nat64;
+  internet_identity : opt AuthenticationConfigInternetIdentity;
+  rules : opt AuthenticationRules;
+};
+type AuthenticationConfigInternetIdentity = record {
+  derivation_origin : opt text;
+  external_alternative_origins : opt vec text;
+};
+type AuthenticationRules = record { allowed_callers : vec principal };
 type CommitBatch = record {
   batch_id : nat;
   headers : vec record { text; text };
   chunk_ids : vec nat;
 };
 type CommitProposal = record { sha256 : blob; proposal_id : nat };
-type Config = record { storage : StorageConfig };
+type Config = record {
+  authentication : opt AuthenticationConfig;
+  storage : StorageConfig;
+};
 type ConfigMaxMemorySize = record { stable : opt nat64; heap : opt nat64 };
 type Controller = record {
   updated_at : nat64;
@@ -164,6 +179,11 @@ type SegmentsDeploymentOptions = record {
   mission_control_version : opt text;
   satellite_version : opt text;
 };
+type SetAuthenticationConfig = record {
+  version : opt nat64;
+  internet_identity : opt AuthenticationConfigInternetIdentity;
+  rules : opt AuthenticationRules;
+};
 type SetController = record {
   metadata : vec record { text; text };
   scope : ControllerScope;
@@ -241,6 +261,7 @@ service : () -> {
   del_controllers : (DeleteControllersArgs) -> ();
   del_custom_domain : (text) -> ();
   delete_proposal_assets : (DeleteProposalAssets) -> ();
+  get_auth_config : () -> (opt AuthenticationConfig) query;
   get_config : () -> (Config) query;
   get_create_orbiter_fee : (GetCreateCanisterFeeArgs) -> (opt Tokens) query;
   get_create_satellite_fee : (GetCreateCanisterFeeArgs) -> (opt Tokens) query;
@@ -267,6 +288,7 @@ service : () -> {
       vec record { principal; MissionControl },
     ) query;
   reject_proposal : (CommitProposal) -> (null);
+  set_auth_config : (SetAuthenticationConfig) -> (AuthenticationConfig);
   set_controllers : (SetControllersArgs) -> ();
   set_custom_domain : (text, opt text) -> ();
   set_fee : (SegmentKind, Tokens) -> ();

--- a/src/console/src/api/config.rs
+++ b/src/console/src/api/config.rs
@@ -1,8 +1,13 @@
+use crate::auth::store::{
+    get_config as get_auth_config_store, set_config as set_auth_config_store,
+};
 use crate::cdn::strategies_impls::cdn::CdnHeap;
 use crate::cdn::strategies_impls::storage::StorageState;
 use crate::guards::caller_is_admin_controller;
 use crate::types::interface::Config;
 use ic_cdk_macros::{query, update};
+use junobuild_auth::types::config::AuthenticationConfig;
+use junobuild_auth::types::interface::SetAuthenticationConfig;
 use junobuild_shared::ic::UnwrapOrTrap;
 use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::interface::SetStorageConfig;
@@ -14,7 +19,12 @@ use junobuild_storage::types::interface::SetStorageConfig;
 #[query(guard = "caller_is_admin_controller")]
 pub fn get_config() -> Config {
     let storage = junobuild_cdn::storage::heap::get_config(&CdnHeap);
-    Config { storage }
+    let authentication = get_auth_config_store();
+
+    Config {
+        storage,
+        authentication,
+    }
 }
 
 // ---------------------------------------------------------
@@ -29,4 +39,18 @@ pub fn set_storage_config(config: SetStorageConfig) -> StorageConfig {
 #[query(guard = "caller_is_admin_controller")]
 pub fn get_storage_config() -> StorageConfig {
     junobuild_cdn::storage::heap::get_config(&CdnHeap)
+}
+
+// ---------------------------------------------------------
+// Authentication config
+// ---------------------------------------------------------
+
+#[update(guard = "caller_is_admin_controller")]
+pub fn set_auth_config(config: SetAuthenticationConfig) -> AuthenticationConfig {
+    set_auth_config_store(&config).unwrap_or_trap()
+}
+
+#[query(guard = "caller_is_admin_controller")]
+pub fn get_auth_config() -> Option<AuthenticationConfig> {
+    get_auth_config_store()
 }

--- a/src/console/src/auth/store.rs
+++ b/src/console/src/auth/store.rs
@@ -1,6 +1,25 @@
 use crate::auth::strategy_impls::AuthHeap;
-use junobuild_auth::state::{get_salt as get_state_salt, insert_salt};
+use junobuild_auth::state::{
+    get_config as get_state_config, get_salt as get_state_salt, insert_salt,
+    set_config as set_store_config,
+};
+use junobuild_auth::types::config::AuthenticationConfig;
+use junobuild_auth::types::interface::SetAuthenticationConfig;
 use junobuild_auth::types::state::Salt;
+
+pub fn set_config(
+    proposed_config: &SetAuthenticationConfig,
+) -> Result<AuthenticationConfig, String> {
+    let config = set_store_config(&AuthHeap, &proposed_config)?;
+
+    // If we ever need it, in the Satellite we update_alternative_origins here.
+
+    Ok(config)
+}
+
+pub fn get_config() -> Option<AuthenticationConfig> {
+    get_state_config(&AuthHeap)
+}
 
 pub fn set_salt(salt: &Salt) {
     insert_salt(&AuthHeap, salt);

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -22,6 +22,8 @@ use crate::types::state::Payments;
 use candid::Principal;
 use ic_cdk_macros::export_candid;
 use ic_ledger_types::Tokens;
+use junobuild_auth::types::config::AuthenticationConfig;
+use junobuild_auth::types::interface::SetAuthenticationConfig;
 use junobuild_cdn::proposals::CommitProposal;
 use junobuild_cdn::proposals::ListProposalResults;
 use junobuild_cdn::proposals::ListProposalsParams;

--- a/src/console/src/types.rs
+++ b/src/console/src/types.rs
@@ -110,6 +110,7 @@ pub mod state {
 
 pub mod interface {
     use candid::CandidType;
+    use junobuild_auth::types::config::AuthenticationConfig;
     use junobuild_cdn::proposals::ProposalId;
     use junobuild_storage::types::config::StorageConfig;
     use serde::{Deserialize, Serialize};
@@ -117,6 +118,7 @@ pub mod interface {
     #[derive(CandidType, Deserialize)]
     pub struct Config {
         pub storage: StorageConfig,
+        pub authentication: Option<AuthenticationConfig>,
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -30,6 +30,20 @@ export interface AssetNoContent {
 export interface AssetsUpgradeOptions {
 	clear_existing_assets: [] | [boolean];
 }
+export interface AuthenticationConfig {
+	updated_at: [] | [bigint];
+	created_at: [] | [bigint];
+	version: [] | [bigint];
+	internet_identity: [] | [AuthenticationConfigInternetIdentity];
+	rules: [] | [AuthenticationRules];
+}
+export interface AuthenticationConfigInternetIdentity {
+	derivation_origin: [] | [string];
+	external_alternative_origins: [] | [Array<string>];
+}
+export interface AuthenticationRules {
+	allowed_callers: Array<Principal>;
+}
 export interface CommitBatch {
 	batch_id: bigint;
 	headers: Array<[string, string]>;
@@ -40,6 +54,7 @@ export interface CommitProposal {
 	proposal_id: bigint;
 }
 export interface Config {
+	authentication: [] | [AuthenticationConfig];
 	storage: StorageConfig;
 }
 export interface ConfigMaxMemorySize {
@@ -202,6 +217,11 @@ export interface SegmentsDeploymentOptions {
 	mission_control_version: [] | [string];
 	satellite_version: [] | [string];
 }
+export interface SetAuthenticationConfig {
+	version: [] | [bigint];
+	internet_identity: [] | [AuthenticationConfigInternetIdentity];
+	rules: [] | [AuthenticationRules];
+}
 export interface SetController {
 	metadata: Array<[string, string]>;
 	scope: ControllerScope;
@@ -285,6 +305,7 @@ export interface _SERVICE {
 	del_controllers: ActorMethod<[DeleteControllersArgs], undefined>;
 	del_custom_domain: ActorMethod<[string], undefined>;
 	delete_proposal_assets: ActorMethod<[DeleteProposalAssets], undefined>;
+	get_auth_config: ActorMethod<[], [] | [AuthenticationConfig]>;
 	get_config: ActorMethod<[], Config>;
 	get_create_orbiter_fee: ActorMethod<[GetCreateCanisterFeeArgs], [] | [Tokens]>;
 	get_create_satellite_fee: ActorMethod<[GetCreateCanisterFeeArgs], [] | [Tokens]>;
@@ -311,6 +332,7 @@ export interface _SERVICE {
 	list_proposals: ActorMethod<[ListProposalsParams], ListProposalResults>;
 	list_user_mission_control_centers: ActorMethod<[], Array<[Principal, MissionControl]>>;
 	reject_proposal: ActorMethod<[CommitProposal], null>;
+	set_auth_config: ActorMethod<[SetAuthenticationConfig], AuthenticationConfig>;
 	set_controllers: ActorMethod<[SetControllersArgs], undefined>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;
 	set_fee: ActorMethod<[SegmentKind, Tokens], undefined>;

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -38,6 +38,20 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
+	const AuthenticationConfigInternetIdentity = IDL.Record({
+		derivation_origin: IDL.Opt(IDL.Text),
+		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
+	});
+	const AuthenticationRules = IDL.Record({
+		allowed_callers: IDL.Vec(IDL.Principal)
+	});
+	const AuthenticationConfig = IDL.Record({
+		updated_at: IDL.Opt(IDL.Nat64),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
+		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
+		rules: IDL.Opt(AuthenticationRules)
+	});
 	const StorageConfigIFrame = IDL.Variant({
 		Deny: IDL.Null,
 		AllowAny: IDL.Null,
@@ -66,7 +80,10 @@ export const idlFactory = ({ IDL }) => {
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
 	});
-	const Config = IDL.Record({ storage: StorageConfig });
+	const Config = IDL.Record({
+		authentication: IDL.Opt(AuthenticationConfig),
+		storage: StorageConfig
+	});
 	const GetCreateCanisterFeeArgs = IDL.Record({ user: IDL.Principal });
 	const ProposalStatus = IDL.Variant({
 		Initialized: IDL.Null,
@@ -249,6 +266,11 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(ProposalKey, Proposal)),
 		items_length: IDL.Nat64
 	});
+	const SetAuthenticationConfig = IDL.Record({
+		version: IDL.Opt(IDL.Nat64),
+		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
+		rules: IDL.Opt(AuthenticationRules)
+	});
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -295,6 +317,7 @@ export const idlFactory = ({ IDL }) => {
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		delete_proposal_assets: IDL.Func([DeleteProposalAssets], [], []),
+		get_auth_config: IDL.Func([], [IDL.Opt(AuthenticationConfig)], []),
 		get_config: IDL.Func([], [Config], []),
 		get_create_orbiter_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], []),
 		get_create_satellite_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], []),
@@ -327,6 +350,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, Tokens], [], []),

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -38,6 +38,20 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
+	const AuthenticationConfigInternetIdentity = IDL.Record({
+		derivation_origin: IDL.Opt(IDL.Text),
+		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
+	});
+	const AuthenticationRules = IDL.Record({
+		allowed_callers: IDL.Vec(IDL.Principal)
+	});
+	const AuthenticationConfig = IDL.Record({
+		updated_at: IDL.Opt(IDL.Nat64),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
+		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
+		rules: IDL.Opt(AuthenticationRules)
+	});
 	const StorageConfigIFrame = IDL.Variant({
 		Deny: IDL.Null,
 		AllowAny: IDL.Null,
@@ -66,7 +80,10 @@ export const idlFactory = ({ IDL }) => {
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
 	});
-	const Config = IDL.Record({ storage: StorageConfig });
+	const Config = IDL.Record({
+		authentication: IDL.Opt(AuthenticationConfig),
+		storage: StorageConfig
+	});
 	const GetCreateCanisterFeeArgs = IDL.Record({ user: IDL.Principal });
 	const ProposalStatus = IDL.Variant({
 		Initialized: IDL.Null,
@@ -249,6 +266,11 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(ProposalKey, Proposal)),
 		items_length: IDL.Nat64
 	});
+	const SetAuthenticationConfig = IDL.Record({
+		version: IDL.Opt(IDL.Nat64),
+		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
+		rules: IDL.Opt(AuthenticationRules)
+	});
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -295,6 +317,7 @@ export const idlFactory = ({ IDL }) => {
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		delete_proposal_assets: IDL.Func([DeleteProposalAssets], [], []),
+		get_auth_config: IDL.Func([], [IDL.Opt(AuthenticationConfig)], ['query']),
 		get_config: IDL.Func([], [Config], ['query']),
 		get_create_orbiter_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], ['query']),
 		get_create_satellite_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], ['query']),
@@ -327,6 +350,7 @@ export const idlFactory = ({ IDL }) => {
 			['query']
 		),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, Tokens], [], []),

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -38,6 +38,20 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
+	const AuthenticationConfigInternetIdentity = IDL.Record({
+		derivation_origin: IDL.Opt(IDL.Text),
+		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
+	});
+	const AuthenticationRules = IDL.Record({
+		allowed_callers: IDL.Vec(IDL.Principal)
+	});
+	const AuthenticationConfig = IDL.Record({
+		updated_at: IDL.Opt(IDL.Nat64),
+		created_at: IDL.Opt(IDL.Nat64),
+		version: IDL.Opt(IDL.Nat64),
+		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
+		rules: IDL.Opt(AuthenticationRules)
+	});
 	const StorageConfigIFrame = IDL.Variant({
 		Deny: IDL.Null,
 		AllowAny: IDL.Null,
@@ -66,7 +80,10 @@ export const idlFactory = ({ IDL }) => {
 		raw_access: IDL.Opt(StorageConfigRawAccess),
 		redirects: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, StorageConfigRedirect)))
 	});
-	const Config = IDL.Record({ storage: StorageConfig });
+	const Config = IDL.Record({
+		authentication: IDL.Opt(AuthenticationConfig),
+		storage: StorageConfig
+	});
 	const GetCreateCanisterFeeArgs = IDL.Record({ user: IDL.Principal });
 	const ProposalStatus = IDL.Variant({
 		Initialized: IDL.Null,
@@ -249,6 +266,11 @@ export const idlFactory = ({ IDL }) => {
 		items: IDL.Vec(IDL.Tuple(ProposalKey, Proposal)),
 		items_length: IDL.Nat64
 	});
+	const SetAuthenticationConfig = IDL.Record({
+		version: IDL.Opt(IDL.Nat64),
+		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
+		rules: IDL.Opt(AuthenticationRules)
+	});
 	const SetController = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		scope: ControllerScope,
@@ -295,6 +317,7 @@ export const idlFactory = ({ IDL }) => {
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		del_custom_domain: IDL.Func([IDL.Text], [], []),
 		delete_proposal_assets: IDL.Func([DeleteProposalAssets], [], []),
+		get_auth_config: IDL.Func([], [IDL.Opt(AuthenticationConfig)], ['query']),
 		get_config: IDL.Func([], [Config], ['query']),
 		get_create_orbiter_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], ['query']),
 		get_create_satellite_fee: IDL.Func([GetCreateCanisterFeeArgs], [IDL.Opt(Tokens)], ['query']),
@@ -327,6 +350,7 @@ export const idlFactory = ({ IDL }) => {
 			['query']
 		),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
+		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, Tokens], [], []),

--- a/src/tests/constants/auth-tests.constants.ts
+++ b/src/tests/constants/auth-tests.constants.ts
@@ -1,0 +1,4 @@
+export const EXTERNAL_ALTERNATIVE_ORIGINS = ['other.com', 'another.com'];
+export const EXTERNAL_ALTERNATIVE_ORIGINS_URLS = EXTERNAL_ALTERNATIVE_ORIGINS.map(
+	(url) => `https://${url}`
+);

--- a/src/tests/specs/console/console.auth.spec.ts
+++ b/src/tests/specs/console/console.auth.spec.ts
@@ -1,0 +1,45 @@
+import { type ConsoleActor, idlFactoryConsole } from '$declarations';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { type Actor, PocketIc } from '@dfinity/pic';
+import { inject } from 'vitest';
+import { testAuthConfig, testReturnAutConfig } from '../../utils/auth-assertions-tests.utils';
+import { CONSOLE_WASM_PATH } from '../../utils/setup-tests.utils';
+
+describe('Console > Storage', () => {
+	let pic: PocketIc;
+	let actor: Actor<ConsoleActor>;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const { actor: c } = await pic.setupCanister<ConsoleActor>({
+			idlFactory: idlFactoryConsole,
+			wasm: CONSOLE_WASM_PATH,
+			sender: controller.getPrincipal()
+		});
+
+		actor = c;
+		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	describe('admin', () => {
+		beforeAll(() => {
+			actor.setIdentity(controller);
+		});
+
+		testAuthConfig({
+			actor: () => actor
+		});
+
+		testReturnAutConfig({
+			actor: () => actor,
+			version: 4n
+		});
+	});
+});

--- a/src/tests/specs/console/console.config.spec.ts
+++ b/src/tests/specs/console/console.config.spec.ts
@@ -1,0 +1,88 @@
+import { type ConsoleActor, type ConsoleDid, idlFactoryConsole } from '$declarations';
+import { AnonymousIdentity } from '@dfinity/agent';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
+import { type Actor, PocketIc } from '@dfinity/pic';
+import { toNullable } from '@dfinity/utils';
+import { inject } from 'vitest';
+import { CONSOLE_WASM_PATH } from '../../utils/setup-tests.utils';
+
+describe('Console > Storage', () => {
+	let pic: PocketIc;
+	let actor: Actor<ConsoleActor>;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	beforeAll(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const { actor: c } = await pic.setupCanister<ConsoleActor>({
+			idlFactory: idlFactoryConsole,
+			wasm: CONSOLE_WASM_PATH,
+			sender: controller.getPrincipal()
+		});
+
+		actor = c;
+		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	describe.each([
+		{ title: 'Anonymous', user: new AnonymousIdentity() },
+		{ title: 'Some identity', user: Ed25519KeyIdentity.generate() }
+	])('$title', ({ title, user }) => {
+		const ERROR_NOT_ADMIN_CONTROLLER = 'Caller is not a controller of the console.';
+
+		beforeAll(() => {
+			actor.setIdentity(user);
+		});
+
+		it('should throw errors on setting storage config', async () => {
+			const { set_storage_config } = actor;
+
+			await expect(
+				set_storage_config({
+					headers: [],
+					iframe: toNullable(),
+					redirects: toNullable(),
+					rewrites: [],
+					raw_access: toNullable(),
+					max_memory_size: toNullable(),
+					version: toNullable()
+				})
+			).rejects.toThrow(ERROR_NOT_ADMIN_CONTROLLER);
+		});
+
+		it('should throw errors on setting auth config', async () => {
+			const { set_auth_config } = actor;
+
+			const config: ConsoleDid.SetAuthenticationConfig = {
+				internet_identity: [],
+				rules: [],
+				version: []
+			};
+
+			await expect(set_auth_config(config)).rejects.toThrow(ERROR_NOT_ADMIN_CONTROLLER);
+		});
+
+		it('should throw errors on getting storage config', async () => {
+			const { get_storage_config } = actor;
+
+			await expect(get_storage_config()).rejects.toThrow(ERROR_NOT_ADMIN_CONTROLLER);
+		});
+
+		it('should throw errors on getting auth config', async () => {
+			const { get_auth_config } = actor;
+
+			await expect(get_auth_config()).rejects.toThrow(ERROR_NOT_ADMIN_CONTROLLER);
+		});
+
+		it('should throw errors on getting config', async () => {
+			const { get_config } = actor;
+
+			await expect(get_config()).rejects.toThrow(ERROR_NOT_ADMIN_CONTROLLER);
+		});
+	});
+});

--- a/src/tests/utils/auth-assertions-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-tests.utils.ts
@@ -1,0 +1,278 @@
+import type { ConsoleActor, SatelliteActor, SatelliteDid } from '$declarations';
+import type { Actor } from '@dfinity/pic';
+import { fromNullable, nonNullish, toNullable } from '@dfinity/utils';
+import { JUNO_AUTH_ERROR_INVALID_ORIGIN } from '@junobuild/errors';
+import {
+	EXTERNAL_ALTERNATIVE_ORIGINS,
+	EXTERNAL_ALTERNATIVE_ORIGINS_URLS
+} from '../constants/auth-tests.constants';
+
+export const testAuthConfig = ({
+	actor,
+	withWellKnownIIAlternativeOrigins
+}: {
+	actor: () => Actor<SatelliteActor | ConsoleActor>;
+	withWellKnownIIAlternativeOrigins?: () => string;
+}) => {
+	const canisterIdUrl = withWellKnownIIAlternativeOrigins?.();
+
+	const assertConfig = async ({
+		config,
+		version
+	}: {
+		config: SatelliteDid.SetAuthenticationConfig;
+		version: bigint;
+	}) => {
+		const { get_auth_config } = actor();
+
+		const result = fromNullable(await get_auth_config());
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				...config,
+				created_at: [expect.any(BigInt)],
+				updated_at: [expect.any(BigInt)],
+				version: [version]
+			})
+		);
+
+		expect(fromNullable(result?.created_at ?? []) ?? 0n).toBeGreaterThan(0n);
+		expect(fromNullable(result?.updated_at ?? []) ?? 0n).toBeGreaterThan(0n);
+	};
+
+	it('should have empty config per default', async () => {
+		const { get_auth_config } = actor();
+
+		const config = await get_auth_config();
+
+		expect(config).toEqual([]);
+	});
+
+	const invalidDomain = 'domain%20.com';
+
+	it('should throw if derivation origin is malformed', async () => {
+		const { set_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [
+				{
+					derivation_origin: [invalidDomain],
+					external_alternative_origins: toNullable()
+				}
+			],
+			rules: [],
+			version: []
+		};
+
+		await expect(set_auth_config(config)).rejects.toThrow(
+			`${JUNO_AUTH_ERROR_INVALID_ORIGIN} (${invalidDomain})`
+		);
+	});
+
+	it('should throw if external alternative origin is malformed', async () => {
+		const { set_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [
+				{
+					derivation_origin: toNullable(),
+					external_alternative_origins: [[invalidDomain]]
+				}
+			],
+			rules: [],
+			version: []
+		};
+
+		await expect(set_auth_config(config)).rejects.toThrow(
+			`${JUNO_AUTH_ERROR_INVALID_ORIGIN} (${invalidDomain})`
+		);
+	});
+
+	it('should set config auth domain', async () => {
+		const { set_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [
+				{
+					derivation_origin: ['domain.com'],
+					external_alternative_origins: toNullable()
+				}
+			],
+			rules: [],
+			version: []
+		};
+
+		await set_auth_config(config);
+
+		await assertConfig({ config, version: 1n });
+	});
+
+	if (nonNullish(canisterIdUrl)) {
+		it('should expose /.well-known/ii-alternative-origins', async () => {
+			const { http_request } = actor();
+
+			const { body } = await http_request({
+				body: [],
+				certificate_version: toNullable(),
+				headers: [],
+				method: 'GET',
+				url: '/.well-known/ii-alternative-origins'
+			});
+
+			const decoder = new TextDecoder();
+			const responseBody = decoder.decode(body as Uint8Array<ArrayBufferLike>);
+
+			expect(responseBody).toEqual(JSON.stringify({ alternativeOrigins: [canisterIdUrl] }));
+			expect(JSON.parse(responseBody).alternativeOrigins).toEqual([canisterIdUrl]);
+		});
+	}
+
+	it('should set external alternative origins', async () => {
+		const { set_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [
+				{
+					derivation_origin: ['domain.com'],
+					external_alternative_origins: [EXTERNAL_ALTERNATIVE_ORIGINS]
+				}
+			],
+			rules: [],
+			version: [1n]
+		};
+
+		await set_auth_config(config);
+
+		await assertConfig({ config, version: 2n });
+	});
+
+	if (nonNullish(canisterIdUrl)) {
+		it('should expose /.well-known/ii-alternative-origins with external origins', async () => {
+			const { http_request } = actor();
+
+			const { body } = await http_request({
+				body: [],
+				certificate_version: toNullable(),
+				headers: [],
+				method: 'GET',
+				url: '/.well-known/ii-alternative-origins'
+			});
+
+			const decoder = new TextDecoder();
+			const responseBody = decoder.decode(body as Uint8Array<ArrayBufferLike>);
+
+			expect(responseBody).toEqual(
+				JSON.stringify({
+					alternativeOrigins: [canisterIdUrl, ...EXTERNAL_ALTERNATIVE_ORIGINS_URLS]
+				})
+			);
+			expect(JSON.parse(responseBody).alternativeOrigins).toEqual([
+				canisterIdUrl,
+				...EXTERNAL_ALTERNATIVE_ORIGINS_URLS
+			]);
+		});
+	}
+
+	it('should set config auth domain to none', async () => {
+		const { set_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [
+				{
+					derivation_origin: [],
+					external_alternative_origins: toNullable()
+				}
+			],
+			rules: [],
+			version: [2n]
+		};
+
+		await set_auth_config(config);
+
+		await assertConfig({ config, version: 3n });
+	});
+
+	if (withWellKnownIIAlternativeOrigins) {
+		it('should not expose /.well-known/ii-alternative-origins', async () => {
+			const { http_request } = actor();
+
+			const { status_code } = await http_request({
+				body: [],
+				certificate_version: toNullable(),
+				headers: [],
+				method: 'GET',
+				url: '/.well-known/ii-alternative-origins'
+			});
+
+			expect(status_code).toBe(404);
+		});
+	}
+
+	it('should set config for ii to none', async () => {
+		const { set_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [],
+			rules: [],
+			version: [3n]
+		};
+
+		await set_auth_config(config);
+
+		await assertConfig({ config, version: 4n });
+	});
+
+	if (withWellKnownIIAlternativeOrigins) {
+		it('should not expose /.well-known/ii-alternative-origins if the all config as been deleted as well', async () => {
+			const { http_request } = actor();
+
+			const { status_code } = await http_request({
+				body: [],
+				certificate_version: toNullable(),
+				headers: [],
+				method: 'GET',
+				url: '/.well-known/ii-alternative-origins'
+			});
+
+			expect(status_code).toBe(404);
+		});
+	}
+};
+
+export const testReturnAutConfig = ({
+	actor,
+	version
+}: {
+	actor: () => Actor<SatelliteActor | ConsoleActor>;
+	version: bigint;
+}) => {
+	it('should return config on set', async () => {
+		const { set_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [
+				{
+					derivation_origin: ['domain.com'],
+					external_alternative_origins: toNullable()
+				}
+			],
+			rules: [],
+			version: [version]
+		};
+
+		const updatedConfig = await set_auth_config(config);
+
+		expect(updatedConfig).toEqual(
+			expect.objectContaining({
+				...config,
+				created_at: [expect.any(BigInt)],
+				updated_at: [expect.any(BigInt)],
+				version: [version + 1n]
+			})
+		);
+
+		expect(fromNullable(updatedConfig?.updated_at ?? []) ?? 0n).toBeGreaterThan(
+			fromNullable(updatedConfig?.created_at ?? []) ?? 0n
+		);
+	});
+};


### PR DESCRIPTION
# Motivation

Add `authentication: Option<AuthenticationHeapState>` to the heap of the Console and expose getter and setter to API.
