### PR TITLE
test(utils): add test on uint8array

### DIFF
--- a/src/libs/utils/src/serializers/uint8array.rs
+++ b/src/libs/utils/src/serializers/uint8array.rs
@@ -62,3 +62,72 @@ impl<'de> Visitor<'de> for DocDataUint8ArrayVisitor {
         Ok(DocDataUint8Array { value: bytes })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{self};
+
+    #[test]
+    fn serialize_doc_data_uint8array() {
+        let data = DocDataUint8Array {
+            value: vec![1, 2, 3, 5],
+        };
+        let s = serde_json::to_string(&data).expect("serialize");
+        assert_eq!(s, r#"{"__uint8array__":[1,2,3,5]}"#);
+    }
+
+    #[test]
+    fn deserialize_doc_data_uint8array() {
+        let s = r#"{"__uint8array__":[1,2,3,5]}"#;
+        let data: DocDataUint8Array = serde_json::from_str(s).expect("deserialize");
+        assert_eq!(data.value, vec![1, 2, 3, 5]);
+    }
+
+    #[test]
+    fn round_trip() {
+        let original = DocDataUint8Array {
+            value: vec![0, 1, 2, 3, 5],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: DocDataUint8Array = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.value, original.value);
+    }
+
+    #[test]
+    fn error_on_missing_field() {
+        let err = serde_json::from_str::<DocDataUint8Array>(r#"{}"#).unwrap_err();
+        assert!(
+            err.to_string().contains("missing field `__uint8array__`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn error_on_duplicate_field() {
+        let s = r#"{"__uint8array__":[1,2],"__uint8array__":[3,4]}"#;
+        let err = serde_json::from_str::<DocDataUint8Array>(s).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate field `__uint8array__`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn error_on_invalid_uint8array_format() {
+        let s = r#"{"__uint8array__":"not-a-uint8array"}"#;
+        let err = serde_json::from_str::<DocDataUint8Array>(s).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid type: string \"not-a-uint8array\""),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_display_implementation() {
+        let data = DocDataUint8Array {
+            value: vec![1, 2, 3],
+        };
+        assert_eq!(format!("{}", data), "[1, 2, 3]");
+    }
+}


### PR DESCRIPTION
# Motivation

[Related issue](https://github.com/junobuild/juno/issues/2127#event-20463858830)

Add Rust unit tests for the DocDataUint8Array 
- serializer, 
- deserializer, 
- display implementation.
