### PR TITLE
feat(satellite): rename GoogleData into OpenIdData

### DIFF
--- a/src/libs/satellite/src/auth/register.rs
+++ b/src/libs/satellite/src/auth/register.rs
@@ -4,7 +4,7 @@ use crate::db::types::store::AssertSetDocOptions;
 use crate::errors::user::JUNO_DATASTORE_ERROR_USER_PROVIDER_GOOGLE_INVALID_DATA;
 use crate::rules::store::get_rule_db;
 use crate::user::core::types::state::{AuthProvider, OpenIdData, ProviderData, UserData};
-use crate::{Doc};
+use crate::Doc;
 use candid::Principal;
 use junobuild_auth::delegation::types::UserKey;
 use junobuild_auth::openid::types::interface::OpenIdCredential;

--- a/src/libs/satellite/src/user/core/types.rs
+++ b/src/libs/satellite/src/user/core/types.rs
@@ -34,6 +34,7 @@ pub mod state {
     pub enum ProviderData {
         #[serde(rename = "webauthn")]
         WebAuthn(WebAuthnData),
+        #[serde(rename = "openid")]
         OpenId(OpenIdData),
     }
 

--- a/src/libs/satellite/src/user/core/types.rs
+++ b/src/libs/satellite/src/user/core/types.rs
@@ -34,7 +34,7 @@ pub mod state {
     pub enum ProviderData {
         #[serde(rename = "webauthn")]
         WebAuthn(WebAuthnData),
-        Google(GoogleData),
+        OpenId(OpenIdData),
     }
 
     #[derive(Serialize, Deserialize)]
@@ -47,7 +47,7 @@ pub mod state {
     // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
     #[derive(Serialize, Deserialize, Eq, PartialEq)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
-    pub struct GoogleData {
+    pub struct OpenIdData {
         pub email: Option<String>,
         pub name: Option<String>,
         pub given_name: Option<String>,

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.user.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.user.spec.ts
@@ -21,7 +21,7 @@ describe('Satellite > Auth > User', () => {
 		provider: 'google',
 		banned: null,
 		providerData: {
-			google: {
+			openid: {
 				email: 'user@example.com',
 				name: 'Hello World',
 				givenName: 'Hello',
@@ -138,8 +138,8 @@ describe('Satellite > Auth > User', () => {
 		expect(data).toEqual({
 			...mockUserData,
 			providerData: {
-				google: {
-					...mockUserData.providerData.google,
+				openid: {
+					...mockUserData.providerData.openid,
 					name: updatePayload.name,
 					givenName: updatePayload.given_name,
 					familyName: updatePayload.family_name,

--- a/src/tests/specs/satellite/stock/user/satellite.user.spec.ts
+++ b/src/tests/specs/satellite/stock/user/satellite.user.spec.ts
@@ -280,7 +280,7 @@ describe('Satellite > User', () => {
 						})
 					).rejects.toThrow(
 						new RegExp(
-							`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown variant \`test\`, expected \`webauthn\` or \`google\` at line 1 column 45.`,
+							`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown variant \`test\`, expected \`webauthn\` or \`openid\` at line 1 column 45.`,
 							'i'
 						)
 					);
@@ -711,7 +711,7 @@ describe('Satellite > User', () => {
 				})
 			).rejects.toThrow(
 				new RegExp(
-					`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown variant \`test\`, expected \`webauthn\` or \`google\` at line 1 column 54.`,
+					`${JUNO_DATASTORE_ERROR_USER_INVALID_DATA}: unknown variant \`test\`, expected \`webauthn\` or \`openid\` at line 1 column 54.`,
 					'i'
 				)
 			);


### PR DESCRIPTION
# Motivation

If we add more OpenId based provider in the future, they will provide the same structure of user data.
