### PR TITLE
feat(auth): decode more optional claims fields

### DIFF
--- a/src/libs/auth/src/openid/impls.rs
+++ b/src/libs/auth/src/openid/impls.rs
@@ -13,9 +13,12 @@ impl From<TokenData<Claims>> for OpenIdCredential {
         Self {
             sub: token.claims.sub,
             iss: token.claims.iss,
-            name: token.claims.name,
             email: token.claims.email,
+            name: token.claims.name,
+            given_name: token.claims.given_name,
+            family_name: token.claims.family_name,
             picture: token.claims.picture,
+            locale: token.claims.locale,
         }
     }
 }

--- a/src/libs/auth/src/openid/jwt/kid.rs
+++ b/src/libs/auth/src/openid/jwt/kid.rs
@@ -58,8 +58,11 @@ mod unsafe_find_kid_tests {
             iat: Some(now),
             email: None,
             name: None,
+            given_name: None,
+            family_name: None,
             picture: None,
             nonce: None,
+            locale: None,
         }
     }
 

--- a/src/libs/auth/src/openid/jwt/types.rs
+++ b/src/libs/auth/src/openid/jwt/types.rs
@@ -11,11 +11,14 @@ pub(crate) mod token {
         pub nbf: Option<u64>,
         pub iat: Option<u64>,
 
+        pub nonce: Option<String>,
+
         pub email: Option<String>,
         pub name: Option<String>,
+        pub given_name: Option<String>,
+        pub family_name: Option<String>,
         pub picture: Option<String>,
-
-        pub nonce: Option<String>,
+        pub locale: Option<String>,
     }
 
     #[derive(Clone, Deserialize)]

--- a/src/libs/auth/src/openid/types.rs
+++ b/src/libs/auth/src/openid/types.rs
@@ -10,7 +10,10 @@ pub(crate) mod interface {
 
         pub email: Option<String>,
         pub name: Option<String>,
+        pub given_name: Option<String>,
+        pub family_name: Option<String>,
         pub picture: Option<String>,
+        pub locale: Option<String>,
     }
 }
 


### PR DESCRIPTION
# Motivation

Related for #2140. Few of those optional fields can be useful for devs, like knowing the local or given name ("Hello xxxx").
