### PR TITLE
feat(frontend): mission control in store, not just id

### DIFF
--- a/src/frontend/src/lib/derived/mission-control.derived.ts
+++ b/src/frontend/src/lib/derived/mission-control.derived.ts
@@ -1,14 +1,16 @@
-import { missionControlIdCertifiedStore } from '$lib/stores/mission-control.store';
+import { missionControlCertifiedStore } from '$lib/stores/mission-control.store';
+import { fromNullable } from '@dfinity/utils';
 import { derived } from 'svelte/store';
 
 // TODO: find a better name but, I don't want to use missionControlId because it would clashes with the properties called missionControlId
 export const missionControlIdDerived = derived(
-	[missionControlIdCertifiedStore],
-	([$missionControlDataStore]) => $missionControlDataStore?.data
+	[missionControlCertifiedStore],
+	([$missionControlDataStore]) =>
+		fromNullable($missionControlDataStore?.data.mission_control_id ?? [])
 );
 
 export const missionControlIdLoaded = derived(
-	[missionControlIdCertifiedStore],
+	[missionControlCertifiedStore],
 	([$missionControlIdCertifiedStore]) => $missionControlIdCertifiedStore !== undefined
 );
 

--- a/src/frontend/src/lib/services/console.services.ts
+++ b/src/frontend/src/lib/services/console.services.ts
@@ -5,10 +5,9 @@ import {
 } from '$lib/api/console.api';
 import { missionControlErrorSignOut } from '$lib/services/auth/auth.services';
 import { i18n } from '$lib/stores/i18n.store';
-import { missionControlIdCertifiedStore } from '$lib/stores/mission-control.store';
+import { missionControlCertifiedStore } from '$lib/stores/mission-control.store';
 import { toasts } from '$lib/stores/toasts.store';
 import type { OptionIdentity } from '$lib/types/itentity';
-import type { MissionControlId } from '$lib/types/mission-control';
 import type { Identity } from '@dfinity/agent';
 import { fromNullable, isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
@@ -18,7 +17,7 @@ interface Certified {
 }
 
 type PollAndInitResult = {
-	missionControlId: MissionControlId;
+	missionControl: ConsoleDid.MissionControl;
 } & Certified;
 
 export const initMissionControl = async ({
@@ -33,12 +32,12 @@ export const initMissionControl = async ({
 
 	try {
 		// Poll to init mission control center
-		const { missionControlId, certified } = await pollAndInitMissionControl({
+		const { missionControl, certified } = await pollAndInitMissionControl({
 			identity
 		});
 
-		missionControlIdCertifiedStore.set({
-			data: missionControlId,
+		missionControlCertifiedStore.set({
+			data: missionControl,
 			certified
 		});
 
@@ -72,9 +71,11 @@ const pollAndInitMissionControl = async ({
 	// eslint-disable-next-line no-async-promise-executor
 	new Promise<PollAndInitResult>(async (resolve, reject) => {
 		try {
-			const { missionControlId, certified } = await getOrInitMissionControlId({
+			const { missionControl, certified } = await getOrInitMissionControl({
 				identity
 			});
+
+			const missionControlId = fromNullable(missionControl.mission_control_id);
 
 			// TODO: we can/should probably add a max time to not retry forever even though the user will probably close their browsers.
 			if (isNullish(missionControlId)) {
@@ -89,28 +90,11 @@ const pollAndInitMissionControl = async ({
 				return;
 			}
 
-			resolve({ missionControlId, certified });
+			resolve({ missionControl, certified });
 		} catch (err: unknown) {
 			reject(err);
 		}
 	});
-
-const getOrInitMissionControlId = async (params: {
-	identity: Identity;
-}): Promise<
-	{
-		missionControlId: MissionControlId | undefined;
-	} & Certified
-> => {
-	const { missionControl, certified } = await getOrInitMissionControl(params);
-
-	const missionControlId = fromNullable(missionControl.mission_control_id);
-
-	return {
-		missionControlId,
-		certified
-	};
-};
 
 export const getOrInitMissionControl = async ({
 	identity

--- a/src/frontend/src/lib/stores/mission-control.store.ts
+++ b/src/frontend/src/lib/stores/mission-control.store.ts
@@ -1,9 +1,8 @@
-import type { MissionControlDid } from '$declarations';
+import type { ConsoleDid, MissionControlDid } from '$declarations';
 import { initCertifiedStore } from '$lib/stores/_certified.store';
 import { initUncertifiedStore } from '$lib/stores/_uncertified.store';
-import type { MissionControlId } from '$lib/types/mission-control';
 
-export const missionControlIdCertifiedStore = initCertifiedStore<MissionControlId>();
+export const missionControlCertifiedStore = initCertifiedStore<ConsoleDid.MissionControl>();
 
 export const missionControlUserUncertifiedStore = initUncertifiedStore<MissionControlDid.User>();
 


### PR DESCRIPTION
# Motivation

We need the all mission control entity received from the Console in store, this way we can display the openid provider data.
