### PR TITLE
fix(auth): get delegation race condition

### DIFF
--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -26,7 +26,7 @@ export interface AssetNoContent {
 export interface AssetsUpgradeOptions {
 	clear_existing_assets: [] | [boolean];
 }
-export type AuthenticateUserArgs = { OpenId: OpenIdDelegationArgs };
+export type AuthenticateUserArgs = { OpenId: OpenIdPrepareDelegationArgs };
 export type AuthenticateUserError =
 	| {
 			PrepareDelegation: PrepareDelegationError;
@@ -37,7 +37,7 @@ export type AuthenticateUserResultResponse =
 	| { Err: AuthenticateUserError };
 export interface AuthenticatedUser {
 	doc: Doc;
-	public_key: Uint8Array | number[];
+	delegation: PreparedDelegation;
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
@@ -131,7 +131,7 @@ export interface Doc {
 	created_at: bigint;
 	version: [] | [bigint];
 }
-export type GetDelegationArgs = { OpenId: OpenIdDelegationArgs };
+export type GetDelegationArgs = { OpenId: OpenIdGetDelegationArgs };
 export type GetDelegationError =
 	| { JwtFindProvider: JwtFindProviderError }
 	| { GetCachedJwks: null }
@@ -258,7 +258,13 @@ export interface MemorySize {
 	stable: bigint;
 	heap: bigint;
 }
-export interface OpenIdDelegationArgs {
+export interface OpenIdGetDelegationArgs {
+	jwt: string;
+	session_key: Uint8Array | number[];
+	salt: Uint8Array | number[];
+	expiration: bigint;
+}
+export interface OpenIdPrepareDelegationArgs {
 	jwt: string;
 	session_key: Uint8Array | number[];
 	salt: Uint8Array | number[];
@@ -280,6 +286,10 @@ export type PrepareDelegationError =
 	| { JwtVerify: JwtVerifyError }
 	| { GetOrFetchJwks: GetOrRefreshJwksError }
 	| { DeriveSeedFailed: string };
+export interface PreparedDelegation {
+	user_key: Uint8Array | number[];
+	expiration: bigint;
+}
 export interface Proposal {
 	status: ProposalStatus;
 	updated_at: bigint;

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -6,12 +6,14 @@ export const idlFactory = ({ IDL }) => {
 		controllers: IDL.Vec(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs)
 	});
-	const OpenIdDelegationArgs = IDL.Record({
+	const OpenIdPrepareDelegationArgs = IDL.Record({
 		jwt: IDL.Text,
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const AuthenticateUserArgs = IDL.Variant({
+		OpenId: OpenIdPrepareDelegationArgs
+	});
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -20,9 +22,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const PreparedDelegation = IDL.Record({
+		user_key: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
 	const AuthenticatedUser = IDL.Record({
 		doc: Doc,
-		public_key: IDL.Vec(IDL.Nat8)
+		delegation: PreparedDelegation
 	});
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
@@ -210,7 +216,13 @@ export const idlFactory = ({ IDL }) => {
 		authentication: IDL.Opt(AuthenticationConfig),
 		storage: StorageConfig
 	});
-	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const OpenIdGetDelegationArgs = IDL.Record({
+		jwt: IDL.Text,
+		session_key: IDL.Vec(IDL.Nat8),
+		salt: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
+	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdGetDelegationArgs });
 	const Delegation = IDL.Record({
 		pubkey: IDL.Vec(IDL.Nat8),
 		targets: IDL.Opt(IDL.Vec(IDL.Principal)),

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -6,12 +6,14 @@ export const idlFactory = ({ IDL }) => {
 		controllers: IDL.Vec(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs)
 	});
-	const OpenIdDelegationArgs = IDL.Record({
+	const OpenIdPrepareDelegationArgs = IDL.Record({
 		jwt: IDL.Text,
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const AuthenticateUserArgs = IDL.Variant({
+		OpenId: OpenIdPrepareDelegationArgs
+	});
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -20,9 +22,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const PreparedDelegation = IDL.Record({
+		user_key: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
 	const AuthenticatedUser = IDL.Record({
 		doc: Doc,
-		public_key: IDL.Vec(IDL.Nat8)
+		delegation: PreparedDelegation
 	});
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
@@ -210,7 +216,13 @@ export const idlFactory = ({ IDL }) => {
 		authentication: IDL.Opt(AuthenticationConfig),
 		storage: StorageConfig
 	});
-	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const OpenIdGetDelegationArgs = IDL.Record({
+		jwt: IDL.Text,
+		session_key: IDL.Vec(IDL.Nat8),
+		salt: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
+	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdGetDelegationArgs });
 	const Delegation = IDL.Record({
 		pubkey: IDL.Vec(IDL.Nat8),
 		targets: IDL.Opt(IDL.Vec(IDL.Principal)),

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -6,12 +6,14 @@ export const idlFactory = ({ IDL }) => {
 		controllers: IDL.Vec(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs)
 	});
-	const OpenIdDelegationArgs = IDL.Record({
+	const OpenIdPrepareDelegationArgs = IDL.Record({
 		jwt: IDL.Text,
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const AuthenticateUserArgs = IDL.Variant({
+		OpenId: OpenIdPrepareDelegationArgs
+	});
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -20,9 +22,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const PreparedDelegation = IDL.Record({
+		user_key: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
 	const AuthenticatedUser = IDL.Record({
 		doc: Doc,
-		public_key: IDL.Vec(IDL.Nat8)
+		delegation: PreparedDelegation
 	});
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
@@ -210,7 +216,13 @@ export const idlFactory = ({ IDL }) => {
 		authentication: IDL.Opt(AuthenticationConfig),
 		storage: StorageConfig
 	});
-	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const OpenIdGetDelegationArgs = IDL.Record({
+		jwt: IDL.Text,
+		session_key: IDL.Vec(IDL.Nat8),
+		salt: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
+	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdGetDelegationArgs });
 	const Delegation = IDL.Record({
 		pubkey: IDL.Vec(IDL.Nat8),
 		targets: IDL.Opt(IDL.Vec(IDL.Principal)),

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -26,7 +26,7 @@ export interface AssetNoContent {
 export interface AssetsUpgradeOptions {
 	clear_existing_assets: [] | [boolean];
 }
-export type AuthenticateUserArgs = { OpenId: OpenIdDelegationArgs };
+export type AuthenticateUserArgs = { OpenId: OpenIdPrepareDelegationArgs };
 export type AuthenticateUserError =
 	| {
 			PrepareDelegation: PrepareDelegationError;
@@ -37,7 +37,7 @@ export type AuthenticateUserResultResponse =
 	| { Err: AuthenticateUserError };
 export interface AuthenticatedUser {
 	doc: Doc;
-	public_key: Uint8Array | number[];
+	delegation: PreparedDelegation;
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
@@ -131,7 +131,7 @@ export interface Doc {
 	created_at: bigint;
 	version: [] | [bigint];
 }
-export type GetDelegationArgs = { OpenId: OpenIdDelegationArgs };
+export type GetDelegationArgs = { OpenId: OpenIdGetDelegationArgs };
 export type GetDelegationError =
 	| { JwtFindProvider: JwtFindProviderError }
 	| { GetCachedJwks: null }
@@ -258,7 +258,13 @@ export interface MemorySize {
 	stable: bigint;
 	heap: bigint;
 }
-export interface OpenIdDelegationArgs {
+export interface OpenIdGetDelegationArgs {
+	jwt: string;
+	session_key: Uint8Array | number[];
+	salt: Uint8Array | number[];
+	expiration: bigint;
+}
+export interface OpenIdPrepareDelegationArgs {
 	jwt: string;
 	session_key: Uint8Array | number[];
 	salt: Uint8Array | number[];
@@ -280,6 +286,10 @@ export type PrepareDelegationError =
 	| { JwtVerify: JwtVerifyError }
 	| { GetOrFetchJwks: GetOrRefreshJwksError }
 	| { DeriveSeedFailed: string };
+export interface PreparedDelegation {
+	user_key: Uint8Array | number[];
+	expiration: bigint;
+}
 export interface Proposal {
 	status: ProposalStatus;
 	updated_at: bigint;

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -6,12 +6,14 @@ export const idlFactory = ({ IDL }) => {
 		controllers: IDL.Vec(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs)
 	});
-	const OpenIdDelegationArgs = IDL.Record({
+	const OpenIdPrepareDelegationArgs = IDL.Record({
 		jwt: IDL.Text,
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const AuthenticateUserArgs = IDL.Variant({
+		OpenId: OpenIdPrepareDelegationArgs
+	});
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -20,9 +22,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const PreparedDelegation = IDL.Record({
+		user_key: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
 	const AuthenticatedUser = IDL.Record({
 		doc: Doc,
-		public_key: IDL.Vec(IDL.Nat8)
+		delegation: PreparedDelegation
 	});
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
@@ -210,7 +216,13 @@ export const idlFactory = ({ IDL }) => {
 		authentication: IDL.Opt(AuthenticationConfig),
 		storage: StorageConfig
 	});
-	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const OpenIdGetDelegationArgs = IDL.Record({
+		jwt: IDL.Text,
+		session_key: IDL.Vec(IDL.Nat8),
+		salt: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
+	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdGetDelegationArgs });
 	const Delegation = IDL.Record({
 		pubkey: IDL.Vec(IDL.Nat8),
 		targets: IDL.Opt(IDL.Vec(IDL.Principal)),

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -6,12 +6,14 @@ export const idlFactory = ({ IDL }) => {
 		controllers: IDL.Vec(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs)
 	});
-	const OpenIdDelegationArgs = IDL.Record({
+	const OpenIdPrepareDelegationArgs = IDL.Record({
 		jwt: IDL.Text,
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const AuthenticateUserArgs = IDL.Variant({
+		OpenId: OpenIdPrepareDelegationArgs
+	});
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -20,9 +22,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const PreparedDelegation = IDL.Record({
+		user_key: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
 	const AuthenticatedUser = IDL.Record({
 		doc: Doc,
-		public_key: IDL.Vec(IDL.Nat8)
+		delegation: PreparedDelegation
 	});
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
@@ -210,7 +216,13 @@ export const idlFactory = ({ IDL }) => {
 		authentication: IDL.Opt(AuthenticationConfig),
 		storage: StorageConfig
 	});
-	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const OpenIdGetDelegationArgs = IDL.Record({
+		jwt: IDL.Text,
+		session_key: IDL.Vec(IDL.Nat8),
+		salt: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
+	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdGetDelegationArgs });
 	const Delegation = IDL.Record({
 		pubkey: IDL.Vec(IDL.Nat8),
 		targets: IDL.Opt(IDL.Vec(IDL.Principal)),

--- a/src/libs/auth/src/delegation/get.rs
+++ b/src/libs/auth/src/delegation/get.rs
@@ -1,7 +1,6 @@
 use crate::delegation::types::{
-    Delegation, GetDelegationError, GetDelegationResult, SessionKey, SignedDelegation,
+    Delegation, GetDelegationError, GetDelegationResult, SessionKey, SignedDelegation, Timestamp,
 };
-use crate::delegation::utils::duration::build_expiration;
 use crate::delegation::utils::seed::calculate_seed;
 use crate::delegation::utils::signature::{build_signature_inputs, build_signature_msg};
 use crate::delegation::utils::targets::build_targets;
@@ -14,6 +13,7 @@ use serde_bytes::ByteBuf;
 
 pub fn openid_get_delegation(
     session_key: &SessionKey,
+    expiration: Timestamp,
     client_id: &OpenIdProviderClientId,
     credential: &OpenIdCredential,
     auth_heap: &impl AuthHeapStrategy,
@@ -21,6 +21,7 @@ pub fn openid_get_delegation(
 ) -> GetDelegationResult {
     get_delegation(
         session_key,
+        expiration,
         client_id,
         &OpenIdCredentialKey::from(credential),
         auth_heap,
@@ -30,6 +31,7 @@ pub fn openid_get_delegation(
 
 pub fn get_delegation(
     session_key: &SessionKey,
+    expiration: Timestamp,
     client_id: &str,
     key: &OpenIdCredentialKey,
     auth_heap: &impl AuthHeapStrategy,
@@ -37,8 +39,6 @@ pub fn get_delegation(
 ) -> GetDelegationResult {
     let seed = calculate_seed(client_id, key, &get_salt(auth_heap))
         .map_err(GetDelegationError::DeriveSeedFailed)?;
-
-    let expiration = build_expiration(auth_heap);
 
     let targets = build_targets(auth_heap);
 

--- a/src/libs/auth/src/delegation/prepare.rs
+++ b/src/libs/auth/src/delegation/prepare.rs
@@ -1,5 +1,6 @@
 use crate::delegation::types::{
     PrepareDelegationError, PrepareDelegationResult, PreparedDelegation, PublicKey, SessionKey,
+    Timestamp,
 };
 use crate::delegation::utils::duration::build_expiration;
 use crate::delegation::utils::seed::calculate_seed;
@@ -41,7 +42,7 @@ fn prepare_delegation(
 ) -> PrepareDelegationResult {
     let seed = calculate_seed(client_id, key, &get_salt(auth_heap))
         .map_err(PrepareDelegationError::DeriveSeedFailed)?;
-    
+
     let expiration = build_expiration(auth_heap);
 
     add_delegation_signature(session_key, expiration, seed.as_ref(), auth_heap);
@@ -50,7 +51,7 @@ fn prepare_delegation(
 
     let delegation = PreparedDelegation {
         user_key: ByteBuf::from(der_encode_canister_sig_key(seed.to_vec())),
-        expiration
+        expiration,
     };
 
     Ok(delegation)
@@ -58,7 +59,7 @@ fn prepare_delegation(
 
 fn add_delegation_signature(
     session_key: &PublicKey,
-    expiration: u64,
+    expiration: Timestamp,
     seed: &[u8],
     auth_heap: &impl AuthHeapStrategy,
 ) {

--- a/src/libs/auth/src/delegation/types.rs
+++ b/src/libs/auth/src/delegation/types.rs
@@ -6,14 +6,19 @@ use serde::Serialize;
 use serde_bytes::ByteBuf;
 
 #[derive(CandidType, Serialize, Deserialize)]
-pub struct OpenIdDelegationArgs {
+pub struct OpenIdPrepareDelegationArgs {
     pub jwt: String,
     pub salt: Salt,
     pub session_key: SessionKey,
 }
 
-pub type OpenIdPrepareDelegationArgs = OpenIdDelegationArgs;
-pub type OpenIdGetDelegationArgs = OpenIdDelegationArgs;
+#[derive(CandidType, Serialize, Deserialize)]
+pub struct OpenIdGetDelegationArgs {
+    pub jwt: String,
+    pub salt: Salt,
+    pub session_key: SessionKey,
+    pub expiration: Timestamp,
+}
 
 pub type UserKey = PublicKey;
 pub type PublicKey = ByteBuf;

--- a/src/libs/auth/src/delegation/types.rs
+++ b/src/libs/auth/src/delegation/types.rs
@@ -27,6 +27,7 @@ pub type GetDelegationResult = Result<SignedDelegation, GetDelegationError>;
 #[derive(CandidType, Serialize, Deserialize)]
 pub struct PreparedDelegation {
     pub user_key: UserKey,
+    pub expiration: Timestamp,
 }
 
 #[derive(CandidType, Serialize, Deserialize)]

--- a/src/libs/auth/src/delegation/utils/signature.rs
+++ b/src/libs/auth/src/delegation/utils/signature.rs
@@ -1,4 +1,4 @@
-use crate::delegation::types::{DelegationTargets, SessionKey};
+use crate::delegation::types::{DelegationTargets, SessionKey, Timestamp};
 use crate::delegation::utils::targets::targets_to_bytes;
 use ic_canister_sig_creation::signature_map::CanisterSigInputs;
 use ic_canister_sig_creation::{delegation_signature_msg, DELEGATION_SIG_DOMAIN};
@@ -13,7 +13,7 @@ pub fn build_signature_inputs<'a>(seed: &'a [u8], message: &'a [u8]) -> Canister
 
 pub fn build_signature_msg(
     session_key: &SessionKey,
-    expiration: u64,
+    expiration: Timestamp,
     targets: &Option<DelegationTargets>,
 ) -> Vec<u8> {
     delegation_signature_msg(session_key, expiration, targets_to_bytes(targets).as_ref())

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -20,7 +20,7 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdDelegationArgs };
+type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticateUserError = variant {
   PrepareDelegation : PrepareDelegationError;
   RegisterUser : text;
@@ -29,7 +29,7 @@ type AuthenticateUserResultResponse = variant {
   Ok : AuthenticatedUser;
   Err : AuthenticateUserError;
 };
-type AuthenticatedUser = record { doc : Doc; public_key : blob };
+type AuthenticatedUser = record { doc : Doc; delegation : PreparedDelegation };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -103,7 +103,7 @@ type Doc = record {
   created_at : nat64;
   version : opt nat64;
 };
-type GetDelegationArgs = variant { OpenId : OpenIdDelegationArgs };
+type GetDelegationArgs = variant { OpenId : OpenIdGetDelegationArgs };
 type GetDelegationError = variant {
   JwtFindProvider : JwtFindProviderError;
   GetCachedJwks;
@@ -215,7 +215,13 @@ type ListRulesResults = record {
 };
 type Memory = variant { Heap; Stable };
 type MemorySize = record { stable : nat64; heap : nat64 };
-type OpenIdDelegationArgs = record {
+type OpenIdGetDelegationArgs = record {
+  jwt : text;
+  session_key : blob;
+  salt : blob;
+  expiration : nat64;
+};
+type OpenIdPrepareDelegationArgs = record {
   jwt : text;
   session_key : blob;
   salt : blob;
@@ -230,6 +236,7 @@ type PrepareDelegationError = variant {
   GetOrFetchJwks : GetOrRefreshJwksError;
   DeriveSeedFailed : text;
 };
+type PreparedDelegation = record { user_key : blob; expiration : nat64 };
 type Proposal = record {
   status : ProposalStatus;
   updated_at : nat64;

--- a/src/libs/satellite/src/auth/authenticate.rs
+++ b/src/libs/satellite/src/auth/authenticate.rs
@@ -25,10 +25,7 @@ pub async fn openid_authenticate_user(
             let key = &delegation.user_key;
 
             register_user(key, &credential)
-                .map(|doc| AuthenticatedUser {
-                    delegation,
-                    doc,
-                })
+                .map(|doc| AuthenticatedUser { delegation, doc })
                 .map_err(AuthenticateUserError::RegisterUser)
         }
         Err(err) => Err(AuthenticateUserError::PrepareDelegation(err)),

--- a/src/libs/satellite/src/auth/authenticate.rs
+++ b/src/libs/satellite/src/auth/authenticate.rs
@@ -22,11 +22,11 @@ pub async fn openid_authenticate_user(
 
     let result = match prepared_delegation {
         Ok((delegation, credential)) => {
-            let key = delegation.user_key;
+            let key = &delegation.user_key;
 
-            register_user(&key, &credential)
+            register_user(key, &credential)
                 .map(|doc| AuthenticatedUser {
-                    public_key: key,
+                    delegation,
                     doc,
                 })
                 .map_err(AuthenticateUserError::RegisterUser)

--- a/src/libs/satellite/src/auth/delegation.rs
+++ b/src/libs/satellite/src/auth/delegation.rs
@@ -48,6 +48,7 @@ pub fn openid_get_delegation(
 
     delegation::openid_get_delegation(
         &args.session_key,
+        args.expiration,
         &client_id,
         &credential,
         &AuthHeap,

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -59,7 +59,10 @@ pub mod interface {
     use crate::db::types::config::DbConfig;
     use crate::Doc;
     use candid::CandidType;
-    use junobuild_auth::delegation::types::{GetDelegationError, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs, PrepareDelegationError, PreparedDelegation, SignedDelegation};
+    use junobuild_auth::delegation::types::{
+        GetDelegationError, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs,
+        PrepareDelegationError, PreparedDelegation, SignedDelegation,
+    };
     use junobuild_auth::state::types::config::AuthenticationConfig;
     use junobuild_cdn::proposals::ProposalId;
     use junobuild_storage::types::config::StorageConfig;

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -59,10 +59,7 @@ pub mod interface {
     use crate::db::types::config::DbConfig;
     use crate::Doc;
     use candid::CandidType;
-    use junobuild_auth::delegation::types::{
-        GetDelegationError, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs,
-        PrepareDelegationError, SignedDelegation, UserKey,
-    };
+    use junobuild_auth::delegation::types::{GetDelegationError, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs, PrepareDelegationError, PreparedDelegation, SignedDelegation};
     use junobuild_auth::state::types::config::AuthenticationConfig;
     use junobuild_cdn::proposals::ProposalId;
     use junobuild_storage::types::config::StorageConfig;
@@ -89,7 +86,7 @@ pub mod interface {
 
     #[derive(CandidType, Serialize, Deserialize)]
     pub struct AuthenticatedUser {
-        pub public_key: UserKey,
+        pub delegation: PreparedDelegation,
         pub doc: Doc,
     }
 

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -22,7 +22,7 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdDelegationArgs };
+type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticateUserError = variant {
   PrepareDelegation : PrepareDelegationError;
   RegisterUser : text;
@@ -31,7 +31,7 @@ type AuthenticateUserResultResponse = variant {
   Ok : AuthenticatedUser;
   Err : AuthenticateUserError;
 };
-type AuthenticatedUser = record { doc : Doc; public_key : blob };
+type AuthenticatedUser = record { doc : Doc; delegation : PreparedDelegation };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -105,7 +105,7 @@ type Doc = record {
   created_at : nat64;
   version : opt nat64;
 };
-type GetDelegationArgs = variant { OpenId : OpenIdDelegationArgs };
+type GetDelegationArgs = variant { OpenId : OpenIdGetDelegationArgs };
 type GetDelegationError = variant {
   JwtFindProvider : JwtFindProviderError;
   GetCachedJwks;
@@ -217,7 +217,13 @@ type ListRulesResults = record {
 };
 type Memory = variant { Heap; Stable };
 type MemorySize = record { stable : nat64; heap : nat64 };
-type OpenIdDelegationArgs = record {
+type OpenIdGetDelegationArgs = record {
+  jwt : text;
+  session_key : blob;
+  salt : blob;
+  expiration : nat64;
+};
+type OpenIdPrepareDelegationArgs = record {
   jwt : text;
   session_key : blob;
   salt : blob;
@@ -232,6 +238,7 @@ type PrepareDelegationError = variant {
   GetOrFetchJwks : GetOrRefreshJwksError;
   DeriveSeedFailed : text;
 };
+type PreparedDelegation = record { user_key : blob; expiration : nat64 };
 type Proposal = record {
   status : ProposalStatus;
   updated_at : nat64;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -22,7 +22,7 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdDelegationArgs };
+type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticateUserError = variant {
   PrepareDelegation : PrepareDelegationError;
   RegisterUser : text;
@@ -31,7 +31,7 @@ type AuthenticateUserResultResponse = variant {
   Ok : AuthenticatedUser;
   Err : AuthenticateUserError;
 };
-type AuthenticatedUser = record { doc : Doc; public_key : blob };
+type AuthenticatedUser = record { doc : Doc; delegation : PreparedDelegation };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -105,7 +105,7 @@ type Doc = record {
   created_at : nat64;
   version : opt nat64;
 };
-type GetDelegationArgs = variant { OpenId : OpenIdDelegationArgs };
+type GetDelegationArgs = variant { OpenId : OpenIdGetDelegationArgs };
 type GetDelegationError = variant {
   JwtFindProvider : JwtFindProviderError;
   GetCachedJwks;
@@ -217,7 +217,13 @@ type ListRulesResults = record {
 };
 type Memory = variant { Heap; Stable };
 type MemorySize = record { stable : nat64; heap : nat64 };
-type OpenIdDelegationArgs = record {
+type OpenIdGetDelegationArgs = record {
+  jwt : text;
+  session_key : blob;
+  salt : blob;
+  expiration : nat64;
+};
+type OpenIdPrepareDelegationArgs = record {
   jwt : text;
   session_key : blob;
   salt : blob;
@@ -232,6 +238,7 @@ type PrepareDelegationError = variant {
   GetOrFetchJwks : GetOrRefreshJwksError;
   DeriveSeedFailed : text;
 };
+type PreparedDelegation = record { user_key : blob; expiration : nat64 };
 type Proposal = record {
   status : ProposalStatus;
   updated_at : nat64;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -26,7 +26,7 @@ export interface AssetNoContent {
 export interface AssetsUpgradeOptions {
 	clear_existing_assets: [] | [boolean];
 }
-export type AuthenticateUserArgs = { OpenId: OpenIdDelegationArgs };
+export type AuthenticateUserArgs = { OpenId: OpenIdPrepareDelegationArgs };
 export type AuthenticateUserError =
 	| {
 			PrepareDelegation: PrepareDelegationError;
@@ -37,7 +37,7 @@ export type AuthenticateUserResultResponse =
 	| { Err: AuthenticateUserError };
 export interface AuthenticatedUser {
 	doc: Doc;
-	public_key: Uint8Array | number[];
+	delegation: PreparedDelegation;
 }
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
@@ -131,7 +131,7 @@ export interface Doc {
 	created_at: bigint;
 	version: [] | [bigint];
 }
-export type GetDelegationArgs = { OpenId: OpenIdDelegationArgs };
+export type GetDelegationArgs = { OpenId: OpenIdGetDelegationArgs };
 export type GetDelegationError =
 	| { JwtFindProvider: JwtFindProviderError }
 	| { GetCachedJwks: null }
@@ -258,7 +258,13 @@ export interface MemorySize {
 	stable: bigint;
 	heap: bigint;
 }
-export interface OpenIdDelegationArgs {
+export interface OpenIdGetDelegationArgs {
+	jwt: string;
+	session_key: Uint8Array | number[];
+	salt: Uint8Array | number[];
+	expiration: bigint;
+}
+export interface OpenIdPrepareDelegationArgs {
 	jwt: string;
 	session_key: Uint8Array | number[];
 	salt: Uint8Array | number[];
@@ -280,6 +286,10 @@ export type PrepareDelegationError =
 	| { JwtVerify: JwtVerifyError }
 	| { GetOrFetchJwks: GetOrRefreshJwksError }
 	| { DeriveSeedFailed: string };
+export interface PreparedDelegation {
+	user_key: Uint8Array | number[];
+	expiration: bigint;
+}
 export interface Proposal {
 	status: ProposalStatus;
 	updated_at: bigint;

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -6,12 +6,14 @@ export const idlFactory = ({ IDL }) => {
 		controllers: IDL.Vec(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs)
 	});
-	const OpenIdDelegationArgs = IDL.Record({
+	const OpenIdPrepareDelegationArgs = IDL.Record({
 		jwt: IDL.Text,
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const AuthenticateUserArgs = IDL.Variant({
+		OpenId: OpenIdPrepareDelegationArgs
+	});
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -20,9 +22,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const PreparedDelegation = IDL.Record({
+		user_key: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
 	const AuthenticatedUser = IDL.Record({
 		doc: Doc,
-		public_key: IDL.Vec(IDL.Nat8)
+		delegation: PreparedDelegation
 	});
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
@@ -210,7 +216,13 @@ export const idlFactory = ({ IDL }) => {
 		authentication: IDL.Opt(AuthenticationConfig),
 		storage: StorageConfig
 	});
-	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const OpenIdGetDelegationArgs = IDL.Record({
+		jwt: IDL.Text,
+		session_key: IDL.Vec(IDL.Nat8),
+		salt: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
+	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdGetDelegationArgs });
 	const Delegation = IDL.Record({
 		pubkey: IDL.Vec(IDL.Nat8),
 		targets: IDL.Opt(IDL.Vec(IDL.Principal)),

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -6,12 +6,14 @@ export const idlFactory = ({ IDL }) => {
 		controllers: IDL.Vec(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs)
 	});
-	const OpenIdDelegationArgs = IDL.Record({
+	const OpenIdPrepareDelegationArgs = IDL.Record({
 		jwt: IDL.Text,
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const AuthenticateUserArgs = IDL.Variant({
+		OpenId: OpenIdPrepareDelegationArgs
+	});
 	const Doc = IDL.Record({
 		updated_at: IDL.Nat64,
 		owner: IDL.Principal,
@@ -20,9 +22,13 @@ export const idlFactory = ({ IDL }) => {
 		created_at: IDL.Nat64,
 		version: IDL.Opt(IDL.Nat64)
 	});
+	const PreparedDelegation = IDL.Record({
+		user_key: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
 	const AuthenticatedUser = IDL.Record({
 		doc: Doc,
-		public_key: IDL.Vec(IDL.Nat8)
+		delegation: PreparedDelegation
 	});
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
@@ -210,7 +216,13 @@ export const idlFactory = ({ IDL }) => {
 		authentication: IDL.Opt(AuthenticationConfig),
 		storage: StorageConfig
 	});
-	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdDelegationArgs });
+	const OpenIdGetDelegationArgs = IDL.Record({
+		jwt: IDL.Text,
+		session_key: IDL.Vec(IDL.Nat8),
+		salt: IDL.Vec(IDL.Nat8),
+		expiration: IDL.Nat64
+	});
+	const GetDelegationArgs = IDL.Variant({ OpenId: OpenIdGetDelegationArgs });
 	const Delegation = IDL.Record({
 		pubkey: IDL.Vec(IDL.Nat8),
 		targets: IDL.Opt(IDL.Vec(IDL.Principal)),

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -22,7 +22,7 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdDelegationArgs };
+type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticateUserError = variant {
   PrepareDelegation : PrepareDelegationError;
   RegisterUser : text;
@@ -31,7 +31,7 @@ type AuthenticateUserResultResponse = variant {
   Ok : AuthenticatedUser;
   Err : AuthenticateUserError;
 };
-type AuthenticatedUser = record { doc : Doc; public_key : blob };
+type AuthenticatedUser = record { doc : Doc; delegation : PreparedDelegation };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -105,7 +105,7 @@ type Doc = record {
   created_at : nat64;
   version : opt nat64;
 };
-type GetDelegationArgs = variant { OpenId : OpenIdDelegationArgs };
+type GetDelegationArgs = variant { OpenId : OpenIdGetDelegationArgs };
 type GetDelegationError = variant {
   JwtFindProvider : JwtFindProviderError;
   GetCachedJwks;
@@ -217,7 +217,13 @@ type ListRulesResults = record {
 };
 type Memory = variant { Heap; Stable };
 type MemorySize = record { stable : nat64; heap : nat64 };
-type OpenIdDelegationArgs = record {
+type OpenIdGetDelegationArgs = record {
+  jwt : text;
+  session_key : blob;
+  salt : blob;
+  expiration : nat64;
+};
+type OpenIdPrepareDelegationArgs = record {
   jwt : text;
   session_key : blob;
   salt : blob;
@@ -232,6 +238,7 @@ type PrepareDelegationError = variant {
   GetOrFetchJwks : GetOrRefreshJwksError;
   DeriveSeedFailed : text;
 };
+type PreparedDelegation = record { user_key : blob; expiration : nat64 };
 type Proposal = record {
   status : ProposalStatus;
   updated_at : nat64;

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
@@ -276,6 +276,26 @@ describe('Satellite > Delegation > Get delegation', async () => {
 				expect(deg.pubkey).toBeDefined();
 			});
 
+			it('should return NoSuchDelegation if a non matching expiration is passed', async () => {
+				const {
+					delegation: { expiration }
+				} = await prepare();
+
+				const { get_delegation } = actor;
+
+				const res = await get_delegation({
+					OpenId: { jwt: mockJwt, session_key: publicKey, salt, expiration: expiration + 1n }
+				});
+
+				if ('Ok' in res) {
+					expect(true).toBeFalsy();
+
+					return;
+				}
+
+				expect('NoSuchDelegation' in res.Err).toBeTruthy();
+			});
+
 			it('should fail with NoSuchDelegation on wrong session_key', async () => {
 				const {
 					delegation: { expiration }

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
@@ -207,6 +207,7 @@ describe('Satellite > Delegation > Get delegation', async () => {
 
 				if ('Err' in result) {
 					expect(true).toBeFalsy();
+
 					throw new Error('Unreachable');
 				}
 

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.get-delegation.spec.ts
@@ -179,12 +179,9 @@ describe('Satellite > Delegation > Get delegation', async () => {
 			let mockJwks: MockOpenIdJwt['jwks'];
 			let mockJwt: MockOpenIdJwt['jwt'];
 
-			const prepare = async (): Promise<
-				| {
-						delegation: PreparedDelegation;
-				  }
-
-			> => {
+			const prepare = async (): Promise<{
+				delegation: PreparedDelegation;
+			}> => {
 				await pic.advanceTime(15 * 60_000);
 
 				await tick(pic);
@@ -210,7 +207,7 @@ describe('Satellite > Delegation > Get delegation', async () => {
 
 				if ('Err' in result) {
 					expect(true).toBeFalsy();
-					throw new Error("Unreachable");
+					throw new Error('Unreachable');
 				}
 
 				const { Ok } = result;
@@ -256,7 +253,9 @@ describe('Satellite > Delegation > Get delegation', async () => {
 			});
 
 			it('should succeeds after prepare_delegation', async () => {
-				const {delegation: {expiration}} = await prepare();
+				const {
+					delegation: { expiration }
+				} = await prepare();
 
 				const { get_delegation } = actor;
 				const delegation = await get_delegation({
@@ -277,7 +276,9 @@ describe('Satellite > Delegation > Get delegation', async () => {
 			});
 
 			it('should fail with NoSuchDelegation on wrong session_key', async () => {
-				const {delegation: {expiration}} = await prepare();
+				const {
+					delegation: { expiration }
+				} = await prepare();
 
 				const otherSession = await ECDSAKeyIdentity.generate();
 				const otherPub = new Uint8Array(otherSession.getPublicKey().toDer());
@@ -299,7 +300,9 @@ describe('Satellite > Delegation > Get delegation', async () => {
 			});
 
 			it('should fail for attacker (nonce mismatch) even after prepare', async () => {
-				const {delegation: {expiration}} = await prepare();
+				const {
+					delegation: { expiration }
+				} = await prepare();
 
 				const attacker = Ed25519KeyIdentity.generate();
 				actor.setIdentity(attacker);
@@ -344,7 +347,7 @@ describe('Satellite > Delegation > Get delegation', async () => {
 				const { get_delegation } = actor;
 
 				const delegation = await get_delegation({
-					OpenId: { jwt: badJwt, session_key: publicKey, salt, expiration: mockExpiration },
+					OpenId: { jwt: badJwt, session_key: publicKey, salt, expiration: mockExpiration }
 				});
 
 				if ('Ok' in delegation) {

--- a/src/tests/utils/auth-identity-tests.utils.ts
+++ b/src/tests/utils/auth-identity-tests.utils.ts
@@ -63,10 +63,13 @@ export const authenticateAndMakeIdentity = async ({
 
 	const { Ok } = prepareDelegation;
 
-	const { public_key: userKey, doc: userDoc } = Ok;
+	const {
+		delegation: { expiration, user_key: userKey },
+		doc: userDoc
+	} = Ok;
 
 	const signedDelegation = await get_delegation({
-		OpenId: { jwt, session_key: publicKey, salt }
+		OpenId: { jwt, session_key: publicKey, salt, expiration }
 	});
 
 	if ('Err' in signedDelegation) {


### PR DESCRIPTION
# Motivation

While testing, I faced some intermitent issue when sign-in. Prepare delegation/authenticate user worked out but, for some reasons, get delegation returned error 🤷‍♂️.

We were discussing the solution and one clever colleague noticed that I was using the same utils to build the expiration and targets for the signature. In the former, he then noticed I was using `time()` which might be the root cause of the issue. Prepare delegation might sign a delegation with an expiration X but, when I query the get delegation, it's possible that it tries sometimes when it's a bit slower to get it with time X + 1 -> not the same key to retrieve the signature. 

So we need to return the expiration with the prepare delegation and pass it up with the get.