### PR TITLE
feat(satellite): assert user rate tokens before preparing delegation

### DIFF
--- a/src/libs/satellite/src/auth/assert.rs
+++ b/src/libs/satellite/src/auth/assert.rs
@@ -1,6 +1,10 @@
+use crate::db::runtime::increment_and_assert_rate;
 use crate::errors::auth::JUNO_AUTH_ERROR_CALLER_NOT_ALLOWED;
+use crate::rules::store::get_rule_db;
 use candid::Principal;
 use junobuild_auth::state::types::config::AuthenticationConfig;
+use junobuild_collections::constants::db::COLLECTION_USER_KEY;
+use junobuild_collections::msg::msg_db_collection_not_found;
 use junobuild_shared::controllers::controller_can_write;
 use junobuild_shared::types::state::Controllers;
 use junobuild_shared::utils::principal_equal;
@@ -37,4 +41,13 @@ pub fn assert_caller_is_allowed(
     }
 
     Err(JUNO_AUTH_ERROR_CALLER_NOT_ALLOWED.to_string())
+}
+
+pub fn increment_and_assert_user_rate() -> Result<(), String> {
+    let user_collection = COLLECTION_USER_KEY.to_string();
+
+    let rule = get_rule_db(&user_collection)
+        .ok_or_else(|| msg_db_collection_not_found(&user_collection))?;
+
+    increment_and_assert_rate(&user_collection, &rule.rate_config)
 }

--- a/src/libs/satellite/src/auth/authenticate.rs
+++ b/src/libs/satellite/src/auth/authenticate.rs
@@ -1,3 +1,4 @@
+use crate::auth::assert::increment_and_assert_user_rate;
 use crate::auth::delegation;
 use crate::auth::delegation::openid_prepare_delegation;
 use crate::auth::register::register_user;
@@ -16,7 +17,10 @@ pub async fn openid_authenticate_user(
         .openid
         .ok_or("Authentication with OpenId disabled.")?;
 
-    // TODO: rate tokens assertions
+    // We assert early on to avoid generating a delegation which won't be used
+    // in case the user cannot be created. We also want to prevent creating delegations
+    // while the rate limiter is reached.
+    increment_and_assert_user_rate()?;
 
     let prepared_delegation = openid_prepare_delegation(args, &openid.providers).await;
 

--- a/src/libs/satellite/src/db/assert.rs
+++ b/src/libs/satellite/src/db/assert.rs
@@ -3,6 +3,7 @@ use crate::db::runtime::increment_and_assert_rate;
 use crate::db::types::config::DbConfig;
 use crate::db::types::interface::SetDbConfig;
 use crate::db::types::state::{DocAssertDelete, DocAssertSet, DocContext};
+use crate::db::types::store::AssertSetDocOptions;
 use crate::errors::db::{JUNO_DATASTORE_ERROR_CANNOT_READ, JUNO_DATASTORE_ERROR_CANNOT_WRITE};
 use crate::hooks::db::{invoke_assert_delete_doc, invoke_assert_set_doc};
 use crate::types::store::{AssertContext, StoreContext};
@@ -68,6 +69,7 @@ pub fn assert_set_doc(
     }: &StoreContext,
     &AssertContext { rule, auth_config }: &AssertContext,
     config: &Option<DbConfig>,
+    options: &AssertSetDocOptions,
     key: &Key,
     value: &SetDoc,
     current_doc: &Option<Doc>,
@@ -106,7 +108,9 @@ pub fn assert_set_doc(
 
     increment_and_assert_db_usage(caller, controllers, collection, rule.max_changes_per_user)?;
 
-    increment_and_assert_rate(collection, &rule.rate_config)?;
+    if options.with_assert_rate {
+        increment_and_assert_rate(collection, &rule.rate_config)?;
+    }
 
     Ok(())
 }

--- a/src/libs/satellite/src/db/mod.rs
+++ b/src/libs/satellite/src/db/mod.rs
@@ -1,7 +1,7 @@
 mod assert;
 pub mod impls;
 pub mod internal;
-mod runtime;
+pub mod runtime;
 mod state;
 pub mod store;
 pub mod types;

--- a/src/libs/satellite/src/db/store.rs
+++ b/src/libs/satellite/src/db/store.rs
@@ -13,6 +13,7 @@ use crate::db::state::{
 use crate::db::types::config::DbConfig;
 use crate::db::types::interface::{DelDoc, SetDbConfig, SetDoc};
 use crate::db::types::state::{Doc, DocContext, DocUpsert};
+use crate::db::types::store::AssertSetDocOptions;
 use crate::db::utils::filter_values;
 use crate::memory::state::STATE;
 use crate::types::store::{AssertContext, StoreContext};
@@ -24,7 +25,6 @@ use junobuild_shared::list::list_values;
 use junobuild_shared::types::core::Key;
 use junobuild_shared::types::list::{ListParams, ListResults};
 use junobuild_shared::types::state::{Controllers, UserId};
-
 // ---------------------------------------------------------
 // Collection
 // ---------------------------------------------------------
@@ -163,7 +163,42 @@ pub fn set_doc_store(
         collection: &collection,
     };
 
-    let data = secure_set_doc(&context, &config, key.clone(), value)?;
+    let assert_options = AssertSetDocOptions {
+        with_assert_rate: true,
+    };
+
+    let data = secure_set_doc(&context, &config, &assert_options, key.clone(), value)?;
+
+    Ok(DocContext {
+        key,
+        collection,
+        data,
+    })
+}
+
+/// Internal variant of `set_doc_store`.
+///
+/// Performs a secure insert or update of a document in the specified collection,
+/// using custom assertion options.
+///
+/// Useful for the authentication flow using prepare delegation.
+pub fn internal_set_doc_store(
+    caller: UserId,
+    collection: CollectionKey,
+    key: Key,
+    value: SetDoc,
+    assert_options: &AssertSetDocOptions,
+) -> Result<DocContext<DocUpsert>, String> {
+    let controllers: Controllers = get_controllers();
+    let config = get_config();
+
+    let context = StoreContext {
+        caller,
+        controllers: &controllers,
+        collection: &collection,
+    };
+
+    let data = secure_set_doc(&context, &config, &assert_options, key.clone(), value)?;
 
     Ok(DocContext {
         key,
@@ -175,6 +210,7 @@ pub fn set_doc_store(
 fn secure_set_doc(
     context: &StoreContext,
     config: &Option<DbConfig>,
+    assert_options: &AssertSetDocOptions,
     key: Key,
     value: SetDoc,
 ) -> Result<DocUpsert, String> {
@@ -186,19 +222,28 @@ fn secure_set_doc(
         auth_config: &auth_config,
     };
 
-    set_doc_impl(context, &assert_context, config, key, value)
+    set_doc_impl(context, &assert_context, config, assert_options, key, value)
 }
 
 fn set_doc_impl(
     context: &StoreContext,
     assert_context: &AssertContext,
     config: &Option<DbConfig>,
+    assert_options: &AssertSetDocOptions,
     key: Key,
     value: SetDoc,
 ) -> Result<DocUpsert, String> {
     let current_doc = get_state_doc(context.collection, &key, assert_context.rule)?;
 
-    assert_set_doc(context, assert_context, config, &key, &value, &current_doc)?;
+    assert_set_doc(
+        context,
+        assert_context,
+        config,
+        assert_options,
+        &key,
+        &value,
+        &current_doc,
+    )?;
 
     let doc: Doc = Doc::prepare(context.caller, &current_doc, value);
 

--- a/src/libs/satellite/src/db/types.rs
+++ b/src/libs/satellite/src/db/types.rs
@@ -149,3 +149,9 @@ pub mod interface {
         pub version: Option<Version>,
     }
 }
+
+pub mod store {
+    pub struct AssertSetDocOptions {
+        pub with_assert_rate: bool,
+    }
+}

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
@@ -1,23 +1,18 @@
 import type { SatelliteActor } from '$declarations';
-import { type DelegationIdentity, ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
+import { ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Actor, PocketIc } from '@dfinity/pic';
 import { assertNonNullish, fromNullable } from '@dfinity/utils';
 import { mockClientId } from '../../../../mocks/jwt.mocks';
 import { generateNonce } from '../../../../utils/auth-nonce-tests.utils';
-import { makeMockGoogleOpenIdJwt, type MockOpenIdJwt } from '../../../../utils/jwt-tests.utils';
+import { makeMockGoogleOpenIdJwt } from '../../../../utils/jwt-tests.utils';
 import { assertOpenIdHttpsOutcalls } from '../../../../utils/observatory-openid-tests.utils';
 import { tick } from '../../../../utils/pic-tests.utils';
-import { setupSatelliteAuth, type TestSession } from '../../../../utils/satellite-auth-tests.utils';
+import { setupSatelliteAuth } from '../../../../utils/satellite-auth-tests.utils';
 
 describe('Satellite > Auth > Rate', async () => {
 	let pic: PocketIc;
 
 	let satelliteActor: Actor<SatelliteActor>;
-
-	let session: TestSession;
-
-	let mockJwt: MockOpenIdJwt;
-	let mockIdentity: DelegationIdentity;
 
 	let controller: Ed25519KeyIdentity;
 
@@ -32,14 +27,11 @@ describe('Satellite > Auth > Rate', async () => {
 		const {
 			pic: p,
 			satellite: { actor },
-			session: s,
 			controller: c
 		} = await setupSatelliteAuth();
 
 		pic = p;
 		satelliteActor = actor;
-
-		session = s;
 
 		controller = c;
 	});

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
@@ -1,0 +1,149 @@
+import type { SatelliteActor } from '$declarations';
+import { type DelegationIdentity, ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Actor, PocketIc } from '@dfinity/pic';
+import { assertNonNullish, fromNullable } from '@dfinity/utils';
+import { mockClientId } from '../../../../mocks/jwt.mocks';
+import { generateNonce } from '../../../../utils/auth-nonce-tests.utils';
+import { makeMockGoogleOpenIdJwt, type MockOpenIdJwt } from '../../../../utils/jwt-tests.utils';
+import { assertOpenIdHttpsOutcalls } from '../../../../utils/observatory-openid-tests.utils';
+import { tick } from '../../../../utils/pic-tests.utils';
+import { setupSatelliteAuth, type TestSession } from '../../../../utils/satellite-auth-tests.utils';
+
+describe('Satellite > Auth > Rate', async () => {
+	let pic: PocketIc;
+
+	let satelliteActor: Actor<SatelliteActor>;
+
+	let session: TestSession;
+
+	let mockJwt: MockOpenIdJwt;
+	let mockIdentity: DelegationIdentity;
+
+	let controller: Ed25519KeyIdentity;
+
+	const user = Ed25519KeyIdentity.generate();
+
+	const sessionKey = await ECDSAKeyIdentity.generate();
+	const publicKey = new Uint8Array(sessionKey.getPublicKey().toDer());
+
+	const { nonce, salt } = await generateNonce({ caller: user });
+
+	beforeAll(async () => {
+		const {
+			pic: p,
+			satellite: { actor },
+			session: s,
+			controller: c
+		} = await setupSatelliteAuth();
+
+		pic = p;
+		satelliteActor = actor;
+
+		session = s;
+
+		controller = c;
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	const config = async ({
+		max_tokens,
+		time_per_token_ns
+	}: {
+		max_tokens: bigint;
+		time_per_token_ns: bigint;
+	}) => {
+		satelliteActor.setIdentity(controller);
+
+		const { get_rule, set_rule } = satelliteActor;
+
+		const collectionType = { Db: null };
+		const collection = '#user';
+
+		const result = await get_rule(collectionType, collection);
+
+		const rule = fromNullable(result);
+
+		assertNonNullish(rule);
+
+		await set_rule(collectionType, collection, {
+			...rule,
+			rate_config: [
+				{
+					max_tokens,
+					time_per_token_ns
+				}
+			]
+		});
+	};
+
+	const generateJwtCertificate = async ({
+		advanceTime,
+		refreshJwts = true,
+		kid
+	}: {
+		advanceTime?: number;
+		refreshJwts?: boolean;
+		kid?: string;
+	}): Promise<{ jwt: string }> => {
+		await pic.advanceTime(advanceTime ?? 1000 * 60 * 15); // Observatory refresh every 15min
+		await tick(pic);
+
+		const now = await pic.getTime();
+
+		const { jwks, jwt } = await makeMockGoogleOpenIdJwt({
+			clientId: mockClientId,
+			date: new Date(now),
+			nonce,
+			kid
+		});
+
+		if (!refreshJwts) {
+			return { jwt };
+		}
+
+		// Refresh certificate in Observatory
+		await assertOpenIdHttpsOutcalls({ pic, jwks });
+
+		return { jwt };
+	};
+
+	it('should throw error if user rate is reached', async () => {
+		satelliteActor.setIdentity(user);
+
+		const { jwt } = await generateJwtCertificate({});
+
+		const { authenticate_user } = satelliteActor;
+
+		const result = await authenticate_user({
+			OpenId: { jwt, session_key: publicKey, salt }
+		});
+
+		expect('Ok' in result);
+
+		await config({
+			max_tokens: 1n,
+			time_per_token_ns: 2_000_000_000n // 2s
+		});
+
+		satelliteActor.setIdentity(user);
+
+		const { jwt: jwt2 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 500 });
+
+		const result2 = await authenticate_user({
+			OpenId: { jwt: jwt2, session_key: publicKey, salt }
+		});
+
+		expect('Ok' in result2);
+
+		const { jwt: jwt3 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 400 });
+
+		await expect(
+			authenticate_user({
+				OpenId: { jwt: jwt3, session_key: publicKey, salt }
+			})
+		).rejects.toThrow('Rate limit reached, try again later.');
+	});
+});


### PR DESCRIPTION
# Motivation

We want to assert early on the rate tokens for the users to avoid generating a delegation which won't be used in case the user cannot be created. We also want to prevent creating delegations while the rate limiter is reached, security measure.
