### PR TITLE
chore(did): migrate junobuild-didc to @icp-sdk/bindgen

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -72,14 +72,6 @@ The following additional tools are required when building the modules:
 > [!NOTE]
 > The script `./docker/bootstrap` takes care of installing Rustup, the toolchain, and the following tools.
 
-### junobuild-didc
-
-`didc` is required to generate [Candid](https://github.com/dfinity/candid) files.
-
-```bash
-cargo install junobuild-didc
-```
-
 ### candid-extractor
 
 `candid-extractor` is needed to extract Candid interfaces. Install it with:

--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -54,7 +54,6 @@ install_tool() {
 install_tool ic-wasm 0.8.5
 install_tool wasi2ic 0.2.16
 install_tool candid-extractor 0.1.6
-install_tool junobuild-didc 0.2.0
 
 # make sure the packages are actually installed (rustup waits for the first invoke to lazyload)
 cargo --version

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
 				"@dfinity/internet-identity-playwright": "^2.0.0",
 				"@dfinity/pic": "^0.16.0",
 				"@dfinity/response-verification": "^3.0.3",
+				"@icp-sdk/bindgen": "^0.2.0",
 				"@junobuild/cli-tools": "^0.9.0",
 				"@junobuild/config": "^2.6.0",
 				"@junobuild/config-loader": "^0.4.6",
@@ -1759,6 +1760,19 @@
 			},
 			"peerDependencies": {
 				"@icp-sdk/core": "^4"
+			}
+		},
+		"node_modules/@icp-sdk/bindgen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@icp-sdk/bindgen/-/bindgen-0.2.0.tgz",
+			"integrity": "sha512-LUCgnZSvCtcCnJro9pS8/YQ3k/EPDiY6wx/8dxgGMM+A1PsdPUIzdQJYV4aQibjGZyc+v74EtpXfiM2UsfOWlw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"commander": "^14.0.1"
+			},
+			"bin": {
+				"icp-bindgen": "dist/esm/cli/icp-bindgen.js"
 			}
 		},
 		"node_modules/@icp-sdk/canisters": {
@@ -4473,6 +4487,16 @@
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/commander": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+			"integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -7904,7 +7928,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 		"@dfinity/internet-identity-playwright": "^2.0.0",
 		"@dfinity/pic": "^0.16.0",
 		"@dfinity/response-verification": "^3.0.3",
+		"@icp-sdk/bindgen": "^0.2.0",
 		"@junobuild/cli-tools": "^0.9.0",
 		"@junobuild/config": "^2.6.0",
 		"@junobuild/config-loader": "^0.4.6",

--- a/scripts/did.update.types.mjs
+++ b/scripts/did.update.types.mjs
@@ -1,79 +1,8 @@
 #!/usr/bin/env node
 
-import { existsSync, readdirSync } from 'fs';
-import { readFile, rename, writeFile } from 'fs/promises';
-import { join } from 'path';
-
-/**
- * We have to manipulate the types as long as https://github.com/dfinity/sdk/discussions/2761 is not implemented
- */
-const cleanTypes = async ({ dest = `./src/declarations` }) => {
-	const promises = readdirSync(dest).map(
-		(dir) =>
-			// eslint-disable-next-line no-async-promise-executor
-			new Promise(async (resolve) => {
-				const indexPath = join(dest, dir, 'index.js');
-
-				if (!existsSync(indexPath)) {
-					resolve();
-					return;
-				}
-
-				const content = await readFile(indexPath, 'utf-8');
-				const clean = content.replace(
-					/export const canisterId = process\.env\.\w*_CANISTER_ID;/g,
-					''
-				);
-
-				const valid = clean.replace(/export const idlFactory = \({ IDL }\) => {/g, '');
-
-				await writeFile(indexPath, valid, 'utf-8');
-
-				resolve();
-			})
-	);
-
-	await Promise.all(promises);
-};
-
-/**
- * We have to manipulate the factory otherwise the editor prompt for following TypeScript error:
- *
- * TS7031: Binding element 'IDL' implicitly has an 'any' type.
- *
- */
-const cleanFactory = async ({ dest = `./src/declarations` }) => {
-	const promises = readdirSync(dest).map(
-		(dir) =>
-			// eslint-disable-next-line no-async-promise-executor
-			new Promise(async (resolve) => {
-				const factoryPath = join(dest, dir, `${dir}.did.js`);
-
-				if (!existsSync(factoryPath)) {
-					resolve();
-					return;
-				}
-
-				const content = await readFile(factoryPath, 'utf-8');
-				const cleanFactory = content.replace(
-					/export const idlFactory = \({ IDL }\) => {/g,
-					`// @ts-ignore
-export const idlFactory = ({ IDL }) => {`
-				);
-				const cleanInit = cleanFactory.replace(
-					/export const init = \({ IDL }\) => {/g,
-					`// @ts-ignore
-export const init = ({ IDL }) => {`
-				);
-
-				await writeFile(factoryPath, cleanInit, 'utf-8');
-
-				resolve();
-			})
-	);
-
-	await Promise.all(promises);
-};
+import { existsSync, readdirSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
+import { join } from 'node:path';
 
 const renameFactory = async ({ dest = `./src/declarations` }) => {
 	const promises = readdirSync(dest).map(
@@ -97,18 +26,11 @@ const renameFactory = async ({ dest = `./src/declarations` }) => {
 	await Promise.all(promises);
 };
 
-(async () => {
-	try {
-		await cleanTypes({});
-		await cleanFactory({});
-		await renameFactory({});
+try {
+	await renameFactory({});
+	await renameFactory({ dest: './src/tests/declarations' });
 
-		await cleanTypes({ dest: './src/tests/declarations' });
-		await cleanFactory({ dest: './src/tests/declarations' });
-		await renameFactory({ dest: './src/tests/declarations' });
-
-		console.log(`Types declarations copied!`);
-	} catch (err) {
-		console.error(`Error while copying the types declarations.`, err);
-	}
-})();
+	console.log('Declarations renamed to factories!');
+} catch (err) {
+	console.error('Error while renaming the types declarations.', err);
+}


### PR DESCRIPTION
# Motivation

According the SDK team, `@icp-sdk/bindgen` is the declarations generator moving forward.
In OISY we are also facing conflicts if we do not migrate as the tool introduce breaking changes and those have been applied to ic-js.
There is no other way to get those breaking changes, therefore, I cannot upgrade ` junobuild-didc` unless I would rewrite those manually.

Therefore we have to migrate for a consistent ecosystem.
