### PR TITLE
test(satellite): spin up test satellite for ID

### DIFF
--- a/src/tests/constants/satellite-tests.constants.ts
+++ b/src/tests/constants/satellite-tests.constants.ts
@@ -1,4 +1,8 @@
+import { Principal } from '@dfinity/principal';
+
 export const MEMORIES = [
 	{ title: 'Heap', memory: { Heap: null } },
 	{ title: 'Stable', memory: { Stable: null } }
 ];
+
+export const SATELLITE_ID = Principal.fromText('jx5yt-yyaaa-aaaal-abzbq-cai');

--- a/src/tests/utils/satellite-tests.utils.ts
+++ b/src/tests/utils/satellite-tests.utils.ts
@@ -5,6 +5,7 @@ import { type Actor, PocketIc } from '@dfinity/pic';
 import type { Principal } from '@dfinity/principal';
 import { nonNullish } from '@dfinity/utils';
 import { inject } from 'vitest';
+import { SATELLITE_ID } from '../constants/satellite-tests.constants';
 import { SATELLITE_WASM_PATH, satelliteInitArgs } from './setup-tests.utils';
 
 export const deleteDefaultIndexHTML = async ({
@@ -59,7 +60,8 @@ export const setupSatelliteStock = async (
 				: controller,
 			memory
 		}),
-		sender: controller.getPrincipal()
+		sender: controller.getPrincipal(),
+		targetCanisterId: SATELLITE_ID
 	});
 
 	if (!withIndexHtml) {


### PR DESCRIPTION
# Motivation

In #2138 I spun up the stock and extended Satellite within the same test and for some weird unknown reasons they both ended with same ID. Therefore, to mitigate the issue, I just spin up the stock one with a pre-defined ID.
