### PR TITLE
fix(frontend): new BN API missing canister_id in first GET

### DIFF
--- a/src/frontend/src/lib/schemas/custom-domain.schema.ts
+++ b/src/frontend/src/lib/schemas/custom-domain.schema.ts
@@ -13,9 +13,14 @@ const CustomDomainResponseDataSchema = z.strictObject({
 	domain: z.string()
 });
 
-const CustomDomainResponseDataWithCanisterIdSchema = z.strictObject({
+const CustomDomainResponseDataWithNullableCanisterIdSchema = z.strictObject({
 	...CustomDomainResponseDataSchema.shape,
-	canister_id: PrincipalTextSchema
+	// Workaround: while we observed the canister_id is provided for GET /validate and POST being provided, we also noticed
+	// that the first GET request after POST did **not** provide the information, which leads to a validation issue.
+	// Since this field is not used within the codebase, for consistency — to avoid having different types —
+	// and to prevent similar issues in case those APIs someday do not provide the information in the future,
+	// we set the field as nullable.
+	canister_id: PrincipalTextSchema.nullable()
 });
 
 const CustomDomainResponseErrorSchema = z.strictObject({
@@ -34,7 +39,7 @@ const CustomDomainValidationStatusSchema = z.enum(['valid']);
 const GetCustomDomainValidateSuccessSchema = z.strictObject({
 	status: CustomDomainResponseStatusSchema.extract(['success']),
 	message: z.string(),
-	data: CustomDomainResponseDataWithCanisterIdSchema.extend({
+	data: CustomDomainResponseDataWithNullableCanisterIdSchema.extend({
 		validation_status: CustomDomainValidationStatusSchema
 	})
 });
@@ -50,7 +55,7 @@ const GetCustomDomainStateErrorSchema = CustomDomainResponseErrorSchema;
 export const GetCustomDomainStateSuccessSchema = z.strictObject({
 	status: CustomDomainResponseStatusSchema.extract(['success']),
 	message: z.string(),
-	data: CustomDomainResponseDataWithCanisterIdSchema.extend({
+	data: CustomDomainResponseDataWithNullableCanisterIdSchema.extend({
 		registration_status: CustomDomainStateSchema
 	})
 });
@@ -66,7 +71,7 @@ const PostCustomDomainStateErrorSchema = CustomDomainResponseErrorSchema;
 export const PostCustomDomainStateSuccessSchema = z.strictObject({
 	status: CustomDomainResponseStatusSchema.extract(['success']),
 	message: z.string(),
-	data: CustomDomainResponseDataWithCanisterIdSchema
+	data: CustomDomainResponseDataWithNullableCanisterIdSchema
 });
 
 export const PostCustomDomainStateSchema = PostCustomDomainStateSuccessSchema.or(


### PR DESCRIPTION
# Motivation

See comment and following trace of calls:


Full trace.

Wed, 19 Nov 2025 07:07:31 GMT
https://icp0.io/custom-domains/v1/www.proposals.network/validate
GET

```
{
    "status": "success",
    "message": "Domain is eligible for registration: DNS records are valid and canister ownership is verified",
    "data": {
        "domain": "www.proposals.network",
        "canister_id": "gz2uc-6yaaa-aaaal-adgyq-cai",
        "validation_status": "valid"
    }
}
```

Wed, 19 Nov 2025 07:07:33 GMT
https://icp0.io/custom-domains/v1/www.proposals.network
POST

```
{
    "status": "success",
    "message": "Domain registration request accepted and may take a few minutes to process",
    "data": {
        "domain": "www.proposals.network",
        "canister_id": "gz2uc-6yaaa-aaaal-adgyq-cai"
    }
}
```

Wed, 19 Nov 2025 07:07:39 GMT
https://icp0.io/custom-domains/v1/www.proposals.network
GET

```
{
    "status": "success",
    "message": "Registration status of the domain",
    "data": {
        "domain": "www.proposals.network",
        "canister_id": null,
        "registration_status": "registering"
    }
}
```

Wed, 19 Nov 2025 07:07:49 GMT
https://icp0.io/custom-domains/v1/www.proposals.network
GET

```
{
    "status": "success",
    "message": "Registration status of the domain",
    "data": {
        "domain": "www.proposals.network",
        "canister_id": null,
        "registration_status": "registering"
    }
}
```

Then later, I reloaded my screen and got the canister ID

Wed, 19 Nov 2025 07:14:04 GMT
https://icp0.io/custom-domains/v1/www.proposals.network
GET

```
{
    "status": "success",
    "message": "Registration status of the domain",
    "data": {
        "domain": "www.proposals.network",
        "canister_id": "gz2uc-6yaaa-aaaal-adgyq-cai",
        "registration_status": "registered"
    }
}
```