### PR TITLE
feat(frontend): migrate delete custom domain to API v1 (and other improvements)

### DIFF
--- a/src/frontend/src/lib/rest/bn.v0.rest.ts
+++ b/src/frontend/src/lib/rest/bn.v0.rest.ts
@@ -1,6 +1,6 @@
 import type { SatelliteDid } from '$declarations';
 import type { CustomDomainRegistration } from '$lib/types/custom-domain';
-import { assertNonNullish, fromNullable, isNullish } from '@dfinity/utils';
+import { fromNullable, isNullish } from '@dfinity/utils';
 
 const BN_REGISTRATIONS_URL = import.meta.env.VITE_BN_REGISTRATIONS_URL;
 
@@ -35,32 +35,4 @@ export const getCustomDomainRegistrationV0 = async ({
 	const result: CustomDomainRegistration['v0']['State'] = await response.json();
 
 	return result;
-};
-
-/**
- * @deprecated
- */
-export const deleteDomainV0 = async ({ bn_id }: SatelliteDid.CustomDomain): Promise<void> => {
-	assertNonNullish(
-		BN_REGISTRATIONS_URL,
-		'Boundary Node API URL not defined. This service is unavailable.'
-	);
-
-	const id = fromNullable(bn_id);
-
-	if (isNullish(id) || id === '') {
-		throw new Error(`No existing BN id provided to delete custom domain.`);
-	}
-
-	const response = await fetch(`${BN_REGISTRATIONS_URL}/${id}`, {
-		method: 'DELETE',
-		headers: {
-			'Content-Type': 'application/json'
-		}
-	});
-
-	if (!response.ok) {
-		const text = await response.text();
-		throw new Error(`Deleting custom domain in the boundary nodes failed. ${text}`);
-	}
 };

--- a/src/frontend/src/lib/schemas/custom-domain.schema.ts
+++ b/src/frontend/src/lib/schemas/custom-domain.schema.ts
@@ -72,3 +72,17 @@ export const PostCustomDomainStateSuccessSchema = z.strictObject({
 export const PostCustomDomainStateSchema = PostCustomDomainStateSuccessSchema.or(
 	PostCustomDomainStateErrorSchema
 );
+
+// DELETE BN_API/{domain}
+
+const DeleteCustomDomainStateErrorSchema = CustomDomainResponseErrorSchema;
+
+export const DeleteCustomDomainStateSuccessSchema = z.strictObject({
+	status: CustomDomainResponseStatusSchema.extract(['success']),
+	message: z.string(),
+	data: CustomDomainResponseDataSchema
+});
+
+export const DeleteCustomDomainStateSchema = DeleteCustomDomainStateSuccessSchema.or(
+	DeleteCustomDomainStateErrorSchema
+);

--- a/src/frontend/src/lib/services/custom-domain.services.ts
+++ b/src/frontend/src/lib/services/custom-domain.services.ts
@@ -4,12 +4,12 @@ import {
 	listCustomDomains as listCustomDomainsApi,
 	setCustomDomain as setCustomDomainApi
 } from '$lib/api/satellites.api';
-import { deleteDomainV0 } from '$lib/rest/bn.v0.rest';
-import { registerDomain } from '$lib/rest/bn.v1.rest';
+import { deleteDomain, registerDomain } from '$lib/rest/bn.v1.rest';
 import { authStore } from '$lib/stores/auth.store';
 import { customDomainsStore } from '$lib/stores/custom-domains.store';
 import { i18n } from '$lib/stores/i18n.store';
 import { toasts } from '$lib/stores/toasts.store';
+import type { CustomDomainName } from '$lib/types/custom-domain';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
@@ -22,7 +22,7 @@ export const setCustomDomain = async ({
 	domainName
 }: {
 	satelliteId: Principal;
-	domainName: string;
+	domainName: CustomDomainName;
 }) => {
 	const { identity } = get(authStore);
 
@@ -50,14 +50,14 @@ export const deleteCustomDomain = async ({
 }: {
 	satelliteId: Principal;
 	customDomain: SatelliteDid.CustomDomain;
-	domainName: string;
+	domainName: CustomDomainName;
 	deleteCustomDomain: boolean;
 }) => {
 	const { identity } = get(authStore);
 
 	if (deleteCustomDomain && nonNullish(fromNullable(customDomain.bn_id))) {
 		// Delete domain name in BN
-		await deleteDomainV0(customDomain);
+		await deleteDomain({ domainName });
 	}
 
 	// Remove custom domain from satellite

--- a/src/frontend/src/lib/types/custom-domain.ts
+++ b/src/frontend/src/lib/types/custom-domain.ts
@@ -1,9 +1,7 @@
 import type { SatelliteDid } from '$declarations';
 import type {
 	CustomDomainStateSchema,
-	GetCustomDomainStateSchema,
-	GetCustomDomainValidateSchema,
-	PostCustomDomainStateSchema
+	GetCustomDomainStateSchema
 } from '$lib/schemas/custom-domain.schema';
 import type * as z from 'zod';
 
@@ -55,9 +53,7 @@ interface CustomDomainRegistrationV0Response {
 	state: CustomDomainRegistrationV0State | CustomDomainRegistrationV0StateFailed;
 }
 
-export type GetCustomDomainValidate = z.infer<typeof GetCustomDomainValidateSchema>;
 export type GetCustomDomainState = z.infer<typeof GetCustomDomainStateSchema>;
-export type PostCustomDomainState = z.infer<typeof PostCustomDomainStateSchema>;
 
 export interface CustomDomainRegistration {
 	/**

--- a/src/frontend/src/lib/workers/hosting.worker.ts
+++ b/src/frontend/src/lib/workers/hosting.worker.ts
@@ -89,7 +89,7 @@ const syncCustomDomainRegistrationV1 = async ({
 }: {
 	domain: CustomDomainName;
 }): Promise<CustomDomainState> => {
-	const response = await getCustomDomainRegistration({ domain });
+	const response = await getCustomDomainRegistration({ domainName: domain });
 
 	if (response?.status === 'success') {
 		const {


### PR DESCRIPTION
# Motivation

We want to migrate the DELETE of custom domain to the new API of the BN (v1). Few other improvements here as well.

Parts of #2337
