### PR TITLE
feat(satellite): revert "use with pattern for accessing authentication on heap"

### DIFF
--- a/src/libs/satellite/src/auth/strategy_impls.rs
+++ b/src/libs/satellite/src/auth/strategy_impls.rs
@@ -1,4 +1,4 @@
-use crate::memory::state::services::{with_heap_authentication, with_heap_authentication_mut};
+use crate::memory::state::STATE;
 use junobuild_auth::state::types::state::AuthenticationHeapState;
 use junobuild_auth::strategies::AuthHeapStrategy;
 
@@ -6,13 +6,19 @@ pub struct AuthHeap;
 
 impl AuthHeapStrategy for AuthHeap {
     fn with_auth_state<R>(&self, f: impl FnOnce(&Option<AuthenticationHeapState>) -> R) -> R {
-        with_heap_authentication(|authentication| f(authentication))
+        STATE.with(|state| {
+            let authentication = &state.borrow().heap.authentication;
+            f(authentication)
+        })
     }
 
     fn with_auth_state_mut<R>(
         &self,
         f: impl FnOnce(&mut Option<AuthenticationHeapState>) -> R,
     ) -> R {
-        with_heap_authentication_mut(|authentication| f(authentication))
+        STATE.with(|state| {
+            let mut borrow = state.borrow_mut();
+            f(&mut borrow.heap.authentication)
+        })
     }
 }

--- a/src/libs/satellite/src/memory/state/services/raw.rs
+++ b/src/libs/satellite/src/memory/state/services/raw.rs
@@ -1,9 +1,5 @@
 use crate::memory::state::STATE;
-use crate::types::state::{HeapState, RuntimeState, State};
-
-fn read_state<R>(f: impl FnOnce(&State) -> R) -> R {
-    STATE.with(|cell| f(&cell.borrow()))
-}
+use crate::types::state::{RuntimeState, State};
 
 fn mutate_state<R>(f: impl FnOnce(&mut State) -> R) -> R {
     STATE.with(|cell| f(&mut cell.borrow_mut()))
@@ -11,12 +7,4 @@ fn mutate_state<R>(f: impl FnOnce(&mut State) -> R) -> R {
 
 pub fn mutate_runtime_state<R>(f: impl FnOnce(&mut RuntimeState) -> R) -> R {
     mutate_state(|state| f(&mut state.runtime))
-}
-
-pub fn read_heap_state<R>(f: impl FnOnce(&HeapState) -> R) -> R {
-    read_state(|state| f(&state.heap))
-}
-
-pub fn mutate_heap_state<R>(f: impl FnOnce(&mut HeapState) -> R) -> R {
-    mutate_state(|state| f(&mut state.heap))
 }

--- a/src/libs/satellite/src/memory/state/services/withs.rs
+++ b/src/libs/satellite/src/memory/state/services/withs.rs
@@ -1,17 +1,6 @@
-use crate::memory::state::services::{mutate_heap_state, mutate_runtime_state, read_heap_state};
-use junobuild_auth::state::types::state::AuthenticationHeapState;
+use crate::memory::state::services::mutate_runtime_state;
 use rand::prelude::StdRng;
 
 pub fn with_runtime_rng_mut<R>(f: impl FnOnce(&mut Option<StdRng>) -> R) -> R {
     mutate_runtime_state(|state| f(&mut state.rng))
-}
-
-pub fn with_heap_authentication<R>(f: impl FnOnce(&Option<AuthenticationHeapState>) -> R) -> R {
-    read_heap_state(|heap| f(&heap.authentication))
-}
-
-pub fn with_heap_authentication_mut<R>(
-    f: impl FnOnce(&mut Option<AuthenticationHeapState>) -> R,
-) -> R {
-    mutate_heap_state(|heap| f(&mut heap.authentication))
 }


### PR DESCRIPTION
# Motivation

Revert #2129. On a second thought, the new implementation will also finds place in `junobuild_auth` therefore we will use the strategy anyway.
