### PR TITLE
chore(auth): remove refactoring todo

### DIFF
--- a/src/libs/auth/src/openid/jwt/kid.rs
+++ b/src/libs/auth/src/openid/jwt/kid.rs
@@ -3,8 +3,6 @@ use crate::openid::jwt::types::errors::JwtFindKidError;
 use crate::openid::jwt::types::token::UnsafeClaims;
 use jsonwebtoken::dangerous;
 
-// TODO: refactor decode_jwt_header for perf reason
-
 /// ⚠️ **Warning:** This function decodes the JWT *without verifying its signature*.
 /// Use only to inspect the header (e.g., `kid`) before performing a verified decode
 /// before finalizing any task.


### PR DESCRIPTION
# Motivation

From a performance perspective there wouldn't be a big win and from a code architectural perspective, it's clean to have an assertion before any sensible usage of the jwt.
