### PR TITLE
feat(frontend): auth store generic sign-in function

### DIFF
--- a/src/frontend/src/lib/services/auth/_internet-identity.services.ts
+++ b/src/frontend/src/lib/services/auth/_internet-identity.services.ts
@@ -11,9 +11,9 @@ import { SignInError, SignInUserInterruptError } from '$lib/types/errors';
 import { popupCenter } from '$lib/utils/window.utils';
 import { ERROR_USER_INTERRUPT } from '@dfinity/auth-client';
 
-export const signInWithII: SignInFn = ({ authClient }) => 
+export const signInWithII: SignInFn = ({ authClient }) =>
 	// eslint-disable-next-line no-async-promise-executor
-	 new Promise<SignedInIdentity>(async (resolve, reject) => {
+	new Promise<SignedInIdentity>(async (resolve, reject) => {
 		const identityProvider = isDev()
 			? /apple/i.test(navigator?.vendor)
 				? `${LOCAL_REPLICA_HOST}?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
@@ -37,5 +37,4 @@ export const signInWithII: SignInFn = ({ authClient }) =>
 			identityProvider,
 			windowOpenerFeatures: popupCenter({ width: AUTH_POPUP_WIDTH, height: AUTH_POPUP_HEIGHT })
 		});
-	})
-;
+	});

--- a/src/frontend/src/lib/services/auth/_internet-identity.services.ts
+++ b/src/frontend/src/lib/services/auth/_internet-identity.services.ts
@@ -1,0 +1,41 @@
+import {
+	AUTH_MAX_TIME_TO_LIVE,
+	AUTH_POPUP_HEIGHT,
+	AUTH_POPUP_WIDTH,
+	INTERNET_IDENTITY_CANISTER_ID,
+	LOCAL_REPLICA_HOST
+} from '$lib/constants/app.constants';
+import { isDev } from '$lib/env/app.env';
+import type { SignedInIdentity, SignInFn } from '$lib/types/auth';
+import { SignInError, SignInUserInterruptError } from '$lib/types/errors';
+import { popupCenter } from '$lib/utils/window.utils';
+import { ERROR_USER_INTERRUPT } from '@dfinity/auth-client';
+
+export const signInWithII: SignInFn = ({ authClient }) => {
+	// eslint-disable-next-line no-async-promise-executor
+	return new Promise<SignedInIdentity>(async (resolve, reject) => {
+		const identityProvider = isDev()
+			? /apple/i.test(navigator?.vendor)
+				? `${LOCAL_REPLICA_HOST}?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
+				: `http://${INTERNET_IDENTITY_CANISTER_ID}.${new URL(LOCAL_REPLICA_HOST).host}`
+			: `https://identity.internetcomputer.org`;
+
+		await authClient?.login({
+			maxTimeToLive: AUTH_MAX_TIME_TO_LIVE,
+			allowPinAuthentication: false,
+			onSuccess: () => {
+				resolve({ identity: authClient?.getIdentity() });
+			},
+			onError: (error?: string) => {
+				if (error === ERROR_USER_INTERRUPT) {
+					reject(new SignInUserInterruptError(error));
+					return;
+				}
+
+				reject(new SignInError(error));
+			},
+			identityProvider,
+			windowOpenerFeatures: popupCenter({ width: AUTH_POPUP_WIDTH, height: AUTH_POPUP_HEIGHT })
+		});
+	});
+};

--- a/src/frontend/src/lib/services/auth/_internet-identity.services.ts
+++ b/src/frontend/src/lib/services/auth/_internet-identity.services.ts
@@ -11,9 +11,9 @@ import { SignInError, SignInUserInterruptError } from '$lib/types/errors';
 import { popupCenter } from '$lib/utils/window.utils';
 import { ERROR_USER_INTERRUPT } from '@dfinity/auth-client';
 
-export const signInWithII: SignInFn = ({ authClient }) => {
+export const signInWithII: SignInFn = ({ authClient }) => 
 	// eslint-disable-next-line no-async-promise-executor
-	return new Promise<SignedInIdentity>(async (resolve, reject) => {
+	 new Promise<SignedInIdentity>(async (resolve, reject) => {
 		const identityProvider = isDev()
 			? /apple/i.test(navigator?.vendor)
 				? `${LOCAL_REPLICA_HOST}?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
@@ -37,5 +37,5 @@ export const signInWithII: SignInFn = ({ authClient }) => {
 			identityProvider,
 			windowOpenerFeatures: popupCenter({ width: AUTH_POPUP_WIDTH, height: AUTH_POPUP_HEIGHT })
 		});
-	});
-};
+	})
+;

--- a/src/frontend/src/lib/services/auth/auth.services.ts
+++ b/src/frontend/src/lib/services/auth/auth.services.ts
@@ -19,6 +19,7 @@ import { replaceHistory } from '$lib/utils/route.utils';
 import { isNullish } from '@dfinity/utils';
 import { clear } from 'idb-keyval';
 import { get } from 'svelte/store';
+import { signInWithII as signInWithIIFn } from './_internet-identity.services';
 
 export const signInWithII = async (): Promise<{
 	success: 'ok' | 'cancelled' | 'error';
@@ -27,7 +28,7 @@ export const signInWithII = async (): Promise<{
 	busy.show();
 
 	try {
-		await authStore.signInWithII();
+		await authStore.signIn({ signInFn: signInWithIIFn });
 
 		return { success: 'ok' };
 	} catch (err: unknown) {

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -1,18 +1,10 @@
-import {
-	AUTH_MAX_TIME_TO_LIVE,
-	AUTH_POPUP_HEIGHT,
-	AUTH_POPUP_WIDTH,
-	INTERNET_IDENTITY_CANISTER_ID,
-	LOCAL_REPLICA_HOST
-} from '$lib/constants/app.constants';
-import { isDev } from '$lib/env/app.env';
 import { AuthBroadcastChannel } from '$lib/providers/auth-broadcast.provider';
 import { createAuthClient, safeCreateAuthClient } from '$lib/providers/auth-client.provider';
-import { SignInError, SignInInitError, SignInUserInterruptError } from '$lib/types/errors';
+import type { SignInFn } from '$lib/types/auth';
+import { SignInInitError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/itentity';
 import type { Option } from '$lib/types/utils';
-import { popupCenter } from '$lib/utils/window.utils';
-import { type AuthClient, ERROR_USER_INTERRUPT } from '@dfinity/auth-client';
+import { type AuthClient } from '@dfinity/auth-client';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { type Readable, writable } from 'svelte/store';
 
@@ -25,7 +17,7 @@ let authClient: Option<AuthClient>;
 export interface AuthStore extends Readable<AuthStoreData> {
 	sync: () => Promise<void>;
 	forceSync: () => Promise<void>;
-	signInWithII: () => Promise<void>;
+	signIn: (params: { signInFn: SignInFn }) => Promise<void>;
 	signOut: () => Promise<void>;
 }
 
@@ -73,54 +65,33 @@ const initAuthStore = (): AuthStore => {
 			await sync({ forceSync: true });
 		},
 
-		signInWithII: () =>
-			// eslint-disable-next-line no-async-promise-executor
-			new Promise<void>(async (resolve, reject) => {
-				if (isNullish(authClient)) {
-					reject(new SignInInitError());
-					return;
+		signIn: async ({ signInFn }) => {
+			if (isNullish(authClient)) {
+				throw new SignInInitError();
+			}
+
+			const { identity } = await signInFn({ authClient });
+
+			set({ identity });
+
+			const broadCastSignIn = () => {
+				try {
+					// If the user has more than one tab open in the same browser,
+					// there could be a mismatch of the cached delegation chain vs the identity key of the `authClient` object.
+					// This causes the `authClient` to be unable to correctly sign calls, raising Trust Errors.
+					// To mitigate this, we use a BroadcastChannel to notify other tabs when a login has occurred, so that they can sync their `authClient` object.
+					const bc = new AuthBroadcastChannel();
+					bc.postLoginSuccess();
+				} catch (err: unknown) {
+					// We don't really care if the broadcast channel fails to open or if it fails to post messages.
+					// This is a non-critical feature that improves the UX when OISY is open in multiple tabs.
+					// We just print a warning in the console for debugging purposes.
+					console.warn('Auth BroadcastChannel posting failed', err);
 				}
+			};
 
-				const identityProvider = isDev()
-					? /apple/i.test(navigator?.vendor)
-						? `${LOCAL_REPLICA_HOST}?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
-						: `http://${INTERNET_IDENTITY_CANISTER_ID}.${new URL(LOCAL_REPLICA_HOST).host}`
-					: `https://identity.internetcomputer.org`;
-
-				await authClient?.login({
-					maxTimeToLive: AUTH_MAX_TIME_TO_LIVE,
-					allowPinAuthentication: false,
-					onSuccess: () => {
-						set({ identity: authClient?.getIdentity() });
-
-						try {
-							// If the user has more than one tab open in the same browser,
-							// there could be a mismatch of the cached delegation chain vs the identity key of the `authClient` object.
-							// This causes the `authClient` to be unable to correctly sign calls, raising Trust Errors.
-							// To mitigate this, we use a BroadcastChannel to notify other tabs when a login has occurred, so that they can sync their `authClient` object.
-							const bc = new AuthBroadcastChannel();
-							bc.postLoginSuccess();
-						} catch (err: unknown) {
-							// We don't really care if the broadcast channel fails to open or if it fails to post messages.
-							// This is a non-critical feature that improves the UX when OISY is open in multiple tabs.
-							// We just print a warning in the console for debugging purposes.
-							console.warn('Auth BroadcastChannel posting failed', err);
-						}
-
-						resolve();
-					},
-					onError: (error?: string) => {
-						if (error === ERROR_USER_INTERRUPT) {
-							reject(new SignInUserInterruptError(error));
-							return;
-						}
-
-						reject(new SignInError(error));
-					},
-					identityProvider,
-					windowOpenerFeatures: popupCenter({ width: AUTH_POPUP_WIDTH, height: AUTH_POPUP_HEIGHT })
-				});
-			}),
+			broadCastSignIn();
+		},
 
 		signOut: async () => {
 			const client: AuthClient = authClient ?? (await createAuthClient());

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -4,7 +4,7 @@ import type { SignInFn } from '$lib/types/auth';
 import { SignInInitError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/itentity';
 import type { Option } from '$lib/types/utils';
-import { type AuthClient } from '@dfinity/auth-client';
+import type { AuthClient } from '@dfinity/auth-client';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { type Readable, writable } from 'svelte/store';
 

--- a/src/frontend/src/lib/types/auth.ts
+++ b/src/frontend/src/lib/types/auth.ts
@@ -1,5 +1,5 @@
 import type { OptionIdentity } from '$lib/types/itentity';
 import type { AuthClient } from '@dfinity/auth-client';
 
-export type SignedInIdentity = { identity: OptionIdentity };
+export interface SignedInIdentity { identity: OptionIdentity }
 export type SignInFn = (params: { authClient: AuthClient }) => Promise<SignedInIdentity>;

--- a/src/frontend/src/lib/types/auth.ts
+++ b/src/frontend/src/lib/types/auth.ts
@@ -1,5 +1,5 @@
-import type { AuthClient } from '@dfinity/auth-client';
 import type { OptionIdentity } from '$lib/types/itentity';
+import type { AuthClient } from '@dfinity/auth-client';
 
 export type SignedInIdentity = { identity: OptionIdentity };
-export type SignInFn = (params: {authClient: AuthClient}) => Promise<SignedInIdentity>;
+export type SignInFn = (params: { authClient: AuthClient }) => Promise<SignedInIdentity>;

--- a/src/frontend/src/lib/types/auth.ts
+++ b/src/frontend/src/lib/types/auth.ts
@@ -1,5 +1,7 @@
 import type { OptionIdentity } from '$lib/types/itentity';
 import type { AuthClient } from '@dfinity/auth-client';
 
-export interface SignedInIdentity { identity: OptionIdentity }
+export interface SignedInIdentity {
+	identity: OptionIdentity;
+}
 export type SignInFn = (params: { authClient: AuthClient }) => Promise<SignedInIdentity>;

--- a/src/frontend/src/lib/types/auth.ts
+++ b/src/frontend/src/lib/types/auth.ts
@@ -1,0 +1,5 @@
+import type { AuthClient } from '@dfinity/auth-client';
+import type { OptionIdentity } from '$lib/types/itentity';
+
+export type SignedInIdentity = { identity: OptionIdentity };
+export type SignInFn = (params: {authClient: AuthClient}) => Promise<SignedInIdentity>;


### PR DESCRIPTION
# Motivation

We want to sign-in with Google and get an identity. So, we need to make the store generic to accept other sign-in while avoid to leak any logic related to handling sign-out or auth client mumbo jumbo.
