### PR TITLE
feat(console): clean-up before creating mission control with jwt

### DIFF
--- a/src/console/src/api/mission_control.rs
+++ b/src/console/src/api/mission_control.rs
@@ -1,4 +1,4 @@
-use crate::factory::mission_control::init_user_mission_control;
+use crate::factory::mission_control::init_user_mission_control_with_caller;
 use crate::guards::{caller_is_admin_controller, caller_is_observatory};
 use crate::store::stable::{
     get_existing_mission_control, get_mission_control, list_mission_controls,
@@ -32,10 +32,7 @@ fn list_user_mission_control_centers() -> MissionControls {
 
 #[update]
 async fn init_user_mission_control_center() -> MissionControl {
-    let caller = caller();
-    let console = id();
-
-    init_user_mission_control(&console, &caller)
+    init_user_mission_control_with_caller()
         .await
         .unwrap_or_trap()
 }

--- a/src/console/src/factory/mission_control.rs
+++ b/src/console/src/factory/mission_control.rs
@@ -6,41 +6,38 @@ use crate::store::stable::{
     add_mission_control, delete_mission_control, get_mission_control, init_empty_mission_control,
 };
 use crate::types::state::MissionControl;
-use candid::{Nat, Principal};
+use candid::Nat;
 use junobuild_shared::constants_shared::CREATE_MISSION_CONTROL_CYCLES;
+use junobuild_shared::ic::api::{caller, id};
 use junobuild_shared::mgmt::ic::create_canister_install_code;
 use junobuild_shared::mgmt::types::ic::CreateCanisterInitSettingsArg;
 use junobuild_shared::types::state::UserId;
 
-pub async fn init_user_mission_control(
-    console: &Principal,
-    caller: &Principal,
-) -> Result<MissionControl, String> {
-    let result = get_mission_control(caller);
-    match result {
-        Err(error) => Err(error.to_string()),
-        Ok(mission_control) => match mission_control {
-            Some(mission_control) => Ok(mission_control),
-            None => {
-                // Guard too many requests
-                increment_mission_controls_rate()?;
+pub async fn init_user_mission_control_with_caller() -> Result<MissionControl, String> {
+    let caller = caller();
 
-                create_mission_control(caller, console).await
-            }
-        },
+    let mission_control = get_mission_control(&caller)?;
+
+    match mission_control {
+        Some(mission_control) => Ok(mission_control),
+        None => {
+            // Guard too many requests
+            increment_mission_controls_rate()?;
+
+            init_empty_mission_control(&caller);
+
+            create_mission_control(&caller).await
+        }
     }
 }
 
-async fn create_mission_control(
-    user: &UserId,
-    console: &Principal,
-) -> Result<MissionControl, String> {
-    init_empty_mission_control(user);
+async fn create_mission_control(user_id: &UserId) -> Result<MissionControl, String> {
+    let wasm_arg = mission_control_wasm_arg(user_id)?;
 
-    let wasm_arg = mission_control_wasm_arg(user)?;
+    let console = id();
 
     let create_settings_arg = CreateCanisterInitSettingsArg {
-        controllers: Vec::from([*console, *user]),
+        controllers: Vec::from([*console, *user_id]),
         freezing_threshold: Nat::from(FREEZING_THRESHOLD_ONE_YEAR),
     };
 
@@ -54,13 +51,15 @@ async fn create_mission_control(
     match create {
         Err(e) => {
             // We delete the pending empty mission control center from the list - e.g. this can happens if manager is out of cycles and user would be blocked
-            delete_mission_control(user);
+            delete_mission_control(user_id);
             Err(["Canister cannot be initialized.", &e].join(""))
         }
         Ok(mission_control_id) => {
-            let mission_control = add_mission_control(user, &mission_control_id);
+            // There error is unlikely to happen as the implementation ensures a mission control
+            // metadata was created before calling this factory function.
+            let mission_control = add_mission_control(user_id, &mission_control_id)?;
 
-            update_mission_control_controllers(&mission_control_id, user).await?;
+            update_mission_control_controllers(&mission_control_id, user_id).await?;
 
             Ok(mission_control)
         }


### PR DESCRIPTION
# Motivation

A bit of cleanup before integrating the creation of mission control in #2164. I also move the "create empty mission control" before calling the effective factory because the function will become public or reused.
