### PR TITLE
feat(frontend): use custom storage for auth-client and pattern

### DIFF
--- a/src/frontend/src/lib/providers/auth-client.provider.ts
+++ b/src/frontend/src/lib/providers/auth-client.provider.ts
@@ -1,20 +1,42 @@
 import { AuthClient, IdbStorage, KEY_STORAGE_KEY } from '@dfinity/auth-client';
 
-export const createAuthClient = (): Promise<AuthClient> =>
-	AuthClient.create({
-		idleOptions: {
-			disableIdle: true,
-			disableDefaultIdleCallback: true
-		}
-	});
+class AuthClientProvider {
+	// We use a dedicated storage for the auth client to better manage it, e.g. clear it for a new login.
+	// It is similar as the default fallback option of AgentJS.
+	readonly #storage: IdbStorage;
 
-export const resetAuthClient = async (): Promise<AuthClient> => {
-	// Since AgentJS persists the identity key in IndexedDB by default,
-	// it can be tampered with and affect the next login with Internet Identity.
-	// To ensure each session starts clean and safe, we clear the stored keys before creating a new AuthClient
-	// in case the user is not authenticated.
-	const storage = new IdbStorage();
-	await storage.remove(KEY_STORAGE_KEY);
+	constructor() {
+		this.#storage = new IdbStorage();
+	}
 
-	return await createAuthClient();
-};
+	createAuthClient = (): Promise<AuthClient> =>
+		AuthClient.create({
+			storage: this.#storage,
+			idleOptions: {
+				disableIdle: true,
+				disableDefaultIdleCallback: true
+			}
+		});
+
+	/**
+	 * Since icp-js-core persists identity keys in IndexedDB by default,
+	 * they could be tampered with and affect the next login.
+	 * To ensure each session starts clean and safe, we clear the stored keys before creating a new AuthClient.
+	 */
+	safeCreateAuthClient = async (): Promise<AuthClient> => {
+		await this.#storage.remove(KEY_STORAGE_KEY);
+		return await this.createAuthClient();
+	};
+
+	get storage(): IdbStorage {
+		return this.#storage;
+	}
+}
+
+const {
+	storage: __test_only_auth_client_storage__,
+	createAuthClient,
+	safeCreateAuthClient
+} = new AuthClientProvider();
+
+export { __test_only_auth_client_storage__, createAuthClient, safeCreateAuthClient };

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -6,7 +6,7 @@ import {
 	LOCAL_REPLICA_HOST
 } from '$lib/constants/app.constants';
 import { isDev } from '$lib/env/app.env';
-import { createAuthClient, resetAuthClient } from '$lib/providers/auth-client.provider';
+import { createAuthClient, safeCreateAuthClient } from '$lib/providers/auth-client.provider';
 import { SignInError, SignInInitError, SignInUserInterruptError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/itentity';
 import type { Option } from '$lib/types/utils';
@@ -44,7 +44,7 @@ const initAuthStore = (): AuthStore => {
 			const isAuthenticated = await authClient.isAuthenticated();
 
 			if (!isAuthenticated) {
-				authClient = await resetAuthClient();
+				authClient = await safeCreateAuthClient();
 				set({ identity: null });
 				return;
 			}

--- a/src/frontend/tests/lib/providers/auth-client.provider.test.ts
+++ b/src/frontend/tests/lib/providers/auth-client.provider.test.ts
@@ -1,0 +1,113 @@
+import {
+	__test_only_auth_client_storage__ as authClientStorage,
+	createAuthClient,
+	safeCreateAuthClient
+} from '$lib/providers/auth-client.provider';
+import { AuthClient, KEY_STORAGE_DELEGATION, KEY_STORAGE_KEY } from '@dfinity/auth-client';
+
+describe('auth-client.provider', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.spyOn(AuthClient, 'create');
+
+		vi.spyOn(authClientStorage, 'get');
+		vi.spyOn(authClientStorage, 'set');
+		vi.spyOn(authClientStorage, 'remove');
+	});
+
+	describe('createAuthClient', () => {
+		it('should create an auth client', async () => {
+			const result = await createAuthClient();
+
+			expect(result).toBeInstanceOf(AuthClient);
+
+			expect(AuthClient.create).toHaveBeenCalledExactlyOnceWith({
+				storage: authClientStorage,
+				idleOptions: {
+					disableIdle: true,
+					disableDefaultIdleCallback: true
+				}
+			});
+
+			expect(authClientStorage.get).toHaveBeenCalledExactlyOnceWith(KEY_STORAGE_KEY);
+
+			expect(authClientStorage.set).toHaveBeenCalledExactlyOnceWith(
+				KEY_STORAGE_KEY,
+				expect.any(Object)
+			);
+
+			expect(authClientStorage.remove).not.toHaveBeenCalled();
+		});
+
+		it('should not create a new key when called a second time', async () => {
+			const result = await createAuthClient();
+
+			expect(result).toBeInstanceOf(AuthClient);
+
+			expect(AuthClient.create).toHaveBeenCalledExactlyOnceWith({
+				storage: authClientStorage,
+				idleOptions: {
+					disableIdle: true,
+					disableDefaultIdleCallback: true
+				}
+			});
+
+			expect(authClientStorage.get).toHaveBeenCalledTimes(2);
+			expect(authClientStorage.get).toHaveBeenNthCalledWith(1, KEY_STORAGE_KEY);
+			expect(authClientStorage.get).toHaveBeenNthCalledWith(2, KEY_STORAGE_DELEGATION);
+
+			expect(authClientStorage.set).not.toHaveBeenCalled();
+
+			expect(authClientStorage.remove).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('safeCreateAuthClient', () => {
+		it('should create an auth client', async () => {
+			const result = await safeCreateAuthClient();
+
+			expect(result).toBeInstanceOf(AuthClient);
+
+			expect(AuthClient.create).toHaveBeenCalledExactlyOnceWith({
+				storage: authClientStorage,
+				idleOptions: {
+					disableIdle: true,
+					disableDefaultIdleCallback: true
+				}
+			});
+
+			expect(authClientStorage.get).toHaveBeenCalledExactlyOnceWith(KEY_STORAGE_KEY);
+
+			expect(authClientStorage.set).toHaveBeenCalledExactlyOnceWith(
+				KEY_STORAGE_KEY,
+				expect.any(Object)
+			);
+
+			expect(authClientStorage.remove).toHaveBeenCalledExactlyOnceWith(KEY_STORAGE_KEY);
+		});
+
+		it('should create a new key when called a second time', async () => {
+			const result = await safeCreateAuthClient();
+
+			expect(result).toBeInstanceOf(AuthClient);
+
+			expect(AuthClient.create).toHaveBeenCalledExactlyOnceWith({
+				storage: authClientStorage,
+				idleOptions: {
+					disableIdle: true,
+					disableDefaultIdleCallback: true
+				}
+			});
+
+			expect(authClientStorage.get).toHaveBeenCalledExactlyOnceWith(KEY_STORAGE_KEY);
+
+			expect(authClientStorage.set).toHaveBeenCalledExactlyOnceWith(
+				KEY_STORAGE_KEY,
+				expect.any(Object)
+			);
+
+			expect(authClientStorage.remove).toHaveBeenCalledExactlyOnceWith(KEY_STORAGE_KEY);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Similarly to what @AntonioVentilii has done in OISY, we also want to declare a custom idb storage for the `AuthClient` this way we can implement some tests about its usage.

In comparison to OISY, I used a "provider" based naming instead of "api" and I also approched the implementation with an extra class - like a good old Java factory pattern - this way I can embed the storage and not declare it globally.

Relates to #2179.
