### PR TITLE
feat(observatory): get_openid_certificate as update

### DIFF
--- a/src/declarations/observatory/observatory.factory.did.js
+++ b/src/declarations/observatory/observatory.factory.did.js
@@ -115,11 +115,7 @@ export const idlFactory = ({ IDL }) => {
 	return IDL.Service({
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		get_notify_status: IDL.Func([GetNotifications], [NotifyStatus], ['query']),
-		get_openid_certificate: IDL.Func(
-			[GetOpenIdCertificateArgs],
-			[IDL.Opt(OpenIdCertificate)],
-			['query']
-		),
+		get_openid_certificate: IDL.Func([GetOpenIdCertificateArgs], [IDL.Opt(OpenIdCertificate)], []),
 		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], ['query']),
 		notify: IDL.Func([NotifyArgs], [], []),
 		ping: IDL.Func([NotifyArgs], [], []),

--- a/src/declarations/observatory/observatory.factory.did.mjs
+++ b/src/declarations/observatory/observatory.factory.did.mjs
@@ -115,11 +115,7 @@ export const idlFactory = ({ IDL }) => {
 	return IDL.Service({
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		get_notify_status: IDL.Func([GetNotifications], [NotifyStatus], ['query']),
-		get_openid_certificate: IDL.Func(
-			[GetOpenIdCertificateArgs],
-			[IDL.Opt(OpenIdCertificate)],
-			['query']
-		),
+		get_openid_certificate: IDL.Func([GetOpenIdCertificateArgs], [IDL.Opt(OpenIdCertificate)], []),
 		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], ['query']),
 		notify: IDL.Func([NotifyArgs], [], []),
 		ping: IDL.Func([NotifyArgs], [], []),

--- a/src/observatory/observatory.did
+++ b/src/observatory/observatory.did
@@ -89,7 +89,7 @@ service : () -> {
   get_notify_status : (GetNotifications) -> (NotifyStatus) query;
   get_openid_certificate : (GetOpenIdCertificateArgs) -> (
       opt OpenIdCertificate,
-    ) query;
+    );
   list_controllers : () -> (vec record { principal; Controller }) query;
   notify : (NotifyArgs) -> ();
   ping : (NotifyArgs) -> ();

--- a/src/observatory/src/api/openid.rs
+++ b/src/observatory/src/api/openid.rs
@@ -1,7 +1,7 @@
 use crate::guards::{caller_is_admin_controller, caller_is_not_anonymous};
 use crate::openid::scheduler::{start_openid_scheduler, stop_openid_scheduler};
 use crate::store::heap::get_certificate;
-use ic_cdk_macros::{query, update};
+use ic_cdk_macros::{update};
 use junobuild_auth::openid::jwkset::types::interface::GetOpenIdCertificateArgs;
 use junobuild_auth::openid::types::provider::OpenIdCertificate;
 use junobuild_shared::ic::UnwrapOrTrap;
@@ -16,7 +16,7 @@ fn stop_openid_monitoring() {
     stop_openid_scheduler().unwrap_or_trap()
 }
 
-#[query(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_not_anonymous")]
 fn get_openid_certificate(
     GetOpenIdCertificateArgs { provider }: GetOpenIdCertificateArgs,
 ) -> Option<OpenIdCertificate> {


### PR DESCRIPTION
# Motivation

Notably for #2231 - and because it was fundamentally conceptualized as such - we want `get_openid_certificate` to be an update
