### PR TITLE
feat(auth): rename endpoint authenticate_user to authenticate

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -24,11 +24,8 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
-type AuthenticateUserError = variant {
-  PrepareDelegation : PrepareDelegationError;
-};
-type AuthenticatedUser = record { delegation : PreparedDelegation };
+type Authentication = record { delegation : PreparedDelegation };
+type AuthenticationArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -49,6 +46,9 @@ type AuthenticationConfigOpenId = record {
 type AuthenticationConfigOpenIdDelegation = record {
   targets : opt vec principal;
   max_time_to_live : opt nat64;
+};
+type AuthenticationError = variant {
+  PrepareDelegation : PrepareDelegationError;
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CommitBatch = record {
@@ -246,7 +246,7 @@ type ProposalType = variant {
   SegmentsDeployment : SegmentsDeploymentOptions;
 };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
-type Result = variant { Ok : AuthenticatedUser; Err : AuthenticateUserError };
+type Result = variant { Ok : Authentication; Err : AuthenticationError };
 type Result_1 = variant { Ok : SignedDelegation; Err : GetDelegationError };
 type SegmentKind = variant { Orbiter; MissionControl; Satellite };
 type SegmentsDeploymentOptions = record {
@@ -329,7 +329,7 @@ service : () -> {
   add_credits : (principal, Tokens) -> ();
   add_invitation_code : (text) -> ();
   assert_mission_control_center : (AssertMissionControlCenterArgs) -> () query;
-  authenticate_user : (AuthenticateUserArgs) -> (Result);
+  authenticate : (AuthenticationArgs) -> (Result);
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();
   commit_proposal_many_assets_upload : (vec CommitBatch) -> ();

--- a/src/console/src/api/auth.rs
+++ b/src/console/src/api/auth.rs
@@ -1,14 +1,14 @@
-use crate::auth::authenticate::{openid_authenticate_user, openid_get_delegation};
-use crate::types::interface::{AuthenticateUserArgs, AuthenticateUserResult, GetDelegationArgs};
+use crate::auth::authenticate::{openid_authenticate, openid_get_delegation};
+use crate::types::interface::{AuthenticationArgs, AuthenticationResult, GetDelegationArgs};
 use ic_cdk_macros::{query, update};
 use junobuild_auth::delegation::types::GetDelegationResult;
 use junobuild_shared::ic::UnwrapOrTrap;
 
 #[update]
-async fn authenticate_user(args: AuthenticateUserArgs) -> AuthenticateUserResult {
+async fn authenticate(args: AuthenticationArgs) -> AuthenticationResult {
     match args {
-        AuthenticateUserArgs::OpenId(args) => {
-            openid_authenticate_user(&args).await.unwrap_or_trap()
+        AuthenticationArgs::OpenId(args) => {
+            openid_authenticate(&args).await.unwrap_or_trap()
         }
     }
 }

--- a/src/console/src/auth/authenticate.rs
+++ b/src/console/src/auth/authenticate.rs
@@ -1,14 +1,14 @@
 use crate::auth::delegation;
 use crate::auth::strategy_impls::AuthHeap;
-use crate::types::interface::{AuthenticateUserError, AuthenticateUserResult, AuthenticatedUser};
+use crate::types::interface::{AuthenticationError, AuthenticationResult, Authentication};
 use junobuild_auth::delegation::types::{
     GetDelegationResult, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs,
 };
 use junobuild_auth::state::get_providers;
 
-pub async fn openid_authenticate_user(
+pub async fn openid_authenticate(
     args: &OpenIdPrepareDelegationArgs,
-) -> Result<AuthenticateUserResult, String> {
+) -> Result<AuthenticationResult, String> {
     let providers = get_providers(&AuthHeap)?;
 
     // TODO: rate limiter
@@ -19,9 +19,9 @@ pub async fn openid_authenticate_user(
         Ok((delegation, _credential)) => {
             // TODO: register user
 
-            Ok(AuthenticatedUser { delegation })
+            Ok(Authentication { delegation })
         }
-        Err(err) => Err(AuthenticateUserError::PrepareDelegation(err)),
+        Err(err) => Err(AuthenticationError::PrepareDelegation(err)),
     };
 
     Ok(result)

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -13,8 +13,8 @@ mod metadata;
 mod store;
 mod types;
 
-use crate::types::interface::AuthenticateUserArgs;
-use crate::types::interface::AuthenticateUserResult;
+use crate::types::interface::AuthenticationArgs;
+use crate::types::interface::AuthenticationResult;
 use crate::types::interface::Config;
 use crate::types::interface::DeleteProposalAssets;
 use crate::types::interface::GetDelegationArgs;

--- a/src/console/src/types.rs
+++ b/src/console/src/types.rs
@@ -131,19 +131,19 @@ pub mod interface {
     }
 
     #[derive(CandidType, Serialize, Deserialize)]
-    pub enum AuthenticateUserArgs {
+    pub enum AuthenticationArgs {
         OpenId(OpenIdPrepareDelegationArgs),
     }
 
-    pub type AuthenticateUserResult = Result<AuthenticatedUser, AuthenticateUserError>;
+    pub type AuthenticationResult = Result<Authentication, AuthenticationError>;
 
     #[derive(CandidType, Serialize, Deserialize)]
-    pub struct AuthenticatedUser {
+    pub struct Authentication {
         pub delegation: PreparedDelegation,
     }
 
     #[derive(CandidType, Serialize, Deserialize)]
-    pub enum AuthenticateUserError {
+    pub enum AuthenticationError {
         PrepareDelegation(PrepareDelegationError),
     }
 

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -30,13 +30,10 @@ export interface AssetNoContent {
 export interface AssetsUpgradeOptions {
 	clear_existing_assets: [] | [boolean];
 }
-export type AuthenticateUserArgs = { OpenId: OpenIdPrepareDelegationArgs };
-export type AuthenticateUserError = {
-	PrepareDelegation: PrepareDelegationError;
-};
-export interface AuthenticatedUser {
+export interface Authentication {
 	delegation: PreparedDelegation;
 }
+export type AuthenticationArgs = { OpenId: OpenIdPrepareDelegationArgs };
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
 	openid: [] | [AuthenticationConfigOpenId];
@@ -58,6 +55,9 @@ export interface AuthenticationConfigOpenIdDelegation {
 	targets: [] | [Array<Principal>];
 	max_time_to_live: [] | [bigint];
 }
+export type AuthenticationError = {
+	PrepareDelegation: PrepareDelegationError;
+};
 export interface AuthenticationRules {
 	allowed_callers: Array<Principal>;
 }
@@ -288,7 +288,7 @@ export interface RateConfig {
 	max_tokens: bigint;
 	time_per_token_ns: bigint;
 }
-export type Result = { Ok: AuthenticatedUser } | { Err: AuthenticateUserError };
+export type Result = { Ok: Authentication } | { Err: AuthenticationError };
 export type Result_1 = { Ok: SignedDelegation } | { Err: GetDelegationError };
 export type SegmentKind = { Orbiter: null } | { MissionControl: null } | { Satellite: null };
 export interface SegmentsDeploymentOptions {
@@ -380,7 +380,7 @@ export interface _SERVICE {
 	add_credits: ActorMethod<[Principal, Tokens], undefined>;
 	add_invitation_code: ActorMethod<[string], undefined>;
 	assert_mission_control_center: ActorMethod<[AssertMissionControlCenterArgs], undefined>;
-	authenticate_user: ActorMethod<[AuthenticateUserArgs], Result>;
+	authenticate: ActorMethod<[AuthenticationArgs], Result>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal_many_assets_upload: ActorMethod<[Array<CommitBatch>], undefined>;

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -10,14 +10,14 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const PreparedDelegation = IDL.Record({
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({ delegation: PreparedDelegation });
+	const Authentication = IDL.Record({ delegation: PreparedDelegation });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -48,12 +48,12 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError
 	});
 	const Result = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitProposal = IDL.Record({
 		sha256: IDL.Vec(IDL.Nat8),
@@ -399,7 +399,7 @@ export const idlFactory = ({ IDL }) => {
 		add_credits: IDL.Func([IDL.Principal, Tokens], [], []),
 		add_invitation_code: IDL.Func([IDL.Text], [], []),
 		assert_mission_control_center: IDL.Func([AssertMissionControlCenterArgs], [], []),
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [Result], []),
+		authenticate: IDL.Func([AuthenticationArgs], [Result], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -10,14 +10,14 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const PreparedDelegation = IDL.Record({
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({ delegation: PreparedDelegation });
+	const Authentication = IDL.Record({ delegation: PreparedDelegation });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -48,12 +48,12 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError
 	});
 	const Result = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitProposal = IDL.Record({
 		sha256: IDL.Vec(IDL.Nat8),
@@ -399,7 +399,7 @@ export const idlFactory = ({ IDL }) => {
 		add_credits: IDL.Func([IDL.Principal, Tokens], [], []),
 		add_invitation_code: IDL.Func([IDL.Text], [], []),
 		assert_mission_control_center: IDL.Func([AssertMissionControlCenterArgs], [], ['query']),
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [Result], []),
+		authenticate: IDL.Func([AuthenticationArgs], [Result], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -10,14 +10,14 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const PreparedDelegation = IDL.Record({
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({ delegation: PreparedDelegation });
+	const Authentication = IDL.Record({ delegation: PreparedDelegation });
 	const JwtFindProviderError = IDL.Variant({
 		BadClaim: IDL.Text,
 		BadSig: IDL.Text,
@@ -48,12 +48,12 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError
 	});
 	const Result = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitProposal = IDL.Record({
 		sha256: IDL.Vec(IDL.Nat8),
@@ -399,7 +399,7 @@ export const idlFactory = ({ IDL }) => {
 		add_credits: IDL.Func([IDL.Principal, Tokens], [], []),
 		add_invitation_code: IDL.Func([IDL.Text], [], []),
 		assert_mission_control_center: IDL.Func([AssertMissionControlCenterArgs], [], ['query']),
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [Result], []),
+		authenticate: IDL.Func([AuthenticationArgs], [Result], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -26,19 +26,12 @@ export interface AssetNoContent {
 export interface AssetsUpgradeOptions {
 	clear_existing_assets: [] | [boolean];
 }
-export type AuthenticateUserArgs = { OpenId: OpenIdPrepareDelegationArgs };
-export type AuthenticateUserError =
-	| {
-			PrepareDelegation: PrepareDelegationError;
-	  }
-	| { RegisterUser: string };
-export type AuthenticateUserResultResponse =
-	| { Ok: AuthenticatedUser }
-	| { Err: AuthenticateUserError };
-export interface AuthenticatedUser {
+export type AuthenticateResultResponse = { Ok: Authentication } | { Err: AuthenticationError };
+export interface Authentication {
 	doc: Doc;
 	delegation: PreparedDelegation;
 }
+export type AuthenticationArgs = { OpenId: OpenIdPrepareDelegationArgs };
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
 	openid: [] | [AuthenticationConfigOpenId];
@@ -60,6 +53,11 @@ export interface AuthenticationConfigOpenIdDelegation {
 	targets: [] | [Array<Principal>];
 	max_time_to_live: [] | [bigint];
 }
+export type AuthenticationError =
+	| {
+			PrepareDelegation: PrepareDelegationError;
+	  }
+	| { RegisterUser: string };
 export interface AuthenticationRules {
 	allowed_callers: Array<Principal>;
 }
@@ -433,7 +431,7 @@ export interface UploadChunkResult {
 	chunk_id: bigint;
 }
 export interface _SERVICE {
-	authenticate_user: ActorMethod<[AuthenticateUserArgs], AuthenticateUserResultResponse>;
+	authenticate: ActorMethod<[AuthenticationArgs], AuthenticateResultResponse>;
 	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -11,7 +11,7 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const Doc = IDL.Record({
@@ -26,7 +26,7 @@ export const idlFactory = ({ IDL }) => {
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({
+	const Authentication = IDL.Record({
 		doc: Doc,
 		delegation: PreparedDelegation
 	});
@@ -60,13 +60,13 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError,
 		RegisterUser: IDL.Text
 	});
-	const AuthenticateUserResultResponse = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+	const AuthenticateResultResponse = IDL.Variant({
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
@@ -432,7 +432,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
 	return IDL.Service({
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [AuthenticateUserResultResponse], []),
+		authenticate: IDL.Func([AuthenticationArgs], [AuthenticateResultResponse], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -11,7 +11,7 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const Doc = IDL.Record({
@@ -26,7 +26,7 @@ export const idlFactory = ({ IDL }) => {
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({
+	const Authentication = IDL.Record({
 		doc: Doc,
 		delegation: PreparedDelegation
 	});
@@ -60,13 +60,13 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError,
 		RegisterUser: IDL.Text
 	});
-	const AuthenticateUserResultResponse = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+	const AuthenticateResultResponse = IDL.Variant({
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
@@ -432,7 +432,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
 	return IDL.Service({
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [AuthenticateUserResultResponse], []),
+		authenticate: IDL.Func([AuthenticationArgs], [AuthenticateResultResponse], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -11,7 +11,7 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const Doc = IDL.Record({
@@ -26,7 +26,7 @@ export const idlFactory = ({ IDL }) => {
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({
+	const Authentication = IDL.Record({
 		doc: Doc,
 		delegation: PreparedDelegation
 	});
@@ -60,13 +60,13 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError,
 		RegisterUser: IDL.Text
 	});
-	const AuthenticateUserResultResponse = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+	const AuthenticateResultResponse = IDL.Variant({
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
@@ -432,7 +432,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
 	return IDL.Service({
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [AuthenticateUserResultResponse], []),
+		authenticate: IDL.Func([AuthenticationArgs], [AuthenticateResultResponse], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -26,19 +26,12 @@ export interface AssetNoContent {
 export interface AssetsUpgradeOptions {
 	clear_existing_assets: [] | [boolean];
 }
-export type AuthenticateUserArgs = { OpenId: OpenIdPrepareDelegationArgs };
-export type AuthenticateUserError =
-	| {
-			PrepareDelegation: PrepareDelegationError;
-	  }
-	| { RegisterUser: string };
-export type AuthenticateUserResultResponse =
-	| { Ok: AuthenticatedUser }
-	| { Err: AuthenticateUserError };
-export interface AuthenticatedUser {
+export type AuthenticateResultResponse = { Ok: Authentication } | { Err: AuthenticationError };
+export interface Authentication {
 	doc: Doc;
 	delegation: PreparedDelegation;
 }
+export type AuthenticationArgs = { OpenId: OpenIdPrepareDelegationArgs };
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
 	openid: [] | [AuthenticationConfigOpenId];
@@ -60,6 +53,11 @@ export interface AuthenticationConfigOpenIdDelegation {
 	targets: [] | [Array<Principal>];
 	max_time_to_live: [] | [bigint];
 }
+export type AuthenticationError =
+	| {
+			PrepareDelegation: PrepareDelegationError;
+	  }
+	| { RegisterUser: string };
 export interface AuthenticationRules {
 	allowed_callers: Array<Principal>;
 }
@@ -433,7 +431,7 @@ export interface UploadChunkResult {
 	chunk_id: bigint;
 }
 export interface _SERVICE {
-	authenticate_user: ActorMethod<[AuthenticateUserArgs], AuthenticateUserResultResponse>;
+	authenticate: ActorMethod<[AuthenticationArgs], AuthenticateResultResponse>;
 	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -11,7 +11,7 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const Doc = IDL.Record({
@@ -26,7 +26,7 @@ export const idlFactory = ({ IDL }) => {
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({
+	const Authentication = IDL.Record({
 		doc: Doc,
 		delegation: PreparedDelegation
 	});
@@ -60,13 +60,13 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError,
 		RegisterUser: IDL.Text
 	});
-	const AuthenticateUserResultResponse = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+	const AuthenticateResultResponse = IDL.Variant({
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
@@ -432,7 +432,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
 	return IDL.Service({
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [AuthenticateUserResultResponse], []),
+		authenticate: IDL.Func([AuthenticationArgs], [AuthenticateResultResponse], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -11,7 +11,7 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const Doc = IDL.Record({
@@ -26,7 +26,7 @@ export const idlFactory = ({ IDL }) => {
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({
+	const Authentication = IDL.Record({
 		doc: Doc,
 		delegation: PreparedDelegation
 	});
@@ -60,13 +60,13 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError,
 		RegisterUser: IDL.Text
 	});
-	const AuthenticateUserResultResponse = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+	const AuthenticateResultResponse = IDL.Variant({
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
@@ -432,7 +432,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
 	return IDL.Service({
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [AuthenticateUserResultResponse], []),
+		authenticate: IDL.Func([AuthenticationArgs], [AuthenticateResultResponse], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -20,16 +20,12 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
-type AuthenticateUserError = variant {
-  PrepareDelegation : PrepareDelegationError;
-  RegisterUser : text;
+type AuthenticateResultResponse = variant {
+  Ok : Authentication;
+  Err : AuthenticationError;
 };
-type AuthenticateUserResultResponse = variant {
-  Ok : AuthenticatedUser;
-  Err : AuthenticateUserError;
-};
-type AuthenticatedUser = record { doc : Doc; delegation : PreparedDelegation };
+type Authentication = record { doc : Doc; delegation : PreparedDelegation };
+type AuthenticationArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -50,6 +46,10 @@ type AuthenticationConfigOpenId = record {
 type AuthenticationConfigOpenIdDelegation = record {
   targets : opt vec principal;
   max_time_to_live : opt nat64;
+};
+type AuthenticationError = variant {
+  PrepareDelegation : PrepareDelegationError;
+  RegisterUser : text;
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CollectionType = variant { Db; Storage };
@@ -370,9 +370,7 @@ type UploadChunk = record {
 };
 type UploadChunkResult = record { chunk_id : nat };
 service : (InitSatelliteArgs) -> {
-  authenticate_user : (AuthenticateUserArgs) -> (
-      AuthenticateUserResultResponse,
-    );
+  authenticate : (AuthenticationArgs) -> (AuthenticateResultResponse);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/libs/satellite/src/api/auth.rs
+++ b/src/libs/satellite/src/api/auth.rs
@@ -1,11 +1,11 @@
-use crate::auth::authenticate::{openid_authenticate_user, openid_get_delegation};
-use crate::types::interface::{AuthenticateUserArgs, AuthenticateUserResult, GetDelegationArgs};
+use crate::auth::authenticate::{openid_authenticate, openid_get_delegation};
+use crate::types::interface::{AuthenticationArgs, AuthenticationResult, GetDelegationArgs};
 use junobuild_auth::delegation::types::GetDelegationResult;
 use junobuild_shared::ic::UnwrapOrTrap;
 
-pub async fn authenticate_user(args: &AuthenticateUserArgs) -> AuthenticateUserResult {
+pub async fn authenticate(args: &AuthenticationArgs) -> AuthenticationResult {
     match args {
-        AuthenticateUserArgs::OpenId(args) => openid_authenticate_user(args).await.unwrap_or_trap(),
+        AuthenticationArgs::OpenId(args) => openid_authenticate(args).await.unwrap_or_trap(),
     }
 }
 

--- a/src/libs/satellite/src/auth/authenticate.rs
+++ b/src/libs/satellite/src/auth/authenticate.rs
@@ -2,15 +2,15 @@ use crate::auth::assert::increment_and_assert_user_rate;
 use crate::auth::delegation;
 use crate::auth::register::register_user;
 use crate::auth::strategy_impls::AuthHeap;
-use crate::types::interface::{AuthenticateUserError, AuthenticateUserResult, AuthenticatedUser};
+use crate::types::interface::{AuthenticationError, AuthenticationResult, Authentication};
 use junobuild_auth::delegation::types::{
     GetDelegationResult, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs,
 };
 use junobuild_auth::state::get_providers;
 
-pub async fn openid_authenticate_user(
+pub async fn openid_authenticate(
     args: &OpenIdPrepareDelegationArgs,
-) -> Result<AuthenticateUserResult, String> {
+) -> Result<AuthenticationResult, String> {
     let providers = get_providers(&AuthHeap)?;
 
     // We assert early on to avoid generating a delegation which won't be used
@@ -25,10 +25,10 @@ pub async fn openid_authenticate_user(
             let key = &delegation.user_key;
 
             register_user(key, &credential)
-                .map(|doc| AuthenticatedUser { delegation, doc })
-                .map_err(AuthenticateUserError::RegisterUser)
+                .map(|doc| Authentication { delegation, doc })
+                .map_err(AuthenticationError::RegisterUser)
         }
-        Err(err) => Err(AuthenticateUserError::PrepareDelegation(err)),
+        Err(err) => Err(AuthenticationError::PrepareDelegation(err)),
     };
 
     Ok(result)

--- a/src/libs/satellite/src/impls.rs
+++ b/src/libs/satellite/src/impls.rs
@@ -1,6 +1,6 @@
 use crate::memory::internal::init_stable_state;
 use crate::types::interface::{
-    AuthenticateUserResult, AuthenticateUserResultResponse, GetDelegationResultResponse,
+    AuthenticationResult, AuthenticateResultResponse, GetDelegationResultResponse,
 };
 use crate::types::state::{CollectionType, HeapState, RuntimeState, State};
 use junobuild_auth::delegation::types::{GetDelegationError, SignedDelegation};
@@ -38,8 +38,8 @@ impl From<Result<SignedDelegation, GetDelegationError>> for GetDelegationResultR
     }
 }
 
-impl From<AuthenticateUserResult> for AuthenticateUserResultResponse {
-    fn from(r: AuthenticateUserResult) -> Self {
+impl From<AuthenticationResult> for AuthenticateResultResponse {
+    fn from(r: AuthenticationResult) -> Self {
         match r {
             Ok(v) => Self::Ok(v),
             Err(e) => Self::Err(e),

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -23,7 +23,7 @@ use crate::guards::{
     caller_is_admin_controller, caller_is_controller, caller_is_controller_with_write,
 };
 use crate::types::interface::{
-    AuthenticateUserArgs, AuthenticateUserResultResponse, Config, DeleteProposalAssets,
+    AuthenticationArgs, AuthenticateResultResponse, Config, DeleteProposalAssets,
     GetDelegationArgs, GetDelegationResultResponse,
 };
 use crate::types::state::CollectionType;
@@ -166,8 +166,8 @@ pub fn count_collection_docs(collection: CollectionKey) -> usize {
 
 #[doc(hidden)]
 #[update]
-pub async fn authenticate_user(args: AuthenticateUserArgs) -> AuthenticateUserResultResponse {
-    api::auth::authenticate_user(&args).await.into()
+pub async fn authenticate(args: AuthenticationArgs) -> AuthenticateResultResponse {
+    api::auth::authenticate(&args).await.into()
 }
 
 #[doc(hidden)]
@@ -536,7 +536,7 @@ pub fn memory_size() -> MemorySize {
 macro_rules! include_satellite {
     () => {
         use junobuild_satellite::{
-            authenticate_user, commit_asset_upload, commit_proposal, commit_proposal_asset_upload,
+            authenticate, commit_asset_upload, commit_proposal, commit_proposal_asset_upload,
             commit_proposal_many_assets_upload, count_assets, count_collection_assets,
             count_collection_docs, count_docs, count_proposals, del_asset, del_assets,
             del_controllers, del_custom_domain, del_doc, del_docs, del_filtered_assets,

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -81,20 +81,20 @@ pub mod interface {
     }
 
     #[derive(CandidType, Serialize, Deserialize)]
-    pub enum AuthenticateUserArgs {
+    pub enum AuthenticationArgs {
         OpenId(OpenIdPrepareDelegationArgs),
     }
 
-    pub type AuthenticateUserResult = Result<AuthenticatedUser, AuthenticateUserError>;
+    pub type AuthenticationResult = Result<Authentication, AuthenticationError>;
 
     #[derive(CandidType, Serialize, Deserialize)]
-    pub struct AuthenticatedUser {
+    pub struct Authentication {
         pub delegation: PreparedDelegation,
         pub doc: Doc,
     }
 
     #[derive(CandidType, Serialize, Deserialize)]
-    pub enum AuthenticateUserError {
+    pub enum AuthenticationError {
         PrepareDelegation(PrepareDelegationError),
         RegisterUser(String),
     }
@@ -108,9 +108,9 @@ pub mod interface {
     // clashes with didc when developers
     // include_satellite and use Result as well.
     #[derive(CandidType, Serialize, Deserialize)]
-    pub enum AuthenticateUserResultResponse {
-        Ok(AuthenticatedUser),
-        Err(AuthenticateUserError),
+    pub enum AuthenticateResultResponse {
+        Ok(Authentication),
+        Err(AuthenticationError),
     }
 
     #[derive(CandidType, Serialize, Deserialize)]

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -22,16 +22,12 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
-type AuthenticateUserError = variant {
-  PrepareDelegation : PrepareDelegationError;
-  RegisterUser : text;
+type AuthenticateResultResponse = variant {
+  Ok : Authentication;
+  Err : AuthenticationError;
 };
-type AuthenticateUserResultResponse = variant {
-  Ok : AuthenticatedUser;
-  Err : AuthenticateUserError;
-};
-type AuthenticatedUser = record { doc : Doc; delegation : PreparedDelegation };
+type Authentication = record { doc : Doc; delegation : PreparedDelegation };
+type AuthenticationArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -52,6 +48,10 @@ type AuthenticationConfigOpenId = record {
 type AuthenticationConfigOpenIdDelegation = record {
   targets : opt vec principal;
   max_time_to_live : opt nat64;
+};
+type AuthenticationError = variant {
+  PrepareDelegation : PrepareDelegationError;
+  RegisterUser : text;
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CollectionType = variant { Db; Storage };
@@ -372,9 +372,7 @@ type UploadChunk = record {
 };
 type UploadChunkResult = record { chunk_id : nat };
 service : (InitSatelliteArgs) -> {
-  authenticate_user : (AuthenticateUserArgs) -> (
-      AuthenticateUserResultResponse,
-    );
+  authenticate : (AuthenticationArgs) -> (AuthenticateResultResponse);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -22,16 +22,12 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
-type AuthenticateUserError = variant {
-  PrepareDelegation : PrepareDelegationError;
-  RegisterUser : text;
+type AuthenticateResultResponse = variant {
+  Ok : Authentication;
+  Err : AuthenticationError;
 };
-type AuthenticateUserResultResponse = variant {
-  Ok : AuthenticatedUser;
-  Err : AuthenticateUserError;
-};
-type AuthenticatedUser = record { doc : Doc; delegation : PreparedDelegation };
+type Authentication = record { doc : Doc; delegation : PreparedDelegation };
+type AuthenticationArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -52,6 +48,10 @@ type AuthenticationConfigOpenId = record {
 type AuthenticationConfigOpenIdDelegation = record {
   targets : opt vec principal;
   max_time_to_live : opt nat64;
+};
+type AuthenticationError = variant {
+  PrepareDelegation : PrepareDelegationError;
+  RegisterUser : text;
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CollectionType = variant { Db; Storage };
@@ -372,9 +372,7 @@ type UploadChunk = record {
 };
 type UploadChunkResult = record { chunk_id : nat };
 service : (InitSatelliteArgs) -> {
-  authenticate_user : (AuthenticateUserArgs) -> (
-      AuthenticateUserResultResponse,
-    );
+  authenticate : (AuthenticationArgs) -> (AuthenticateResultResponse);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -26,19 +26,12 @@ export interface AssetNoContent {
 export interface AssetsUpgradeOptions {
 	clear_existing_assets: [] | [boolean];
 }
-export type AuthenticateUserArgs = { OpenId: OpenIdPrepareDelegationArgs };
-export type AuthenticateUserError =
-	| {
-			PrepareDelegation: PrepareDelegationError;
-	  }
-	| { RegisterUser: string };
-export type AuthenticateUserResultResponse =
-	| { Ok: AuthenticatedUser }
-	| { Err: AuthenticateUserError };
-export interface AuthenticatedUser {
+export type AuthenticateResultResponse = { Ok: Authentication } | { Err: AuthenticationError };
+export interface Authentication {
 	doc: Doc;
 	delegation: PreparedDelegation;
 }
+export type AuthenticationArgs = { OpenId: OpenIdPrepareDelegationArgs };
 export interface AuthenticationConfig {
 	updated_at: [] | [bigint];
 	openid: [] | [AuthenticationConfigOpenId];
@@ -60,6 +53,11 @@ export interface AuthenticationConfigOpenIdDelegation {
 	targets: [] | [Array<Principal>];
 	max_time_to_live: [] | [bigint];
 }
+export type AuthenticationError =
+	| {
+			PrepareDelegation: PrepareDelegationError;
+	  }
+	| { RegisterUser: string };
 export interface AuthenticationRules {
 	allowed_callers: Array<Principal>;
 }
@@ -434,7 +432,7 @@ export interface UploadChunkResult {
 	chunk_id: bigint;
 }
 export interface _SERVICE {
-	authenticate_user: ActorMethod<[AuthenticateUserArgs], AuthenticateUserResultResponse>;
+	authenticate: ActorMethod<[AuthenticationArgs], AuthenticateResultResponse>;
 	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -11,7 +11,7 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const Doc = IDL.Record({
@@ -26,7 +26,7 @@ export const idlFactory = ({ IDL }) => {
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({
+	const Authentication = IDL.Record({
 		doc: Doc,
 		delegation: PreparedDelegation
 	});
@@ -60,13 +60,13 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError,
 		RegisterUser: IDL.Text
 	});
-	const AuthenticateUserResultResponse = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+	const AuthenticateResultResponse = IDL.Variant({
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
@@ -433,7 +433,7 @@ export const idlFactory = ({ IDL }) => {
 	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
 	const Result = IDL.Variant({ Ok: IDL.Int32, Err: IDL.Text });
 	return IDL.Service({
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [AuthenticateUserResultResponse], []),
+		authenticate: IDL.Func([AuthenticationArgs], [AuthenticateResultResponse], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -11,7 +11,7 @@ export const idlFactory = ({ IDL }) => {
 		session_key: IDL.Vec(IDL.Nat8),
 		salt: IDL.Vec(IDL.Nat8)
 	});
-	const AuthenticateUserArgs = IDL.Variant({
+	const AuthenticationArgs = IDL.Variant({
 		OpenId: OpenIdPrepareDelegationArgs
 	});
 	const Doc = IDL.Record({
@@ -26,7 +26,7 @@ export const idlFactory = ({ IDL }) => {
 		user_key: IDL.Vec(IDL.Nat8),
 		expiration: IDL.Nat64
 	});
-	const AuthenticatedUser = IDL.Record({
+	const Authentication = IDL.Record({
 		doc: Doc,
 		delegation: PreparedDelegation
 	});
@@ -60,13 +60,13 @@ export const idlFactory = ({ IDL }) => {
 		GetOrFetchJwks: GetOrRefreshJwksError,
 		DeriveSeedFailed: IDL.Text
 	});
-	const AuthenticateUserError = IDL.Variant({
+	const AuthenticationError = IDL.Variant({
 		PrepareDelegation: PrepareDelegationError,
 		RegisterUser: IDL.Text
 	});
-	const AuthenticateUserResultResponse = IDL.Variant({
-		Ok: AuthenticatedUser,
-		Err: AuthenticateUserError
+	const AuthenticateResultResponse = IDL.Variant({
+		Ok: Authentication,
+		Err: AuthenticationError
 	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
@@ -433,7 +433,7 @@ export const idlFactory = ({ IDL }) => {
 	const UploadChunkResult = IDL.Record({ chunk_id: IDL.Nat });
 	const Result = IDL.Variant({ Ok: IDL.Int32, Err: IDL.Text });
 	return IDL.Service({
-		authenticate_user: IDL.Func([AuthenticateUserArgs], [AuthenticateUserResultResponse], []),
+		authenticate: IDL.Func([AuthenticationArgs], [AuthenticateResultResponse], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -22,16 +22,12 @@ type AssetNoContent = record {
   version : opt nat64;
 };
 type AssetsUpgradeOptions = record { clear_existing_assets : opt bool };
-type AuthenticateUserArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
-type AuthenticateUserError = variant {
-  PrepareDelegation : PrepareDelegationError;
-  RegisterUser : text;
+type AuthenticateResultResponse = variant {
+  Ok : Authentication;
+  Err : AuthenticationError;
 };
-type AuthenticateUserResultResponse = variant {
-  Ok : AuthenticatedUser;
-  Err : AuthenticateUserError;
-};
-type AuthenticatedUser = record { doc : Doc; delegation : PreparedDelegation };
+type Authentication = record { doc : Doc; delegation : PreparedDelegation };
+type AuthenticationArgs = variant { OpenId : OpenIdPrepareDelegationArgs };
 type AuthenticationConfig = record {
   updated_at : opt nat64;
   openid : opt AuthenticationConfigOpenId;
@@ -52,6 +48,10 @@ type AuthenticationConfigOpenId = record {
 type AuthenticationConfigOpenIdDelegation = record {
   targets : opt vec principal;
   max_time_to_live : opt nat64;
+};
+type AuthenticationError = variant {
+  PrepareDelegation : PrepareDelegationError;
+  RegisterUser : text;
 };
 type AuthenticationRules = record { allowed_callers : vec principal };
 type CollectionType = variant { Db; Storage };
@@ -372,9 +372,7 @@ type UploadChunk = record {
 };
 type UploadChunkResult = record { chunk_id : nat };
 service : (InitSatelliteArgs) -> {
-  authenticate_user : (AuthenticateUserArgs) -> (
-      AuthenticateUserResultResponse,
-    );
+  authenticate : (AuthenticationArgs) -> (AuthenticateResultResponse);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
@@ -107,9 +107,9 @@ describe('Satellite > Auth > Rate', async () => {
 
 		const { jwt } = await generateJwtCertificate({});
 
-		const { authenticate_user } = satelliteActor;
+		const { authenticate } = satelliteActor;
 
-		const result = await authenticate_user({
+		const result = await authenticate({
 			OpenId: { jwt, session_key: publicKey, salt }
 		});
 
@@ -124,7 +124,7 @@ describe('Satellite > Auth > Rate', async () => {
 
 		const { jwt: jwt2 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 500 });
 
-		const result2 = await authenticate_user({
+		const result2 = await authenticate({
 			OpenId: { jwt: jwt2, session_key: publicKey, salt }
 		});
 
@@ -155,7 +155,7 @@ describe('Satellite > Auth > Rate', async () => {
 		const { jwt: jwt3 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 400 });
 
 		await expect(
-			authenticate_user({
+			authenticate({
 				OpenId: { jwt: jwt3, session_key: publicKey, salt }
 			})
 		).rejects.toThrow('Rate limit reached, try again later.');

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.user.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.user.spec.ts
@@ -75,9 +75,9 @@ describe('Satellite > Auth > User', () => {
 		await pic.advanceTime(1000 * 30); // 30s for cooldown guard
 		await tick(pic);
 
-		const { authenticate_user } = satelliteActor;
+		const { authenticate } = satelliteActor;
 
-		const result = await authenticate_user({
+		const result = await authenticate({
 			OpenId: {
 				jwt: mockJwt.jwt,
 				session_key: session.publicKey,
@@ -118,9 +118,9 @@ describe('Satellite > Auth > User', () => {
 			privateKey: mockJwt.privateKey
 		});
 
-		const { authenticate_user } = satelliteActor;
+		const { authenticate } = satelliteActor;
 
-		const result = await authenticate_user({
+		const result = await authenticate({
 			OpenId: {
 				jwt: newJwt,
 				session_key: session.publicKey,

--- a/src/tests/utils/auth-assertions-config-openid-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-config-openid-tests.utils.ts
@@ -113,9 +113,9 @@ export const testAuthConfigObservatory = ({
 		it('should fail if default observatory is targeted', async () => {
 			await configTargetObservatory({});
 
-			const { authenticate_user } = getActor();
+			const { authenticate } = getActor();
 
-			const result = await authenticate_user({
+			const result = await authenticate({
 				OpenId: {
 					jwt: mockJwt,
 					session_key: publicKey,
@@ -166,9 +166,9 @@ export const testAuthConfigObservatory = ({
 			await getPic().advanceTime(1000 * 30); // 30s for cooldown guard
 			await tick(getPic());
 
-			const { authenticate_user } = getActor();
+			const { authenticate } = getActor();
 
-			const result = await authenticate_user({
+			const result = await authenticate({
 				OpenId: {
 					jwt: mockJwt,
 					session_key: publicKey,

--- a/src/tests/utils/auth-assertions-get-delegation-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-get-delegation-tests.utils.ts
@@ -86,7 +86,7 @@ export const testAuthGetDelegation = ({
 				).rejects.toThrow(JUNO_AUTH_ERROR_NOT_CONFIGURED);
 			});
 
-			it('should not authenticate_user when OpenId disabled', async () => {
+			it('should not authenticate when OpenId disabled', async () => {
 				const { set_auth_config, get_delegation } = actor;
 
 				actor.setIdentity(controller);
@@ -194,9 +194,9 @@ export const testAuthGetDelegation = ({
 
 					await assertOpenIdHttpsOutcalls({ pic, jwks: mockJwks });
 
-					const { authenticate_user } = actor;
+					const { authenticate } = actor;
 
-					const result = await authenticate_user({
+					const result = await authenticate({
 						OpenId: { jwt: mockJwt, session_key: publicKey, salt }
 					});
 
@@ -228,8 +228,8 @@ export const testAuthGetDelegation = ({
 					const throwaway = await ECDSAKeyIdentity.generate();
 					const throwawayPub = new Uint8Array(throwaway.getPublicKey().toDer());
 
-					const { authenticate_user } = actor;
-					await authenticate_user({
+					const { authenticate } = actor;
+					await authenticate({
 						OpenId: { jwt: minted.jwt, session_key: throwawayPub, salt }
 					});
 

--- a/src/tests/utils/auth-assertions-prepare-delegation-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-prepare-delegation-tests.utils.ts
@@ -70,10 +70,10 @@ export const testAuthPrepareDelegation = ({
 			});
 
 			it('should fail when authentication is not configured', async () => {
-				const { authenticate_user } = actor;
+				const { authenticate } = actor;
 
 				await expect(
-					authenticate_user({
+					authenticate({
 						OpenId: {
 							jwt: mockJwt,
 							session_key: publicKey,
@@ -84,7 +84,7 @@ export const testAuthPrepareDelegation = ({
 			});
 
 			it('should fail when openid configuration is not set', async () => {
-				const { set_auth_config, authenticate_user } = actor;
+				const { set_auth_config, authenticate } = actor;
 
 				actor.setIdentity(controller);
 
@@ -100,7 +100,7 @@ export const testAuthPrepareDelegation = ({
 				actor.setIdentity(user);
 
 				await expect(
-					authenticate_user({
+					authenticate({
 						OpenId: {
 							jwt: mockJwt,
 							session_key: publicKey,
@@ -151,12 +151,12 @@ export const testAuthPrepareDelegation = ({
 
 				describe('Bad jwt header', () => {
 					it('should fail with JwtFindProvider.BadSig when JWT header is not JSON', async () => {
-						const { authenticate_user } = actor;
+						const { authenticate } = actor;
 
 						// not valid JSON → decode_header fails → BadSig
 						const badSigJwt = assembleJwt({ header: 'not json', payload: mockJwtPayload });
 
-						const result = await authenticate_user({
+						const result = await authenticate({
 							OpenId: { jwt: badSigJwt, session_key: publicKey, salt }
 						});
 
@@ -186,7 +186,7 @@ export const testAuthPrepareDelegation = ({
 					});
 
 					it('should fail with JwtFindProvider.BadClaim("alg") when alg is not RS256', async () => {
-						const { authenticate_user } = actor;
+						const { authenticate } = actor;
 
 						const header = JSON.stringify({
 							alg: 'HS256', // ← wrong on purpose
@@ -196,7 +196,7 @@ export const testAuthPrepareDelegation = ({
 
 						const badAlgJwt = assembleJwt({ header, payload: mockJwtPayload });
 
-						const result = await authenticate_user({
+						const result = await authenticate({
 							OpenId: { jwt: badAlgJwt, session_key: publicKey, salt }
 						});
 
@@ -226,7 +226,7 @@ export const testAuthPrepareDelegation = ({
 					});
 
 					it('should fail with JwtFindProvider.BadClaim("typ") when typ is present and not "JWT"', async () => {
-						const { authenticate_user } = actor;
+						const { authenticate } = actor;
 
 						const header = JSON.stringify({
 							alg: 'RS256',
@@ -236,7 +236,7 @@ export const testAuthPrepareDelegation = ({
 
 						const badTypJwt = assembleJwt({ header, payload: mockJwtPayload });
 
-						const result = await authenticate_user({
+						const result = await authenticate({
 							OpenId: { jwt: badTypJwt, session_key: publicKey, salt }
 						});
 
@@ -267,9 +267,9 @@ export const testAuthPrepareDelegation = ({
 				});
 
 				it('should fail if observatory has no certificate', async () => {
-					const { authenticate_user } = actor;
+					const { authenticate } = actor;
 
-					const result = await authenticate_user({
+					const result = await authenticate({
 						OpenId: {
 							jwt: mockJwt,
 							session_key: publicKey,
@@ -355,9 +355,9 @@ export const testAuthPrepareDelegation = ({
 				it('should fail at authenticating because fetching Jwts is disallowed (cooldown period)', async () => {
 					await generateJwtCertificate({ advanceTime: 1000 });
 
-					const { authenticate_user } = actor;
+					const { authenticate } = actor;
 
-					const result = await authenticate_user({
+					const result = await authenticate({
 						OpenId: {
 							jwt: mockJwt,
 							session_key: publicKey,
@@ -403,9 +403,9 @@ export const testAuthPrepareDelegation = ({
 					it('should fetch certificate but fail with kid not found', async () => {
 						await generateJwtCertificate({ advanceTime: 1000 * 60, refreshJwts: false });
 
-						const { authenticate_user } = actor;
+						const { authenticate } = actor;
 
-						const result = await authenticate_user({
+						const result = await authenticate({
 							OpenId: {
 								jwt: mockJwt,
 								session_key: publicKey,
@@ -443,9 +443,9 @@ export const testAuthPrepareDelegation = ({
 					it('should fetch certificate but fail with invalid signature', async () => {
 						await generateJwtCertificate({ advanceTime: 1000 * 60, refreshJwts: false, kid });
 
-						const { authenticate_user } = actor;
+						const { authenticate } = actor;
 
-						const result = await authenticate_user({
+						const result = await authenticate({
 							OpenId: {
 								jwt: mockJwt,
 								session_key: publicKey,
@@ -485,9 +485,9 @@ export const testAuthPrepareDelegation = ({
 				it('should authenticate user', async () => {
 					await generateJwtCertificate({});
 
-					const { authenticate_user } = actor;
+					const { authenticate } = actor;
 
-					const result = await authenticate_user({
+					const result = await authenticate({
 						OpenId: {
 							jwt: mockJwt,
 							session_key: publicKey,
@@ -504,9 +504,9 @@ export const testAuthPrepareDelegation = ({
 					const attacker = Ed25519KeyIdentity.generate();
 					actor.setIdentity(attacker);
 
-					const { authenticate_user } = actor;
+					const { authenticate } = actor;
 
-					const result = await authenticate_user({
+					const result = await authenticate({
 						OpenId: {
 							jwt: mockJwt,
 							session_key: publicKey,
@@ -549,8 +549,8 @@ export const testAuthPrepareDelegation = ({
 
 					const wrongSalt = crypto.getRandomValues(new Uint8Array(32));
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt: mockJwt, session_key: publicKey, salt: wrongSalt }
 					});
 
@@ -585,8 +585,8 @@ export const testAuthPrepareDelegation = ({
 					await pic.advanceTime(10 * 60_000 + 1_000);
 					await tick(pic);
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt: mockJwt, session_key: publicKey, salt }
 					});
 
@@ -631,8 +631,8 @@ export const testAuthPrepareDelegation = ({
 
 					await assertOpenIdHttpsOutcalls({ pic, jwks });
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt, session_key: publicKey, salt }
 					});
 
@@ -676,8 +676,8 @@ export const testAuthPrepareDelegation = ({
 
 					await assertOpenIdHttpsOutcalls({ pic, jwks });
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt, session_key: publicKey, salt }
 					});
 
@@ -699,8 +699,8 @@ export const testAuthPrepareDelegation = ({
 
 					await assertOpenIdHttpsOutcalls({ pic, jwks });
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt, session_key: publicKey, salt }
 					});
 
@@ -747,8 +747,8 @@ export const testAuthPrepareDelegation = ({
 					await pic.advanceTime(10 * 60_000 + 1_000);
 					await tick(pic);
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt, session_key: publicKey, salt }
 					});
 
@@ -791,8 +791,8 @@ export const testAuthPrepareDelegation = ({
 					const headerNoKid = JSON.stringify({ alg: 'RS256' });
 					const badJwt = assembleJwt({ header: headerNoKid, payload });
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt: badJwt, session_key: publicKey, salt }
 					});
 
@@ -849,8 +849,8 @@ export const testAuthPrepareDelegation = ({
 
 					await assertOpenIdHttpsOutcalls({ pic, jwks: ecJwks });
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt, session_key: publicKey, salt }
 					});
 
@@ -910,8 +910,8 @@ export const testAuthPrepareDelegation = ({
 					const header = JSON.stringify({ alg: 'RS256', kid, typ: 'JWT' });
 					const badNbfJwt = assembleJwt({ header, payload });
 
-					const { authenticate_user } = actor;
-					const result = await authenticate_user({
+					const { authenticate } = actor;
+					const result = await authenticate({
 						OpenId: { jwt: badNbfJwt, session_key: publicKey, salt }
 					});
 

--- a/src/tests/utils/auth-assertions-upgrade-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-upgrade-tests.utils.ts
@@ -71,9 +71,9 @@ export const testAuthUpgrade = ({
 
 			await assertOpenIdHttpsOutcalls({ pic, jwks });
 
-			const { authenticate_user } = actor;
+			const { authenticate } = actor;
 
-			const result = await authenticate_user({
+			const result = await authenticate({
 				OpenId: { jwt, session_key: publicKey, salt }
 			});
 
@@ -91,7 +91,7 @@ export const testAuthUpgrade = ({
 			await tick(pic);
 
 			// Try to re-authenticate
-			const newResult = await authenticate_user({
+			const newResult = await authenticate({
 				OpenId: { jwt, session_key: publicKey, salt }
 			});
 

--- a/src/tests/utils/auth-identity-tests.utils.ts
+++ b/src/tests/utils/auth-identity-tests.utils.ts
@@ -49,9 +49,9 @@ export const authenticateAndMakeIdentity = async <R>({
 
 	await assertOpenIdHttpsOutcalls({ pic, jwks });
 
-	const { authenticate_user, get_delegation } = actor;
+	const { authenticate, get_delegation } = actor;
 
-	const prepareDelegation = await authenticate_user({
+	const prepareDelegation = await authenticate({
 		OpenId: { jwt, session_key: publicKey, salt }
 	});
 


### PR DESCRIPTION
# Motivation

The suffix is not really that needed and does not make sense for the authentication with the console that likely will return a mission control, not a user. Plus `authenticate` is just readable.
