### PR TITLE
refactor(frontend): custom domain name types

### DIFF
--- a/src/frontend/src/lib/components/hosting/CustomDomain.svelte
+++ b/src/frontend/src/lib/components/hosting/CustomDomain.svelte
@@ -10,7 +10,7 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import { HostingWorker } from '$lib/services/workers/worker.hosting.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { CustomDomainRegistrationState } from '$lib/types/custom-domain';
+	import type { CustomDomain, CustomDomainRegistrationState } from '$lib/types/custom-domain';
 	import type { PostMessageDataResponseHosting } from '$lib/types/post-message';
 	import type { Option } from '$lib/types/utils';
 	import { emit } from '$lib/utils/events.utils';
@@ -20,7 +20,7 @@
 		url: string;
 		ariaLabel?: string;
 		type?: 'default' | 'custom';
-		customDomain?: [string, SatelliteDid.CustomDomain] | undefined;
+		customDomain?: CustomDomain | undefined;
 		satellite?: MissionControlDid.Satellite | undefined;
 		config?: SatelliteDid.AuthenticationConfig | undefined;
 	}

--- a/src/frontend/src/lib/components/hosting/CustomDomainActions.svelte
+++ b/src/frontend/src/lib/components/hosting/CustomDomainActions.svelte
@@ -13,6 +13,7 @@
 	import { busy, isBusy } from '$lib/stores/busy.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toasts } from '$lib/stores/toasts.store';
+	import type { CustomDomain } from '$lib/types/custom-domain';
 	import type { JunoModalCustomDomainDetail } from '$lib/types/modal';
 	import type { Option } from '$lib/types/utils';
 	import { buildDeleteAuthenticationConfig } from '$lib/utils/auth.config.utils';
@@ -21,7 +22,7 @@
 
 	interface Props {
 		satellite: MissionControlDid.Satellite;
-		customDomain: [string, SatelliteDid.CustomDomain] | undefined;
+		customDomain: CustomDomain | undefined;
 		displayState: Option<string>;
 		config: SatelliteDid.AuthenticationConfig | undefined;
 	}

--- a/src/frontend/src/lib/components/hosting/CustomDomainInfo.svelte
+++ b/src/frontend/src/lib/components/hosting/CustomDomainInfo.svelte
@@ -1,24 +1,28 @@
+<script lang="ts" module>
+	import type { CustomDomain, CustomDomainRegistrationState } from '$lib/types/custom-domain';
+
+	export interface SelectedCustomDomain {
+		customDomain: CustomDomain | undefined;
+		registrationState: Option<CustomDomainRegistrationState>;
+		mainDomain: boolean;
+	}
+</script>
+
 <script lang="ts">
 	import { nonNullish, fromNullishNullable } from '@dfinity/utils';
 	import { createEventDispatcher } from 'svelte';
 	import { run, stopPropagation } from 'svelte/legacy';
 	import { fade } from 'svelte/transition';
-	import type { SatelliteDid } from '$declarations';
 	import IconCheckCircle from '$lib/components/icons/IconCheckCircle.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import Popover from '$lib/components/ui/Popover.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { CustomDomainRegistrationState } from '$lib/types/custom-domain';
 	import type { Option } from '$lib/types/utils';
 	import { keyOf } from '$lib/utils/utils';
 
 	interface Props {
-		info: {
-			customDomain: [string, SatelliteDid.CustomDomain] | undefined;
-			registrationState: Option<CustomDomainRegistrationState>;
-			mainDomain: boolean;
-		};
+		info: SelectedCustomDomain;
 	}
 
 	let { info }: Props = $props();

--- a/src/frontend/src/lib/components/hosting/Hosting.svelte
+++ b/src/frontend/src/lib/components/hosting/Hosting.svelte
@@ -4,15 +4,15 @@
 	import type { SatelliteDid, MissionControlDid } from '$declarations';
 	import AddCustomDomain from '$lib/components/hosting/AddCustomDomain.svelte';
 	import CustomDomain from '$lib/components/hosting/CustomDomain.svelte';
-	import CustomDomainInfo from '$lib/components/hosting/CustomDomainInfo.svelte';
+	import CustomDomainInfo, {
+		type SelectedCustomDomain
+	} from '$lib/components/hosting/CustomDomainInfo.svelte';
 	import HostingCount from '$lib/components/hosting/HostingCount.svelte';
 	import { sortedSatelliteCustomDomains } from '$lib/derived/satellite-custom-domains.derived';
 	import { getAuthConfig } from '$lib/services/auth/auth.config.services';
 	import { listCustomDomains } from '$lib/services/custom-domain.services';
 	import { authStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { CustomDomainRegistrationState } from '$lib/types/custom-domain';
-	import type { Option } from '$lib/types/utils';
 	import { satelliteUrl } from '$lib/utils/satellite.utils';
 
 	interface Props {
@@ -42,13 +42,7 @@
 
 	onMount(list);
 
-	interface SelectedCustomDomain {
-		customDomain: [string, SatelliteDid.CustomDomain] | undefined;
-		registrationState: Option<CustomDomainRegistrationState>;
-		mainDomain: boolean;
-	}
-
-	let selectedInfo: SelectedCustomDomain | undefined = $state();
+	let selectedInfo = $state<SelectedCustomDomain | undefined>();
 
 	const onDisplayInfo = ({ detail }: CustomEvent<SelectedCustomDomain>) => (selectedInfo = detail);
 </script>

--- a/src/frontend/src/lib/types/custom-domain.ts
+++ b/src/frontend/src/lib/types/custom-domain.ts
@@ -2,7 +2,9 @@ import type { SatelliteDid } from '$declarations';
 
 export type CustomDomainName = string;
 
-export type CustomDomains = [CustomDomainName, SatelliteDid.CustomDomain][];
+export type CustomDomain = [CustomDomainName, SatelliteDid.CustomDomain];
+
+export type CustomDomains = CustomDomain[];
 
 export interface CustomDomainDnsEntry {
 	type: 'TXT' | 'CNAME';


### PR DESCRIPTION
# Motivation

For #2243 we will need to now use the `CustomDomainName` as key, so first let's clean those that did not used the global shorthands.

Parts of #2237.