### PR TITLE
feat: hide mission control tabs while loading (#2121)

### DIFF
--- a/src/frontend/src/routes/(split)/mission-control/+page.svelte
+++ b/src/frontend/src/routes/(split)/mission-control/+page.svelte
@@ -41,15 +41,15 @@
 </script>
 
 <IdentityGuard>
-	<Tabs>
-		{#snippet info()}
-			{#if $authSignedIn}
-				<Warnings />
-			{/if}
-		{/snippet}
+	<Loaders>
+		<MissionControlGuard>
+			<Tabs>
+				{#snippet info()}
+					{#if $authSignedIn}
+						<Warnings />
+					{/if}
+				{/snippet}
 
-		<Loaders>
-			<MissionControlGuard>
 				{#if nonNullish($missionControlIdDerived)}
 					{#if $store.tabId === $store.tabs[0].id}
 						<MissionControl missionControlId={$missionControlIdDerived} />
@@ -57,7 +57,7 @@
 						<MissionControlSettings missionControlId={$missionControlIdDerived} />
 					{/if}
 				{/if}
-			</MissionControlGuard>
-		</Loaders>
-	</Tabs>
+			</Tabs>
+		</MissionControlGuard>
+	</Loaders>
 </IdentityGuard>


### PR DESCRIPTION
# Motivation

For consistency reasons, we do not want to show the tabs on the Mission Control page while it is loading or when Mission Control is not found. This ensures a better user experience and UI consistency across the application.

# Changes

- Moved `<Tabs>` component inside `<MissionControlGuard>` 
- Moved `{#snippet info()}` containing `<Warnings />` inside the guard as well
- Tabs now only render after Mission Control loads successfully

**Before:**
```svelte
<Tabs>
  ...
  <MissionControlGuard>
    ...
  </MissionControlGuard>
</Tabs>
```

**After:**
```svelte
<MissionControlGuard>
  <Tabs>
    ...
  </Tabs>
</MissionControlGuard>
```