### PR TITLE
feat(observatory): redo query for get_openid_certificate

### DIFF
--- a/src/declarations/_factory.ts
+++ b/src/declarations/_factory.ts
@@ -20,6 +20,7 @@ import { idlFactory as idlFactoryCertifiedIC } from '$declarations/ic-management
 import { idlFactory as idlFactoryIC } from '$declarations/ic-management/ic-management.factory.did';
 import { idlFactory as idlFactoryMissionControl } from '$declarations/mission_control/mission_control.factory.did';
 import { idlFactory as idlFactoryObservatory } from '$declarations/observatory/observatory.factory.did';
+import { idlFactory as idlFactoryCertifiedObservatory } from '$declarations/observatory/observatory.factory.certified.did';
 import { idlFactory as idlFactoryOrbiter } from '$declarations/orbiter/orbiter.factory.did';
 import { idlFactory as idlFactorySatellite } from '$declarations/satellite/satellite.factory.did';
 import { idlFactory as idlFactorySputnik } from '$declarations/sputnik/sputnik.factory.did';
@@ -60,6 +61,7 @@ export {
 	idlFactoryMissionControl0014,
 	idlFactoryMissionControl004,
 	idlFactoryObservatory,
+	idlFactoryCertifiedObservatory,
 	idlFactoryObservatory009,
 	idlFactoryOrbiter,
 	idlFactoryOrbiter006,

--- a/src/observatory/src/api/openid.rs
+++ b/src/observatory/src/api/openid.rs
@@ -4,7 +4,7 @@ use crate::guards::{
 };
 use crate::openid::scheduler::{start_openid_scheduler, stop_openid_scheduler};
 use crate::store::heap::get_certificate;
-use ic_cdk_macros::update;
+use ic_cdk_macros::{query, update};
 use junobuild_auth::openid::jwkset::types::interface::GetOpenIdCertificateArgs;
 use junobuild_auth::openid::types::provider::OpenIdCertificate;
 use junobuild_shared::ic::UnwrapOrTrap;
@@ -19,7 +19,7 @@ fn stop_openid_monitoring() {
     stop_openid_scheduler().unwrap_or_trap()
 }
 
-#[update(guard = "caller_is_not_anonymous")]
+#[query(guard = "caller_is_not_anonymous")]
 fn get_openid_certificate(
     GetOpenIdCertificateArgs { provider }: GetOpenIdCertificateArgs,
 ) -> Option<OpenIdCertificate> {

--- a/src/tests/specs/observatory/observatory.openid.rate.spec.ts
+++ b/src/tests/specs/observatory/observatory.openid.rate.spec.ts
@@ -1,4 +1,4 @@
-import { idlFactoryObservatory, type ObservatoryActor } from '$declarations';
+import { idlFactoryCertifiedObservatory, type ObservatoryActor } from '$declarations';
 import { type Actor, PocketIc } from '@dfinity/pic';
 import { AnonymousIdentity } from '@icp-sdk/core/agent';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
@@ -30,7 +30,7 @@ describe('Observatory > OpenId > Rate', async () => {
 		await pic.setTime(mockCertificateDate.getTime());
 
 		const { actor: c } = await pic.setupCanister<ObservatoryActor>({
-			idlFactory: idlFactoryObservatory,
+			idlFactory: idlFactoryCertifiedObservatory,
 			wasm: OBSERVATORY_WASM_PATH,
 			sender: controller.getPrincipal()
 		});


### PR DESCRIPTION
# Motivation

The `get_openid_certificate` is currently a `query` in production. I set it to `update` to develop the rate limiter but, ideally I would be to keep it as update - i.e. rate limit update calls.
