### PR TITLE
feat(auth): google auth client id config

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -26,11 +26,13 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
+  google : opt AuthenticationConfigGoogle;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
+type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
@@ -180,6 +182,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
+  google : opt AuthenticationConfigGoogle;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -32,10 +32,14 @@ export interface AssetsUpgradeOptions {
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
+	google: [] | [AuthenticationConfigGoogle];
 	created_at: [] | [bigint];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
+}
+export interface AuthenticationConfigGoogle {
+	client_id: string;
 }
 export interface AuthenticationConfigInternetIdentity {
 	derivation_origin: [] | [string];
@@ -218,6 +222,7 @@ export interface SegmentsDeploymentOptions {
 	satellite_version: [] | [string];
 }
 export interface SetAuthenticationConfig {
+	google: [] | [AuthenticationConfigGoogle];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -38,6 +38,7 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -47,6 +48,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -267,6 +269,7 @@ export const idlFactory = ({ IDL }) => {
 		items_length: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -38,6 +38,7 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -47,6 +48,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -267,6 +269,7 @@ export const idlFactory = ({ IDL }) => {
 		items_length: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -38,6 +38,7 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -47,6 +48,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -267,6 +269,7 @@ export const idlFactory = ({ IDL }) => {
 		items_length: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -28,10 +28,14 @@ export interface AssetsUpgradeOptions {
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
+	google: [] | [AuthenticationConfigGoogle];
 	created_at: [] | [bigint];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
+}
+export interface AuthenticationConfigGoogle {
+	client_id: string;
 }
 export interface AuthenticationConfigInternetIdentity {
 	derivation_origin: [] | [string];
@@ -252,6 +256,7 @@ export interface SegmentsDeploymentOptions {
 	satellite_version: [] | [string];
 }
 export interface SetAuthenticationConfig {
+	google: [] | [AuthenticationConfigGoogle];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -89,6 +89,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -98,6 +99,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -288,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -89,6 +89,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -98,6 +99,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -288,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -89,6 +89,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -98,6 +99,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -288,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -28,10 +28,14 @@ export interface AssetsUpgradeOptions {
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
+	google: [] | [AuthenticationConfigGoogle];
 	created_at: [] | [bigint];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
+}
+export interface AuthenticationConfigGoogle {
+	client_id: string;
 }
 export interface AuthenticationConfigInternetIdentity {
 	derivation_origin: [] | [string];
@@ -252,6 +256,7 @@ export interface SegmentsDeploymentOptions {
 	satellite_version: [] | [string];
 }
 export interface SetAuthenticationConfig {
+	google: [] | [AuthenticationConfigGoogle];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -89,6 +89,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -98,6 +99,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -288,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -89,6 +89,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -98,6 +99,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -288,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/frontend/src/lib/services/auth/auth.config.services.ts
+++ b/src/frontend/src/lib/services/auth/auth.config.services.ts
@@ -132,6 +132,8 @@ const updateConfig = async ({
 			config: {
 				internet_identity: editConfig?.internet_identity ?? config?.internet_identity ?? [],
 				rules: unmodifiedRules ? (config?.rules ?? []) : editConfigRules,
+				// TODO: support for Google configuration in the Console UI
+				google: [],
 				version: config?.version ?? []
 			},
 			identity

--- a/src/frontend/src/lib/utils/auth.config.utils.ts
+++ b/src/frontend/src/lib/utils/auth.config.utils.ts
@@ -23,6 +23,7 @@ export const buildSetAuthenticationConfig = ({
 						external_alternative_origins
 					}
 				],
+				google: [],
 				rules: []
 			}
 		: {

--- a/src/libs/auth/src/impls.rs
+++ b/src/libs/auth/src/impls.rs
@@ -22,6 +22,7 @@ impl AuthenticationConfig {
 
         AuthenticationConfig {
             internet_identity: user_config.internet_identity.clone(),
+            google: user_config.google.clone(),
             rules: user_config.rules.clone(),
             created_at: Some(created_at),
             updated_at: Some(updated_at),

--- a/src/libs/auth/src/types.rs
+++ b/src/libs/auth/src/types.rs
@@ -39,6 +39,7 @@ pub mod config {
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct AuthenticationConfig {
         pub internet_identity: Option<AuthenticationConfigInternetIdentity>,
+        pub google: Option<AuthenticationConfigGoogle>,
         pub rules: Option<AuthenticationRules>,
         pub version: Option<Version>,
         pub created_at: Option<Timestamp>,
@@ -55,10 +56,15 @@ pub mod config {
     pub struct AuthenticationRules {
         pub allowed_callers: Vec<Principal>,
     }
+
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
+    pub struct AuthenticationConfigGoogle {
+        pub client_id: String,
+    }
 }
 
 pub mod interface {
-    use crate::types::config::{AuthenticationConfigInternetIdentity, AuthenticationRules};
+    use crate::types::config::{AuthenticationConfigGoogle, AuthenticationConfigInternetIdentity, AuthenticationRules};
     use candid::{CandidType, Deserialize};
     use junobuild_shared::types::state::Version;
     use serde::Serialize;
@@ -66,6 +72,7 @@ pub mod interface {
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct SetAuthenticationConfig {
         pub internet_identity: Option<AuthenticationConfigInternetIdentity>,
+        pub google: Option<AuthenticationConfigGoogle>,
         pub rules: Option<AuthenticationRules>,
         pub version: Option<Version>,
     }

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -22,11 +22,13 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
+  google : opt AuthenticationConfigGoogle;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
+type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
@@ -198,6 +200,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
+  google : opt AuthenticationConfigGoogle;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -24,11 +24,13 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
+  google : opt AuthenticationConfigGoogle;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
+type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
@@ -200,6 +202,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
+  google : opt AuthenticationConfigGoogle;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -24,11 +24,13 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
+  google : opt AuthenticationConfigGoogle;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
+type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
@@ -200,6 +202,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
+  google : opt AuthenticationConfigGoogle;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -28,10 +28,14 @@ export interface AssetsUpgradeOptions {
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
+	google: [] | [AuthenticationConfigGoogle];
 	created_at: [] | [bigint];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
+}
+export interface AuthenticationConfigGoogle {
+	client_id: string;
 }
 export interface AuthenticationConfigInternetIdentity {
 	derivation_origin: [] | [string];
@@ -253,6 +257,7 @@ export interface SegmentsDeploymentOptions {
 	satellite_version: [] | [string];
 }
 export interface SetAuthenticationConfig {
+	google: [] | [AuthenticationConfigGoogle];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -89,6 +89,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -98,6 +99,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -288,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -89,6 +89,7 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -98,6 +99,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -288,6 +290,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
+		google: IDL.Opt(AuthenticationConfigGoogle),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -24,11 +24,13 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
+  google : opt AuthenticationConfigGoogle;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
+type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
@@ -200,6 +202,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
+  google : opt AuthenticationConfigGoogle;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/tests/specs/console/console.auth.spec.ts
+++ b/src/tests/specs/console/console.auth.spec.ts
@@ -2,7 +2,11 @@ import { type ConsoleActor, idlFactoryConsole } from '$declarations';
 import { Ed25519KeyIdentity } from '@dfinity/identity';
 import { type Actor, PocketIc } from '@dfinity/pic';
 import { inject } from 'vitest';
-import { testAuthConfig, testReturnAuthConfig } from '../../utils/auth-assertions-tests.utils';
+import {
+	testAuthConfig,
+	testAuthGoogleConfig,
+	testReturnAuthConfig
+} from '../../utils/auth-assertions-tests.utils';
 import { CONSOLE_WASM_PATH } from '../../utils/setup-tests.utils';
 
 describe('Console > Storage', () => {
@@ -40,6 +44,11 @@ describe('Console > Storage', () => {
 		testReturnAuthConfig({
 			actor: () => actor,
 			version: 4n
+		});
+
+		testAuthGoogleConfig({
+			actor: () => actor,
+			version: 5n
 		});
 	});
 });

--- a/src/tests/specs/console/console.config.spec.ts
+++ b/src/tests/specs/console/console.config.spec.ts
@@ -61,6 +61,7 @@ describe('Console > Storage', () => {
 			const config: ConsoleDid.SetAuthenticationConfig = {
 				internet_identity: [],
 				rules: [],
+				google: [],
 				version: []
 			};
 

--- a/src/tests/specs/satellite/stock/satellite.allowed-callers.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.allowed-callers.spec.ts
@@ -71,6 +71,7 @@ describe('Satellite > Allowed Callers', () => {
 
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
+			google: [],
 			rules: [
 				{
 					allowed_callers: allowedCallers
@@ -89,6 +90,7 @@ describe('Satellite > Allowed Callers', () => {
 
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
+			google: [],
 			rules: [
 				{
 					allowed_callers: []
@@ -107,6 +109,7 @@ describe('Satellite > Allowed Callers', () => {
 
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
+			google: [],
 			rules: [],
 			version: nextConfigVersion()
 		};

--- a/src/tests/specs/satellite/stock/satellite.auth.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.auth.spec.ts
@@ -9,7 +9,11 @@ import {
 	EXTERNAL_ALTERNATIVE_ORIGINS,
 	EXTERNAL_ALTERNATIVE_ORIGINS_URLS
 } from '../../../constants/auth-tests.constants';
-import { testAuthConfig, testReturnAuthConfig } from '../../../utils/auth-assertions-tests.utils';
+import {
+	testAuthConfig,
+	testAuthGoogleConfig,
+	testReturnAuthConfig
+} from '../../../utils/auth-assertions-tests.utils';
 import { setupSatelliteStock } from '../../../utils/satellite-tests.utils';
 
 describe('Satellite > Authentication', () => {
@@ -321,6 +325,11 @@ describe('Satellite > Authentication', () => {
 		testReturnAuthConfig({
 			actor: () => actor,
 			version: 11n
+		});
+
+		testAuthGoogleConfig({
+			actor: () => actor,
+			version: 12n
 		});
 	});
 

--- a/src/tests/specs/satellite/stock/satellite.auth.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.auth.spec.ts
@@ -67,6 +67,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
+					google: [],
 					version: [4n]
 				};
 
@@ -104,6 +105,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
+					google: [],
 					version: [5n]
 				};
 
@@ -144,6 +146,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
+					google: [],
 					version: [6n]
 				};
 
@@ -176,6 +179,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
+					google: [],
 					version: [7n]
 				};
 
@@ -217,6 +221,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
+					google: [],
 					version: [8n]
 				};
 
@@ -254,6 +259,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
+					google: [],
 					version: [9n]
 				};
 
@@ -294,6 +300,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
+					google: [],
 					version: [10n]
 				};
 
@@ -331,6 +338,7 @@ describe('Satellite > Authentication', () => {
 						{ derivation_origin: ['demo.com'], external_alternative_origins: toNullable() }
 					],
 					rules: [],
+					google: [],
 					version: [10n]
 				})
 			).rejects.toThrow(JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER);

--- a/src/tests/specs/satellite/stock/satellite.switch-memory.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.switch-memory.spec.ts
@@ -324,6 +324,7 @@ describe('Satellite > Switch storage system memory', () => {
 						}
 					],
 					rules: [],
+					google: [],
 					version: currentConfig?.version ?? []
 				};
 

--- a/src/tests/utils/auth-assertions-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-tests.utils.ts
@@ -63,6 +63,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
+			google: [],
 			version: []
 		};
 
@@ -82,6 +83,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
+			google: [],
 			version: []
 		};
 
@@ -101,6 +103,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
+			google: [],
 			version: []
 		};
 
@@ -140,6 +143,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
+			google: [],
 			version: [1n]
 		};
 
@@ -186,6 +190,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
+			google: [],
 			version: [2n]
 		};
 
@@ -216,6 +221,7 @@ export const testAuthConfig = ({
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
 			rules: [],
+			google: [],
 			version: [3n]
 		};
 
@@ -259,6 +265,7 @@ export const testReturnAuthConfig = ({
 				}
 			],
 			rules: [],
+			google: [],
 			version: [version]
 		};
 

--- a/src/tests/utils/auth-assertions-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-tests.utils.ts
@@ -285,3 +285,51 @@ export const testReturnAuthConfig = ({
 		);
 	});
 };
+
+export const testAuthGoogleConfig = ({
+	actor,
+	version
+}: {
+	actor: () => Actor<SatelliteActor | ConsoleActor>;
+	version: bigint;
+}) => {
+	const CLIENT_ID = '974645666757-ebfaaau4cesdddqahu83e1qqmmmmdrod.apps.googleusercontent.com';
+
+	it('should set google client id', async () => {
+		const { set_auth_config, get_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [],
+			rules: [],
+			google: [
+				{
+					client_id: CLIENT_ID
+				}
+			],
+			version: [version]
+		};
+
+		await set_auth_config(config);
+
+		const updatedConfig = await get_auth_config();
+
+		expect(fromNullable(fromNullable(updatedConfig)?.google ?? [])?.client_id).toEqual(CLIENT_ID);
+	});
+
+	it('should disable google', async () => {
+		const { set_auth_config, get_auth_config } = actor();
+
+		const config: SatelliteDid.SetAuthenticationConfig = {
+			internet_identity: [],
+			rules: [],
+			google: [],
+			version: [version + 1n]
+		};
+
+		await set_auth_config(config);
+
+		const updatedConfig = await get_auth_config();
+
+		expect(fromNullable(fromNullable(updatedConfig)?.google ?? [])).toBeUndefined();
+	});
+};


### PR DESCRIPTION
# Motivation

For sign-in with Google, we (for the console) and devs (with their satellite) will need a Google developer account and related client ID.
