### PR TITLE
feat(auth): make refresh_allowed generic

### DIFF
--- a/src/libs/auth/src/asserts/types.rs
+++ b/src/libs/auth/src/asserts/types.rs
@@ -1,6 +1,13 @@
+use crate::delegation::types::Timestamp;
+
 pub enum RefreshStatus {
     AllowedFirstFetch,
     AllowedAfterCooldown,
     AllowedRetry,
     Denied,
+}
+
+pub trait AssertRefreshRecord {
+    fn last_attempt_at(&self) -> Timestamp;
+    fn last_attempt_streak_count(&self) -> u8;
 }

--- a/src/libs/auth/src/state/impls.rs
+++ b/src/libs/auth/src/state/impls.rs
@@ -1,3 +1,4 @@
+use crate::asserts::types::AssertRefreshRecord;
 use crate::openid::types::provider::OpenIdCertificate;
 use crate::state::types::config::AuthenticationConfig;
 use crate::state::types::interface::SetAuthenticationConfig;
@@ -72,5 +73,14 @@ impl OpenIdCachedCertificate {
     pub fn update_certificate(&mut self, certificate: &OpenIdCertificate) {
         self.certificate = Some(certificate.clone());
         self.last_fetch_attempt.streak_count = 0;
+    }
+}
+
+impl AssertRefreshRecord for OpenIdCachedCertificate {
+    fn last_attempt_at(&self) -> u64 {
+        self.last_fetch_attempt.at
+    }
+    fn last_attempt_streak_count(&self) -> u8 {
+        self.last_fetch_attempt.streak_count
     }
 }


### PR DESCRIPTION
# Motivation

This way we can reuse the logic for refresh_allowed
