### PR TITLE
feat(shared): add configuration to unlock cargo test

### DIFF
--- a/src/libs/shared/src/canister.rs
+++ b/src/libs/shared/src/canister.rs
@@ -1,4 +1,5 @@
 use crate::types::interface::MemorySize;
+#[cfg(target_arch = "wasm32")]
 use core::arch::wasm32::memory_size as wasm_memory_size;
 use ic_cdk::api::stable::{stable_size, WASM_PAGE_SIZE_IN_BYTES};
 
@@ -21,9 +22,16 @@ use ic_cdk::api::stable::{stable_size, WASM_PAGE_SIZE_IN_BYTES};
 /// println!("Stable storage size: {} bytes", memory_usage.stable);
 /// ```
 ///
+#[cfg(target_arch = "wasm32")]
 pub fn memory_size() -> MemorySize {
     MemorySize {
         heap: wasm_memory_size(0) as u64 * WASM_PAGE_SIZE_IN_BYTES,
         stable: stable_size() * WASM_PAGE_SIZE_IN_BYTES,
     }
+}
+
+// For cargo test only
+#[cfg(not(target_arch = "wasm32"))]
+pub fn memory_size() -> MemorySize {
+    MemorySize { heap: 0, stable: 0 }
 }


### PR DESCRIPTION
# Motivation

We couldn't run `cargo test` because `core::arch::wasm32` is required for the wasm memory function but, actually we can stub it with some configuration and therefore unlock using those tests (and not only pocket-ic tests).
