### PR TITLE
chore(frontend): bump eslint lib and fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"zod": "^4.1.11"
 			},
 			"devDependencies": {
-				"@dfinity/eslint-config-oisy-wallet": "^0.2.2",
+				"@dfinity/eslint-config-oisy-wallet": "^0.2.3",
 				"@dfinity/internet-identity-playwright": "^2.0.0",
 				"@dfinity/pic": "^0.16.0",
 				"@dfinity/response-verification": "^3.0.3",
@@ -847,26 +847,30 @@
 			}
 		},
 		"node_modules/@dfinity/eslint-config-oisy-wallet": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@dfinity/eslint-config-oisy-wallet/-/eslint-config-oisy-wallet-0.2.2.tgz",
-			"integrity": "sha512-FOKePMaG/EoA+0DE87/98ZMrnIo6r3a0fqSYfcTFWAvlh9nHzfR5gE2AWlljZkoMmy69Ry5hQ2EtFj9ERdJJ4w==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@dfinity/eslint-config-oisy-wallet/-/eslint-config-oisy-wallet-0.2.3.tgz",
+			"integrity": "sha512-BxwM8xXscifJUYBmk071EOe/QM1Oyfn/GyBj7wblAgRcuTe4oLtNAHOlvG/bVFe4uBsLWNKwNxoNmraQPEAzkA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=22",
+				"npm": ">=11.5.1 <12.0.0"
+			},
 			"peerDependencies": {
 				"@dfinity/utils": "*",
-				"@eslint/compat": "^1.3.1",
+				"@eslint/compat": "^1.3.2",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "^9.30.1",
-				"@typescript-eslint/eslint-plugin": "^8.36.0",
-				"@vitest/eslint-plugin": "^1.3.4",
-				"eslint": "^9.30.1",
-				"eslint-config-love": "^121.0.0",
-				"eslint-config-prettier": "^10.1.5",
+				"@eslint/js": "^9.34.0",
+				"@typescript-eslint/eslint-plugin": "^8.42.0",
+				"@vitest/eslint-plugin": "^1.3.8",
+				"eslint": "^9.34.0",
+				"eslint-config-love": "^122.0.0",
+				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-import": "^2.32.0",
 				"eslint-plugin-local-rules": "^3.0.2",
-				"eslint-plugin-n": "^17.21.0",
+				"eslint-plugin-n": "^17.21.3",
 				"eslint-plugin-prefer-arrow": "^1.2.3",
-				"eslint-plugin-prettier": "^5.5.1",
+				"eslint-plugin-prettier": "^5.5.4",
 				"eslint-plugin-promise": "^7.2.1",
 				"eslint-plugin-svelte": "^3",
 				"globals": "^16.3.0",
@@ -1495,9 +1499,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1505,12 +1509,15 @@
 			}
 		},
 		"node_modules/@eslint/compat": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.3.2.tgz",
-			"integrity": "sha512-jRNwzTbd6p2Rw4sZ1CgWRS8YMtqG15YyZf7zvb6gY2rB2u6n+2Z+ELW0GtL0fQgyl0pr4Y/BzBfng/BdsereRA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
+			"integrity": "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
+			"dependencies": {
+				"@eslint/core": "^0.17.0"
+			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -1524,13 +1531,13 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-			"integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^2.1.6",
+				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
 				"minimatch": "^3.1.2"
 			},
@@ -1552,19 +1559,22 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-			"integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0"
+			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1649,9 +1659,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.35.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-			"integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+			"version": "9.39.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
+			"integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1663,9 +1673,9 @@
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-			"integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1673,13 +1683,13 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.15.2",
+				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
 			},
 			"engines": {
@@ -3367,17 +3377,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.43.0.tgz",
-			"integrity": "sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.47.0.tgz",
+			"integrity": "sha512-fe0rz9WJQ5t2iaLfdbDc9T80GJy0AeO453q8C3YCilnGozvOyCG5t+EZtg7j7D88+c3FipfP/x+wzGnh1xp8ZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.43.0",
-				"@typescript-eslint/type-utils": "8.43.0",
-				"@typescript-eslint/utils": "8.43.0",
-				"@typescript-eslint/visitor-keys": "8.43.0",
+				"@typescript-eslint/scope-manager": "8.47.0",
+				"@typescript-eslint/type-utils": "8.47.0",
+				"@typescript-eslint/utils": "8.47.0",
+				"@typescript-eslint/visitor-keys": "8.47.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
@@ -3391,7 +3401,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.43.0",
+				"@typescript-eslint/parser": "^8.47.0",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
@@ -3407,17 +3417,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.43.0.tgz",
-			"integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.47.0.tgz",
+			"integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.43.0",
-				"@typescript-eslint/types": "8.43.0",
-				"@typescript-eslint/typescript-estree": "8.43.0",
-				"@typescript-eslint/visitor-keys": "8.43.0",
+				"@typescript-eslint/scope-manager": "8.47.0",
+				"@typescript-eslint/types": "8.47.0",
+				"@typescript-eslint/typescript-estree": "8.47.0",
+				"@typescript-eslint/visitor-keys": "8.47.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -3433,14 +3443,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.43.0.tgz",
-			"integrity": "sha512-htB/+D/BIGoNTQYffZw4uM4NzzuolCoaA/BusuSIcC8YjmBYQioew5VUZAYdAETPjeed0hqCaW7EHg+Robq8uw==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.47.0.tgz",
+			"integrity": "sha512-2X4BX8hUeB5JcA1TQJ7GjcgulXQ+5UkNb0DL8gHsHUHdFoiCTJoYLTpib3LtSDPZsRET5ygN4qqIWrHyYIKERA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.43.0",
-				"@typescript-eslint/types": "^8.43.0",
+				"@typescript-eslint/tsconfig-utils": "^8.47.0",
+				"@typescript-eslint/types": "^8.47.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -3455,14 +3465,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.43.0.tgz",
-			"integrity": "sha512-daSWlQ87ZhsjrbMLvpuuMAt3y4ba57AuvadcR7f3nl8eS3BjRc8L9VLxFLk92RL5xdXOg6IQ+qKjjqNEimGuAg==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.47.0.tgz",
+			"integrity": "sha512-a0TTJk4HXMkfpFkL9/WaGTNuv7JWfFTQFJd6zS9dVAjKsojmv9HT55xzbEpnZoY+VUb+YXLMp+ihMLz/UlZfDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.43.0",
-				"@typescript-eslint/visitor-keys": "8.43.0"
+				"@typescript-eslint/types": "8.47.0",
+				"@typescript-eslint/visitor-keys": "8.47.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3473,9 +3483,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.43.0.tgz",
-			"integrity": "sha512-ALC2prjZcj2YqqL5X/bwWQmHA2em6/94GcbB/KKu5SX3EBDOsqztmmX1kMkvAJHzxk7TazKzJfFiEIagNV3qEA==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.47.0.tgz",
+			"integrity": "sha512-ybUAvjy4ZCL11uryalkKxuT3w3sXJAuWhOoGS3T/Wu+iUu1tGJmk5ytSY8gbdACNARmcYEB0COksD2j6hfGK2g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3490,15 +3500,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.43.0.tgz",
-			"integrity": "sha512-qaH1uLBpBuBBuRf8c1mLJ6swOfzCXryhKND04Igr4pckzSEW9JX5Aw9AgW00kwfjWJF0kk0ps9ExKTfvXfw4Qg==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.47.0.tgz",
+			"integrity": "sha512-QC9RiCmZ2HmIdCEvhd1aJELBlD93ErziOXXlHEZyuBo3tBiAZieya0HLIxp+DoDWlsQqDawyKuNEhORyku+P8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.43.0",
-				"@typescript-eslint/typescript-estree": "8.43.0",
-				"@typescript-eslint/utils": "8.43.0",
+				"@typescript-eslint/types": "8.47.0",
+				"@typescript-eslint/typescript-estree": "8.47.0",
+				"@typescript-eslint/utils": "8.47.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -3515,9 +3525,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
-			"integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.47.0.tgz",
+			"integrity": "sha512-nHAE6bMKsizhA2uuYZbEbmp5z2UpffNrPEqiKIeN7VsV6UY/roxanWfoRrf6x/k9+Obf+GQdkm0nPU+vnMXo9A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3529,16 +3539,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.43.0.tgz",
-			"integrity": "sha512-7Vv6zlAhPb+cvEpP06WXXy/ZByph9iL6BQRBDj4kmBsW98AqEeQHlj/13X+sZOrKSo9/rNKH4Ul4f6EICREFdw==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.47.0.tgz",
+			"integrity": "sha512-k6ti9UepJf5NpzCjH31hQNLHQWupTRPhZ+KFF8WtTuTpy7uHPfeg2NM7cP27aCGajoEplxJDFVCEm9TGPYyiVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.43.0",
-				"@typescript-eslint/tsconfig-utils": "8.43.0",
-				"@typescript-eslint/types": "8.43.0",
-				"@typescript-eslint/visitor-keys": "8.43.0",
+				"@typescript-eslint/project-service": "8.47.0",
+				"@typescript-eslint/tsconfig-utils": "8.47.0",
+				"@typescript-eslint/types": "8.47.0",
+				"@typescript-eslint/visitor-keys": "8.47.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -3584,16 +3594,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.43.0.tgz",
-			"integrity": "sha512-S1/tEmkUeeswxd0GGcnwuVQPFWo8NzZTOMxCvw8BX7OMxnNae+i8Tm7REQen/SwUIPoPqfKn7EaZ+YLpiB3k9g==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.47.0.tgz",
+			"integrity": "sha512-g7XrNf25iL4TJOiPqatNuaChyqt49a/onq5YsJ9+hXeugK+41LVg7AxikMfM02PC6jbNtZLCJj6AUcQXJS/jGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.43.0",
-				"@typescript-eslint/types": "8.43.0",
-				"@typescript-eslint/typescript-estree": "8.43.0"
+				"@typescript-eslint/scope-manager": "8.47.0",
+				"@typescript-eslint/types": "8.47.0",
+				"@typescript-eslint/typescript-estree": "8.47.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3608,13 +3618,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.43.0.tgz",
-			"integrity": "sha512-T+S1KqRD4sg/bHfLwrpF/K3gQLBM1n7Rp7OjjikjTEssI2YJzQpi5WXoynOaQ93ERIuq3O8RBTOUYDKszUCEHw==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.47.0.tgz",
+			"integrity": "sha512-SIV3/6eftCy1bNzCQoPmbWsRLujS8t5iDIZ4spZOBHqrM+yfX2ogg8Tt3PDTAVKw3sSCiUgg30uOAvK2r9zGjQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.43.0",
+				"@typescript-eslint/types": "8.47.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -3639,19 +3649,22 @@
 			}
 		},
 		"node_modules/@vitest/eslint-plugin": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.3.9.tgz",
-			"integrity": "sha512-wsNe7xy44ovm/h9ISDkDNcv0aOnUsaOYDqan2y6qCFAUQ0odFr6df/+FdGKHZN+mCM+SvIDWoXuvm5T5V3Kh6w==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.4.3.tgz",
+			"integrity": "sha512-ba+YDKyZdViNAOg8P86a9tIEawPA/O+nLbwhg8g7nkqsLOAVum6GoZhkNxgwX621oqWAbB8N2xb+G5kkpXehcA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "^8.41.0",
-				"@typescript-eslint/utils": "^8.24.1"
+				"@typescript-eslint/scope-manager": "^8.46.1",
+				"@typescript-eslint/utils": "^8.46.1"
+			},
+			"engines": {
+				"node": ">=18"
 			},
 			"peerDependencies": {
-				"eslint": ">= 8.57.0",
-				"typescript": ">= 5.0.0",
+				"eslint": ">=8.57.0",
+				"typescript": ">=5.0.0",
 				"vitest": "*"
 			},
 			"peerDependenciesMeta": {
@@ -5238,26 +5251,25 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.35.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-			"integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+			"version": "9.39.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
+			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.0",
-				"@eslint/config-helpers": "^0.3.1",
-				"@eslint/core": "^0.15.2",
+				"@eslint/config-array": "^0.21.1",
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/core": "^0.17.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.35.0",
-				"@eslint/plugin-kit": "^0.3.5",
+				"@eslint/js": "9.39.1",
+				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
@@ -5316,9 +5328,9 @@
 			}
 		},
 		"node_modules/eslint-config-love": {
-			"version": "121.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-love/-/eslint-config-love-121.0.0.tgz",
-			"integrity": "sha512-1d5Nht3rddN/N6sNQymh4tq2AT+t3rU9KVmblGsMUjqLsyOdFDlyCFyZz//UN4EvcJQQOtUSYjx8l8FENx/XdQ==",
+			"version": "122.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-love/-/eslint-config-love-122.0.0.tgz",
+			"integrity": "sha512-3gjqxqnoQDpGY/JAGLRdnaahGrjSXUO/+IbcxG6faZB9tImHKsetuuy3Nx39UP7WLjbgQqpD7m2yf4b50Ttw4g==",
 			"dev": true,
 			"funding": [
 				{
@@ -5330,12 +5342,12 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "^8.32.0",
+				"@typescript-eslint/utils": "^8.41.0",
 				"eslint-plugin-eslint-comments": "^3.2.0",
 				"eslint-plugin-import": "^2.32.0",
 				"eslint-plugin-n": "^17.0.0",
 				"eslint-plugin-promise": "^7.0.0",
-				"typescript-eslint": "^8.32.0"
+				"typescript-eslint": "^8.41.0"
 			},
 			"peerDependencies": {
 				"eslint": "^9.12.0",
@@ -5537,9 +5549,9 @@
 			"peer": true
 		},
 		"node_modules/eslint-plugin-n": {
-			"version": "17.22.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.22.0.tgz",
-			"integrity": "sha512-+YQ4dW8gg3eVZ3A8lL6zugEmA+Le5IEpCXsI8vKvDvSIB8gEh2N3PKqDwI+J8uLb7nphTJkwiv2e5OlnEDNvpQ==",
+			"version": "17.23.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.23.1.tgz",
+			"integrity": "sha512-68PealUpYoHOBh332JLLD9Sj7OQUDkFpmcfqt8R9sySfFSeuGJjMTJQvCRRB96zO3A/PELRLkPrzsHmzEFQQ5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5640,9 +5652,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-svelte": {
-			"version": "3.12.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.12.3.tgz",
-			"integrity": "sha512-YVNhKsHZeXVvsjZcSMjnce9gO31frICu453p5JjFiXNszHoG9k8WvsA/LAoLi4K8T69G7DIrgg1AqasDJLpgoQ==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.13.0.tgz",
+			"integrity": "sha512-2ohCCQJJTNbIpQCSDSTWj+FN0OVfPmSO03lmSNT7ytqMaWF6kpT86LdzDqtm4sh7TVPl/OEWJ/d7R87bXP2Vjg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -5656,7 +5668,7 @@
 				"postcss-load-config": "^3.1.4",
 				"postcss-safe-parser": "^7.0.0",
 				"semver": "^7.6.3",
-				"svelte-eslint-parser": "^1.3.0"
+				"svelte-eslint-parser": "^1.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6138,6 +6150,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/generator-function": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6219,9 +6241,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-			"integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6736,14 +6758,15 @@
 			}
 		},
 		"node_modules/is-generator-function": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-			"integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"call-bound": "^1.0.3",
-				"get-proto": "^1.0.0",
+				"call-bound": "^1.0.4",
+				"generator-function": "^2.0.0",
+				"get-proto": "^1.0.1",
 				"has-tostringtag": "^1.0.2",
 				"safe-regex-test": "^1.1.0"
 			},
@@ -7039,9 +7062,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7881,6 +7904,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -8404,13 +8428,13 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.10",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+			"version": "1.22.11",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.16.0",
+				"is-core-module": "^2.16.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -9221,9 +9245,9 @@
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.3.2.tgz",
-			"integrity": "sha512-whla4VlUbwJidn/bNyC3Ho3pBrXnR2CBEkuJwtaURW+wfwgKHPaYtZAmwAkp6HWWKCw1ILZL6iKsFdVY11rpDA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.0.tgz",
+			"integrity": "sha512-fjPzOfipR5S7gQ/JvI9r2H8y9gMGXO3JtmrylHLLyahEMquXI0lrebcjT+9/hNgDej0H7abTyox5HpHmW1PSWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9235,7 +9259,8 @@
 				"postcss-selector-parser": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+				"pnpm": "10.18.3"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ota-meshi"
@@ -9286,9 +9311,9 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
-			"integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9635,16 +9660,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.43.0.tgz",
-			"integrity": "sha512-FyRGJKUGvcFekRRcBKFBlAhnp4Ng8rhe8tuvvkR9OiU0gfd4vyvTRQHEckO6VDlH57jbeUQem2IpqPq9kLJH+w==",
+			"version": "8.47.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.47.0.tgz",
+			"integrity": "sha512-Lwe8i2XQ3WoMjua/r1PHrCTpkubPYJCAfOurtn+mtTzqB6jNd+14n9UN1bJ4s3F49x9ixAm0FLflB/JzQ57M8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.43.0",
-				"@typescript-eslint/parser": "8.43.0",
-				"@typescript-eslint/typescript-estree": "8.43.0",
-				"@typescript-eslint/utils": "8.43.0"
+				"@typescript-eslint/eslint-plugin": "8.47.0",
+				"@typescript-eslint/parser": "8.47.0",
+				"@typescript-eslint/typescript-estree": "8.47.0",
+				"@typescript-eslint/utils": "8.47.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"emulator:wait": "node scripts/emulator.wait.mjs"
 	},
 	"devDependencies": {
-		"@dfinity/eslint-config-oisy-wallet": "^0.2.2",
+		"@dfinity/eslint-config-oisy-wallet": "^0.2.3",
 		"@dfinity/internet-identity-playwright": "^2.0.0",
 		"@dfinity/pic": "^0.16.0",
 		"@dfinity/response-verification": "^3.0.3",

--- a/src/frontend/src/lib/components/analytics/AnalyticsFilter.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsFilter.svelte
@@ -41,10 +41,6 @@
 		const { result } = await loadAnalytics();
 
 		loading = false;
-
-		if (result === 'error') {
-			return;
-		}
 	};
 </script>
 

--- a/src/frontend/src/lib/components/analytics/AnalyticsFilter.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsFilter.svelte
@@ -38,7 +38,7 @@
 	const applyFilters = async () => {
 		loading = true;
 
-		const { result } = await loadAnalytics();
+		await loadAnalytics();
 
 		loading = false;
 	};

--- a/src/frontend/src/lib/components/core/Spotlight.svelte
+++ b/src/frontend/src/lib/components/core/Spotlight.svelte
@@ -63,8 +63,6 @@
 			const action = firstChild.querySelector('a') ?? firstChild.querySelector('button');
 			action?.focus();
 		}
-
-		return;
 	};
 
 	const onkeydown = ($event: KeyboardEvent) => {
@@ -87,7 +85,6 @@
 			case 'ArrowUp':
 				$event.preventDefault();
 				selectItem('up');
-				return;
 		}
 	};
 

--- a/src/frontend/src/lib/components/data/DataNav.svelte
+++ b/src/frontend/src/lib/components/data/DataNav.svelte
@@ -11,7 +11,6 @@
 		onedit: (rule: CollectionRule | undefined) => void;
 	}
 
-	// eslint-disable-next-line svelte/no-unused-props
 	let props: Props = $props();
 
 	const { store }: DataContext<unknown> = getContext<DataContext<unknown>>(DATA_CONTEXT_KEY);

--- a/src/frontend/src/lib/services/workers/worker.auth.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.auth.services.ts
@@ -17,7 +17,6 @@ export class AuthWorker extends AppWorker {
 					return;
 				case 'delegationRemainingTime':
 					authRemainingTimeStore.set((data.data as PostMessageDataResponseAuth)?.authRemainingTime);
-					return;
 			}
 		};
 	}

--- a/src/frontend/src/lib/services/workers/worker.cycles.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.cycles.services.ts
@@ -23,7 +23,6 @@ export class CyclesWorker extends AppWorker {
 					return;
 				case 'syncCanisters':
 					syncCanistersSyncData(data.data as PostMessageDataResponseCanistersSyncData);
-					return;
 			}
 		};
 	}

--- a/src/frontend/src/lib/services/workers/worker.hosting.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.hosting.services.ts
@@ -16,7 +16,6 @@ export class HostingWorker extends AppWorker {
 			switch (msg) {
 				case 'customDomainRegistrationState':
 					this.#hostingCallback?.(data.data as PostMessageDataResponseHosting);
-					return;
 			}
 		};
 	}

--- a/src/frontend/src/lib/services/workers/worker.monitoring.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.monitoring.services.ts
@@ -24,7 +24,6 @@ export class MonitoringWorker extends AppWorker {
 					return;
 				case 'syncCanisters':
 					syncCanistersMonitoring(data.data as PostMessageDataResponseCanistersMonitoring);
-					return;
 			}
 		};
 	}

--- a/src/frontend/src/lib/services/workers/worker.registry.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.registry.services.ts
@@ -22,7 +22,6 @@ export class RegistryWorker extends AppWorker {
 					onRegistryError({
 						error: (data.data as PostMessageDataResponseError).error
 					});
-					return;
 			}
 		};
 	}

--- a/src/frontend/src/lib/services/workers/worker.wallet.services.ts
+++ b/src/frontend/src/lib/services/workers/worker.wallet.services.ts
@@ -37,7 +37,6 @@ export class WalletWorker extends AppWorker {
 					return;
 				case 'syncExchange':
 					onSyncExchange(data.data as PostMessageDataResponseExchange);
-					return;
 			}
 		};
 	}

--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -16,7 +16,6 @@ export const onAuthMessage = async ({
 			return;
 		case 'stopIdleTimer':
 			stopIdleTimer();
-			return;
 	}
 };
 

--- a/src/frontend/src/lib/workers/cycles.worker.ts
+++ b/src/frontend/src/lib/workers/cycles.worker.ts
@@ -33,7 +33,6 @@ export const onCyclesMessage = async ({ data: dataMsg }: MessageEvent<PostMessag
 		case 'restartCyclesTimer':
 			stopCyclesTimer();
 			await startCyclesTimer({ data });
-			return;
 	}
 };
 

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -18,7 +18,6 @@ export const onExchangeMessage = async ({ data: dataMsg }: MessageEvent<PostMess
 			return;
 		case 'startWalletTimer':
 			await startTimer();
-			return;
 	}
 };
 

--- a/src/frontend/src/lib/workers/hosting.worker.ts
+++ b/src/frontend/src/lib/workers/hosting.worker.ts
@@ -15,7 +15,6 @@ export const onHostingMessage = async ({ data: dataMsg }: MessageEvent<PostMessa
 			return;
 		case 'startCustomDomainRegistrationTimer':
 			await startTimer({ data });
-			return;
 	}
 };
 

--- a/src/frontend/src/lib/workers/monitoring.worker.ts
+++ b/src/frontend/src/lib/workers/monitoring.worker.ts
@@ -41,7 +41,6 @@ export const onMonitoringMessage = async ({ data: dataMsg }: MessageEvent<PostMe
 		case 'restartMonitoringTimer':
 			stopMonitoringTimer();
 			await startMonitoringTimer({ data });
-			return;
 	}
 };
 

--- a/src/frontend/src/lib/workers/registry.worker.ts
+++ b/src/frontend/src/lib/workers/registry.worker.ts
@@ -40,7 +40,6 @@ export const onRegistryMessage = async ({ data: dataMsg }: MessageEvent<PostMess
 	switch (msg) {
 		case 'loadRegistry':
 			await loadRegistry({ data });
-			return;
 	}
 };
 

--- a/src/frontend/src/lib/workers/wallet.worker.ts
+++ b/src/frontend/src/lib/workers/wallet.worker.ts
@@ -39,7 +39,6 @@ export const onWalletMessage = async ({ data: dataMsg }: MessageEvent<PostMessag
 		case 'restartWalletTimer':
 			stopTimer();
 			await startTimer({ data });
-			return;
 	}
 };
 

--- a/src/frontend/tests/lib/api/call/query.api.test.ts
+++ b/src/frontend/tests/lib/api/call/query.api.test.ts
@@ -138,7 +138,10 @@ describe('query.api', () => {
 
 		expect(onLoad).not.toHaveBeenCalled();
 		expect(onError).toHaveBeenCalledTimes(2);
-		expect(onCertifiedError).toHaveBeenCalledOnce();
+		expect(onCertifiedError).toHaveBeenCalledExactlyOnceWith({
+			error: 'test',
+			identity
+		});
 		expect(onError).toHaveBeenCalledWith({
 			certified: false,
 			error: 'test',
@@ -146,10 +149,6 @@ describe('query.api', () => {
 		});
 		expect(onError).toHaveBeenCalledWith({
 			certified: true,
-			error: 'test',
-			identity
-		});
-		expect(onCertifiedError).toHaveBeenCalledWith({
 			error: 'test',
 			identity
 		});

--- a/src/tests/fixtures/test_sputnik/resources/on-delete-asset.ts
+++ b/src/tests/fixtures/test_sputnik/resources/on-delete-asset.ts
@@ -19,7 +19,6 @@ export const onDeleteAsset = defineHook<OnDeleteAsset>({
 			};
 
 			await thr();
-			return;
 		}
 	}
 });

--- a/src/tests/fixtures/test_sputnik/resources/on-delete-filtered-assets.ts
+++ b/src/tests/fixtures/test_sputnik/resources/on-delete-filtered-assets.ts
@@ -19,7 +19,6 @@ export const onDeleteFilteredAssets = defineHook<OnDeleteFilteredAssets>({
 			};
 
 			await thr();
-			return;
 		}
 	}
 });

--- a/src/tests/fixtures/test_sputnik/resources/on-delete-many-assets.ts
+++ b/src/tests/fixtures/test_sputnik/resources/on-delete-many-assets.ts
@@ -19,7 +19,6 @@ export const onDeleteManyAssets = defineHook<OnDeleteManyAssets>({
 			};
 
 			await thr();
-			return;
 		}
 	}
 });

--- a/src/tests/fixtures/test_sputnik/resources/on-upload-asset.ts
+++ b/src/tests/fixtures/test_sputnik/resources/on-upload-asset.ts
@@ -16,7 +16,6 @@ export const onUploadAsset = defineHook<OnUploadAsset>({
 			};
 
 			await thr();
-			return;
 		}
 	}
 });

--- a/src/tests/utils/observatory-openid-tests.utils.ts
+++ b/src/tests/utils/observatory-openid-tests.utils.ts
@@ -1,5 +1,5 @@
 import type { ObservatoryActor, ObservatoryDid } from '$declarations';
-import { type Actor, type PocketIc , CanisterHttpMethod } from '@dfinity/pic';
+import { type Actor, type PocketIc, CanisterHttpMethod } from '@dfinity/pic';
 import { assertNonNullish, fromNullable } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { MockOpenIdJwt } from './jwt-tests.utils';

--- a/src/tests/utils/observatory-openid-tests.utils.ts
+++ b/src/tests/utils/observatory-openid-tests.utils.ts
@@ -1,6 +1,5 @@
 import type { ObservatoryActor, ObservatoryDid } from '$declarations';
-import type { Actor, PocketIc } from '@dfinity/pic';
-import { CanisterHttpMethod } from '@dfinity/pic';
+import { type Actor, type PocketIc , CanisterHttpMethod } from '@dfinity/pic';
 import { assertNonNullish, fromNullable } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { MockOpenIdJwt } from './jwt-tests.utils';

--- a/src/tests/utils/observatory-openid-tests.utils.ts
+++ b/src/tests/utils/observatory-openid-tests.utils.ts
@@ -1,6 +1,6 @@
 import type { ObservatoryActor, ObservatoryDid } from '$declarations';
 import type { Actor, PocketIc } from '@dfinity/pic';
-import { CanisterHttpMethod } from '@dfinity/pic/dist/pocket-ic-types';
+import { CanisterHttpMethod } from '@dfinity/pic';
 import { assertNonNullish, fromNullable } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { MockOpenIdJwt } from './jwt-tests.utils';

--- a/src/tests/utils/satellite-doc-tests.utils.ts
+++ b/src/tests/utils/satellite-doc-tests.utils.ts
@@ -1,6 +1,5 @@
 import type { SatelliteActor, SatelliteDid } from '$declarations';
-import type { Actor } from '@dfinity/pic';
-import type { ActorInterface } from '@dfinity/pic/dist/pocket-ic-actor';
+import type { Actor, ActorInterface } from '@dfinity/pic';
 import { toNullable } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';


### PR DESCRIPTION
# Motivation

Shoutout to @AntonioVentilii for this rule

> /Users/daviddalbusco/projects/juno/juno/src/tests/utils/observatory-openid-tests.utils.ts
>  3:1  error  '@dfinity/pic/dist/pocket-ic-types' import is restricted from being used by a pattern. Do not import directly from a package's /dist/ folder. Use the package's public entry point instead  no-restricted-imports
>
> /Users/daviddalbusco/projects/juno/juno/src/tests/utils/satellite-doc-tests.utils.ts
 > 3:1  error  '@dfinity/pic/dist/pocket-ic-actor' import is restricted from being used by a pattern. Do not import directly from a package's /dist/ folder. Use the package's public entry point instead  no-restricted-imports
 
 Really nice!