### PR TITLE
chore(modules): set release version for Satellite, Console, Observatory and Sputnik

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "candid",
  "ciborium",
@@ -1893,7 +1893,7 @@ checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "satellite"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "sputnik"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "candid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "observatory"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "candid",
  "ciborium",

--- a/src/console/Cargo.toml
+++ b/src/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 publish = false
 

--- a/src/observatory/Cargo.toml
+++ b/src/observatory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "observatory"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/src/satellite/Cargo.toml
+++ b/src/satellite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satellite"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 

--- a/src/sputnik/Cargo.toml
+++ b/src/sputnik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnik"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
# Motivation

We want to release the support for the authentication with Google.
