### PR TITLE
feat(frontend): register custom domain (POST) with new API

### DIFF
--- a/src/frontend/src/lib/rest/bn.v0.rest.ts
+++ b/src/frontend/src/lib/rest/bn.v0.rest.ts
@@ -40,33 +40,6 @@ export const getCustomDomainRegistrationV0 = async ({
 /**
  * @deprecated
  */
-export const registerDomainV0 = async ({ domainName }: { domainName: string }): Promise<string> => {
-	assertNonNullish(
-		BN_REGISTRATIONS_URL,
-		'Boundary Node API URL not defined. This service is unavailable.'
-	);
-
-	const response = await fetch(BN_REGISTRATIONS_URL, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json'
-		},
-		body: JSON.stringify({ name: domainName })
-	});
-
-	if (!response.ok) {
-		const text = await response.text();
-		throw new Error(`Registering ${domainName} with the boundary nodes failed. ${text}`);
-	}
-
-	const result: { id: string } = await response.json();
-
-	return result.id;
-};
-
-/**
- * @deprecated
- */
 export const deleteDomainV0 = async ({ bn_id }: SatelliteDid.CustomDomain): Promise<void> => {
 	assertNonNullish(
 		BN_REGISTRATIONS_URL,

--- a/src/frontend/src/lib/rest/bn.v1.rest.ts
+++ b/src/frontend/src/lib/rest/bn.v1.rest.ts
@@ -1,6 +1,9 @@
-import { GetCustomDomainStateSchema } from '$lib/schemas/custom-domain.schema';
+import {
+	GetCustomDomainStateSchema,
+	PostCustomDomainStateSchema
+} from '$lib/schemas/custom-domain.schema';
 import type { CustomDomainName, CustomDomainRegistration } from '$lib/types/custom-domain';
-import { isEmptyString } from '@dfinity/utils';
+import { assertNonNullish, isEmptyString } from '@dfinity/utils';
 
 const BN_CUSTOM_DOMAINS_URL = import.meta.env.VITE_BN_CUSTOM_DOMAINS_URL;
 
@@ -28,4 +31,30 @@ export const getCustomDomainRegistration = async ({
 	const data = await response.json();
 
 	return GetCustomDomainStateSchema.parse(data);
+};
+
+export const registerDomain = async ({ domainName }: { domainName: string }): Promise<void> => {
+	assertNonNullish(
+		BN_CUSTOM_DOMAINS_URL,
+		'Boundary Node API URL not defined. This service is unavailable.'
+	);
+
+	const response = await fetch(`${BN_CUSTOM_DOMAINS_URL}/${domainName}`, {
+		method: 'POST'
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`Registering ${domainName} with the boundary nodes failed. ${text}`);
+	}
+
+	const data = await response.json();
+
+	const result = PostCustomDomainStateSchema.parse(data);
+
+	if (result.status === 'success') {
+		return;
+	}
+
+	throw new Error(`Registering ${domainName} with the boundary nodes failed. ${result.errors}`);
 };

--- a/src/frontend/src/lib/schemas/custom-domain.schema.ts
+++ b/src/frontend/src/lib/schemas/custom-domain.schema.ts
@@ -58,3 +58,17 @@ export const GetCustomDomainStateSuccessSchema = z.strictObject({
 export const GetCustomDomainStateSchema = GetCustomDomainStateSuccessSchema.or(
 	GetCustomDomainStateErrorSchema
 );
+
+// POST BN_API/{domain}
+
+const PostCustomDomainStateErrorSchema = CustomDomainResponseErrorSchema;
+
+export const PostCustomDomainStateSuccessSchema = z.strictObject({
+	status: CustomDomainResponseStatusSchema.extract(['success']),
+	message: z.string(),
+	data: CustomDomainResponseDataWithCanisterIdSchema
+});
+
+export const PostCustomDomainStateSchema = PostCustomDomainStateSuccessSchema.or(
+	PostCustomDomainStateErrorSchema
+);

--- a/src/frontend/src/lib/services/custom-domain.services.ts
+++ b/src/frontend/src/lib/services/custom-domain.services.ts
@@ -37,9 +37,9 @@ export const setCustomDomain = async ({
 	// Register domain name with BN
 	await registerDomain({ domainName });
 
-	// In case of error we keep the custom domain in `./well-known/ic-domains` - this should not arm.
-	// In the past, we used to update the domain to save the BN_ID but, this information
-	// is not required anymore with the API v1. The domain name itself has become the key.
+	// In case of an error, we keep the custom domain in `./well-known/ic-domains` - this should not harm.
+	// In the past, we used to update the domain to save the BN_ID, but this information
+	// is no longer required with API v1. The domain name itself has become the key.
 };
 
 export const deleteCustomDomain = async ({

--- a/src/frontend/src/lib/services/custom-domain.services.ts
+++ b/src/frontend/src/lib/services/custom-domain.services.ts
@@ -4,7 +4,8 @@ import {
 	listCustomDomains as listCustomDomainsApi,
 	setCustomDomain as setCustomDomainApi
 } from '$lib/api/satellites.api';
-import { deleteDomainV0, registerDomainV0 } from '$lib/rest/bn.v0.rest';
+import { deleteDomainV0 } from '$lib/rest/bn.v0.rest';
+import { registerDomain } from '$lib/rest/bn.v1.rest';
 import { authStore } from '$lib/stores/auth.store';
 import { customDomainsStore } from '$lib/stores/custom-domains.store';
 import { i18n } from '$lib/stores/i18n.store';
@@ -34,15 +35,11 @@ export const setCustomDomain = async ({
 	});
 
 	// Register domain name with BN
-	const boundaryNodesId = await registerDomainV0({ domainName });
+	await registerDomain({ domainName });
 
-	// Save above request ID provided in previous step
-	await setCustomDomainApi({
-		satelliteId,
-		domainName,
-		boundaryNodesId,
-		identity
-	});
+	// In case of error we keep the custom domain in `./well-known/ic-domains` - this should not arm.
+	// In the past, we used to update the domain to save the BN_ID but, this information
+	// is not required anymore with the API v1. The domain name itself has become the key.
 };
 
 export const deleteCustomDomain = async ({

--- a/src/frontend/src/lib/types/custom-domain.ts
+++ b/src/frontend/src/lib/types/custom-domain.ts
@@ -1,5 +1,7 @@
 import type { SatelliteDid } from '$declarations';
 import type {
+	PostCustomDomainStateSchema
+,
 	CustomDomainStateSchema,
 	GetCustomDomainStateSchema,
 	GetCustomDomainValidateSchema
@@ -56,6 +58,7 @@ interface CustomDomainRegistrationV0Response {
 
 export type GetCustomDomainValidate = z.infer<typeof GetCustomDomainValidateSchema>;
 export type GetCustomDomainState = z.infer<typeof GetCustomDomainStateSchema>;
+export type PostCustomDomainState = z.infer<typeof PostCustomDomainStateSchema>;
 
 export interface CustomDomainRegistration {
 	/**
@@ -66,6 +69,5 @@ export interface CustomDomainRegistration {
 	};
 	v1: {
 		State: GetCustomDomainState;
-		Validate: GetCustomDomainValidate;
 	};
 }

--- a/src/frontend/src/lib/types/custom-domain.ts
+++ b/src/frontend/src/lib/types/custom-domain.ts
@@ -1,10 +1,9 @@
 import type { SatelliteDid } from '$declarations';
 import type {
-	PostCustomDomainStateSchema
-,
 	CustomDomainStateSchema,
 	GetCustomDomainStateSchema,
-	GetCustomDomainValidateSchema
+	GetCustomDomainValidateSchema,
+	PostCustomDomainStateSchema
 } from '$lib/schemas/custom-domain.schema';
 import type * as z from 'zod';
 


### PR DESCRIPTION
# Motivation

We want to migrate the registration of custom domain to the new API v1 of the BN.

Parts of #2237

