### PR TITLE
feat(auth): remove expires field from OpenIdCertificate

### DIFF
--- a/src/declarations/observatory/observatory.did.d.ts
+++ b/src/declarations/observatory/observatory.did.d.ts
@@ -97,7 +97,6 @@ export interface OpenIdCertificate {
 	jwks: Jwks;
 	created_at: bigint;
 	version: [] | [bigint];
-	expires_at: [] | [bigint];
 }
 export type OpenIdProvider = { Google: null };
 export interface Segment {

--- a/src/declarations/observatory/observatory.factory.certified.did.js
+++ b/src/declarations/observatory/observatory.factory.certified.did.js
@@ -46,8 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		updated_at: IDL.Nat64,
 		jwks: Jwks,
 		created_at: IDL.Nat64,
-		version: IDL.Opt(IDL.Nat64),
-		expires_at: IDL.Opt(IDL.Nat64)
+		version: IDL.Opt(IDL.Nat64)
 	});
 	const ControllerScope = IDL.Variant({
 		Write: IDL.Null,

--- a/src/declarations/observatory/observatory.factory.did.js
+++ b/src/declarations/observatory/observatory.factory.did.js
@@ -46,8 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		updated_at: IDL.Nat64,
 		jwks: Jwks,
 		created_at: IDL.Nat64,
-		version: IDL.Opt(IDL.Nat64),
-		expires_at: IDL.Opt(IDL.Nat64)
+		version: IDL.Opt(IDL.Nat64)
 	});
 	const ControllerScope = IDL.Variant({
 		Write: IDL.Null,

--- a/src/declarations/observatory/observatory.factory.did.mjs
+++ b/src/declarations/observatory/observatory.factory.did.mjs
@@ -46,8 +46,7 @@ export const idlFactory = ({ IDL }) => {
 		updated_at: IDL.Nat64,
 		jwks: Jwks,
 		created_at: IDL.Nat64,
-		version: IDL.Opt(IDL.Nat64),
-		expires_at: IDL.Opt(IDL.Nat64)
+		version: IDL.Opt(IDL.Nat64)
 	});
 	const ControllerScope = IDL.Variant({
 		Write: IDL.Null,

--- a/src/libs/auth/src/openid/impls.rs
+++ b/src/libs/auth/src/openid/impls.rs
@@ -4,7 +4,7 @@ use crate::openid::types::interface::{OpenIdCredential, OpenIdCredentialKey};
 use crate::openid::types::provider::{OpenIdCertificate, OpenIdProvider};
 use ic_cdk::api::time;
 use jsonwebtoken::TokenData;
-use junobuild_shared::types::state::{Timestamp, Version, Versioned};
+use junobuild_shared::types::state::{Version, Versioned};
 use junobuild_shared::version::next_version;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
@@ -57,32 +57,26 @@ impl OpenIdCertificate {
         next_version(current_certificate)
     }
 
-    pub fn init(jwks: &Jwks, expires_at: &Option<Timestamp>) -> Self {
+    pub fn init(jwks: &Jwks) -> Self {
         let now = time();
 
         let version = Self::get_next_version(&None);
 
         Self {
             jwks: jwks.clone(),
-            expires_at: *expires_at,
             created_at: now,
             updated_at: now,
             version: Some(version),
         }
     }
 
-    pub fn update(
-        current_certificate: &OpenIdCertificate,
-        jwks: &Jwks,
-        expires_at: &Option<Timestamp>,
-    ) -> Self {
+    pub fn update(current_certificate: &OpenIdCertificate, jwks: &Jwks) -> Self {
         let now = time();
 
         let version = Self::get_next_version(&Some(current_certificate.clone()));
 
         Self {
             jwks: jwks.clone(),
-            expires_at: *expires_at,
             updated_at: now,
             version: Some(version),
             ..current_certificate.clone()

--- a/src/libs/auth/src/openid/types.rs
+++ b/src/libs/auth/src/openid/types.rs
@@ -49,11 +49,6 @@ pub mod provider {
     pub struct OpenIdCertificate {
         pub jwks: Jwks,
 
-        // This JWKS might no longer be valid after this timestamp.
-        // e.g. when fetching the Google certificate, the date is derived
-        // from the HTTP response header "expires".
-        pub expires_at: Option<Timestamp>,
-
         pub created_at: Timestamp,
         pub updated_at: Timestamp,
 

--- a/src/observatory/observatory.did
+++ b/src/observatory/observatory.did
@@ -67,7 +67,6 @@ type OpenIdCertificate = record {
   jwks : Jwks;
   created_at : nat64;
   version : opt nat64;
-  expires_at : opt nat64;
 };
 type OpenIdProvider = variant { Google };
 type Segment = record {

--- a/src/observatory/src/openid/certificate.rs
+++ b/src/observatory/src/openid/certificate.rs
@@ -5,7 +5,6 @@ use ic_cdk::futures::spawn;
 use ic_cdk_timers::set_timer;
 use junobuild_auth::openid::jwt::types::cert::Jwks;
 use junobuild_auth::openid::types::provider::OpenIdProvider;
-use junobuild_shared::date::parse_text_datetime_ns;
 use serde_json::from_slice;
 use std::cmp::min;
 use std::time::Duration;
@@ -44,18 +43,9 @@ async fn fetch_and_save_certificate(provider: &OpenIdProvider) -> Result<(), Str
 
     let raw_json_value = http_result.body;
 
-    // Google JWKS responses include an `Expires` header.
-    // It indicates when the current key set should no longer be considered valid.
-    // We don't use this information at the moment, which is why we don't cap it yet.
-    let expires_at = http_result
-        .headers
-        .iter()
-        .find(|header| header.name.eq_ignore_ascii_case("expires"))
-        .and_then(|header| parse_text_datetime_ns(&header.value));
-
     let jwks = from_slice::<Jwks>(&raw_json_value).map_err(|e| e.to_string())?;
 
-    set_openid_certificate(provider, &jwks, &expires_at);
+    set_openid_certificate(provider, &jwks);
 
     Ok(())
 }

--- a/src/observatory/src/store/heap.rs
+++ b/src/observatory/src/store/heap.rs
@@ -8,7 +8,7 @@ use junobuild_shared::controllers::{
     delete_controllers as delete_controllers_impl, set_controllers as set_controllers_impl,
 };
 use junobuild_shared::types::interface::SetController;
-use junobuild_shared::types::state::{ControllerId, Controllers, Timestamp};
+use junobuild_shared::types::state::{ControllerId, Controllers};
 
 // ---------------------------------------------------------
 // Controllers
@@ -76,12 +76,8 @@ pub fn disable_scheduler(provider: &OpenIdProvider) -> Result<(), String> {
     with_openid_mut(|openid| disable_scheduler_impl(provider, openid))
 }
 
-pub fn set_openid_certificate(
-    provider: &OpenIdProvider,
-    jwks: &Jwks,
-    expires_at: &Option<Timestamp>,
-) {
-    with_openid_mut(|openid| set_openid_certificate_impl(provider, jwks, expires_at, openid))
+pub fn set_openid_certificate(provider: &OpenIdProvider, jwks: &Jwks) {
+    with_openid_mut(|openid| set_openid_certificate_impl(provider, jwks, openid))
 }
 
 fn get_certificate_impl(
@@ -150,7 +146,6 @@ fn disable_scheduler_impl(
 fn set_openid_certificate_impl(
     provider: &OpenIdProvider,
     jwks: &Jwks,
-    expires_at: &Option<Timestamp>,
     current_openid: &mut Option<OpenId>,
 ) {
     let openid = current_openid.get_or_insert_with(OpenId::default);
@@ -158,6 +153,6 @@ fn set_openid_certificate_impl(
     openid
         .certificates
         .entry(provider.clone())
-        .and_modify(|c| *c = OpenIdCertificate::update(c, jwks, expires_at))
-        .or_insert_with(|| OpenIdCertificate::init(jwks, expires_at));
+        .and_modify(|c| *c = OpenIdCertificate::update(c, jwks))
+        .or_insert_with(|| OpenIdCertificate::init(jwks));
 }

--- a/src/tests/specs/observatory/observatory.openid.spec.ts
+++ b/src/tests/specs/observatory/observatory.openid.spec.ts
@@ -102,7 +102,6 @@ describe('Observatory > OpenId', async () => {
 		expect(certificate).toEqual(
 			expect.objectContaining({
 				jwks: mapGoogleCertificateToJwks(),
-				expires_at: [],
 				created_at: expect.any(BigInt),
 				updated_at: expect.any(BigInt),
 				version: [version]


### PR DESCRIPTION
# Motivation

When fetching Google with an HTTPS outcalls from the Observatory, we cannot reach a consensus with the HTTPS outcalls to interpret the "Expires" information. It might be that the HTTP headers provided by Google slightly differ across replicas/CDN edges.

Given that we do not use yet this information anyway, let's remove it from the code base and DID declarations.
