### PR TITLE
feat(storage): remove deprecation notice for init_proposal_asset_upload and commit_proposal_asset_upload

### DIFF
--- a/src/console/src/api/storage.rs
+++ b/src/console/src/api/storage.rs
@@ -20,7 +20,6 @@ use junobuild_storage::types::state::FullPath;
 // Storage
 // ---------------------------------------------------------
 
-#[deprecated(note = "Use init_proposal_many_assets_upload instead")]
 #[update(guard = "caller_is_admin_controller")]
 fn init_proposal_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadResult {
     let caller = caller();
@@ -61,7 +60,6 @@ fn upload_proposal_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
     UploadChunkResult { chunk_id }
 }
 
-#[deprecated(note = "Use commit_proposal_many_assets_upload instead")]
 #[update(guard = "caller_is_admin_controller")]
 fn commit_proposal_asset_upload(commit: CommitBatch) {
     let caller = caller();

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -289,7 +289,6 @@ pub fn delete_proposal_assets(params: DeleteProposalAssets) {
 // ---------------------------------------------------------
 
 #[doc(hidden)]
-#[deprecated(note = "Use init_proposal_many_assets_upload instead")]
 #[update(guard = "caller_is_controller")]
 pub fn init_proposal_asset_upload(init: InitAssetKey, proposal_id: ProposalId) -> InitUploadResult {
     api::cdn::init_proposal_asset_upload(init, proposal_id)
@@ -311,7 +310,6 @@ pub fn upload_proposal_asset_chunk(chunk: UploadChunk) -> UploadChunkResult {
 }
 
 #[doc(hidden)]
-#[deprecated(note = "Use commit_proposal_many_assets_upload instead")]
 #[update(guard = "caller_is_controller")]
 pub fn commit_proposal_asset_upload(commit: CommitBatch) {
     api::cdn::commit_proposal_asset_upload(commit)


### PR DESCRIPTION
# Motivation

After much thinking about it, I decided not to roll out breaking changes and therefore will just remove the deprecation notice on `init_proposal_asset_upload` and `commit_proposal_asset_upload`.

Technically we can deprecate those endpoints and use the "many" related endpoints instead, but it requires changes in the JS library upload asset (see https://github.com/junobuild/juno-js/pull/601). I'm concerned about shipping a change that would lead to developers having issues deploying their sites with GitHub Actions because the action would be updated but not their Satellites.

Ultimately, it's little maintenance overhead to keep those functions, and they're restricted to controllers anyway.