### PR TITLE
feat(auth): session expiration default to one day

### DIFF
--- a/src/libs/auth/src/delegation/constants.rs
+++ b/src/libs/auth/src/delegation/constants.rs
@@ -2,8 +2,8 @@ const MINUTE_NS: u64 = 60 * 1_000_000_000;
 const HOUR_NS: u64 = 60 * MINUTE_NS;
 const DAY_NS: u64 = 24 * HOUR_NS;
 
-// 30 minutes in nanoseconds
-pub const DEFAULT_EXPIRATION_PERIOD_NS: u64 = 30 * MINUTE_NS;
+// 1 day in nanoseconds
+pub const DEFAULT_EXPIRATION_PERIOD_NS: u64 = DAY_NS;
 
 // The maximum expiration time for delegation set to a month
 pub const MAX_EXPIRATION_PERIOD_NS: u64 = 30 * DAY_NS;

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.session-duration.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.session-duration.spec.ts
@@ -45,7 +45,7 @@ describe('Satellite > Auth > Session duration', () => {
 	});
 
 	const MINUTE = 60n * 1_000_000_000n;
-	const DEFAULT_MAX_TIME_TO_LIVE = 30n * MINUTE;
+	const DEFAULT_MAX_TIME_TO_LIVE = 24n * 60n * MINUTE; // A day
 
 	const configAuthExpiration = async ({
 		version,


### PR DESCRIPTION
# Motivation

As discussed with @ilbertt, given that identities deferred from the jwt will be by default scoped to target solely the satellite that issue it, we can extend the default expiration time to a more user friendly duration that 30 minutes. That's why we bump it to a day.
