### PR TITLE
feat(observatory): migrate mission control to Call::bounded_wait

### DIFF
--- a/src/observatory/src/console.rs
+++ b/src/observatory/src/console.rs
@@ -1,7 +1,7 @@
 use candid::Principal;
-use ic_cdk::api::call::CallResult;
-use ic_cdk::call;
+use ic_cdk::call::Call;
 use junobuild_shared::env::CONSOLE;
+use junobuild_shared::ic::DecodeCandid;
 use junobuild_shared::types::interface::AssertMissionControlCenterArgs;
 use junobuild_shared::types::state::{MissionControlId, UserId};
 
@@ -16,10 +16,10 @@ pub async fn assert_mission_control_center(
         mission_control_id: *mission_control_id,
     };
 
-    let result: CallResult<((),)> = call(console, "assert_mission_control_center", (args,)).await;
+    let _ = Call::bounded_wait(console, "assert_mission_control_center")
+        .with_arg(args)
+        .await
+        .decode_candid::<()>()?;
 
-    match result {
-        Err((_, message)) => Err(["Mission control is unknown.", &message].join(" - ")),
-        Ok((_,)) => Ok(()),
-    }
+    Ok(())
 }

--- a/src/tests/specs/observatory/observatory.notify.spec.ts
+++ b/src/tests/specs/observatory/observatory.notify.spec.ts
@@ -98,7 +98,7 @@ describe('Observatory > Notify', () => {
 		it('should throw errors if caller is not a mission control', async () => {
 			const { notify } = observatoryActor;
 
-			await expect(notify(mockNotifyArgs)).rejects.toThrow('Mission control is unknown.');
+			await expect(notify(mockNotifyArgs)).rejects.toThrow('User does not have a mission control center.');
 		});
 
 		it('should throw errors if caller is not observatory', async () => {


### PR DESCRIPTION
# Motivation

Relates to #1499
