### PR TITLE
feat(frontend): redo delete custom domain with old API for backwards compatibility

### DIFF
--- a/src/frontend/src/lib/rest/bn.v0.rest.ts
+++ b/src/frontend/src/lib/rest/bn.v0.rest.ts
@@ -1,6 +1,6 @@
 import type { SatelliteDid } from '$declarations';
 import type { CustomDomainRegistration } from '$lib/types/custom-domain';
-import { fromNullable, isNullish } from '@dfinity/utils';
+import { assertNonNullish, fromNullable, isNullish } from '@dfinity/utils';
 
 const BN_REGISTRATIONS_URL = import.meta.env.VITE_BN_REGISTRATIONS_URL;
 
@@ -35,4 +35,26 @@ export const getCustomDomainRegistrationV0 = async ({
 	const result: CustomDomainRegistration['v0']['State'] = await response.json();
 
 	return result;
+};
+
+/**
+ * @deprecated
+ */
+export const deleteDomainV0 = async ({ bnId }: { bnId: string }): Promise<void> => {
+	assertNonNullish(
+		BN_REGISTRATIONS_URL,
+		'Boundary Node API URL not defined. This service is unavailable.'
+	);
+
+	const response = await fetch(`${BN_REGISTRATIONS_URL}/${bnId}`, {
+		method: 'DELETE',
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`Deleting custom domain in the boundary nodes failed. ${text}`);
+	}
 };

--- a/src/frontend/src/lib/services/custom-domain.services.ts
+++ b/src/frontend/src/lib/services/custom-domain.services.ts
@@ -3,6 +3,7 @@ import {
 	deleteCustomDomain as deleteCustomDomainApi,
 	listCustomDomains as listCustomDomainsApi
 } from '$lib/api/satellites.api';
+import { deleteDomainV0 } from '$lib/rest/bn.v0.rest';
 import { deleteDomain } from '$lib/rest/bn.v1.rest';
 import { authStore } from '$lib/stores/auth.store';
 import { customDomainsStore } from '$lib/stores/custom-domains.store';
@@ -29,9 +30,21 @@ export const deleteCustomDomain = async ({
 }) => {
 	assertNonNullish(identity, get(i18n).core.not_logged_in);
 
-	if (deleteCustomDomain && nonNullish(fromNullable(customDomain.bn_id))) {
+	if (deleteCustomDomain) {
 		// Delete domain name in BN
-		await deleteDomain({ domainName });
+		const unregisterCustomDomain = async () => {
+			const bnId = fromNullable(customDomain.bn_id);
+			if (nonNullish(bnId)) {
+				await deleteDomainV0({
+					bnId
+				});
+				return;
+			}
+
+			await deleteDomain({ domainName });
+		};
+
+		await unregisterCustomDomain();
 	}
 
 	// Remove custom domain from satellite


### PR DESCRIPTION
# Motivation

Until all custom domains are transferred in the BN.

Parts of #2237

