### PR TITLE
feat(auth): optional observatory id

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -37,6 +37,7 @@ type AuthenticationConfigInternetIdentity = record {
   external_alternative_origins : opt vec text;
 };
 type AuthenticationConfigOpenId = record {
+  observatory_id : opt principal;
   providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -43,6 +43,7 @@ export interface AuthenticationConfigInternetIdentity {
 	external_alternative_origins: [] | [Array<string>];
 }
 export interface AuthenticationConfigOpenId {
+	observatory_id: [] | [Principal];
 	providers: Array<[OpenIdProvider, OpenIdProviderConfig]>;
 }
 export interface AuthenticationRules {

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -41,6 +41,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -41,6 +41,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -41,6 +41,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -43,6 +43,7 @@ export interface AuthenticationConfigInternetIdentity {
 	external_alternative_origins: [] | [Array<string>];
 }
 export interface AuthenticationConfigOpenId {
+	observatory_id: [] | [Principal];
 	providers: Array<[OpenIdProvider, OpenIdProviderConfig]>;
 }
 export interface AuthenticationRules {
@@ -126,6 +127,7 @@ export type GetDelegationError =
 	| { DeriveSeedFailed: string };
 export type GetDelegationResultResponse = { Ok: SignedDelegation } | { Err: GetDelegationError };
 export type GetOrRefreshJwksError =
+	| { InvalidConfig: string }
 	| { MissingKid: null }
 	| { BadClaim: string }
 	| { KeyNotFoundCooldown: null }

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
 		NoKeyForKid: IDL.Null
 	});
 	const GetOrRefreshJwksError = IDL.Variant({
+		InvalidConfig: IDL.Text,
 		MissingKid: IDL.Null,
 		BadClaim: IDL.Text,
 		KeyNotFoundCooldown: IDL.Null,
@@ -136,6 +137,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
 		NoKeyForKid: IDL.Null
 	});
 	const GetOrRefreshJwksError = IDL.Variant({
+		InvalidConfig: IDL.Text,
 		MissingKid: IDL.Null,
 		BadClaim: IDL.Text,
 		KeyNotFoundCooldown: IDL.Null,
@@ -136,6 +137,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
 		NoKeyForKid: IDL.Null
 	});
 	const GetOrRefreshJwksError = IDL.Variant({
+		InvalidConfig: IDL.Text,
 		MissingKid: IDL.Null,
 		BadClaim: IDL.Text,
 		KeyNotFoundCooldown: IDL.Null,
@@ -136,6 +137,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -43,6 +43,7 @@ export interface AuthenticationConfigInternetIdentity {
 	external_alternative_origins: [] | [Array<string>];
 }
 export interface AuthenticationConfigOpenId {
+	observatory_id: [] | [Principal];
 	providers: Array<[OpenIdProvider, OpenIdProviderConfig]>;
 }
 export interface AuthenticationRules {
@@ -126,6 +127,7 @@ export type GetDelegationError =
 	| { DeriveSeedFailed: string };
 export type GetDelegationResultResponse = { Ok: SignedDelegation } | { Err: GetDelegationError };
 export type GetOrRefreshJwksError =
+	| { InvalidConfig: string }
 	| { MissingKid: null }
 	| { BadClaim: string }
 	| { KeyNotFoundCooldown: null }

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
 		NoKeyForKid: IDL.Null
 	});
 	const GetOrRefreshJwksError = IDL.Variant({
+		InvalidConfig: IDL.Text,
 		MissingKid: IDL.Null,
 		BadClaim: IDL.Text,
 		KeyNotFoundCooldown: IDL.Null,
@@ -136,6 +137,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
 		NoKeyForKid: IDL.Null
 	});
 	const GetOrRefreshJwksError = IDL.Variant({
+		InvalidConfig: IDL.Text,
 		MissingKid: IDL.Null,
 		BadClaim: IDL.Text,
 		KeyNotFoundCooldown: IDL.Null,
@@ -136,6 +137,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/libs/auth/src/openid/jwkset/fetch.rs
+++ b/src/libs/auth/src/openid/jwkset/fetch.rs
@@ -2,14 +2,11 @@ use crate::openid::jwkset::types::interface::GetOpenIdCertificateArgs;
 use crate::openid::types::provider::{OpenIdCertificate, OpenIdProvider};
 use candid::Principal;
 use ic_cdk::call::Call;
-use junobuild_shared::env::OBSERVATORY;
 
 pub async fn fetch_openid_certificate(
     provider: &OpenIdProvider,
+    observatory: Principal,
 ) -> Result<Option<OpenIdCertificate>, String> {
-    // TODO: optional parameter observatory ID
-    let observatory = Principal::from_text(OBSERVATORY).map_err(|e| e.to_string())?;
-
     let certificate = Call::bounded_wait(observatory, "get_openid_certificate")
         .with_arg(GetOpenIdCertificateArgs::from(provider))
         .await

--- a/src/libs/auth/src/openid/jwkset/jwks.rs
+++ b/src/libs/auth/src/openid/jwkset/jwks.rs
@@ -3,6 +3,7 @@ use crate::openid::jwkset::constants::{
     REFRESH_COOLDOWN_NS,
 };
 use crate::openid::jwkset::fetch::fetch_openid_certificate;
+use crate::openid::jwkset::targets::target_observatory_id;
 use crate::openid::jwkset::types::errors::GetOrRefreshJwksError;
 use crate::openid::jwt::types::cert::Jwks;
 use crate::openid::jwt::unsafe_find_jwt_kid;
@@ -52,7 +53,10 @@ pub async fn get_or_refresh_jwks(
         }
     }
 
-    let fetched_certificate = fetch_openid_certificate(provider)
+    let observatory_id =
+        target_observatory_id(auth_heap).map_err(GetOrRefreshJwksError::InvalidConfig)?;
+
+    let fetched_certificate = fetch_openid_certificate(provider, observatory_id)
         .await
         .map_err(GetOrRefreshJwksError::FetchFailed)?
         .ok_or(GetOrRefreshJwksError::CertificateNotFound)?;

--- a/src/libs/auth/src/openid/jwkset/mod.rs
+++ b/src/libs/auth/src/openid/jwkset/mod.rs
@@ -2,6 +2,7 @@ mod constants;
 mod fetch;
 mod impls;
 mod jwks;
+mod targets;
 pub mod types;
 
 pub(crate) use jwks::*;

--- a/src/libs/auth/src/openid/jwkset/targets.rs
+++ b/src/libs/auth/src/openid/jwkset/targets.rs
@@ -1,0 +1,18 @@
+use crate::state::get_config;
+use crate::strategies::AuthHeapStrategy;
+use candid::Principal;
+use junobuild_shared::env::OBSERVATORY;
+
+pub fn target_observatory_id(auth_heap: &impl AuthHeapStrategy) -> Result<Principal, String> {
+    let observatory_id = get_config(auth_heap).as_ref().and_then(|config| {
+        config
+            .openid
+            .as_ref()
+            .and_then(|openid| openid.observatory_id)
+    });
+
+    let target =
+        observatory_id.unwrap_or(Principal::from_text(OBSERVATORY).map_err(|e| e.to_string())?);
+
+    Ok(target)
+}

--- a/src/libs/auth/src/openid/jwkset/types.rs
+++ b/src/libs/auth/src/openid/jwkset/types.rs
@@ -9,6 +9,7 @@ pub(crate) mod errors {
         MissingKid,
         KeyNotFoundCooldown,
         KeyNotFound,
+        InvalidConfig(String),
         FetchFailed(String),
         MissingLastAttempt(String),
         CertificateNotFound,

--- a/src/libs/auth/src/state/types.rs
+++ b/src/libs/auth/src/state/types.rs
@@ -72,6 +72,7 @@ pub mod config {
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]
     pub struct AuthenticationConfigOpenId {
         pub providers: OpenIdProviders,
+        pub observatory_id: Option<Principal>,
     }
 
     #[derive(Default, CandidType, Serialize, Deserialize, Clone)]

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -37,6 +37,7 @@ type AuthenticationConfigInternetIdentity = record {
   external_alternative_origins : opt vec text;
 };
 type AuthenticationConfigOpenId = record {
+  observatory_id : opt principal;
   providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
@@ -105,6 +106,7 @@ type GetDelegationResultResponse = variant {
   Err : GetDelegationError;
 };
 type GetOrRefreshJwksError = variant {
+  InvalidConfig : text;
   MissingKid;
   BadClaim : text;
   KeyNotFoundCooldown;

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -39,6 +39,7 @@ type AuthenticationConfigInternetIdentity = record {
   external_alternative_origins : opt vec text;
 };
 type AuthenticationConfigOpenId = record {
+  observatory_id : opt principal;
   providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
@@ -107,6 +108,7 @@ type GetDelegationResultResponse = variant {
   Err : GetDelegationError;
 };
 type GetOrRefreshJwksError = variant {
+  InvalidConfig : text;
   MissingKid;
   BadClaim : text;
   KeyNotFoundCooldown;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -39,6 +39,7 @@ type AuthenticationConfigInternetIdentity = record {
   external_alternative_origins : opt vec text;
 };
 type AuthenticationConfigOpenId = record {
+  observatory_id : opt principal;
   providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
@@ -107,6 +108,7 @@ type GetDelegationResultResponse = variant {
   Err : GetDelegationError;
 };
 type GetOrRefreshJwksError = variant {
+  InvalidConfig : text;
   MissingKid;
   BadClaim : text;
   KeyNotFoundCooldown;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -43,6 +43,7 @@ export interface AuthenticationConfigInternetIdentity {
 	external_alternative_origins: [] | [Array<string>];
 }
 export interface AuthenticationConfigOpenId {
+	observatory_id: [] | [Principal];
 	providers: Array<[OpenIdProvider, OpenIdProviderConfig]>;
 }
 export interface AuthenticationRules {
@@ -126,6 +127,7 @@ export type GetDelegationError =
 	| { DeriveSeedFailed: string };
 export type GetDelegationResultResponse = { Ok: SignedDelegation } | { Err: GetDelegationError };
 export type GetOrRefreshJwksError =
+	| { InvalidConfig: string }
 	| { MissingKid: null }
 	| { BadClaim: string }
 	| { KeyNotFoundCooldown: null }

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
 		NoKeyForKid: IDL.Null
 	});
 	const GetOrRefreshJwksError = IDL.Variant({
+		InvalidConfig: IDL.Text,
 		MissingKid: IDL.Null,
 		BadClaim: IDL.Text,
 		KeyNotFoundCooldown: IDL.Null,
@@ -136,6 +137,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -27,6 +27,7 @@ export const idlFactory = ({ IDL }) => {
 		NoKeyForKid: IDL.Null
 	});
 	const GetOrRefreshJwksError = IDL.Variant({
+		InvalidConfig: IDL.Text,
 		MissingKid: IDL.Null,
 		BadClaim: IDL.Text,
 		KeyNotFoundCooldown: IDL.Null,
@@ -136,6 +137,7 @@ export const idlFactory = ({ IDL }) => {
 	const OpenIdProvider = IDL.Variant({ Google: IDL.Null });
 	const OpenIdProviderConfig = IDL.Record({ client_id: IDL.Text });
 	const AuthenticationConfigOpenId = IDL.Record({
+		observatory_id: IDL.Opt(IDL.Principal),
 		providers: IDL.Vec(IDL.Tuple(OpenIdProvider, OpenIdProviderConfig))
 	});
 	const AuthenticationConfigInternetIdentity = IDL.Record({

--- a/src/tests/fixtures/test_satellite/src/lib.rs
+++ b/src/tests/fixtures/test_satellite/src/lib.rs
@@ -5,7 +5,10 @@ use ic_cdk::update;
 use junobuild_macros::{
     on_delete_doc, on_init_random_seed, on_init_sync, on_post_upgrade_sync, on_set_doc,
 };
-use junobuild_satellite::{caller, error, id, include_satellite, info, random, set_doc_store, warn_with_data, OnDeleteDocContext, OnSetDocContext, SetDoc};
+use junobuild_satellite::{
+    caller, error, id, include_satellite, info, random, set_doc_store, warn_with_data,
+    OnDeleteDocContext, OnSetDocContext, SetDoc,
+};
 use junobuild_utils::{
     decode_doc_data, encode_doc_data, DocDataBigInt, DocDataPrincipal, DocDataUint8Array,
 };

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -39,6 +39,7 @@ type AuthenticationConfigInternetIdentity = record {
   external_alternative_origins : opt vec text;
 };
 type AuthenticationConfigOpenId = record {
+  observatory_id : opt principal;
   providers : vec record { OpenIdProvider; OpenIdProviderConfig };
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
@@ -107,6 +108,7 @@ type GetDelegationResultResponse = variant {
   Err : GetDelegationError;
 };
 type GetOrRefreshJwksError = variant {
+  InvalidConfig : text;
   MissingKid;
   BadClaim : text;
   KeyNotFoundCooldown;

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.config.openid.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.config.openid.spec.ts
@@ -1,0 +1,187 @@
+import {
+	idlFactoryObservatory,
+	type ObservatoryActor,
+	type SatelliteActor,
+	type SatelliteDid
+} from '$declarations';
+import { ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Actor, PocketIc } from '@dfinity/pic';
+import type { Principal } from '@dfinity/principal';
+import { toNullable } from '@dfinity/utils';
+import { mockCertificateDate, mockClientId } from '../../../../mocks/jwt.mocks';
+import { generateNonce } from '../../../../utils/auth-nonce-tests.utils';
+import { makeMockGoogleOpenIdJwt } from '../../../../utils/jwt-tests.utils';
+import { assertOpenIdHttpsOutcalls } from '../../../../utils/observatory-openid-tests.utils';
+import { tick } from '../../../../utils/pic-tests.utils';
+import { setupSatelliteStock } from '../../../../utils/satellite-tests.utils';
+import { OBSERVATORY_WASM_PATH } from '../../../../utils/setup-tests.utils';
+
+describe('Satellite > Authentication > Prepare', async () => {
+	let pic: PocketIc;
+
+	let actor: Actor<SatelliteActor>;
+	let controller: Ed25519KeyIdentity;
+
+	const user = Ed25519KeyIdentity.generate();
+
+	const sessionKey = await ECDSAKeyIdentity.generate();
+	const publicKey = new Uint8Array(sessionKey.getPublicKey().toDer());
+
+	const { nonce, salt } = await generateNonce({ caller: user });
+
+	beforeAll(async () => {
+		const {
+			actor: a,
+			pic: p,
+			controller: cO
+		} = await setupSatelliteStock({
+			dateTime: mockCertificateDate,
+			withIndexHtml: false,
+			memory: { Heap: null }
+		});
+
+		pic = p;
+		actor = a;
+		controller = cO;
+
+		actor.setIdentity(user);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	describe('Observatory', () => {
+		let observatoryActor: Actor<ObservatoryActor>;
+		let observatoryCanisterId: Principal;
+		let mockJwt: string;
+
+		const configTargetObservatory = async ({
+			observatoryId,
+			version
+		}: {
+			observatoryId?: Principal;
+			version?: bigint;
+		}) => {
+			const { set_auth_config } = actor;
+
+			actor.setIdentity(controller);
+
+			const config: SatelliteDid.SetAuthenticationConfig = {
+				internet_identity: [],
+				rules: [],
+				openid: [
+					{
+						providers: [
+							[
+								{ Google: null },
+								{
+									client_id: mockClientId
+								}
+							]
+						],
+						observatory_id: toNullable(observatoryId)
+					}
+				],
+				version: toNullable(version)
+			};
+
+			await set_auth_config(config);
+
+			actor.setIdentity(user);
+		};
+
+		beforeAll(async () => {
+			const { actor: obsA, canisterId: obsC } = await pic.setupCanister<ObservatoryActor>({
+				idlFactory: idlFactoryObservatory,
+				wasm: OBSERVATORY_WASM_PATH,
+				sender: controller.getPrincipal()
+			});
+
+			observatoryActor = obsA;
+			observatoryCanisterId = obsC;
+
+			observatoryActor.setIdentity(controller);
+
+			const { start_openid_monitoring } = observatoryActor;
+			await start_openid_monitoring();
+
+			await pic.advanceTime(1000 * 60 * 15); // Observatory refresh every 15min
+			await tick(pic);
+
+			const now = await pic.getTime();
+
+			const { jwks, jwt } = await makeMockGoogleOpenIdJwt({
+				clientId: mockClientId,
+				date: new Date(now),
+				nonce
+			});
+
+			// Refresh certificate in Observatory
+			await assertOpenIdHttpsOutcalls({ pic, jwks });
+
+			mockJwt = jwt;
+		});
+
+		it('should fail if default observatory is targeted', async () => {
+			await configTargetObservatory({});
+
+			const { authenticate_user } = actor;
+
+			const { delegation } = await authenticate_user({
+				OpenId: {
+					jwt: mockJwt,
+					session_key: publicKey,
+					salt
+				}
+			});
+
+			if ('Ok' in delegation) {
+				expect(true).toBeFalsy();
+
+				return;
+			}
+
+			const { Err } = delegation;
+
+			if (!('GetOrFetchJwks' in Err)) {
+				expect(true).toBeFalsy();
+
+				return;
+			}
+
+			const { GetOrFetchJwks } = Err;
+
+			if (!('FetchFailed' in GetOrFetchJwks)) {
+				expect(true).toBeFalsy();
+
+				return;
+			}
+
+			const { FetchFailed } = GetOrFetchJwks;
+
+			expect(FetchFailed).toEqual(
+				'Fetching OpenID certificate failed: CallRejected(CallRejected { raw_reject_code: 3, reject_message: "No route to canister klbfr-lqaaa-aaaak-qbwsa-cai" })'
+			);
+		});
+
+		it('should succeed with custom observatory jwts', async () => {
+			await configTargetObservatory({ version: 1n, observatoryId: observatoryCanisterId });
+
+			await pic.advanceTime(1000 * 30); // 30s for cooldown guard
+			await tick(pic);
+
+			const { authenticate_user } = actor;
+
+			const { delegation } = await authenticate_user({
+				OpenId: {
+					jwt: mockJwt,
+					session_key: publicKey,
+					salt
+				}
+			});
+
+			expect('Ok' in delegation).toBeTruthy();
+		});
+	});
+});

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
@@ -129,7 +129,8 @@ describe('Satellite > Delegation > Get delegation', async () => {
 									client_id: mockClientId
 								}
 							]
-						]
+						],
+						observatory_id: []
 					}
 				],
 				version: [1n]

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.prepare.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.prepare.spec.ts
@@ -133,7 +133,8 @@ describe('Satellite > Authentication > Prepare', async () => {
 									client_id: mockClientId
 								}
 							]
-						]
+						],
+						observatory_id: []
 					}
 				],
 				version: [1n]

--- a/src/tests/utils/auth-assertions-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-tests.utils.ts
@@ -351,7 +351,8 @@ export const testAuthGoogleConfig = ({
 								client_id: mockClientId
 							}
 						]
-					]
+					],
+					observatory_id: []
 				}
 			],
 			version: [version]
@@ -406,7 +407,8 @@ export const testAuthGoogleConfig = ({
 								client_id: mockClientId
 							}
 						]
-					]
+					],
+					observatory_id: []
 				}
 			],
 			version: [version + 2n]

--- a/src/tests/utils/satellite-auth-tests.utils.ts
+++ b/src/tests/utils/satellite-auth-tests.utils.ts
@@ -75,7 +75,8 @@ export const setupSatelliteAuth = async (): Promise<{
 		rules: [],
 		openid: [
 			{
-				providers: [[{ Google: null }, { client_id: mockClientId }]]
+				providers: [[{ Google: null }, { client_id: mockClientId }]],
+				observatory_id: []
 			}
 		],
 		version: [1n]


### PR DESCRIPTION
# Motivation

We are not going to use this option at launch but, anticipating the future, I want to provide developer a way to use another observatory than the Juno one e.g. if one day we offer them a way to spin their own module.
