### PR TITLE
feat(frontend): reuse sign-in actions and go to home

### DIFF
--- a/src/frontend/src/lib/components/guards/IdentityGuard.svelte
+++ b/src/frontend/src/lib/components/guards/IdentityGuard.svelte
@@ -12,6 +12,8 @@
 
 {#if $authStore.identity === null}
 	<p>{$i18n.core.not_logged_in}</p>
+
+	<a class="button" href="/">{$i18n.not_found.go_home}</a>
 {:else}
 	{@render children()}
 {/if}

--- a/src/frontend/src/lib/components/sign-in/SignIn.svelte
+++ b/src/frontend/src/lib/components/sign-in/SignIn.svelte
@@ -3,6 +3,7 @@
 	import SignInII from '$lib/components/sign-in/SignInII.svelte';
 	import ContainerCentered from '$lib/components/ui/ContainerCentered.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import SignInActions from '$lib/components/sign-in/SignInActions.svelte';
 
 	let quotes: string[] = $derived([
 		$i18n.sign_in.quote_1,
@@ -24,11 +25,7 @@
 	<h1>{title}</h1>
 
 	{#snippet action()}
-		<div class="sign-in">
-			<SignInGoogle />
-
-			<SignInII />
-		</div>
+		<SignInActions />
 	{/snippet}
 </ContainerCentered>
 
@@ -46,10 +43,5 @@
 		@include media.min-width(large) {
 			--bigger-title: 1.4;
 		}
-	}
-
-	.sign-in {
-		display: flex;
-		flex-direction: column;
 	}
 </style>

--- a/src/frontend/src/lib/components/sign-in/SignInActions.svelte
+++ b/src/frontend/src/lib/components/sign-in/SignInActions.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import SignInGoogle from '$lib/components/sign-in/SignInGoogle.svelte';
+	import SignInII from '$lib/components/sign-in/SignInII.svelte';
+</script>
+
+<div class="sign-in">
+	<SignInGoogle />
+
+	<SignInII />
+</div>
+
+<style lang="scss">
+	.sign-in {
+		display: flex;
+		flex-direction: column;
+
+		width: fit-content;
+	}
+</style>

--- a/src/frontend/src/routes/(standalone)/cli/+page.svelte
+++ b/src/frontend/src/routes/(standalone)/cli/+page.svelte
@@ -8,10 +8,12 @@
 	import { missionControlIdDerived } from '$lib/derived/mission-control.derived';
 	import { sortedSatellites } from '$lib/derived/satellites.derived';
 	import { onIntersection } from '$lib/directives/intersection.directives';
-	import { signInWithII } from '$lib/services/auth/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { onLayoutTitleIntersection } from '$lib/stores/layout-intersecting.store';
 	import type { Option } from '$lib/types/utils';
+	import SignInActions from '$lib/components/sign-in/SignInActions.svelte';
+	import ContainerCentered from '$lib/components/ui/ContainerCentered.svelte';
+	import Message from '$lib/components/ui/Message.svelte';
 
 	interface Props {
 		data: {
@@ -46,13 +48,29 @@
 				</MetadataLoader>
 			</MissionControlGuard>
 		{:else}
-			<p>
-				{$i18n.cli.sign_in}
-			</p>
+			<ContainerCentered>
+				<p>
+					{$i18n.cli.sign_in}
+				</p>
 
-			<button onclick={signInWithII}>{$i18n.core.sign_in}</button>
+				<SignInActions />
+			</ContainerCentered>
 		{/if}
 	{:else}
-		<p>{$i18n.errors.cli_missing_params}</p>
+		<ContainerCentered>
+			<Message>
+				{#snippet icon()}
+					<span>❌</span>
+				{/snippet}
+
+				<p>{$i18n.errors.cli_missing_params}</p>
+			</Message>
+		</ContainerCentered>
 	{/if}
 </div>
+
+<style lang="scss">
+	p {
+		max-width: 450px;
+	}
+</style>


### PR DESCRIPTION
# Motivation

I removed the sign-in button top-right so need a "go home" and also we need the sign-in on the cli page.
