### PR TITLE
feat(auth): type prepare delegation result and drop expiration

### DIFF
--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -277,10 +277,11 @@ export type PrepareDelegationError =
 	| { GetOrFetchJwks: GetOrRefreshJwksError }
 	| { DeriveSeedFailed: string };
 export type PrepareDelegationResultData =
-	| {
-			Ok: [Uint8Array | number[], bigint];
-	  }
+	| { Ok: PreparedDelegation }
 	| { Err: PrepareDelegationError };
+export interface PreparedDelegation {
+	user_key: Uint8Array | number[];
+}
 export interface Proposal {
 	status: ProposalStatus;
 	updated_at: bigint;

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -14,6 +14,7 @@ export const idlFactory = ({ IDL }) => {
 	const AuthenticateUserArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
+	const PreparedDelegation = IDL.Record({ user_key: IDL.Vec(IDL.Nat8) });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -45,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		DeriveSeedFailed: IDL.Text
 	});
 	const PrepareDelegationResultData = IDL.Variant({
-		Ok: IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat64),
+		Ok: PreparedDelegation,
 		Err: PrepareDelegationError
 	});
 	const AuthenticateUserResult = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -14,6 +14,7 @@ export const idlFactory = ({ IDL }) => {
 	const AuthenticateUserArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
+	const PreparedDelegation = IDL.Record({ user_key: IDL.Vec(IDL.Nat8) });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -45,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		DeriveSeedFailed: IDL.Text
 	});
 	const PrepareDelegationResultData = IDL.Variant({
-		Ok: IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat64),
+		Ok: PreparedDelegation,
 		Err: PrepareDelegationError
 	});
 	const AuthenticateUserResult = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -14,6 +14,7 @@ export const idlFactory = ({ IDL }) => {
 	const AuthenticateUserArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
+	const PreparedDelegation = IDL.Record({ user_key: IDL.Vec(IDL.Nat8) });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -45,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		DeriveSeedFailed: IDL.Text
 	});
 	const PrepareDelegationResultData = IDL.Variant({
-		Ok: IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat64),
+		Ok: PreparedDelegation,
 		Err: PrepareDelegationError
 	});
 	const AuthenticateUserResult = IDL.Record({

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -277,10 +277,11 @@ export type PrepareDelegationError =
 	| { GetOrFetchJwks: GetOrRefreshJwksError }
 	| { DeriveSeedFailed: string };
 export type PrepareDelegationResultData =
-	| {
-			Ok: [Uint8Array | number[], bigint];
-	  }
+	| { Ok: PreparedDelegation }
 	| { Err: PrepareDelegationError };
+export interface PreparedDelegation {
+	user_key: Uint8Array | number[];
+}
 export interface Proposal {
 	status: ProposalStatus;
 	updated_at: bigint;

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -14,6 +14,7 @@ export const idlFactory = ({ IDL }) => {
 	const AuthenticateUserArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
+	const PreparedDelegation = IDL.Record({ user_key: IDL.Vec(IDL.Nat8) });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -45,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		DeriveSeedFailed: IDL.Text
 	});
 	const PrepareDelegationResultData = IDL.Variant({
-		Ok: IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat64),
+		Ok: PreparedDelegation,
 		Err: PrepareDelegationError
 	});
 	const AuthenticateUserResult = IDL.Record({

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -14,6 +14,7 @@ export const idlFactory = ({ IDL }) => {
 	const AuthenticateUserArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
+	const PreparedDelegation = IDL.Record({ user_key: IDL.Vec(IDL.Nat8) });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -45,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		DeriveSeedFailed: IDL.Text
 	});
 	const PrepareDelegationResultData = IDL.Variant({
-		Ok: IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat64),
+		Ok: PreparedDelegation,
 		Err: PrepareDelegationError
 	});
 	const AuthenticateUserResult = IDL.Record({

--- a/src/libs/auth/src/delegation/prepare.rs
+++ b/src/libs/auth/src/delegation/prepare.rs
@@ -2,8 +2,8 @@ use crate::delegation::duration::build_expiration;
 use crate::delegation::seed::calculate_seed;
 use crate::delegation::targets::{build_targets, targets_to_bytes};
 use crate::delegation::types::{
-    DelegationTargets, PrepareDelegationError, PrepareDelegationResult, PublicKey, SessionKey,
-    Timestamp,
+    DelegationTargets, PrepareDelegationError, PrepareDelegationResult, PreparedDelegation,
+    PublicKey, SessionKey, Timestamp,
 };
 use crate::openid::types::interface::{OpenIdCredential, OpenIdCredentialKey};
 use crate::state::get_salt;
@@ -56,10 +56,9 @@ fn prepare_delegation(
 
     certificate.update_certified_data();
 
-    let delegation = (
-        ByteBuf::from(der_encode_canister_sig_key(seed.to_vec())),
-        expiration,
-    );
+    let delegation = PreparedDelegation {
+        user_key: ByteBuf::from(der_encode_canister_sig_key(seed.to_vec())),
+    };
 
     Ok(delegation)
 }

--- a/src/libs/auth/src/delegation/types.rs
+++ b/src/libs/auth/src/delegation/types.rs
@@ -25,10 +25,13 @@ pub type SessionKey = PublicKey;
 pub type Timestamp = u64;
 pub type Signature = ByteBuf;
 
-pub type PrepareDelegationResult = Result<UserKeyTimestamp, PrepareDelegationError>;
+pub type PrepareDelegationResult = Result<PreparedDelegation, PrepareDelegationError>;
 pub type GetDelegationResult = Result<SignedDelegation, GetDelegationError>;
 
-pub type UserKeyTimestamp = (UserKey, Timestamp);
+#[derive(CandidType, Serialize, Deserialize)]
+pub struct PreparedDelegation {
+    pub user_key: UserKey,
+}
 
 #[derive(CandidType, Serialize, Deserialize)]
 pub struct SignedDelegation {

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -230,9 +230,10 @@ type PrepareDelegationError = variant {
   DeriveSeedFailed : text;
 };
 type PrepareDelegationResultData = variant {
-  Ok : record { blob; nat64 };
+  Ok : PreparedDelegation;
   Err : PrepareDelegationError;
 };
+type PreparedDelegation = record { user_key : blob };
 type Proposal = record {
   status : ProposalStatus;
   updated_at : nat64;

--- a/src/libs/satellite/src/impls.rs
+++ b/src/libs/satellite/src/impls.rs
@@ -2,7 +2,7 @@ use crate::memory::internal::init_stable_state;
 use crate::types::interface::{GetDelegationResultResponse, PrepareDelegationResultData};
 use crate::types::state::{CollectionType, HeapState, RuntimeState, State};
 use junobuild_auth::delegation::types::{
-    GetDelegationError, PrepareDelegationError, SignedDelegation, UserKeyTimestamp,
+    GetDelegationError, PrepareDelegationError, PreparedDelegation, SignedDelegation,
 };
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
@@ -29,8 +29,8 @@ impl Display for CollectionType {
     }
 }
 
-impl From<Result<UserKeyTimestamp, PrepareDelegationError>> for PrepareDelegationResultData {
-    fn from(r: Result<UserKeyTimestamp, PrepareDelegationError>) -> Self {
+impl From<Result<PreparedDelegation, PrepareDelegationError>> for PrepareDelegationResultData {
+    fn from(r: Result<PreparedDelegation, PrepareDelegationError>) -> Self {
         match r {
             Ok(v) => Self::Ok(v),
             Err(e) => Self::Err(e),

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -60,7 +60,7 @@ pub mod interface {
     use candid::CandidType;
     use junobuild_auth::delegation::types::{
         GetDelegationError, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs,
-        PrepareDelegationError, SignedDelegation, UserKeyTimestamp,
+        PrepareDelegationError, PreparedDelegation, SignedDelegation,
     };
     use junobuild_auth::state::types::config::AuthenticationConfig;
     use junobuild_cdn::proposals::ProposalId;
@@ -99,7 +99,7 @@ pub mod interface {
     // include_satellite and use Result as well.
     #[derive(CandidType, Serialize, Deserialize)]
     pub enum PrepareDelegationResultData {
-        Ok(UserKeyTimestamp),
+        Ok(PreparedDelegation),
         Err(PrepareDelegationError),
     }
 

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -232,9 +232,10 @@ type PrepareDelegationError = variant {
   DeriveSeedFailed : text;
 };
 type PrepareDelegationResultData = variant {
-  Ok : record { blob; nat64 };
+  Ok : PreparedDelegation;
   Err : PrepareDelegationError;
 };
+type PreparedDelegation = record { user_key : blob };
 type Proposal = record {
   status : ProposalStatus;
   updated_at : nat64;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -232,9 +232,10 @@ type PrepareDelegationError = variant {
   DeriveSeedFailed : text;
 };
 type PrepareDelegationResultData = variant {
-  Ok : record { blob; nat64 };
+  Ok : PreparedDelegation;
   Err : PrepareDelegationError;
 };
+type PreparedDelegation = record { user_key : blob };
 type Proposal = record {
   status : ProposalStatus;
   updated_at : nat64;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -277,10 +277,11 @@ export type PrepareDelegationError =
 	| { GetOrFetchJwks: GetOrRefreshJwksError }
 	| { DeriveSeedFailed: string };
 export type PrepareDelegationResultData =
-	| {
-			Ok: [Uint8Array | number[], bigint];
-	  }
+	| { Ok: PreparedDelegation }
 	| { Err: PrepareDelegationError };
+export interface PreparedDelegation {
+	user_key: Uint8Array | number[];
+}
 export interface Proposal {
 	status: ProposalStatus;
 	updated_at: bigint;

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -14,6 +14,7 @@ export const idlFactory = ({ IDL }) => {
 	const AuthenticateUserArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
+	const PreparedDelegation = IDL.Record({ user_key: IDL.Vec(IDL.Nat8) });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -45,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		DeriveSeedFailed: IDL.Text
 	});
 	const PrepareDelegationResultData = IDL.Variant({
-		Ok: IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat64),
+		Ok: PreparedDelegation,
 		Err: PrepareDelegationError
 	});
 	const AuthenticateUserResult = IDL.Record({

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -14,6 +14,7 @@ export const idlFactory = ({ IDL }) => {
 	const AuthenticateUserArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
+	const PreparedDelegation = IDL.Record({ user_key: IDL.Vec(IDL.Nat8) });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -45,7 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		DeriveSeedFailed: IDL.Text
 	});
 	const PrepareDelegationResultData = IDL.Variant({
-		Ok: IDL.Tuple(IDL.Vec(IDL.Nat8), IDL.Nat64),
+		Ok: PreparedDelegation,
 		Err: PrepareDelegationError
 	});
 	const AuthenticateUserResult = IDL.Record({

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -232,9 +232,10 @@ type PrepareDelegationError = variant {
   DeriveSeedFailed : text;
 };
 type PrepareDelegationResultData = variant {
-  Ok : record { blob; nat64 };
+  Ok : PreparedDelegation;
   Err : PrepareDelegationError;
 };
+type PreparedDelegation = record { user_key : blob };
 type Proposal = record {
   status : ProposalStatus;
   updated_at : nat64;

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
@@ -177,7 +177,6 @@ describe('Satellite > Delegation > Get delegation', async () => {
 			const prepare = async (): Promise<
 				| {
 						userKey: Uint8Array | number[];
-						expiration: bigint;
 				  }
 				| undefined
 			> => {
@@ -212,8 +211,8 @@ describe('Satellite > Delegation > Get delegation', async () => {
 
 				const { Ok } = delegation;
 
-				const [userKey, expiration] = Ok;
-				return { userKey, expiration };
+				const { user_key: userKey } = Ok;
+				return { userKey };
 			};
 
 			it('should return NoSuchDelegation if called before prepare (for this session_key/expiration)', async () => {

--- a/src/tests/utils/auth-identity-tests.utils.ts
+++ b/src/tests/utils/auth-identity-tests.utils.ts
@@ -58,7 +58,7 @@ export const authenticateAndMakeIdentity = async ({
 
 	const { Ok } = prepareDelegation;
 
-	const [userKey, expiration] = Ok;
+	const { user_key: userKey } = Ok;
 
 	const signedDelegation = await get_delegation({
 		OpenId: { jwt, session_key: publicKey, salt }


### PR DESCRIPTION
# Motivation

- It's cleaner to have a struct as response given that we are going to manipulate it
- We do not need to return the expiration anymore as it is now set with configuration
