### PR TITLE
feat(observatory): use non replicated calls and direct POST to Resend

### DIFF
--- a/src/observatory/src/impls.rs
+++ b/src/observatory/src/impls.rs
@@ -59,12 +59,16 @@ impl Storable for NotificationKey {
 
 impl NotificationKey {
     pub fn idempotency_key(&self) -> String {
-        format!(
+        let key = format!(
             "{}___{}___{}",
             self.segment_id.to_text(),
             self.created_at,
             self.nonce
-        )
+        );
+
+        // We're likely to generate 66 chars, but to be future-proof and for simplicity, we truncate
+        // to 256 as required by the documentation: https://resend.com/docs/api-reference/emails/send-email#param-idempotency-key
+        key.chars().take(256).collect()
     }
 }
 

--- a/src/observatory/src/notifications/http/request.rs
+++ b/src/observatory/src/notifications/http/request.rs
@@ -28,8 +28,7 @@ fn get_email_request(
     api_key: &ApiKey,
     email: &EmailRequestBody,
 ) -> Result<HttpRequestArgs, String> {
-    let email_notifications_url =
-        "https://europe-west6-juno-observatory.cloudfunctions.net/observatory/notifications/email";
+    let email_notifications_url = "https://api.resend.com/emails";
 
     let request_headers = vec![
         HttpHeader {
@@ -57,8 +56,7 @@ fn get_email_request(
         max_response_bytes: None,
         transform: param_transform(),
         headers: request_headers,
-        // TODO: set to false
-        is_replicated: None,
+        is_replicated: Some(false),
     })
 }
 

--- a/src/tests/utils/observatory-tests.utils.ts
+++ b/src/tests/utils/observatory-tests.utils.ts
@@ -44,6 +44,7 @@ export const testDepositedCyclesNotification = async ({
 	metadataName?: string;
 	actor: ObservatoryActor | ObservatoryActor009;
 	pic: PocketIc;
+	expectedApiUrl?: string;
 }) => {
 	const { ping } = actor;
 
@@ -90,6 +91,7 @@ export const testFailedDepositCyclesNotification = async ({
 	metadataName?: string;
 	actor: ObservatoryActor;
 	pic: PocketIc;
+	expectedApiUrl?: string;
 }) => {
 	const { ping } = actor;
 
@@ -132,7 +134,8 @@ export const assertNotificationHttpsOutcalls = async ({
 	templateTitle,
 	expectedCycles,
 	expectedIdempotencyKeySegmentId,
-	expectedTimestamp = '2025-05-12T07:53:19+00:00'
+	expectedTimestamp = '2025-05-12T07:53:19+00:00',
+	expectedApiUrl = 'https://api.resend.com/emails'
 }: {
 	url: string;
 	moduleName: 'Mission Control' | 'Satellite' | 'Orbiter';
@@ -144,6 +147,7 @@ export const assertNotificationHttpsOutcalls = async ({
 	expectedCycles?: string;
 	expectedIdempotencyKeySegmentId: Principal;
 	expectedTimestamp?: string;
+	expectedApiUrl?: string;
 }) => {
 	await tick(pic);
 
@@ -153,9 +157,7 @@ export const assertNotificationHttpsOutcalls = async ({
 
 	const { requestId, subnetId, url, headers: headersArray, body } = pendingHttpOutCall;
 
-	expect(url).toEqual(
-		'https://europe-west6-juno-observatory.cloudfunctions.net/observatory/notifications/email'
-	);
+	expect(url).toEqual(expectedApiUrl);
 
 	const headers = headersArray.reduce<Record<string, string>>(
 		(acc, [key, value]) => ({ ...acc, [key]: value }),


### PR DESCRIPTION
# Motivation

IPv4 and non replicated call - which is suffisent for an email notification of which the response is not interpreted anyway - is now supported on the IC

Resend also now supports idempotency key https://resend.com/docs/api-reference/emails/send-email#param-idempotency-key

And we can finally get rid of the https://github.com/junobuild/proxy

Resolve #1847