### PR TITLE
feat(console): use rate limiter in authenticate

### DIFF
--- a/src/console/src/auth/authenticate.rs
+++ b/src/console/src/auth/authenticate.rs
@@ -6,13 +6,15 @@ use junobuild_auth::delegation::types::{
     GetDelegationResult, OpenIdGetDelegationArgs, OpenIdPrepareDelegationArgs,
 };
 use junobuild_auth::state::get_providers;
+use crate::store::heap::increment_mission_controls_rate;
 
 pub async fn openid_authenticate(
     args: &OpenIdPrepareDelegationArgs,
 ) -> Result<AuthenticationResult, String> {
     let providers = get_providers(&AuthHeap)?;
 
-    // TODO: rate limiter
+    // Guard too many requests
+    increment_mission_controls_rate()?;
 
     let prepared_delegation = delegation::openid_prepare_delegation(args, &providers).await;
 

--- a/src/tests/specs/console/auth/console.auth.mission-control.spec.ts
+++ b/src/tests/specs/console/auth/console.auth.mission-control.spec.ts
@@ -77,6 +77,7 @@ describe('Satellite > Auth > Mission Control', () => {
 		const {
 			OpenId: { data, provider: provider_name }
 		} = provider;
+
 		expect('Google' in provider_name).toBeTruthy();
 
 		expect(data).toEqual(mockUserData);
@@ -95,6 +96,7 @@ describe('Satellite > Auth > Mission Control', () => {
 		const { get_user } = micActor;
 
 		const user = await get_user();
+
 		expect(user.toText()).toEqual(missionControl.owner.toText());
 	});
 
@@ -137,6 +139,7 @@ describe('Satellite > Auth > Mission Control', () => {
 		const {
 			OpenId: { data, provider: provider_name }
 		} = provider;
+
 		expect('Google' in provider_name).toBeTruthy();
 
 		expect(data).toEqual(mockUserData);
@@ -193,6 +196,7 @@ describe('Satellite > Auth > Mission Control', () => {
 		const {
 			OpenId: { data, provider: provider_name }
 		} = provider;
+
 		expect('Google' in provider_name).toBeTruthy();
 
 		expect(data).toEqual({

--- a/src/tests/specs/console/auth/console.auth.rate.spec.ts
+++ b/src/tests/specs/console/auth/console.auth.rate.spec.ts
@@ -3,7 +3,6 @@ import { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Actor, PocketIc } from '@dfinity/pic';
 import { testAuthRate } from '../../../utils/auth-assertions-rate-tests.utils';
 import { setupConsoleAuth } from '../../../utils/auth-tests.utils';
-import { configMissionControlRateTokens } from '../../../utils/console-tests.utils';
 import { tick } from '../../../utils/pic-tests.utils';
 
 describe('Console > Auth > Rate', async () => {
@@ -18,7 +17,7 @@ describe('Console > Auth > Rate', async () => {
 			pic: p,
 			console: { actor },
 			controller: c
-		} = await setupConsoleAuth();
+		} = await setupConsoleAuth({ withApplyRateTokens: false });
 
 		pic = p;
 		consoleActor = actor;
@@ -26,9 +25,7 @@ describe('Console > Auth > Rate', async () => {
 		controller = c;
 
 		// Set current running rate limiter
-		await configMissionControlRateTokens({
-			actor: consoleActor,
-			controller,
+		await config({
 			max_tokens: 2n,
 			time_per_token_ns: 60_000_000_000n // 1min = 60000000000n
 		});
@@ -41,10 +38,31 @@ describe('Console > Auth > Rate', async () => {
 		await pic?.tearDown();
 	});
 
+	const config = async ({
+		max_tokens,
+		time_per_token_ns
+	}: {
+		max_tokens: bigint;
+		time_per_token_ns: bigint;
+	}) => {
+		consoleActor.setIdentity(controller);
+
+		const { update_rate_config } = consoleActor;
+
+		await update_rate_config(
+			{ MissionControl: null },
+			{
+				max_tokens,
+				time_per_token_ns
+			}
+		);
+
+		await tick(pic);
+	};
+
 	testAuthRate({
 		pic: () => pic,
 		actor: () => consoleActor,
-		config: (params) =>
-			configMissionControlRateTokens({ ...params, actor: consoleActor, controller })
+		config
 	});
 });

--- a/src/tests/specs/console/auth/console.auth.rate.spec.ts
+++ b/src/tests/specs/console/auth/console.auth.rate.spec.ts
@@ -1,11 +1,8 @@
 import type { ConsoleActor } from '$declarations';
-import { ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Actor, PocketIc } from '@dfinity/pic';
-import { mockClientId } from '../../../mocks/jwt.mocks';
-import { generateNonce } from '../../../utils/auth-nonce-tests.utils';
+import { testAuthRate } from '../../../utils/auth-assertions-rate-tests.utils';
 import { setupConsoleAuth } from '../../../utils/auth-tests.utils';
-import { makeMockGoogleOpenIdJwt } from '../../../utils/jwt-tests.utils';
-import { assertOpenIdHttpsOutcalls } from '../../../utils/observatory-openid-tests.utils';
 import { tick } from '../../../utils/pic-tests.utils';
 
 describe('Console > Auth > Rate', async () => {
@@ -14,13 +11,6 @@ describe('Console > Auth > Rate', async () => {
 	let consoleActor: Actor<ConsoleActor>;
 
 	let controller: Ed25519KeyIdentity;
-
-	const user = Ed25519KeyIdentity.generate();
-
-	const sessionKey = await ECDSAKeyIdentity.generate();
-	const publicKey = new Uint8Array(sessionKey.getPublicKey().toDer());
-
-	const { nonce, salt } = await generateNonce({ caller: user });
 
 	beforeAll(async () => {
 		const {
@@ -70,93 +60,9 @@ describe('Console > Auth > Rate', async () => {
 		await tick(pic);
 	};
 
-	const generateJwtCertificate = async ({
-		advanceTime,
-		refreshJwts = true,
-		kid
-	}: {
-		advanceTime?: number;
-		refreshJwts?: boolean;
-		kid?: string;
-	}): Promise<{ jwt: string }> => {
-		await pic.advanceTime(advanceTime ?? 1000 * 60 * 15); // Observatory refresh every 15min
-		await tick(pic);
-
-		const now = await pic.getTime();
-
-		const { jwks, jwt } = await makeMockGoogleOpenIdJwt({
-			clientId: mockClientId,
-			date: new Date(now),
-			nonce,
-			kid
-		});
-
-		if (!refreshJwts) {
-			return { jwt };
-		}
-
-		// Refresh certificate in Observatory
-		await assertOpenIdHttpsOutcalls({ pic, jwks });
-
-		return { jwt };
-	};
-
-	it('should throw error if user rate is reached', async () => {
-		consoleActor.setIdentity(user);
-
-		const { jwt } = await generateJwtCertificate({});
-
-		const { authenticate } = consoleActor;
-
-		const result = await authenticate({
-			OpenId: { jwt, session_key: publicKey, salt }
-		});
-
-		expect('Ok' in result).toBeTruthy();
-
-		await config({
-			max_tokens: 2n,
-			time_per_token_ns: 2_000_000_000n // 2s
-		});
-
-		consoleActor.setIdentity(user);
-
-		const { jwt: jwt2 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 500 });
-
-		const result2 = await authenticate({
-			OpenId: { jwt: jwt2, session_key: publicKey, salt }
-		});
-
-		// The error in result2 does not matter much here.
-		// Goal is to assert the rate limiter.
-		if ('Ok' in result2) {
-			expect(true).toBeFalsy();
-
-			return;
-		}
-
-		const { Err } = result2;
-
-		if (!('PrepareDelegation' in Err)) {
-			expect(true).toBeFalsy();
-
-			return;
-		}
-
-		const { PrepareDelegation } = Err;
-
-		if (!('GetOrFetchJwks' in PrepareDelegation)) {
-			expect(true).toBeFalsy();
-
-			return;
-		}
-
-		const { jwt: jwt3 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 400 });
-
-		await expect(
-			authenticate({
-				OpenId: { jwt: jwt3, session_key: publicKey, salt }
-			})
-		).rejects.toThrow('Rate limit reached, try again later.');
+	testAuthRate({
+		pic: () => pic,
+		actor: () => consoleActor,
+		config
 	});
 });

--- a/src/tests/specs/console/auth/console.auth.rate.spec.ts
+++ b/src/tests/specs/console/auth/console.auth.rate.spec.ts
@@ -3,6 +3,7 @@ import { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Actor, PocketIc } from '@dfinity/pic';
 import { testAuthRate } from '../../../utils/auth-assertions-rate-tests.utils';
 import { setupConsoleAuth } from '../../../utils/auth-tests.utils';
+import { configMissionControlRateTokens } from '../../../utils/console-tests.utils';
 import { tick } from '../../../utils/pic-tests.utils';
 
 describe('Console > Auth > Rate', async () => {
@@ -25,7 +26,9 @@ describe('Console > Auth > Rate', async () => {
 		controller = c;
 
 		// Set current running rate limiter
-		await config({
+		await configMissionControlRateTokens({
+			actor: consoleActor,
+			controller,
 			max_tokens: 2n,
 			time_per_token_ns: 60_000_000_000n // 1min = 60000000000n
 		});
@@ -38,31 +41,10 @@ describe('Console > Auth > Rate', async () => {
 		await pic?.tearDown();
 	});
 
-	const config = async ({
-		max_tokens,
-		time_per_token_ns
-	}: {
-		max_tokens: bigint;
-		time_per_token_ns: bigint;
-	}) => {
-		consoleActor.setIdentity(controller);
-
-		const { update_rate_config } = consoleActor;
-
-		await update_rate_config(
-			{ MissionControl: null },
-			{
-				max_tokens,
-				time_per_token_ns
-			}
-		);
-
-		await tick(pic);
-	};
-
 	testAuthRate({
 		pic: () => pic,
 		actor: () => consoleActor,
-		config
+		config: (params) =>
+			configMissionControlRateTokens({ ...params, actor: consoleActor, controller })
 	});
 });

--- a/src/tests/specs/console/auth/console.auth.rate.spec.ts
+++ b/src/tests/specs/console/auth/console.auth.rate.spec.ts
@@ -1,0 +1,162 @@
+import type { ConsoleActor } from '$declarations';
+import { ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Actor, PocketIc } from '@dfinity/pic';
+import { mockClientId } from '../../../mocks/jwt.mocks';
+import { generateNonce } from '../../../utils/auth-nonce-tests.utils';
+import { setupConsoleAuth } from '../../../utils/auth-tests.utils';
+import { makeMockGoogleOpenIdJwt } from '../../../utils/jwt-tests.utils';
+import { assertOpenIdHttpsOutcalls } from '../../../utils/observatory-openid-tests.utils';
+import { tick } from '../../../utils/pic-tests.utils';
+
+describe('Console > Auth > Rate', async () => {
+	let pic: PocketIc;
+
+	let consoleActor: Actor<ConsoleActor>;
+
+	let controller: Ed25519KeyIdentity;
+
+	const user = Ed25519KeyIdentity.generate();
+
+	const sessionKey = await ECDSAKeyIdentity.generate();
+	const publicKey = new Uint8Array(sessionKey.getPublicKey().toDer());
+
+	const { nonce, salt } = await generateNonce({ caller: user });
+
+	beforeAll(async () => {
+		const {
+			pic: p,
+			console: { actor },
+			controller: c
+		} = await setupConsoleAuth();
+
+		pic = p;
+		consoleActor = actor;
+
+		controller = c;
+
+		// Set current running rate limiter
+		await config({
+			max_tokens: 2n,
+			time_per_token_ns: 60_000_000_000n // 1min = 60000000000n
+		});
+
+		await pic.advanceTime(60_000);
+		await tick(pic);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	const config = async ({
+		max_tokens,
+		time_per_token_ns
+	}: {
+		max_tokens: bigint;
+		time_per_token_ns: bigint;
+	}) => {
+		consoleActor.setIdentity(controller);
+
+		const { update_rate_config } = consoleActor;
+
+		await update_rate_config(
+			{ MissionControl: null },
+			{
+				max_tokens,
+				time_per_token_ns
+			}
+		);
+
+		await tick(pic);
+	};
+
+	const generateJwtCertificate = async ({
+		advanceTime,
+		refreshJwts = true,
+		kid
+	}: {
+		advanceTime?: number;
+		refreshJwts?: boolean;
+		kid?: string;
+	}): Promise<{ jwt: string }> => {
+		await pic.advanceTime(advanceTime ?? 1000 * 60 * 15); // Observatory refresh every 15min
+		await tick(pic);
+
+		const now = await pic.getTime();
+
+		const { jwks, jwt } = await makeMockGoogleOpenIdJwt({
+			clientId: mockClientId,
+			date: new Date(now),
+			nonce,
+			kid
+		});
+
+		if (!refreshJwts) {
+			return { jwt };
+		}
+
+		// Refresh certificate in Observatory
+		await assertOpenIdHttpsOutcalls({ pic, jwks });
+
+		return { jwt };
+	};
+
+	it('should throw error if user rate is reached', async () => {
+		consoleActor.setIdentity(user);
+
+		const { jwt } = await generateJwtCertificate({});
+
+		const { authenticate } = consoleActor;
+
+		const result = await authenticate({
+			OpenId: { jwt, session_key: publicKey, salt }
+		});
+
+		expect('Ok' in result).toBeTruthy();
+
+		await config({
+			max_tokens: 2n,
+			time_per_token_ns: 2_000_000_000n // 2s
+		});
+
+		consoleActor.setIdentity(user);
+
+		const { jwt: jwt2 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 500 });
+
+		const result2 = await authenticate({
+			OpenId: { jwt: jwt2, session_key: publicKey, salt }
+		});
+
+		// The error in result2 does not matter much here.
+		// Goal is to assert the rate limiter.
+		if ('Ok' in result2) {
+			expect(true).toBeFalsy();
+
+			return;
+		}
+
+		const { Err } = result2;
+
+		if (!('PrepareDelegation' in Err)) {
+			expect(true).toBeFalsy();
+
+			return;
+		}
+
+		const { PrepareDelegation } = Err;
+
+		if (!('GetOrFetchJwks' in PrepareDelegation)) {
+			expect(true).toBeFalsy();
+
+			return;
+		}
+
+		const { jwt: jwt3 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 400 });
+
+		await expect(
+			authenticate({
+				OpenId: { jwt: jwt3, session_key: publicKey, salt }
+			})
+		).rejects.toThrow('Rate limit reached, try again later.');
+	});
+});

--- a/src/tests/specs/console/auth/console.auth.rate.spec.ts
+++ b/src/tests/specs/console/auth/console.auth.rate.spec.ts
@@ -1,11 +1,11 @@
 import type { ConsoleActor } from '$declarations';
-import { Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Actor, PocketIc } from '@dfinity/pic';
 import { testAuthRate } from '../../../utils/auth-assertions-rate-tests.utils';
 import { setupConsoleAuth } from '../../../utils/auth-tests.utils';
 import { tick } from '../../../utils/pic-tests.utils';
 
-describe('Console > Auth > Rate', async () => {
+describe('Console > Auth > Rate', () => {
 	let pic: PocketIc;
 
 	let consoleActor: Actor<ConsoleActor>;

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
@@ -1,13 +1,9 @@
 import type { SatelliteActor } from '$declarations';
-import { ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
+import { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Actor, PocketIc } from '@dfinity/pic';
 import { assertNonNullish, fromNullable } from '@dfinity/utils';
-import { mockClientId } from '../../../../mocks/jwt.mocks';
-import { generateNonce } from '../../../../utils/auth-nonce-tests.utils';
+import { testAuthRate } from '../../../../utils/auth-assertions-rate-tests.utils';
 import { setupSatelliteAuth } from '../../../../utils/auth-tests.utils';
-import { makeMockGoogleOpenIdJwt } from '../../../../utils/jwt-tests.utils';
-import { assertOpenIdHttpsOutcalls } from '../../../../utils/observatory-openid-tests.utils';
-import { tick } from '../../../../utils/pic-tests.utils';
 
 describe('Satellite > Auth > Rate', async () => {
 	let pic: PocketIc;
@@ -15,13 +11,6 @@ describe('Satellite > Auth > Rate', async () => {
 	let satelliteActor: Actor<SatelliteActor>;
 
 	let controller: Ed25519KeyIdentity;
-
-	const user = Ed25519KeyIdentity.generate();
-
-	const sessionKey = await ECDSAKeyIdentity.generate();
-	const publicKey = new Uint8Array(sessionKey.getPublicKey().toDer());
-
-	const { nonce, salt } = await generateNonce({ caller: user });
 
 	beforeAll(async () => {
 		const {
@@ -71,93 +60,9 @@ describe('Satellite > Auth > Rate', async () => {
 		});
 	};
 
-	const generateJwtCertificate = async ({
-		advanceTime,
-		refreshJwts = true,
-		kid
-	}: {
-		advanceTime?: number;
-		refreshJwts?: boolean;
-		kid?: string;
-	}): Promise<{ jwt: string }> => {
-		await pic.advanceTime(advanceTime ?? 1000 * 60 * 15); // Observatory refresh every 15min
-		await tick(pic);
-
-		const now = await pic.getTime();
-
-		const { jwks, jwt } = await makeMockGoogleOpenIdJwt({
-			clientId: mockClientId,
-			date: new Date(now),
-			nonce,
-			kid
-		});
-
-		if (!refreshJwts) {
-			return { jwt };
-		}
-
-		// Refresh certificate in Observatory
-		await assertOpenIdHttpsOutcalls({ pic, jwks });
-
-		return { jwt };
-	};
-
-	it('should throw error if user rate is reached', async () => {
-		satelliteActor.setIdentity(user);
-
-		const { jwt } = await generateJwtCertificate({});
-
-		const { authenticate } = satelliteActor;
-
-		const result = await authenticate({
-			OpenId: { jwt, session_key: publicKey, salt }
-		});
-
-		expect('Ok' in result).toBeTruthy();
-
-		await config({
-			max_tokens: 1n,
-			time_per_token_ns: 2_000_000_000n // 2s
-		});
-
-		satelliteActor.setIdentity(user);
-
-		const { jwt: jwt2 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 500 });
-
-		const result2 = await authenticate({
-			OpenId: { jwt: jwt2, session_key: publicKey, salt }
-		});
-
-		// The error in result2 does not matter much here.
-		// Goal is to assert the rate limiter.
-		if ('Ok' in result2) {
-			expect(true).toBeFalsy();
-
-			return;
-		}
-
-		const { Err } = result2;
-
-		if (!('PrepareDelegation' in Err)) {
-			expect(true).toBeFalsy();
-
-			return;
-		}
-
-		const { PrepareDelegation } = Err;
-
-		if (!('GetOrFetchJwks' in PrepareDelegation)) {
-			expect(true).toBeFalsy();
-
-			return;
-		}
-
-		const { jwt: jwt3 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 400 });
-
-		await expect(
-			authenticate({
-				OpenId: { jwt: jwt3, session_key: publicKey, salt }
-			})
-		).rejects.toThrow('Rate limit reached, try again later.');
+	testAuthRate({
+		pic: () => pic,
+		actor: () => satelliteActor,
+		config
 	});
 });

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.rate.spec.ts
@@ -1,11 +1,11 @@
 import type { SatelliteActor } from '$declarations';
-import { Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Actor, PocketIc } from '@dfinity/pic';
 import { assertNonNullish, fromNullable } from '@dfinity/utils';
 import { testAuthRate } from '../../../../utils/auth-assertions-rate-tests.utils';
 import { setupSatelliteAuth } from '../../../../utils/auth-tests.utils';
 
-describe('Satellite > Auth > Rate', async () => {
+describe('Satellite > Auth > Rate', () => {
 	let pic: PocketIc;
 
 	let satelliteActor: Actor<SatelliteActor>;

--- a/src/tests/utils/auth-assertions-rate-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-rate-tests.utils.ts
@@ -1,4 +1,4 @@
-import { type ConsoleActor, type SatelliteActor } from '$declarations';
+import type { ConsoleActor, SatelliteActor } from '$declarations';
 import { ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
 import type { Actor, PocketIc } from '@dfinity/pic';
 import { mockClientId } from '../mocks/jwt.mocks';

--- a/src/tests/utils/auth-assertions-rate-tests.utils.ts
+++ b/src/tests/utils/auth-assertions-rate-tests.utils.ts
@@ -1,0 +1,126 @@
+import { type ConsoleActor, type SatelliteActor } from '$declarations';
+import { ECDSAKeyIdentity, Ed25519KeyIdentity } from '@dfinity/identity';
+import type { Actor, PocketIc } from '@dfinity/pic';
+import { mockClientId } from '../mocks/jwt.mocks';
+import { generateNonce } from './auth-nonce-tests.utils';
+import { makeMockGoogleOpenIdJwt } from './jwt-tests.utils';
+import { assertOpenIdHttpsOutcalls } from './observatory-openid-tests.utils';
+import { tick } from './pic-tests.utils';
+
+export const testAuthRate = ({
+	actor: getActor,
+	pic: getPic,
+	config
+}: {
+	actor: () => Actor<SatelliteActor | ConsoleActor>;
+	pic: () => PocketIc;
+	config: (params: { max_tokens: bigint; time_per_token_ns: bigint }) => Promise<void>;
+}) => {
+	describe('Rate', async () => {
+		let pic: PocketIc;
+
+		let actor: Actor<SatelliteActor | ConsoleActor>;
+
+		const user = Ed25519KeyIdentity.generate();
+
+		const sessionKey = await ECDSAKeyIdentity.generate();
+		const publicKey = new Uint8Array(sessionKey.getPublicKey().toDer());
+
+		const { nonce, salt } = await generateNonce({ caller: user });
+
+		beforeAll(() => {
+			pic = getPic();
+			actor = getActor();
+		});
+
+		const generateJwtCertificate = async ({
+			advanceTime,
+			refreshJwts = true,
+			kid
+		}: {
+			advanceTime?: number;
+			refreshJwts?: boolean;
+			kid?: string;
+		}): Promise<{ jwt: string }> => {
+			await pic.advanceTime(advanceTime ?? 1000 * 60 * 15); // Observatory refresh every 15min
+			await tick(pic);
+
+			const now = await pic.getTime();
+
+			const { jwks, jwt } = await makeMockGoogleOpenIdJwt({
+				clientId: mockClientId,
+				date: new Date(now),
+				nonce,
+				kid
+			});
+
+			if (!refreshJwts) {
+				return { jwt };
+			}
+
+			// Refresh certificate in Observatory
+			await assertOpenIdHttpsOutcalls({ pic, jwks });
+
+			return { jwt };
+		};
+
+		it('should throw error if user rate is reached', async () => {
+			actor.setIdentity(user);
+
+			const { jwt } = await generateJwtCertificate({});
+
+			const { authenticate } = actor;
+
+			const result = await authenticate({
+				OpenId: { jwt, session_key: publicKey, salt }
+			});
+
+			expect('Ok' in result).toBeTruthy();
+
+			await config({
+				max_tokens: 1n,
+				time_per_token_ns: 2_000_000_000n // 2s
+			});
+
+			actor.setIdentity(user);
+
+			const { jwt: jwt2 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 500 });
+
+			const result2 = await authenticate({
+				OpenId: { jwt: jwt2, session_key: publicKey, salt }
+			});
+
+			// The error in result2 does not matter much here.
+			// Goal is to assert the rate limiter.
+			if ('Ok' in result2) {
+				expect(true).toBeFalsy();
+
+				return;
+			}
+
+			const { Err } = result2;
+
+			if (!('PrepareDelegation' in Err)) {
+				expect(true).toBeFalsy();
+
+				return;
+			}
+
+			const { PrepareDelegation } = Err;
+
+			if (!('GetOrFetchJwks' in PrepareDelegation)) {
+				expect(true).toBeFalsy();
+
+				return;
+			}
+
+			const { jwt: jwt3 } = await generateJwtCertificate({ refreshJwts: false, advanceTime: 400 });
+
+			await expect(
+				authenticate({
+					OpenId: { jwt: jwt3, session_key: publicKey, salt }
+				})
+			).rejects.toThrow('Rate limit reached, try again later.');
+		});
+	});
+};

--- a/src/tests/utils/auth-tests.utils.ts
+++ b/src/tests/utils/auth-tests.utils.ts
@@ -66,7 +66,9 @@ export const setupSatelliteAuth = async (): Promise<
 	};
 };
 
-export const setupConsoleAuth = async (): Promise<
+export const setupConsoleAuth = async (
+	{ withApplyRateTokens }: { withApplyRateTokens?: boolean } = { withApplyRateTokens: true }
+): Promise<
 	SetupAuth & {
 		console: { canisterId: Principal; actor: Actor<ConsoleActor> };
 	}
@@ -77,7 +79,8 @@ export const setupConsoleAuth = async (): Promise<
 		controller: cO,
 		canisterId: cId
 	} = await setupConsole({
-		dateTime: mockCertificateDate
+		dateTime: mockCertificateDate,
+		withApplyRateTokens
 	});
 
 	const pic = p;

--- a/src/tests/utils/console-tests.utils.ts
+++ b/src/tests/utils/console-tests.utils.ts
@@ -524,5 +524,39 @@ export const setupConsole = async ({
 		sender: controller.getPrincipal()
 	});
 
+	await configMissionControlRateTokens({
+		actor,
+		controller,
+		max_tokens: 10n,
+		time_per_token_ns: 1_000_000_000n // 1s per token
+	});
+
+	await pic.advanceTime(120_000);
+	await tick(pic);
+
 	return { pic, controller, actor, canisterId };
+};
+
+export const configMissionControlRateTokens = async ({
+	max_tokens,
+	time_per_token_ns,
+	actor,
+	controller
+}: {
+	max_tokens: bigint;
+	time_per_token_ns: bigint;
+	actor: Actor<ConsoleActor>;
+	controller: Ed25519KeyIdentity;
+}) => {
+	actor.setIdentity(controller);
+
+	const { update_rate_config } = actor;
+
+	await update_rate_config(
+		{ MissionControl: null },
+		{
+			max_tokens,
+			time_per_token_ns
+		}
+	);
 };

--- a/src/tests/utils/console-tests.utils.ts
+++ b/src/tests/utils/console-tests.utils.ts
@@ -502,9 +502,11 @@ export const updateRateConfig = async ({
 };
 
 export const setupConsole = async ({
-	dateTime
+	dateTime,
+	withApplyRateTokens = true
 }: {
 	dateTime?: Date;
+	withApplyRateTokens?: boolean;
 }): Promise<{
 	pic: PocketIc;
 	controller: Ed25519KeyIdentity;
@@ -524,15 +526,17 @@ export const setupConsole = async ({
 		sender: controller.getPrincipal()
 	});
 
-	await configMissionControlRateTokens({
-		actor,
-		controller,
-		max_tokens: 10n,
-		time_per_token_ns: 1_000_000_000n // 1s per token
-	});
+	if (withApplyRateTokens) {
+		await configMissionControlRateTokens({
+			actor,
+			controller,
+			max_tokens: 10n,
+			time_per_token_ns: 1_000_000_000n // 1s per token
+		});
 
-	await pic.advanceTime(120_000);
-	await tick(pic);
+		await pic.advanceTime(120_000);
+		await tick(pic);
+	}
 
 	return { pic, controller, actor, canisterId };
 };


### PR DESCRIPTION
# Motivation

We want to avoid having to many requests in the authenticate as well.
