### PR TITLE
build(auth): use patch jsonwebtoken v10.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,8 +1195,8 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.0.0"
-source = "git+https://github.com/peterpeterparker/jsonwebtoken?branch=feat%2Ficp#afc06b71c1c9d873560c1fa0bb96b8aaad12edb2"
+version = "10.1.0"
+source = "git+https://github.com/peterpeterparker/jsonwebtoken?branch=patch-v10.1.0#730b8877792d6dd4e421b9e60a909393df4abc4f"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/src/libs/auth/Cargo.toml
+++ b/src/libs/auth/Cargo.toml
@@ -26,14 +26,14 @@ ic-canister-sig-creation = "1.3.0"
 url.workspace = true
 sha2.workspace = true
 base64.workspace = true
-jsonwebtoken = { git = "https://github.com/peterpeterparker/jsonwebtoken", branch = "feat/icp", default-features = false, features = [
+jsonwebtoken = { git = "https://github.com/peterpeterparker/jsonwebtoken", branch = "patch-v10.1.0", default-features = false, features = [
 	"rust_crypto"
 ] }
 getrandom02 = { package = "getrandom", version = "0.2.16", features = ["custom"] }
 junobuild-shared = "0.3.0"
 
 [dev-dependencies]
-jsonwebtoken = { git = "https://github.com/peterpeterparker/jsonwebtoken", branch = "feat/icp", default-features = false, features = [
+jsonwebtoken = { git = "https://github.com/peterpeterparker/jsonwebtoken", branch = "patch-v10.1.0", default-features = false, features = [
 	"rust_crypto",
 	"use_pem"
 ] }


### PR DESCRIPTION
# Motivation

jsonwebtoken [v10.1.0](https://github.com/Keats/jsonwebtoken/releases/tag/v10.1.0) was released. It's cleaner to use a patch of the version than one from main branch.
