### PR TITLE
fix(auth): jwt candid serialization (serde conflicts)

### DIFF
--- a/src/libs/auth/src/openid/jwt/types.rs
+++ b/src/libs/auth/src/openid/jwt/types.rs
@@ -39,7 +39,6 @@ pub mod cert {
 
         // Type-Specific Key Properties.
         // https://tools.ietf.org/html/rfc7517#section-4
-        #[serde(flatten)]
         pub params: JwkParams,
     }
 
@@ -64,7 +63,6 @@ pub mod cert {
     // Algorithm-specific parameters for JSON Web Keys.
     // https://tools.ietf.org/html/rfc7518#section-6
     #[derive(CandidType, Serialize, Deserialize, Clone)]
-    #[serde(untagged)]
     pub enum JwkParams {
         // Elliptic Curve parameters.
         Ec(JwkParamsEc),

--- a/src/observatory/src/openid/http/impls.rs
+++ b/src/observatory/src/openid/http/impls.rs
@@ -1,0 +1,49 @@
+use crate::openid::http::types::{JwkJson, JwksJson};
+use junobuild_auth::openid::jwt::types::cert::{
+    Jwk, JwkParams, JwkParamsEc, JwkParamsOct, JwkParamsOkp, JwkParamsRsa, JwkType, Jwks,
+};
+
+impl From<JwkJson> for Jwk {
+    fn from(j: JwkJson) -> Self {
+        match j {
+            JwkJson::Rsa { alg, kid, n, e } => Jwk {
+                kty: JwkType::Rsa,
+                alg,
+                kid,
+                params: JwkParams::Rsa(JwkParamsRsa { n, e }),
+            },
+            JwkJson::Ec {
+                alg,
+                kid,
+                crv,
+                x,
+                y,
+            } => Jwk {
+                kty: JwkType::Ec,
+                alg,
+                kid,
+                params: JwkParams::Ec(JwkParamsEc { crv, x, y }),
+            },
+            JwkJson::Oct { alg, kid, k } => Jwk {
+                kty: JwkType::Oct,
+                alg,
+                kid,
+                params: JwkParams::Oct(JwkParamsOct { k }),
+            },
+            JwkJson::Okp { alg, kid, crv, x } => Jwk {
+                kty: JwkType::Okp,
+                alg,
+                kid,
+                params: JwkParams::Okp(JwkParamsOkp { crv, x }),
+            },
+        }
+    }
+}
+
+impl From<JwksJson> for Jwks {
+    fn from(jwks: JwksJson) -> Self {
+        Jwks {
+            keys: jwks.keys.into_iter().map(Into::into).collect(),
+        }
+    }
+}

--- a/src/observatory/src/openid/http/mod.rs
+++ b/src/observatory/src/openid/http/mod.rs
@@ -1,3 +1,5 @@
 mod constants;
+mod impls;
 pub(super) mod request;
 pub mod response;
+mod types;

--- a/src/observatory/src/openid/http/response.rs
+++ b/src/observatory/src/openid/http/response.rs
@@ -1,3 +1,4 @@
+use crate::openid::http::types::JwksJson;
 use candid::Nat;
 use ic_cdk::management_canister::{HttpRequestResult, TransformArgs};
 use ic_cdk::trap;
@@ -6,11 +7,20 @@ use junobuild_shared::ic::UnwrapOrTrap;
 
 const HTTP_STATUS_OK: u8 = 200;
 
-// Google certs occasionally return responses where keys and their properties appear in random order.
-// To ensure consistency across all nodes, we deserialize, sort the keys, and then reserialize the response.
-//
-// We trap in case of an unexpected JSON response, as http_request does not return a result
-// in case of any error or unexpected status code.
+/// Google’s JWKS may arrive with keys/fields in arbitrary order.
+/// To make downstream behavior deterministic across replicas, we:
+/// 1) parse the raw JSON (Google’s flattened JWK shape),
+/// 2) convert it into our Candid-safe types (variant `params`),
+/// 3) sort keys by `kid`,
+/// 4) re-serialize to JSON (still our Candid-safe JWK shape).
+///
+/// Notes:
+/// - We *trap* on any unexpected input because `http_request` does not surface
+///   an application-level error to the caller; the transform must decide.
+/// - Google uses flattened params (`n/e`, `crv/x/y`, …) per JWK. Our Candid-safe
+///   type keeps `params` as a *variant* (Rsa/Ec/Oct/Okp). We parse with JSON DTOs
+///   (`JwksJson`/`JwkJson`) then convert to `Jwks` for stable Candid.
+/// - We require `kid` for every key (common operational invariant).
 pub fn transform_certificate_response(raw: TransformArgs) -> HttpRequestResult {
     let response = raw.response;
 
@@ -18,17 +28,23 @@ pub fn transform_certificate_response(raw: TransformArgs) -> HttpRequestResult {
         trap(format!("Invalid HTTP status code: {:?}", response.status));
     }
 
-    let jwks: Jwks = serde_json::from_slice(&response.body)
+    // Parse Google JWKS JSON (flattened), then convert to our core JWK shape.
+    let jwks_json: JwksJson = serde_json::from_slice(&response.body)
         .map_err(|_| "Invalid Jwks JSON")
         .unwrap_or_trap();
 
+    let jwks: Jwks = jwks_json.into();
+
+    // Enforce presence of `kid` for all keys (helps deterministic ordering + ops).
     if jwks.keys.iter().any(|k| k.kid.is_none()) {
         trap("Missing kid in Jwks");
     }
 
+    // Deterministic order: sort by kid.
     let mut keys = jwks.keys.clone();
     keys.sort_by(|a, b| a.kid.as_ref().unwrap().cmp(b.kid.as_ref().unwrap()));
 
+    // Re-serialize in our Candid-safe JSON shape.
     let body = serde_json::to_vec(&Jwks { keys })
         .map_err(|_| "Jwks serialize error")
         .unwrap_or_trap();

--- a/src/observatory/src/openid/http/types.rs
+++ b/src/observatory/src/openid/http/types.rs
@@ -1,0 +1,39 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(tag = "kty")] // drive shape from "kty"
+pub enum JwkJson {
+    #[serde(rename = "RSA")]
+    Rsa {
+        alg: Option<String>,
+        kid: Option<String>,
+        n: String,
+        e: String,
+    },
+    #[serde(rename = "EC")]
+    Ec {
+        alg: Option<String>,
+        kid: Option<String>,
+        crv: String,
+        x: String,
+        y: String,
+    },
+    #[serde(rename = "oct")]
+    Oct {
+        alg: Option<String>,
+        kid: Option<String>,
+        k: String,
+    },
+    #[serde(rename = "OKP")]
+    Okp {
+        alg: Option<String>,
+        kid: Option<String>,
+        crv: String,
+        x: String,
+    },
+}
+
+#[derive(Deserialize)]
+pub struct JwksJson {
+    pub keys: Vec<JwkJson>,
+}


### PR DESCRIPTION
# Motivation

Turns out that if I use serde annotation `flatten` and `untagged`, Candid cannot serialize the type. Debugged for our why the Observatory was always returning None when I expected Some(certificate) when calling it from a Satellite. Those annotations were the root cause of the problem.

So we have to use a specific type for JSON and convert them to Candid with implementations - i.e. manually.
