### PR TITLE
feat(frontend): split auth core and ii config

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthConfigCore.svelte
+++ b/src/frontend/src/lib/components/auth/AuthConfigCore.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import { fromNullishNullable, isNullish, nonNullish } from '@dfinity/utils';
+	import { fade } from 'svelte/transition';
+	import type { SatelliteDid } from '$declarations';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { JunoModalEditAuthConfigDetail } from '$lib/types/modal';
+	import { i18nFormat } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		config: SatelliteDid.AuthenticationConfig | undefined;
+		rule: SatelliteDid.Rule | undefined;
+		supportConfig: boolean;
+		supportSettings: boolean;
+		openModal: (params: Pick<JunoModalEditAuthConfigDetail, 'edit'>) => Promise<void>;
+	}
+
+	let { config, rule, supportConfig, supportSettings, openModal }: Props = $props();
+
+	let allowedCallers = $derived(fromNullishNullable(config?.rules)?.allowed_callers);
+
+	let maxTokens: number | undefined = $state(undefined);
+
+	$effect(() => {
+		const rateConfig = fromNullishNullable(rule?.rate_config);
+		maxTokens = nonNullish(rateConfig?.max_tokens) ? Number(rateConfig.max_tokens) : undefined;
+	});
+</script>
+
+<div class="card-container with-title">
+	<span class="title">{$i18n.core.config}</span>
+
+	<div class="columns-3 fit-column-1">
+		<div>
+			{#if supportSettings}
+				<div in:fade>
+					<Value>
+						{#snippet label()}
+							{$i18n.collections.rate_limit}
+						{/snippet}
+
+						{#if isNullish(rule)}
+							<p><SkeletonText /></p>
+						{:else if isNullish(maxTokens)}
+							<p>{$i18n.collections.no_rate_limit}</p>
+						{:else}
+							<p>{maxTokens}</p>
+						{/if}
+					</Value>
+				</div>
+			{/if}
+		</div>
+
+		<div>
+			{#if supportConfig}
+				<div in:fade>
+					<Value>
+						{#snippet label()}
+							{$i18n.authentication.allowed_callers}
+						{/snippet}
+
+						{#if isNullish(allowedCallers) || allowedCallers.length === 0}
+							<p>{$i18n.authentication.no_restrictions}</p>
+						{:else if allowedCallers.length === 1}
+							<p>{$i18n.authentication.one_identity}</p>
+						{:else}
+							<p>
+								{i18nFormat($i18n.authentication.identities, [
+									{
+										placeholder: '{0}',
+										value: `${allowedCallers.length}`
+									}
+								])}
+							</p>
+						{/if}
+					</Value>
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<button
+	disabled={!supportConfig || !supportSettings}
+	onclick={async () => await openModal({ edit: 'core' })}
+	in:fade>{$i18n.core.edit_config}</button
+>
+
+<style lang="scss">
+	@use '../../styles/mixins/text';
+	@use '../../styles/mixins/media';
+
+	.card-container {
+		min-height: 168px;
+
+		@include media.min-width(medium) {
+			min-height: 94px;
+		}
+	}
+
+	p {
+		@include media.min-width(medium) {
+			margin: 0;
+		}
+
+		@include text.truncate;
+	}
+
+	button {
+		margin: 0 0 var(--padding-8x);
+	}
+</style>

--- a/src/frontend/src/lib/components/auth/AuthConfigII.svelte
+++ b/src/frontend/src/lib/components/auth/AuthConfigII.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { fromNullishNullable, isNullish, nonNullish } from '@dfinity/utils';
+	import { fade } from 'svelte/transition';
+	import type { SatelliteDid } from '$declarations';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { JunoModalEditAuthConfigDetail } from '$lib/types/modal';
+
+	interface Props {
+		config: SatelliteDid.AuthenticationConfig | undefined;
+		supportConfig: boolean;
+		openModal: (params: Pick<JunoModalEditAuthConfigDetail, 'edit'>) => Promise<void>;
+	}
+
+	let { config, supportConfig, openModal }: Props = $props();
+
+	let derivationOrigin = $derived(
+		fromNullishNullable(fromNullishNullable(config?.internet_identity)?.derivation_origin)
+	);
+	let externalAlternativeOrigins = $derived(
+		fromNullishNullable(
+			fromNullishNullable(config?.internet_identity)?.external_alternative_origins
+		)
+	);
+</script>
+
+<div class="card-container with-title">
+	<span class="title">Internet Identity</span>
+
+	<div class="columns-3 fit-column-1">
+		<div>
+			{#if supportConfig}
+				<div in:fade>
+					<Value>
+						{#snippet label()}
+							{$i18n.authentication.main_domain}
+						{/snippet}
+
+						{#if isNullish(derivationOrigin)}
+							<p>{$i18n.authentication.not_configured}</p>
+						{:else}
+							<p>{derivationOrigin}</p>
+						{/if}
+					</Value>
+				</div>
+
+				{#if nonNullish(externalAlternativeOrigins)}
+					<div in:fade>
+						<Value>
+							{#snippet label()}
+								{$i18n.authentication.external_alternative_origins}
+							{/snippet}
+
+							<p>{externalAlternativeOrigins.join(',')}</p>
+						</Value>
+					</div>
+				{/if}
+			{/if}
+		</div>
+	</div>
+</div>
+
+<button
+	disabled={!supportConfig}
+	onclick={async () => await openModal({ edit: 'internet_identity' })}
+	in:fade>{$i18n.core.configure}</button
+>
+
+<style lang="scss">
+	@use '../../styles/mixins/text';
+	@use '../../styles/mixins/media';
+
+	.card-container {
+		min-height: 94px;
+
+		@include media.min-width(medium) {
+			min-height: 94px;
+		}
+	}
+
+	p {
+		@include media.min-width(medium) {
+			margin: 0;
+		}
+
+		@include text.truncate;
+	}
+
+	button {
+		margin: 0 0 var(--padding-8x);
+	}
+</style>

--- a/src/frontend/src/lib/components/modals/AuthConfigModal.svelte
+++ b/src/frontend/src/lib/components/modals/AuthConfigModal.svelte
@@ -23,6 +23,8 @@
 
 	let config = $state((detail as JunoModalEditAuthConfigDetail).config);
 
+	let edit = $state((detail as JunoModalEditAuthConfigDetail).edit);
+
 	let maxTokens = $state<number | undefined>(undefined);
 
 	let selectedDerivationOrigin = $state<URL | undefined>(undefined);
@@ -76,6 +78,7 @@
 	{:else}
 		<AuthConfigForm
 			{config}
+			{edit}
 			onsubmit={handleSubmit}
 			{rule}
 			{satellite}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -364,6 +364,8 @@
 		"main_domain": "Main domain (\"derivation origin\")",
 		"not_configured": "Not configured",
 		"edit_configuration": "Update the configuration of your authentication using the form below.",
+		"edit_internet_identity": "Configure the Internet Identity settings below.",
+		"edit_google": "Configure the Google authentication settings below.",
 		"main_domain_warn": "You are about to change your primary domain. Please ensure this is the desired action, as all existing users will no longer be recognized by your app.",
 		"external_alternative_origins": "External alternative origins",
 		"external_alternative_origins_placeholder": "A comma-separated list of external domains to allow for derivation",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -364,6 +364,8 @@
 		"main_domain": "主域名（\"派生源\"）",
 		"not_configured": "未配置",
 		"edit_configuration": "使用下面的表单更新您的身份认证配置。",
+		"edit_internet_identity": "在下方配置 Internet Identity 设置。",
+		"edit_google": "在下方配置 Google 身份验证设置。",
 		"main_domain_warn": "您即将更改主域名。请确认这是您期望的操作，因为所有现存用户将不再被您的应用识别。",
 		"external_alternative_origins": "外部备用源",
 		"external_alternative_origins_placeholder": "以逗号分隔的外部域名列表，用于允许派生",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -374,6 +374,8 @@ interface I18nAuthentication {
 	main_domain: string;
 	not_configured: string;
 	edit_configuration: string;
+	edit_internet_identity: string;
+	edit_google: string;
 	main_domain_warn: string;
 	external_alternative_origins: string;
 	external_alternative_origins_placeholder: string;

--- a/src/frontend/src/lib/types/modal.ts
+++ b/src/frontend/src/lib/types/modal.ts
@@ -92,6 +92,7 @@ export interface JunoModalEditOrbiterConfigDetail {
 export interface JunoModalEditAuthConfigDetail extends JunoModalWithSatellite {
 	rule: SatelliteDid.Rule | undefined;
 	config: SatelliteDid.AuthenticationConfig | undefined;
+	edit: 'core' | 'internet_identity';
 }
 
 export interface JunoModalCreateMonitoringStrategyDetail {


### PR DESCRIPTION
# Motivation

We want to introduce configuring Google so we first refactor the screen and modal to split core and Internet Identity config.

<img width="1533" height="1034" alt="Capture d’écran 2025-11-04 à 08 43 06" src="https://github.com/user-attachments/assets/926ab3bb-b2b9-4bea-bd92-a960e8c6bfc9" />


