### PR TITLE
feat(frontend): optional custom domain for GET only

### DIFF
--- a/src/frontend/src/lib/schemas/custom-domain.schema.ts
+++ b/src/frontend/src/lib/schemas/custom-domain.schema.ts
@@ -13,14 +13,14 @@ const CustomDomainResponseDataSchema = z.strictObject({
 	domain: z.string()
 });
 
+const CustomDomainResponseDataWithCanisterIdSchema = z.strictObject({
+	...CustomDomainResponseDataSchema.shape,
+	canister_id: PrincipalTextSchema
+});
+
 const CustomDomainResponseDataWithNullableCanisterIdSchema = z.strictObject({
 	...CustomDomainResponseDataSchema.shape,
-	// Workaround: while we observed the canister_id is provided for GET /validate and POST being provided, we also noticed
-	// that the first GET request after POST did **not** provide the information, which leads to a validation issue.
-	// Since this field is not used within the codebase, for consistency — to avoid having different types —
-	// and to prevent similar issues in case those APIs someday do not provide the information in the future,
-	// we set the field as nullable.
-	canister_id: PrincipalTextSchema.nullable()
+	canister_id: PrincipalTextSchema.nullish()
 });
 
 const CustomDomainResponseErrorSchema = z.strictObject({
@@ -39,7 +39,7 @@ const CustomDomainValidationStatusSchema = z.enum(['valid']);
 const GetCustomDomainValidateSuccessSchema = z.strictObject({
 	status: CustomDomainResponseStatusSchema.extract(['success']),
 	message: z.string(),
-	data: CustomDomainResponseDataWithNullableCanisterIdSchema.extend({
+	data: CustomDomainResponseDataWithCanisterIdSchema.extend({
 		validation_status: CustomDomainValidationStatusSchema
 	})
 });
@@ -71,7 +71,7 @@ const PostCustomDomainStateErrorSchema = CustomDomainResponseErrorSchema;
 export const PostCustomDomainStateSuccessSchema = z.strictObject({
 	status: CustomDomainResponseStatusSchema.extract(['success']),
 	message: z.string(),
-	data: CustomDomainResponseDataWithNullableCanisterIdSchema
+	data: CustomDomainResponseDataWithCanisterIdSchema
 });
 
 export const PostCustomDomainStateSchema = PostCustomDomainStateSuccessSchema.or(


### PR DESCRIPTION
# Motivation

Follow-up of #2266

Rüdi confirmed the following:

> The canister ID is optional for GET, but not for validate/POST/PATCH

Furthermore

> In Rust it is `Option<Principal>`
