### PR TITLE
feat(auth): getrandom v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
@@ -528,7 +539,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1012,6 +1023,7 @@ name = "junobuild-auth"
 version = "0.0.1"
 dependencies = [
  "candid",
+ "getrandom 0.2.16",
  "ic-canister-sig-creation",
  "ic-cdk",
  "ic-certification",
@@ -1062,7 +1074,7 @@ version = "0.2.6"
 dependencies = [
  "candid",
  "ciborium",
- "getrandom",
+ "getrandom 0.3.2",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-cdk-timers",
@@ -1088,7 +1100,7 @@ dependencies = [
  "candid",
  "ciborium",
  "futures",
- "getrandom",
+ "getrandom 0.3.2",
  "ic-cdk",
  "ic-ledger-types",
  "ic-stable-structures 0.7.0",
@@ -1200,7 +1212,7 @@ dependencies = [
  "candid",
  "canfund",
  "ciborium",
- "getrandom",
+ "getrandom 0.3.2",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-cdk-timers",
@@ -1254,7 +1266,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ciborium",
- "getrandom",
+ "getrandom 0.3.2",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-cdk-timers",
@@ -1408,7 +1420,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.2",
  "zerocopy",
 ]
 
@@ -1915,6 +1927,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"

--- a/src/libs/auth/Cargo.toml
+++ b/src/libs/auth/Cargo.toml
@@ -22,4 +22,5 @@ serde.workspace = true
 ic-certification.workspace = true
 ic-canister-sig-creation = "1.3.0"
 url.workspace = true
+getrandom02 = { package = "getrandom", version = "0.2.16", features = ["custom"] }
 junobuild-shared = "0.3.0"

--- a/src/libs/auth/src/lib.rs
+++ b/src/libs/auth/src/lib.rs
@@ -1,4 +1,5 @@
 mod impls;
+mod random;
 pub mod state;
 pub mod strategies;
 pub mod types;

--- a/src/libs/auth/src/random.rs
+++ b/src/libs/auth/src/random.rs
@@ -1,0 +1,11 @@
+// We have to use getrandom v0.2 as a dependency because jsonwebtoken won't compile without it.
+// In our implementation, randomness is never used for verifying JWTs.
+// To avoid any accidental use while we initialize and use getrandom v0.3,
+// we provide a v0.2 implementation that always fails at runtime.
+//
+// Source: https://github.com/ilbertt/ic-react-native-jwt-auth/blob/main/src/ic_backend/src/lib.rs#L177
+getrandom02::register_custom_getrandom!(always_fail);
+
+pub fn always_fail(_buf: &mut [u8]) -> Result<(), getrandom02::Error> {
+    Err(getrandom02::Error::UNSUPPORTED)
+}


### PR DESCRIPTION
# Motivation

In order to use [jsonwebtoken](https://github.com/Keats/jsonwebtoken) crate for openid in #1872 we need `getrandom@0.2` as depency which conflicts with the version we are using, v0.3. That's why we add it as a dependency under a patch name. We solely need it to compile as it is not used for verifying token. To ensure it is not use at runtime, we add a guard.
