### PR TITLE
refactor(satellite): split write and delete asset assertion

### DIFF
--- a/src/libs/satellite/src/assets/storage/assert.rs
+++ b/src/libs/satellite/src/assets/storage/assert.rs
@@ -91,7 +91,7 @@ pub fn assert_create_batch(
     Ok(())
 }
 
-pub fn assert_delete_asset(
+pub fn assert_write_asset(
     context: &StoreContext,
     &AssertContext { rule, auth_config }: &AssertContext,
     asset: &Asset,
@@ -117,9 +117,11 @@ pub fn assert_delete_asset(
 
     increment_and_assert_rate_runtime(context.collection, &rule.rate_config)?;
 
-    invoke_assert_delete_asset(&context.caller, asset)?;
-
     Ok(())
+}
+
+pub fn assert_delete_asset(context: &StoreContext, asset: &Asset) -> Result<(), String> {
+    invoke_assert_delete_asset(&context.caller, asset)
 }
 
 fn assert_read_permission(

--- a/src/libs/satellite/src/assets/storage/store.rs
+++ b/src/libs/satellite/src/assets/storage/store.rs
@@ -1,6 +1,6 @@
 use crate::assets::storage::assert::{
     assert_create_batch, assert_delete_asset, assert_get_asset, assert_list_assets,
-    assert_set_config,
+    assert_set_config, assert_write_asset,
 };
 use crate::assets::storage::certified_assets::runtime::init_certified_assets as init_runtime_certified_assets;
 use crate::assets::storage::state::{
@@ -427,7 +427,9 @@ fn delete_asset_impl(
     match asset {
         None => Err(JUNO_STORAGE_ERROR_ASSET_NOT_FOUND.to_string()),
         Some(asset) => {
-            assert_delete_asset(context, assert_context, &asset)?;
+            assert_write_asset(context, assert_context, &asset)?;
+
+            assert_delete_asset(context, &asset)?;
 
             let certificate = &StorageCertificate;
 


### PR DESCRIPTION
# Motivation

This way we can reuse write assertions for #2297
