### PR TITLE
feat(frontend): Move Tabs and Warnings inside SatelliteGuard in Satellite Pages

### DIFF
--- a/src/frontend/src/routes/(split)/authentication/+page.svelte
+++ b/src/frontend/src/routes/(split)/authentication/+page.svelte
@@ -40,17 +40,17 @@
 </script>
 
 <IdentityGuard>
-	<SatelliteGuard>
-		{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
-			<Tabs>
-				<Loaders>
+		<Loaders>
+			<SatelliteGuard>
+				<Tabs>
+					{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
 					{#if $store.tabId === $store.tabs[0].id}
 						<Users satelliteId={$satelliteStore.satellite_id} />
 					{:else if $store.tabId === $store.tabs[1].id}
 						<AuthSettings satellite={$satelliteStore} />
 					{/if}
-				</Loaders>
-			</Tabs>
-		{/if}
-	</SatelliteGuard>
+				{/if}
+				</Tabs>
+			</SatelliteGuard>
+		</Loaders>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/authentication/+page.svelte
+++ b/src/frontend/src/routes/(split)/authentication/+page.svelte
@@ -40,17 +40,17 @@
 </script>
 
 <IdentityGuard>
-	<Tabs>
-		<Loaders>
-			<SatelliteGuard>
-				{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+	<SatelliteGuard>
+		{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+			<Tabs>
+				<Loaders>
 					{#if $store.tabId === $store.tabs[0].id}
 						<Users satelliteId={$satelliteStore.satellite_id} />
 					{:else if $store.tabId === $store.tabs[1].id}
 						<AuthSettings satellite={$satelliteStore} />
 					{/if}
-				{/if}
-			</SatelliteGuard>
-		</Loaders>
-	</Tabs>
+				</Loaders>
+			</Tabs>
+		{/if}
+	</SatelliteGuard>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/datastore/+page.svelte
+++ b/src/frontend/src/routes/(split)/datastore/+page.svelte
@@ -39,14 +39,14 @@
 </script>
 
 <IdentityGuard>
-	<SatelliteGuard>
-		{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
-			<Tabs>
-				<Loaders>
-					<Db satelliteId={$satelliteStore.satellite_id} />
-				</Loaders>
-			</Tabs>
-		{/if}
-	</SatelliteGuard>
+		<Loaders>
+			<SatelliteGuard>
+				<Tabs>
+					{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+						<Db satelliteId={$satelliteStore.satellite_id} />
+					{/if}
+				</Tabs>
+			</SatelliteGuard>
+		</Loaders>
 </IdentityGuard>
 

--- a/src/frontend/src/routes/(split)/datastore/+page.svelte
+++ b/src/frontend/src/routes/(split)/datastore/+page.svelte
@@ -39,13 +39,14 @@
 </script>
 
 <IdentityGuard>
-	<Tabs>
-		<Loaders>
-			<SatelliteGuard>
-				{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+	<SatelliteGuard>
+		{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+			<Tabs>
+				<Loaders>
 					<Db satelliteId={$satelliteStore.satellite_id} />
-				{/if}
-			</SatelliteGuard>
-		</Loaders>
-	</Tabs>
+				</Loaders>
+			</Tabs>
+		{/if}
+	</SatelliteGuard>
 </IdentityGuard>
+

--- a/src/frontend/src/routes/(split)/functions/+page.svelte
+++ b/src/frontend/src/routes/(split)/functions/+page.svelte
@@ -40,17 +40,18 @@
 </script>
 
 <IdentityGuard>
-	<Tabs>
-		<Loaders>
-			<SatelliteGuard>
-				{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+	<SatelliteGuard>
+		{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+			<Tabs>
+				<Loaders>
 					{#if $store.tabId === $store.tabs[0].id}
 						<Logs satelliteId={$satelliteStore.satellite_id} />
 					{:else if $store.tabId === $store.tabs[1].id}
 						<Cdn satellite={$satelliteStore} />
 					{/if}
-				{/if}
-			</SatelliteGuard>
-		</Loaders>
-	</Tabs>
+				</Loaders>
+			</Tabs>
+		{/if}
+	</SatelliteGuard>
 </IdentityGuard>
+

--- a/src/frontend/src/routes/(split)/functions/+page.svelte
+++ b/src/frontend/src/routes/(split)/functions/+page.svelte
@@ -40,18 +40,19 @@
 </script>
 
 <IdentityGuard>
-	<SatelliteGuard>
-		{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+	<Loaders>
+		<SatelliteGuard>
 			<Tabs>
-				<Loaders>
+				{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
 					{#if $store.tabId === $store.tabs[0].id}
 						<Logs satelliteId={$satelliteStore.satellite_id} />
 					{:else if $store.tabId === $store.tabs[1].id}
 						<Cdn satellite={$satelliteStore} />
 					{/if}
-				</Loaders>
+				{/if}
 			</Tabs>
-		{/if}
-	</SatelliteGuard>
+		</SatelliteGuard>
+	</Loaders>
 </IdentityGuard>
+
 

--- a/src/frontend/src/routes/(split)/hosting/+page.svelte
+++ b/src/frontend/src/routes/(split)/hosting/+page.svelte
@@ -41,19 +41,20 @@
 </script>
 
 <IdentityGuard>
-	<Tabs>
-		<Loaders>
-			<SatelliteGuard>
-				<MissionControlGuard>
-					{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+	<SatelliteGuard>
+		<MissionControlGuard>
+			{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+				<Tabs>
+					<Loaders>
 						{#if $store.tabId === $store.tabs[0].id}
 							<Hosting satellite={$satelliteStore} />
 						{:else if $store.tabId === $store.tabs[1].id}
 							<HostingSettings satellite={$satelliteStore} />
 						{/if}
-					{/if}
-				</MissionControlGuard>
-			</SatelliteGuard>
-		</Loaders>
-	</Tabs>
+					</Loaders>
+				</Tabs>
+			{/if}
+		</MissionControlGuard>
+	</SatelliteGuard>
 </IdentityGuard>
+

--- a/src/frontend/src/routes/(split)/hosting/+page.svelte
+++ b/src/frontend/src/routes/(split)/hosting/+page.svelte
@@ -41,20 +41,20 @@
 </script>
 
 <IdentityGuard>
-	<SatelliteGuard>
-		<MissionControlGuard>
-			{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
-				<Tabs>
-					<Loaders>
+	<Loaders>
+		<SatelliteGuard>
+			<Tabs>
+				<MissionControlGuard>
+					{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
 						{#if $store.tabId === $store.tabs[0].id}
 							<Hosting satellite={$satelliteStore} />
 						{:else if $store.tabId === $store.tabs[1].id}
 							<HostingSettings satellite={$satelliteStore} />
 						{/if}
-					</Loaders>
-				</Tabs>
-			{/if}
-		</MissionControlGuard>
-	</SatelliteGuard>
+					{/if}
+				</MissionControlGuard>
+			</Tabs>
+		</SatelliteGuard>
+	</Loaders>
 </IdentityGuard>
 

--- a/src/frontend/src/routes/(split)/satellite/+page.svelte
+++ b/src/frontend/src/routes/(split)/satellite/+page.svelte
@@ -64,3 +64,4 @@
 		</Tabs>
 	</SatelliteGuard>
 </IdentityGuard>
+

--- a/src/frontend/src/routes/(split)/satellite/+page.svelte
+++ b/src/frontend/src/routes/(split)/satellite/+page.svelte
@@ -42,15 +42,15 @@
 </script>
 
 <IdentityGuard>
-	<SatelliteGuard>
-		<Tabs>
-			{#snippet info()}
-				{#if nonNullish($satelliteStore)}
-					<Warnings satellite={$satelliteStore} />
-				{/if}
-			{/snippet}
+	<Loaders monitoring>
+		<SatelliteGuard>
+			<Tabs>
+				{#snippet info()}
+					{#if nonNullish($satelliteStore)}
+						<Warnings satellite={$satelliteStore} />
+					{/if}
+				{/snippet}
 
-			<Loaders monitoring>
 				<MissionControlGuard>
 					{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
 						{#if $store.tabId === $store.tabs[0].id}
@@ -60,7 +60,7 @@
 						{/if}
 					{/if}
 				</MissionControlGuard>
-			</Loaders>
-		</Tabs>
-	</SatelliteGuard>
+			</Tabs>
+		</SatelliteGuard>
+	</Loaders>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/satellite/+page.svelte
+++ b/src/frontend/src/routes/(split)/satellite/+page.svelte
@@ -42,15 +42,15 @@
 </script>
 
 <IdentityGuard>
-	<Tabs>
-		{#snippet info()}
-			{#if nonNullish($satelliteStore)}
-				<Warnings satellite={$satelliteStore} />
-			{/if}
-		{/snippet}
+	<SatelliteGuard>
+		<Tabs>
+			{#snippet info()}
+				{#if nonNullish($satelliteStore)}
+					<Warnings satellite={$satelliteStore} />
+				{/if}
+			{/snippet}
 
-		<Loaders monitoring>
-			<SatelliteGuard>
+			<Loaders monitoring>
 				<MissionControlGuard>
 					{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
 						{#if $store.tabId === $store.tabs[0].id}
@@ -60,7 +60,7 @@
 						{/if}
 					{/if}
 				</MissionControlGuard>
-			</SatelliteGuard>
-		</Loaders>
-	</Tabs>
+			</Loaders>
+		</Tabs>
+	</SatelliteGuard>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/storage/+page.svelte
+++ b/src/frontend/src/routes/(split)/storage/+page.svelte
@@ -39,13 +39,13 @@
 </script>
 
 <IdentityGuard>
-	<Tabs>
-		<Loaders>
-			<SatelliteGuard>
-				{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
-					<Storage satelliteId={$satelliteStore?.satellite_id} />
-				{/if}
-			</SatelliteGuard>
-		</Loaders>
-	</Tabs>
+	<SatelliteGuard>
+		{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+			<Tabs>
+				<Loaders>
+					<Storage satelliteId={$satelliteStore.satellite_id} />
+				</Loaders>
+			</Tabs>
+		{/if}
+	</SatelliteGuard>
 </IdentityGuard>

--- a/src/frontend/src/routes/(split)/storage/+page.svelte
+++ b/src/frontend/src/routes/(split)/storage/+page.svelte
@@ -39,13 +39,14 @@
 </script>
 
 <IdentityGuard>
-	<SatelliteGuard>
-		{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+	<Loaders>
+		<SatelliteGuard>
 			<Tabs>
-				<Loaders>
-					<Storage satelliteId={$satelliteStore.satellite_id} />
-				</Loaders>
+				{#if nonNullish($satelliteStore) && nonNullish($missionControlIdDerived)}
+					<Storage satelliteId={$satelliteStore?.satellite_id} />
+				{/if}
 			</Tabs>
-		{/if}
-	</SatelliteGuard>
+		</SatelliteGuard>
+	</Loaders>
 </IdentityGuard>
+


### PR DESCRIPTION
This PR implements the requested refactor to improve the UI structure on satellite-related pages.


- Moved the <Tabs> component and the <Warnings> snippet inside the <SatelliteGuard> component in all relevant +page.svelte files.

- This ensures that tabs and warnings only appear when a valid satellite is present, as derived from the URL.

- No other UI logic or behavior was changed.

- This change aligns exactly with the issue instructions to avoid showing tabs when no satellite is found, improving clarity and UX on satellite pages.

Please review and let me know if any adjustments are needed. Thank you!
