### PR TITLE
feat(auth): deprecate support for sign-in with NFID

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthProviders.svelte
+++ b/src/frontend/src/lib/components/auth/AuthProviders.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import IconIc from '$lib/components/icons/IconIC.svelte';
-	import IconNFID from '$lib/components/icons/IconNFID.svelte';
 	import IconPasskey from '$lib/components/icons/IconPasskey.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>
@@ -17,11 +16,6 @@
 		<tbody>
 			<tr>
 				<td><span class="provider"><IconIc /> Internet Identity</span></td>
-				<td class="status">{$i18n.core.enabled}</td>
-			</tr>
-
-			<tr>
-				<td><span class="provider"><IconNFID /> NFID</span></td>
 				<td class="status">{$i18n.core.enabled}</td>
 			</tr>
 

--- a/src/libs/satellite/src/user/core/types.rs
+++ b/src/libs/satellite/src/user/core/types.rs
@@ -13,6 +13,7 @@ pub mod state {
     #[serde(rename_all = "snake_case")]
     pub enum AuthProvider {
         InternetIdentity,
+        #[deprecated(note = "Support for NFID is deprecated in the tooling and documentation")]
         Nfid,
         #[serde(rename = "webauthn")]
         WebAuthn,


### PR DESCRIPTION
# Motivation

I get the feeling that NFID is now more of a wallet than an authentication provider "à la Internet Identity". On top of that, the current login provider UI appears visually broken (see screenshot). I'm also not aware of anyone using NFID sign-in in the Juno ecosystem. Since I'm about to rewrite the authentication documentation to introduce OpenID support, I’m considering deprecating it.

To be clear, I won’t remove the field on the backend, and it will remain an option in the JS library for now but, won't appear in the documentation or as being enabled in the Console UI.

<img width="617" height="817" alt="Capture d’écran 2025-11-03 à 21 36 41" src="https://github.com/user-attachments/assets/457ad4e7-8a1c-49df-8967-183c0dcc51db" />

