### PR TITLE
chore(tools): requires junobuild-didc v0.2.0

### DIFF
--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -54,7 +54,7 @@ install_tool() {
 install_tool ic-wasm 0.8.5
 install_tool wasi2ic 0.2.16
 install_tool candid-extractor 0.1.6
-install_tool junobuild-didc 0.1.1
+install_tool junobuild-didc 0.2.0
 
 # make sure the packages are actually installed (rustup waits for the first invoke to lazyload)
 cargo --version

--- a/scripts/did.idl.sh
+++ b/scripts/did.idl.sh
@@ -16,11 +16,11 @@ function generate_did_idl() {
 
 # Assert junobuild-didc is installed
 
-if [[ ! "$(command -v junobuild-didc)" || "$(junobuild-didc --version)" != "junobuild-didc 0.1.1" ]]
+if [[ ! "$(command -v junobuild-didc)" || "$(junobuild-didc --version)" != "junobuild-didc 0.2.0" ]]
 then
-    echo "could not find junobuild-didc 0.1.1"
-    echo "junobuild-didc version 0.1.1 is needed, please run the following command:"
-    echo "  cargo install junobuild-didc --version 0.1.1"
+    echo "could not find junobuild-didc 0.2.0"
+    echo "junobuild-didc version 0.2.0 is needed, please run the following command:"
+    echo "  cargo install junobuild-didc --version 0.2.0"
     exit 1
 fi
 


### PR DESCRIPTION
# Motivation

Required to generate imports with `@icp-sdk/core`.