### PR TITLE
feat(mctrl): notify observatory use bounded call

### DIFF
--- a/src/mission_control/src/monitoring/observatory.rs
+++ b/src/mission_control/src/monitoring/observatory.rs
@@ -7,7 +7,7 @@ use junobuild_shared::types::interface::NotifyArgs;
 pub async fn notify_observatory(args: &NotifyArgs) -> Result<(), String> {
     let observatory = Principal::from_text(OBSERVATORY).unwrap();
 
-    let _ = Call::unbounded_wait(observatory, "notify")
+    let _ = Call::bounded_wait(observatory, "notify")
         .with_arg(args)
         .await
         .decode_candid::<()>()?;


### PR DESCRIPTION
# Motivation

I described it as bounded in #2286 but use unbounded. For notifying an email I think we could / should use bounded

Related to #1149
