### PR TITLE
feat(frontend): read juno console config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
 				"@dfinity/response-verification": "^3.0.3",
 				"@junobuild/cli-tools": "^0.8.0",
 				"@junobuild/config": "^2.3.0",
-				"@junobuild/config-loader": "^0.4.5",
+				"@junobuild/config-loader": "^0.4.5-next-2025-11-02.1",
 				"@junobuild/errors": "^0.1.4-next-2025-10-30",
 				"@junobuild/functions": "^0.3.3",
 				"@ltd/j-toml": "^1.38.0",
@@ -151,9 +151,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-			"integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+			"integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -162,22 +162,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-			"integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
+			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.3",
+				"@babel/generator": "^7.28.5",
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-module-transforms": "^7.28.3",
 				"@babel/helpers": "^7.28.4",
-				"@babel/parser": "^7.28.4",
+				"@babel/parser": "^7.28.5",
 				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.4",
-				"@babel/types": "^7.28.4",
+				"@babel/traverse": "^7.28.5",
+				"@babel/types": "^7.28.5",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -205,15 +205,15 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-			"integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/parser": "^7.28.3",
-				"@babel/types": "^7.28.2",
+				"@babel/parser": "^7.28.5",
+				"@babel/types": "^7.28.5",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -266,19 +266,19 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
-			"integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
+			"integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.27.3",
-				"@babel/helper-member-expression-to-functions": "^7.27.1",
+				"@babel/helper-member-expression-to-functions": "^7.28.5",
 				"@babel/helper-optimise-call-expression": "^7.27.1",
 				"@babel/helper-replace-supers": "^7.27.1",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/traverse": "^7.28.3",
+				"@babel/traverse": "^7.28.5",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -311,15 +311,15 @@
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-			"integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+			"integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.28.5",
+				"@babel/types": "^7.28.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -430,9 +430,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -466,14 +466,14 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-			"integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+			"integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.28.4"
+				"@babel/types": "^7.28.5"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -535,15 +535,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
-			"integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
+			"integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.27.3",
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-create-class-features-plugin": "^7.28.5",
 				"@babel/helper-plugin-utils": "^7.27.1",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
 				"@babel/plugin-syntax-typescript": "^7.27.1"
@@ -556,9 +556,9 @@
 			}
 		},
 		"node_modules/@babel/preset-typescript": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
-			"integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+			"integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -567,7 +567,7 @@
 				"@babel/helper-validator-option": "^7.27.1",
 				"@babel/plugin-syntax-jsx": "^7.27.1",
 				"@babel/plugin-transform-modules-commonjs": "^7.27.1",
-				"@babel/plugin-transform-typescript": "^7.27.1"
+				"@babel/plugin-transform-typescript": "^7.28.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -606,19 +606,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-			"integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.3",
+				"@babel/generator": "^7.28.5",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.4",
+				"@babel/parser": "^7.28.5",
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.4",
+				"@babel/types": "^7.28.5",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -626,15 +626,15 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-			"integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1"
+				"@babel/helper-validator-identifier": "^7.28.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1849,15 +1849,15 @@
 			}
 		},
 		"node_modules/@junobuild/config-loader": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@junobuild/config-loader/-/config-loader-0.4.5.tgz",
-			"integrity": "sha512-ddbIyTVPCaXXwS1S/6KOE8As09Dr6O2l2x3nETgGi40uuu8Bi2+Y7NtCIfkR2U57BoHxaNqP4BAsiwUWQ0j/5g==",
+			"version": "0.4.5-next-2025-11-02.1",
+			"resolved": "https://registry.npmjs.org/@junobuild/config-loader/-/config-loader-0.4.5-next-2025-11-02.1.tgz",
+			"integrity": "sha512-9xgm1Bun1T3Jq4l9pXbVWTJh5ECQaaceRAiPbCcFMzzk+sS6q4MqwXJx89XMtC8oCz3cUWm5g+y4dV2tz5caQQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
-				"@babel/core": "7.28.4",
-				"@babel/plugin-transform-modules-commonjs": "7.27.1",
-				"@babel/preset-typescript": "7.27.1",
+				"@babel/core": "*",
+				"@babel/plugin-transform-modules-commonjs": "*",
+				"@babel/preset-typescript": "*",
 				"@junobuild/config": "*"
 			}
 		},
@@ -4028,9 +4028,9 @@
 			"peer": true
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.7.tgz",
-			"integrity": "sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==",
+			"version": "2.8.23",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.23.tgz",
+			"integrity": "sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -4084,9 +4084,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.26.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
-			"integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+			"version": "4.27.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
+			"integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4105,11 +4105,11 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"baseline-browser-mapping": "^2.8.3",
-				"caniuse-lite": "^1.0.30001741",
-				"electron-to-chromium": "^1.5.218",
-				"node-releases": "^2.0.21",
-				"update-browserslist-db": "^1.1.3"
+				"baseline-browser-mapping": "^2.8.19",
+				"caniuse-lite": "^1.0.30001751",
+				"electron-to-chromium": "^1.5.238",
+				"node-releases": "^2.0.26",
+				"update-browserslist-db": "^1.1.4"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -4193,9 +4193,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001745",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
-			"integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+			"version": "1.0.30001753",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
+			"integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4858,9 +4858,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.224",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.224.tgz",
-			"integrity": "sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==",
+			"version": "1.5.244",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz",
+			"integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true
@@ -7571,9 +7571,9 @@
 			"optional": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.21",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
-			"integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+			"version": "2.0.27",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -9791,9 +9791,9 @@
 			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
+			"integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"@dfinity/response-verification": "^3.0.3",
 		"@junobuild/cli-tools": "^0.8.0",
 		"@junobuild/config": "^2.3.0",
-		"@junobuild/config-loader": "^0.4.5",
+		"@junobuild/config-loader": "^0.4.5-next-2025-11-02.1",
 		"@junobuild/errors": "^0.1.4-next-2025-10-30",
 		"@junobuild/functions": "^0.3.3",
 		"@ltd/j-toml": "^1.38.0",

--- a/src/frontend/src/app.d.ts
+++ b/src/frontend/src/app.d.ts
@@ -7,5 +7,3 @@ declare namespace App {
 	// interface Error {}
 	// interface Platform {}
 }
-
-declare const VITE_APP_VERSION: string;

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = VITE_APP_VERSION;
+export const APP_VERSION = import.meta.env.VITE_APP_VERSION;
 
 export const LOCAL_REPLICA_HOST = 'http://localhost:5987';
 
@@ -33,9 +33,9 @@ export const DEFAULT_TCYCLES_TO_RETAIN_ON_DELETION = 0.5;
 
 export const PAGINATION = 10n;
 
+export const CONSOLE_CANISTER_ID = import.meta.env.VITE_CONSOLE_ID;
 export const INTERNET_IDENTITY_CANISTER_ID = 'rdmx6-jaaaa-aaaaa-aaadq-cai';
 export const CMC_CANISTER_ID = 'rkp4c-7iaaa-aaaaa-aaaca-cai';
-export const CONSOLE_CANISTER_ID = 'cokmz-oiaaa-aaaal-aby6q-cai';
 export const OBSERVATORY_CANISTER_ID = 'klbfr-lqaaa-aaaak-qbwsa-cai';
 export const ICP_LEDGER_CANISTER_ID = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
 

--- a/src/frontend/src/lib/services/cdn.services.ts
+++ b/src/frontend/src/lib/services/cdn.services.ts
@@ -1,6 +1,6 @@
 import { isDev } from '$lib/env/app.env';
 import { fetchReleasesMetadata } from '$lib/rest/cdn.rest';
-import { assertNonNullish, isEmptyString } from '@dfinity/utils';
+import { isEmptyString } from '@dfinity/utils';
 import { type ReleasesMetadata, ReleasesMetadataSchema } from '@junobuild/admin';
 
 export const getReleasesMetadata = async (): Promise<ReleasesMetadata> => {
@@ -12,5 +12,5 @@ export const getReleasesMetadata = async (): Promise<ReleasesMetadata> => {
 		return ReleasesMetadataSchema.parse(data);
 	}
 
-	return await fetchReleasesMetadata({ cdnUrl: JUNO_CDN_URL ?? "" });
+	return await fetchReleasesMetadata({ cdnUrl: JUNO_CDN_URL ?? '' });
 };

--- a/src/frontend/src/lib/services/cdn.services.ts
+++ b/src/frontend/src/lib/services/cdn.services.ts
@@ -1,6 +1,6 @@
 import { isDev } from '$lib/env/app.env';
 import { fetchReleasesMetadata } from '$lib/rest/cdn.rest';
-import { isEmptyString } from '@dfinity/utils';
+import { assertNonNullish, isEmptyString } from '@dfinity/utils';
 import { type ReleasesMetadata, ReleasesMetadataSchema } from '@junobuild/admin';
 
 export const getReleasesMetadata = async (): Promise<ReleasesMetadata> => {
@@ -12,5 +12,5 @@ export const getReleasesMetadata = async (): Promise<ReleasesMetadata> => {
 		return ReleasesMetadataSchema.parse(data);
 	}
 
-	return await fetchReleasesMetadata({ cdnUrl: JUNO_CDN_URL });
+	return await fetchReleasesMetadata({ cdnUrl: JUNO_CDN_URL ?? "" });
 };

--- a/src/frontend/src/vite-env.d.ts
+++ b/src/frontend/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+interface ViteTypeOptions {
+	strictImportMetaEnv: unknown;
+}
+
+interface ImportMetaEnv {
+	readonly VITE_APP_VERSION: string;
+	readonly VITE_CONSOLE_ID: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}

--- a/src/frontend/src/vite-env.d.ts
+++ b/src/frontend/src/vite-env.d.ts
@@ -3,8 +3,19 @@ interface ViteTypeOptions {
 }
 
 interface ImportMetaEnv {
+	// package.json
 	readonly VITE_APP_VERSION: string;
+
+	// juno.config.mjs
 	readonly VITE_CONSOLE_ID: string;
+
+	// .env
+	readonly VITE_BN_REGISTRATIONS_URL: string | '' | undefined;
+	readonly VITE_JUNO_CDN_URL: string | '' | undefined;
+	readonly VITE_CYCLE_EXPRESS_URL: string | '' | undefined;
+	readonly VITE_KONGSWAP_API_URL: string | '' | undefined;
+	readonly VITE_ICP_EXPLORER_URL: string | '' | undefined;
+	readonly VITE_EMULATOR_ADMIN_URL: string | '' | undefined;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,10 +36,8 @@ const config: UserConfig = {
 };
 
 export default defineConfig(
-	(): UserConfig => ({
+	async ({ mode }): Promise<UserConfig> => ({
 		...config,
-		define: {
-			...defineViteReplacements()
-		}
+		define: await defineViteReplacements({ mode })
 	})
 );

--- a/vitest.frontend.config.ts
+++ b/vitest.frontend.config.ts
@@ -1,30 +1,31 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { svelteTesting } from '@testing-library/svelte/vite';
+import type { UserConfig } from 'vite';
 import { defineConfig } from 'vitest/config';
 import { defineViteReplacements } from './vite.utils';
 import { defineVitestAlias } from './vitest.utils';
 
-export default defineConfig({
-	plugins: [sveltekit(), svelteTesting()],
-	define: {
-		...defineViteReplacements()
-	},
-	test: {
-		setupFiles: ['./vitest.setup.ts'],
-		globals: true,
-		watch: false,
-		silent: false,
-		reporters: [
-			[
-				'default',
-				{
-					summary: false
-				}
-			]
-		],
-		environment: 'jsdom'
-	},
-	resolve: {
-		alias: defineVitestAlias()
-	}
-});
+export default defineConfig(
+	async ({ mode }): Promise<UserConfig> => ({
+		plugins: [sveltekit(), svelteTesting()],
+		define: await defineViteReplacements({ mode }),
+		test: {
+			setupFiles: ['./vitest.setup.ts'],
+			globals: true,
+			watch: false,
+			silent: false,
+			reporters: [
+				[
+					'default',
+					{
+						summary: false
+					}
+				]
+			],
+			environment: 'jsdom'
+		},
+		resolve: {
+			alias: defineVitestAlias()
+		}
+	})
+);


### PR DESCRIPTION
# Motivation

I'm going to need Google client_id in #2184 and I do not want to duplicate it. Therefore, this PR which reads the `juno.config` and injects environment variables.

I also refactor the way I deal with the APP_VERSION and add typing (as described in vite [documentation](https://vite.dev/guide/env-and-mode.html#intellisense-for-typescript))
