### PR TITLE
feat(frontend): auth-client provider singleton

### DIFF
--- a/src/frontend/src/lib/providers/auth-client.provider.ts
+++ b/src/frontend/src/lib/providers/auth-client.provider.ts
@@ -5,14 +5,25 @@ import {
 	KEY_STORAGE_KEY
 } from '@dfinity/auth-client';
 import type { DelegationChain, ECDSAKeyIdentity } from '@dfinity/identity';
+import { isNullish } from '@dfinity/utils';
 
-class AuthClientProvider {
+export class AuthClientProvider {
+	static #instance: AuthClientProvider;
+
 	// We use a dedicated storage for the auth client to better manage it, e.g. clear it for a new login.
 	// It is similar as the default fallback option of AgentJS.
 	readonly #storage: IdbStorage;
 
-	constructor() {
+	private constructor() {
 		this.#storage = new IdbStorage();
+	}
+
+	static getInstance(): AuthClientProvider {
+		if (isNullish(this.#instance)) {
+			this.#instance = new AuthClientProvider();
+		}
+
+		return this.#instance;
 	}
 
 	createAuthClient = async (): Promise<AuthClient> => {
@@ -57,21 +68,7 @@ class AuthClientProvider {
 		]);
 	};
 
-	get storage(): IdbStorage {
+	get __test_only_auth_client_storage__(): IdbStorage {
 		return this.#storage;
 	}
 }
-
-const {
-	storage: __test_only_auth_client_storage__,
-	createAuthClient,
-	safeCreateAuthClient,
-	setAuthClientStorage
-} = new AuthClientProvider();
-
-export {
-	__test_only_auth_client_storage__,
-	createAuthClient,
-	safeCreateAuthClient,
-	setAuthClientStorage
-};

--- a/src/frontend/src/lib/services/auth/auth.openid.services.ts
+++ b/src/frontend/src/lib/services/auth/auth.openid.services.ts
@@ -1,5 +1,5 @@
 import { CONSOLE_CANISTER_ID, GOOGLE_CLIENT_ID } from '$lib/constants/app.constants';
-import { setAuthClientStorage } from '$lib/providers/auth-client.provider';
+import { AuthClientProvider } from '$lib/providers/auth-client.provider';
 import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toasts } from '$lib/stores/toasts.store';
@@ -41,7 +41,7 @@ const authenticateWithGoogle = async () => {
 		}
 	});
 
-	await setAuthClientStorage({
+	await AuthClientProvider.getInstance().setAuthClientStorage({
 		delegationChain,
 		sessionKey
 	});

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -1,5 +1,5 @@
 import { AuthBroadcastChannel } from '$lib/providers/auth-broadcast.provider';
-import { createAuthClient, safeCreateAuthClient } from '$lib/providers/auth-client.provider';
+import { AuthClientProvider } from '$lib/providers/auth-client.provider';
 import type { SignInWithAuthClient, SignInWithNewAuthClient } from '$lib/types/auth';
 import { SignInInitError } from '$lib/types/errors';
 import type { OptionIdentity } from '$lib/types/itentity';
@@ -34,6 +34,8 @@ const initAuthStore = (): AuthStore => {
 			return authClient;
 		}
 
+		const { createAuthClient, safeCreateAuthClient } = AuthClientProvider.getInstance();
+
 		const refreshed = await createAuthClient();
 
 		if (await refreshed.isAuthenticated()) {
@@ -48,7 +50,9 @@ const initAuthStore = (): AuthStore => {
 	};
 
 	const sync = async ({ forceSync }: { forceSync: boolean }) => {
-		authClient = forceSync ? await createAuthClient() : await pickAuthClient();
+		authClient = forceSync
+			? await AuthClientProvider.getInstance().createAuthClient()
+			: await pickAuthClient();
 
 		const isAuthenticated = await authClient.isAuthenticated();
 
@@ -102,6 +106,8 @@ const initAuthStore = (): AuthStore => {
 		},
 
 		signOut: async () => {
+			const { createAuthClient } = AuthClientProvider.getInstance();
+
 			const client: AuthClient = authClient ?? (await createAuthClient());
 
 			await client.logout();

--- a/src/frontend/src/lib/utils/worker.utils.ts
+++ b/src/frontend/src/lib/utils/worker.utils.ts
@@ -1,11 +1,11 @@
-import { createAuthClient } from '$lib/providers/auth-client.provider';
+import { AuthClientProvider } from '$lib/providers/auth-client.provider';
 import type { Canister } from '$lib/types/canister';
 import type { Identity } from '@dfinity/agent';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { getMany, type UseStore } from 'idb-keyval';
 
 export const loadIdentity = async (): Promise<Identity | null> => {
-	const authClient = await createAuthClient();
+	const authClient = await AuthClientProvider.getInstance().createAuthClient();
 
 	if (!(await authClient.isAuthenticated())) {
 		return null;

--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -1,7 +1,7 @@
 import { AUTH_TIMER_INTERVAL } from '$lib/constants/app.constants';
-import { createAuthClient } from '$lib/providers/auth-client.provider';
+import { AuthClientProvider } from '$lib/providers/auth-client.provider';
 import type { PostMessageRequest } from '$lib/types/post-message';
-import { IdbStorage, KEY_STORAGE_DELEGATION, type AuthClient } from '@dfinity/auth-client';
+import { IdbStorage, KEY_STORAGE_DELEGATION } from '@dfinity/auth-client';
 import { DelegationChain, isDelegationValid } from '@dfinity/identity';
 
 export const onAuthMessage = async ({
@@ -55,7 +55,7 @@ const onIdleSignOut = async () => {
  * @returns true if authenticated
  */
 const checkAuthentication = async (): Promise<boolean> => {
-	const authClient: AuthClient = await createAuthClient();
+	const authClient = await AuthClientProvider.getInstance().createAuthClient();
 	return authClient.isAuthenticated();
 };
 

--- a/src/frontend/tests/lib/providers/auth-client.provider.test.ts
+++ b/src/frontend/tests/lib/providers/auth-client.provider.test.ts
@@ -1,11 +1,13 @@
-import {
-	__test_only_auth_client_storage__ as authClientStorage,
-	createAuthClient,
-	safeCreateAuthClient
-} from '$lib/providers/auth-client.provider';
+import { AuthClientProvider } from '$lib/providers/auth-client.provider';
 import { AuthClient, KEY_STORAGE_DELEGATION, KEY_STORAGE_KEY } from '@dfinity/auth-client';
 
 describe('auth-client.provider', () => {
+	const {
+		__test_only_auth_client_storage__: authClientStorage,
+		createAuthClient,
+		safeCreateAuthClient
+	} = AuthClientProvider.getInstance();
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 


### PR DESCRIPTION
# Motivation

I'm afraid that having the idb storage being created at the root leads to the same random issue as in OISY when idb is not yet open at boot time. Therefore, I modify the provider to become an instance.
