### PR TITLE
refactor(auth): move config check up and expose only authentication module

### DIFF
--- a/src/libs/satellite/src/api/auth.rs
+++ b/src/libs/satellite/src/api/auth.rs
@@ -1,4 +1,4 @@
-use crate::auth::{openid_authenticate_user, openid_get_delegation};
+use crate::auth::authenticate::{openid_authenticate_user, openid_get_delegation};
 use crate::types::interface::{AuthenticateUserArgs, AuthenticateUserResult, GetDelegationArgs};
 use junobuild_auth::delegation::types::GetDelegationResult;
 use junobuild_shared::ic::UnwrapOrTrap;

--- a/src/libs/satellite/src/auth/authenticate.rs
+++ b/src/libs/satellite/src/auth/authenticate.rs
@@ -1,14 +1,24 @@
+use crate::auth::delegation;
 use crate::auth::delegation::openid_prepare_delegation;
 use crate::auth::register::register_user;
+use crate::auth::store::get_config;
 use crate::types::interface::{AuthenticateUserError, AuthenticateUserResult, AuthenticatedUser};
-use junobuild_auth::delegation::types::OpenIdPrepareDelegationArgs;
+use junobuild_auth::delegation::types::{
+    GetDelegationResult, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs,
+};
 
 pub async fn openid_authenticate_user(
     args: &OpenIdPrepareDelegationArgs,
 ) -> Result<AuthenticateUserResult, String> {
+    // TODO: error labels
+    let config = get_config().ok_or("No authentication configuration found.")?;
+    let openid = config
+        .openid
+        .ok_or("Authentication with OpenId disabled.")?;
+
     // TODO: rate tokens assertions
 
-    let prepared_delegation = openid_prepare_delegation(args).await?;
+    let prepared_delegation = openid_prepare_delegation(args, &openid.providers).await;
 
     let result = match prepared_delegation {
         Ok((delegation, credential)) => {
@@ -23,6 +33,20 @@ pub async fn openid_authenticate_user(
         }
         Err(err) => Err(AuthenticateUserError::PrepareDelegation(err)),
     };
+
+    Ok(result)
+}
+
+pub fn openid_get_delegation(
+    args: &OpenIdGetDelegationArgs,
+) -> Result<GetDelegationResult, String> {
+    // TODO: error labels
+    let config = get_config().ok_or("No authentication configuration found.")?;
+    let openid = config
+        .openid
+        .ok_or("Authentication with OpenId disabled.")?;
+
+    let result = delegation::openid_get_delegation(args, &openid.providers);
 
     Ok(result)
 }

--- a/src/libs/satellite/src/auth/mod.rs
+++ b/src/libs/satellite/src/auth/mod.rs
@@ -1,10 +1,7 @@
 pub mod alternative_origins;
 pub mod assert;
-mod authenticate;
+pub mod authenticate;
 mod delegation;
 mod register;
 pub mod store;
 pub mod strategy_impls;
-
-pub use authenticate::*;
-pub use delegation::openid_get_delegation;


### PR DESCRIPTION
# Motivation

Cleaner since I'll add the explicit use of the rate check.
