### PR TITLE
fix(frontend): disable utter annoying AuthClient console.warn

### DIFF
--- a/src/frontend/src/lib/providers/auth-client.provider.ts
+++ b/src/frontend/src/lib/providers/auth-client.provider.ts
@@ -9,14 +9,24 @@ class AuthClientProvider {
 		this.#storage = new IdbStorage();
 	}
 
-	createAuthClient = (): Promise<AuthClient> =>
-		AuthClient.create({
-			storage: this.#storage,
-			idleOptions: {
-				disableIdle: true,
-				disableDefaultIdleCallback: true
-			}
-		});
+	createAuthClient = async (): Promise<AuthClient> => {
+		// TODO: Workaround for agent-js. Disable utter annoying console.warn used as pseudo documentation.
+		const hideAgentJsConsoleWarn = globalThis.console.warn;
+		globalThis.console.warn = (): null => null;
+
+		try {
+			return await AuthClient.create({
+				storage: this.#storage,
+				idleOptions: {
+					disableIdle: true,
+					disableDefaultIdleCallback: true
+				}
+			});
+		} finally {
+			// Redo console.warn
+			globalThis.console.warn = hideAgentJsConsoleWarn;
+		}
+	};
 
 	/**
 	 * Since icp-js-core persists identity keys in IndexedDB by default,


### PR DESCRIPTION
# Motivation

I hate when a library prints anything to the debugger `console`, using it is meant for debugging purposes and not pseudo documentation.

I classify it as "utter" annoying because it's not the first time I have to implement a workaround to disable logs from those AgentJS libraries nor that I reported it, so it annoys me.
