### PR TITLE
feat(frontend): workaround for Webstorm/Rustrover auto-import issue

### DIFF
--- a/src/declarations/_types.ts
+++ b/src/declarations/_types.ts
@@ -1,15 +1,33 @@
-export type * as ConsoleDid from '$declarations/console/console.did';
-export type * as MissionControlDid0013 from '$declarations/deprecated/mission_control-0-0-13.did';
-export type * as MissionControlDid004 from '$declarations/deprecated/mission_control-0-0-4.did';
-export type * as OrbiterDid006 from '$declarations/deprecated/orbiter-0-0-6.did';
-export type * as OrbiterDid007 from '$declarations/deprecated/orbiter-0-0-7.did';
-export type * as OrbiterDid008 from '$declarations/deprecated/orbiter-0-0-8.did';
-export type * as SatelliteDid0016 from '$declarations/deprecated/satellite-0-0-16.did';
-export type * as SatelliteDid0017 from '$declarations/deprecated/satellite-0-0-17.did';
-export type * as SatelliteDid008 from '$declarations/deprecated/satellite-0-0-8.did';
-export type * as MissionControlDid from '$declarations/mission_control/mission_control.did';
-export type * as ObservatoryDid from '$declarations/observatory/observatory.did';
-export type * as OrbiterDid from '$declarations/orbiter/orbiter.did';
-export type * as SatelliteDid from '$declarations/satellite/satellite.did';
-export type * as SputnikDid from '$declarations/sputnik/sputnik.did';
-export type * as ICDid from '@dfinity/ic-management/dist/candid/ic-management';
+import type * as ConsoleDid from '$declarations/console/console.did';
+import type * as MissionControlDid0013 from '$declarations/deprecated/mission_control-0-0-13.did';
+import type * as MissionControlDid004 from '$declarations/deprecated/mission_control-0-0-4.did';
+import type * as OrbiterDid006 from '$declarations/deprecated/orbiter-0-0-6.did';
+import type * as OrbiterDid007 from '$declarations/deprecated/orbiter-0-0-7.did';
+import type * as OrbiterDid008 from '$declarations/deprecated/orbiter-0-0-8.did';
+import type * as SatelliteDid0016 from '$declarations/deprecated/satellite-0-0-16.did';
+import type * as SatelliteDid0017 from '$declarations/deprecated/satellite-0-0-17.did';
+import type * as SatelliteDid008 from '$declarations/deprecated/satellite-0-0-8.did';
+import type * as MissionControlDid from '$declarations/mission_control/mission_control.did';
+import type * as ObservatoryDid from '$declarations/observatory/observatory.did';
+import type * as OrbiterDid from '$declarations/orbiter/orbiter.did';
+import type * as SatelliteDid from '$declarations/satellite/satellite.did';
+import type * as SputnikDid from '$declarations/sputnik/sputnik.did';
+import type * as ICDid from '@dfinity/ic-management/dist/candid/ic-management';
+
+export type {
+	ConsoleDid,
+	ICDid,
+	MissionControlDid,
+	MissionControlDid0013,
+	MissionControlDid004,
+	ObservatoryDid,
+	OrbiterDid,
+	OrbiterDid006,
+	OrbiterDid007,
+	OrbiterDid008,
+	SatelliteDid,
+	SatelliteDid0016,
+	SatelliteDid0017,
+	SatelliteDid008,
+	SputnikDid
+};


### PR DESCRIPTION
# Motivation

Webstorm/Rustrover fails at auto-importing entire modules: https://youtrack.jetbrains.com/issue/WEB-61981

Issue is opens since two years, therefore it's unlikely they will ever fix it.

As a workaround (provided in the issue), the types can be imported before being re-exported.