### PR TITLE
feat(auth): make auth config for openid a bit more generic

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -26,16 +26,18 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
-type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
+};
+type AuthenticationConfigOpenId = record {
+  providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CommitBatch = record {
@@ -142,6 +144,8 @@ type MissionControl = record {
   owner : principal;
   created_at : nat64;
 };
+type OpenIdProvider = variant { Google };
+type OpenIdProviderConfig = record { client_id : text };
 type Payment = record {
   status : PaymentStatus;
   updated_at : nat64;
@@ -182,7 +186,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/console/src/auth/store.rs
+++ b/src/console/src/auth/store.rs
@@ -10,7 +10,7 @@ pub async fn set_config(
 
     // If we ever need it, in the Satellite we update_alternative_origins here.
 
-    if config.google.is_some() {
+    if config.openid_enabled() {
         junobuild_auth::state::init_salt(&AuthHeap).await?;
     }
 

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -32,18 +32,18 @@ export interface AssetsUpgradeOptions {
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
-	google: [] | [AuthenticationConfigGoogle];
+	openid: [] | [AuthenticationConfigOpenId];
 	created_at: [] | [bigint];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
 }
-export interface AuthenticationConfigGoogle {
-	client_id: string;
-}
 export interface AuthenticationConfigInternetIdentity {
 	derivation_origin: [] | [string];
 	external_alternative_origins: [] | [Array<string>];
+}
+export interface AuthenticationConfigOpenId {
+	providers: Array<[OpenIdProvider, OpenIdProviderConfig]>;
 }
 export interface AuthenticationRules {
 	allowed_callers: Array<Principal>;
@@ -179,6 +179,10 @@ export interface MissionControl {
 	owner: Principal;
 	created_at: bigint;
 }
+export type OpenIdProvider = { Google: null };
+export interface OpenIdProviderConfig {
+	client_id: string;
+}
 export interface Payment {
 	status: PaymentStatus;
 	updated_at: bigint;
@@ -222,7 +226,7 @@ export interface SegmentsDeploymentOptions {
 	satellite_version: [] | [string];
 }
 export interface SetAuthenticationConfig {
-	google: [] | [AuthenticationConfigGoogle];
+	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -38,7 +38,11 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -48,7 +52,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -269,7 +273,7 @@ export const idlFactory = ({ IDL }) => {
 		items_length: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -38,7 +38,11 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -48,7 +52,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -269,7 +273,7 @@ export const idlFactory = ({ IDL }) => {
 		items_length: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -38,7 +38,11 @@ export const idlFactory = ({ IDL }) => {
 	const DeleteProposalAssets = IDL.Record({
 		proposal_ids: IDL.Vec(IDL.Nat)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -48,7 +52,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -269,7 +273,7 @@ export const idlFactory = ({ IDL }) => {
 		items_length: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -28,18 +28,18 @@ export interface AssetsUpgradeOptions {
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
-	google: [] | [AuthenticationConfigGoogle];
+	openid: [] | [AuthenticationConfigOpenId];
 	created_at: [] | [bigint];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
 }
-export interface AuthenticationConfigGoogle {
-	client_id: string;
-}
 export interface AuthenticationConfigInternetIdentity {
 	derivation_origin: [] | [string];
 	external_alternative_origins: [] | [Array<string>];
+}
+export interface AuthenticationConfigOpenId {
+	providers: Array<[OpenIdProvider, OpenIdProviderConfig]>;
 }
 export interface AuthenticationRules {
 	allowed_callers: Array<Principal>;
@@ -205,6 +205,10 @@ export interface MemorySize {
 	stable: bigint;
 	heap: bigint;
 }
+export type OpenIdProvider = { Google: null };
+export interface OpenIdProviderConfig {
+	client_id: string;
+}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -256,7 +260,7 @@ export interface SegmentsDeploymentOptions {
 	satellite_version: [] | [string];
 }
 export interface SetAuthenticationConfig {
-	google: [] | [AuthenticationConfigGoogle];
+	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -89,7 +89,11 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -99,7 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -290,7 +294,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -89,7 +89,11 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -99,7 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -290,7 +294,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -89,7 +89,11 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -99,7 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -290,7 +294,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -28,18 +28,18 @@ export interface AssetsUpgradeOptions {
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
-	google: [] | [AuthenticationConfigGoogle];
+	openid: [] | [AuthenticationConfigOpenId];
 	created_at: [] | [bigint];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
 }
-export interface AuthenticationConfigGoogle {
-	client_id: string;
-}
 export interface AuthenticationConfigInternetIdentity {
 	derivation_origin: [] | [string];
 	external_alternative_origins: [] | [Array<string>];
+}
+export interface AuthenticationConfigOpenId {
+	providers: Array<[OpenIdProvider, OpenIdProviderConfig]>;
 }
 export interface AuthenticationRules {
 	allowed_callers: Array<Principal>;
@@ -205,6 +205,10 @@ export interface MemorySize {
 	stable: bigint;
 	heap: bigint;
 }
+export type OpenIdProvider = { Google: null };
+export interface OpenIdProviderConfig {
+	client_id: string;
+}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -256,7 +260,7 @@ export interface SegmentsDeploymentOptions {
 	satellite_version: [] | [string];
 }
 export interface SetAuthenticationConfig {
-	google: [] | [AuthenticationConfigGoogle];
+	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -89,7 +89,11 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -99,7 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -290,7 +294,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -89,7 +89,11 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -99,7 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -290,7 +294,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/frontend/src/lib/services/auth/auth.config.services.ts
+++ b/src/frontend/src/lib/services/auth/auth.config.services.ts
@@ -133,7 +133,7 @@ const updateConfig = async ({
 				internet_identity: editConfig?.internet_identity ?? config?.internet_identity ?? [],
 				rules: unmodifiedRules ? (config?.rules ?? []) : editConfigRules,
 				// TODO: support for Google configuration in the Console UI
-				google: [],
+				openid: [],
 				version: config?.version ?? []
 			},
 			identity

--- a/src/frontend/src/lib/utils/auth.config.utils.ts
+++ b/src/frontend/src/lib/utils/auth.config.utils.ts
@@ -23,7 +23,8 @@ export const buildSetAuthenticationConfig = ({
 						external_alternative_origins
 					}
 				],
-				google: [],
+				// TODO: support for Google configuration in the Console UI
+				openid: [],
 				rules: []
 			}
 		: {

--- a/src/libs/auth/src/impls.rs
+++ b/src/libs/auth/src/impls.rs
@@ -22,7 +22,7 @@ impl AuthenticationConfig {
 
         AuthenticationConfig {
             internet_identity: user_config.internet_identity.clone(),
-            google: user_config.google.clone(),
+            openid: user_config.openid.clone(),
             rules: user_config.rules.clone(),
             created_at: Some(created_at),
             updated_at: Some(updated_at),
@@ -34,5 +34,13 @@ impl AuthenticationConfig {
 impl Versioned for AuthenticationConfig {
     fn version(&self) -> Option<Version> {
         self.version
+    }
+}
+
+impl AuthenticationConfig {
+    pub fn openid_enabled(&self) -> bool {
+        self.openid
+            .as_ref()
+            .map_or(false, |openid| !openid.providers.is_empty())
     }
 }

--- a/src/libs/auth/src/types.rs
+++ b/src/libs/auth/src/types.rs
@@ -35,15 +35,21 @@ pub mod config {
     use junobuild_shared::types::core::DomainName;
     use junobuild_shared::types::state::{Timestamp, Version};
     use serde::Serialize;
+    use std::collections::BTreeMap;
 
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct AuthenticationConfig {
         pub internet_identity: Option<AuthenticationConfigInternetIdentity>,
-        pub google: Option<AuthenticationConfigGoogle>,
+        pub openid: Option<AuthenticationConfigOpenId>,
         pub rules: Option<AuthenticationRules>,
         pub version: Option<Version>,
         pub created_at: Option<Timestamp>,
         pub updated_at: Option<Timestamp>,
+    }
+
+    #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
+    pub struct AuthenticationConfigOpenId {
+        pub providers: OpenIdProviders,
     }
 
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
@@ -57,15 +63,22 @@ pub mod config {
         pub allowed_callers: Vec<Principal>,
     }
 
+    pub type OpenIdProviders = BTreeMap<OpenIdProvider, OpenIdProviderConfig>;
+
+    #[derive(CandidType, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub enum OpenIdProvider {
+        Google,
+    }
+
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
-    pub struct AuthenticationConfigGoogle {
+    pub struct OpenIdProviderConfig {
         pub client_id: String,
     }
 }
 
 pub mod interface {
     use crate::types::config::{
-        AuthenticationConfigGoogle, AuthenticationConfigInternetIdentity, AuthenticationRules,
+        AuthenticationConfigInternetIdentity, AuthenticationConfigOpenId, AuthenticationRules,
     };
     use candid::{CandidType, Deserialize};
     use junobuild_shared::types::state::Version;
@@ -74,7 +87,7 @@ pub mod interface {
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct SetAuthenticationConfig {
         pub internet_identity: Option<AuthenticationConfigInternetIdentity>,
-        pub google: Option<AuthenticationConfigGoogle>,
+        pub openid: Option<AuthenticationConfigOpenId>,
         pub rules: Option<AuthenticationRules>,
         pub version: Option<Version>,
     }

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -22,16 +22,18 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
-type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
+};
+type AuthenticationConfigOpenId = record {
+  providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CollectionType = variant { Db; Storage };
@@ -156,6 +158,8 @@ type ListRulesResults = record {
 };
 type Memory = variant { Heap; Stable };
 type MemorySize = record { stable : nat64; heap : nat64 };
+type OpenIdProvider = variant { Google };
+type OpenIdProviderConfig = record { client_id : text };
 type Permission = variant { Controllers; Private; Public; Managed };
 type Proposal = record {
   status : ProposalStatus;
@@ -200,7 +204,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/libs/satellite/src/auth/store.rs
+++ b/src/libs/satellite/src/auth/store.rs
@@ -11,7 +11,7 @@ pub async fn set_config(
 
     update_alternative_origins(&config)?;
 
-    if config.google.is_some() {
+    if config.openid_enabled() {
         junobuild_auth::state::init_salt(&AuthHeap).await?;
     }
 

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -24,16 +24,18 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
-type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
+};
+type AuthenticationConfigOpenId = record {
+  providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CollectionType = variant { Db; Storage };
@@ -158,6 +160,8 @@ type ListRulesResults = record {
 };
 type Memory = variant { Heap; Stable };
 type MemorySize = record { stable : nat64; heap : nat64 };
+type OpenIdProvider = variant { Google };
+type OpenIdProviderConfig = record { client_id : text };
 type Permission = variant { Controllers; Private; Public; Managed };
 type Proposal = record {
   status : ProposalStatus;
@@ -202,7 +206,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -24,16 +24,18 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
-type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
+};
+type AuthenticationConfigOpenId = record {
+  providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CollectionType = variant { Db; Storage };
@@ -158,6 +160,8 @@ type ListRulesResults = record {
 };
 type Memory = variant { Heap; Stable };
 type MemorySize = record { stable : nat64; heap : nat64 };
+type OpenIdProvider = variant { Google };
+type OpenIdProviderConfig = record { client_id : text };
 type Permission = variant { Controllers; Private; Public; Managed };
 type Proposal = record {
   status : ProposalStatus;
@@ -202,7 +206,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -28,18 +28,18 @@ export interface AssetsUpgradeOptions {
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
-	google: [] | [AuthenticationConfigGoogle];
+	openid: [] | [AuthenticationConfigOpenId];
 	created_at: [] | [bigint];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
 }
-export interface AuthenticationConfigGoogle {
-	client_id: string;
-}
 export interface AuthenticationConfigInternetIdentity {
 	derivation_origin: [] | [string];
 	external_alternative_origins: [] | [Array<string>];
+}
+export interface AuthenticationConfigOpenId {
+	providers: Array<[OpenIdProvider, OpenIdProviderConfig]>;
 }
 export interface AuthenticationRules {
 	allowed_callers: Array<Principal>;
@@ -205,6 +205,10 @@ export interface MemorySize {
 	stable: bigint;
 	heap: bigint;
 }
+export type OpenIdProvider = { Google: null };
+export interface OpenIdProviderConfig {
+	client_id: string;
+}
 export type Permission =
 	| { Controllers: null }
 	| { Private: null }
@@ -257,7 +261,7 @@ export interface SegmentsDeploymentOptions {
 	satellite_version: [] | [string];
 }
 export interface SetAuthenticationConfig {
-	google: [] | [AuthenticationConfigGoogle];
+	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -89,7 +89,11 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -99,7 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -290,7 +294,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -89,7 +89,11 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const AuthenticationConfigGoogle = IDL.Record({ client_id: IDL.Text });
+	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
+	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
+	const AuthenticationConfigOpenId = IDL.Record({
+		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
+	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		external_alternative_origins: IDL.Opt(IDL.Vec(IDL.Text))
@@ -99,7 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const AuthenticationConfig = IDL.Record({
 		updated_at: IDL.Opt(IDL.Nat64),
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		created_at: IDL.Opt(IDL.Nat64),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
@@ -290,7 +294,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
 	const SetAuthenticationConfig = IDL.Record({
-		google: IDL.Opt(AuthenticationConfigGoogle),
+		openid: IDL.Opt(AuthenticationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64),
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -24,16 +24,18 @@ type AssetNoContent = record {
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   created_at : opt nat64;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
-type AuthenticationConfigGoogle = record { client_id : text };
 type AuthenticationConfigInternetIdentity = record {
   derivation_origin : opt text;
   external_alternative_origins : opt vec text;
+};
+type AuthenticationConfigOpenId = record {
+  providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CollectionType = variant { Db; Storage };
@@ -158,6 +160,8 @@ type ListRulesResults = record {
 };
 type Memory = variant { Heap; Stable };
 type MemorySize = record { stable : nat64; heap : nat64 };
+type OpenIdProvider = variant { Google };
+type OpenIdProviderConfig = record { client_id : text };
 type Permission = variant { Controllers; Private; Public; Managed };
 type Proposal = record {
   status : ProposalStatus;
@@ -202,7 +206,7 @@ type SegmentsDeploymentOptions = record {
   satellite_version : opt text;
 };
 type SetAuthenticationConfig = record {
-  google : opt AuthenticationConfigGoogle;
+  openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;

--- a/src/tests/specs/console/console.config.spec.ts
+++ b/src/tests/specs/console/console.config.spec.ts
@@ -61,7 +61,7 @@ describe('Console > Storage', () => {
 			const config: ConsoleDid.SetAuthenticationConfig = {
 				internet_identity: [],
 				rules: [],
-				google: [],
+				openid: [],
 				version: []
 			};
 

--- a/src/tests/specs/satellite/stock/satellite.allowed-callers.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.allowed-callers.spec.ts
@@ -71,7 +71,7 @@ describe('Satellite > Allowed Callers', () => {
 
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
-			google: [],
+			openid: [],
 			rules: [
 				{
 					allowed_callers: allowedCallers
@@ -90,7 +90,7 @@ describe('Satellite > Allowed Callers', () => {
 
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
-			google: [],
+			openid: [],
 			rules: [
 				{
 					allowed_callers: []
@@ -109,7 +109,7 @@ describe('Satellite > Allowed Callers', () => {
 
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
-			google: [],
+			openid: [],
 			rules: [],
 			version: nextConfigVersion()
 		};

--- a/src/tests/specs/satellite/stock/satellite.auth.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.auth.spec.ts
@@ -71,7 +71,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: [4n]
 				};
 
@@ -109,7 +109,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: [5n]
 				};
 
@@ -150,7 +150,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: [6n]
 				};
 
@@ -183,7 +183,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: [7n]
 				};
 
@@ -225,7 +225,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: [8n]
 				};
 
@@ -263,7 +263,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: [9n]
 				};
 
@@ -304,7 +304,7 @@ describe('Satellite > Authentication', () => {
 						}
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: [10n]
 				};
 
@@ -353,7 +353,7 @@ describe('Satellite > Authentication', () => {
 						{ derivation_origin: ['demo.com'], external_alternative_origins: toNullable() }
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: [10n]
 				})
 			).rejects.toThrow(JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER);

--- a/src/tests/specs/satellite/stock/satellite.switch-memory.spec.ts
+++ b/src/tests/specs/satellite/stock/satellite.switch-memory.spec.ts
@@ -324,7 +324,7 @@ describe('Satellite > Switch storage system memory', () => {
 						}
 					],
 					rules: [],
-					google: [],
+					openid: [],
 					version: currentConfig?.version ?? []
 				};
 

--- a/src/tests/utils/auth-assertions-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-tests.utils.ts
@@ -68,7 +68,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
-			google: [],
+			openid: [],
 			version: []
 		};
 
@@ -88,7 +88,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
-			google: [],
+			openid: [],
 			version: []
 		};
 
@@ -108,7 +108,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
-			google: [],
+			openid: [],
 			version: []
 		};
 
@@ -148,7 +148,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
-			google: [],
+			openid: [],
 			version: [1n]
 		};
 
@@ -195,7 +195,7 @@ export const testAuthConfig = ({
 				}
 			],
 			rules: [],
-			google: [],
+			openid: [],
 			version: [2n]
 		};
 
@@ -226,7 +226,7 @@ export const testAuthConfig = ({
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
 			rules: [],
-			google: [],
+			openid: [],
 			version: [3n]
 		};
 
@@ -276,7 +276,7 @@ export const testReturnAuthConfig = ({
 				}
 			],
 			rules: [],
-			google: [],
+			openid: [],
 			version: [version]
 		};
 
@@ -343,9 +343,16 @@ export const testAuthGoogleConfig = ({
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
 			rules: [],
-			google: [
+			openid: [
 				{
-					client_id: CLIENT_ID
+					providers: [
+						[
+							{ Google: null },
+							{
+								client_id: CLIENT_ID
+							}
+						]
+					]
 				}
 			],
 			version: [version]
@@ -355,7 +362,10 @@ export const testAuthGoogleConfig = ({
 
 		const updatedConfig = await get_auth_config();
 
-		expect(fromNullable(fromNullable(updatedConfig)?.google ?? [])?.client_id).toEqual(CLIENT_ID);
+		const google = fromNullable(fromNullable(updatedConfig)?.openid ?? [])?.providers.find(
+			([key]) => 'Google' in key
+		)?.[1];
+		expect(google?.client_id).toEqual(CLIENT_ID);
 
 		await assertLog(LOG_SALT_INITIALIZED);
 	});
@@ -366,7 +376,7 @@ export const testAuthGoogleConfig = ({
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
 			rules: [],
-			google: [],
+			openid: [],
 			version: [version + 1n]
 		};
 
@@ -374,7 +384,10 @@ export const testAuthGoogleConfig = ({
 
 		const updatedConfig = await get_auth_config();
 
-		expect(fromNullable(fromNullable(updatedConfig)?.google ?? [])).toBeUndefined();
+		const google = fromNullable(fromNullable(updatedConfig)?.openid ?? [])?.providers.find(
+			([key]) => 'Google' in key
+		);
+		expect(google).toBeUndefined();
 	});
 
 	it('should not reinitialize salt', async () => {
@@ -383,9 +396,16 @@ export const testAuthGoogleConfig = ({
 		const config: SatelliteDid.SetAuthenticationConfig = {
 			internet_identity: [],
 			rules: [],
-			google: [
+			openid: [
 				{
-					client_id: CLIENT_ID
+					providers: [
+						[
+							{ Google: null },
+							{
+								client_id: CLIENT_ID
+							}
+						]
+					]
 				}
 			],
 			version: [version + 2n]

--- a/src/tests/utils/auth-assertions-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-tests.utils.ts
@@ -365,6 +365,7 @@ export const testAuthGoogleConfig = ({
 		const google = fromNullable(fromNullable(updatedConfig)?.openid ?? [])?.providers.find(
 			([key]) => 'Google' in key
 		)?.[1];
+
 		expect(google?.client_id).toEqual(CLIENT_ID);
 
 		await assertLog(LOG_SALT_INITIALIZED);
@@ -387,6 +388,7 @@ export const testAuthGoogleConfig = ({
 		const google = fromNullable(fromNullable(updatedConfig)?.openid ?? [])?.providers.find(
 			([key]) => 'Google' in key
 		);
+
 		expect(google).toBeUndefined();
 	});
 


### PR DESCRIPTION
# Motivation

More future prone to include more provider and we also require the config to be generic to find the provider that matches the get/prepare delegation request.