### PR TITLE
feat(console)!: deprecate renamed to accounts endpoints

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -365,7 +365,6 @@ service : () -> {
   get_delegation : (GetDelegationArgs) -> (Result_1) query;
   get_proposal : (nat) -> (opt Proposal) query;
   get_storage_config : () -> (StorageConfig) query;
-  get_user_mission_control_center : () -> (opt Account) query;
   http_request : (HttpRequest) -> (HttpResponse) query;
   http_request_streaming_callback : (StreamingCallbackToken) -> (
       StreamingCallbackHttpResponse,
@@ -382,9 +381,6 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_payments : () -> (vec record { nat64; Payment }) query;
   list_proposals : (ListProposalsParams) -> (ListProposalResults) query;
-  list_user_mission_control_centers : () -> (
-      vec record { principal; Account },
-    ) query;
   reject_proposal : (CommitProposal) -> (null);
   set_auth_config : (SetAuthenticationConfig) -> (AuthenticationConfig);
   set_controllers : (SetControllersArgs) -> ();

--- a/src/console/src/api/mission_control.rs
+++ b/src/console/src/api/mission_control.rs
@@ -1,18 +1,10 @@
 use crate::factory::mission_control::init_user_mission_control_with_caller;
-use crate::guards::{caller_is_admin_controller, caller_is_observatory};
-use crate::store::stable::{get_account, get_existing_account, list_accounts};
-use crate::types::state::{Account, Accounts};
+use crate::guards::{caller_is_observatory};
+use crate::store::stable::{get_existing_account};
+use crate::types::state::{Account};
 use ic_cdk_macros::{query, update};
-use junobuild_shared::ic::api::caller;
 use junobuild_shared::ic::UnwrapOrTrap;
 use junobuild_shared::types::interface::AssertMissionControlCenterArgs;
-
-#[deprecated = "Use get_account() instead"]
-#[query]
-fn get_user_mission_control_center() -> Option<Account> {
-    let caller = caller();
-    get_account(&caller).unwrap_or_trap()
-}
 
 #[query(guard = "caller_is_observatory")]
 fn assert_mission_control_center(
@@ -22,12 +14,6 @@ fn assert_mission_control_center(
     }: AssertMissionControlCenterArgs,
 ) {
     get_existing_account(&user, &mission_control_id).unwrap_or_trap();
-}
-
-#[deprecated = "Use list_accounts() instead"]
-#[query(guard = "caller_is_admin_controller")]
-fn list_user_mission_control_centers() -> Accounts {
-    list_accounts()
 }
 
 #[update]

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -424,7 +424,6 @@ export interface _SERVICE {
 	get_delegation: ActorMethod<[GetDelegationArgs], Result_1>;
 	get_proposal: ActorMethod<[bigint], [] | [Proposal]>;
 	get_storage_config: ActorMethod<[], StorageConfig>;
-	get_user_mission_control_center: ActorMethod<[], [] | [Account]>;
 	http_request: ActorMethod<[HttpRequest], HttpResponse>;
 	http_request_streaming_callback: ActorMethod<
 		[StreamingCallbackToken],
@@ -443,7 +442,6 @@ export interface _SERVICE {
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_payments: ActorMethod<[], Array<[bigint, Payment]>>;
 	list_proposals: ActorMethod<[ListProposalsParams], ListProposalResults>;
-	list_user_mission_control_centers: ActorMethod<[], Array<[Principal, Account]>>;
 	reject_proposal: ActorMethod<[CommitProposal], null>;
 	set_auth_config: ActorMethod<[SetAuthenticationConfig], AuthenticationConfig>;
 	set_controllers: ActorMethod<[SetControllersArgs], undefined>;

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -449,7 +449,6 @@ export const idlFactory = ({ IDL }) => {
 		get_delegation: IDL.Func([GetDelegationArgs], [Result_1], []),
 		get_proposal: IDL.Func([IDL.Nat], [IDL.Opt(Proposal)], []),
 		get_storage_config: IDL.Func([], [StorageConfig], []),
-		get_user_mission_control_center: IDL.Func([], [IDL.Opt(Account)], []),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], []),
 		http_request_streaming_callback: IDL.Func(
 			[StreamingCallbackToken],
@@ -470,11 +469,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], []),
 		list_proposals: IDL.Func([ListProposalsParams], [ListProposalResults], []),
-		list_user_mission_control_centers: IDL.Func(
-			[],
-			[IDL.Vec(IDL.Tuple(IDL.Principal, Account))],
-			[]
-		),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -449,7 +449,6 @@ export const idlFactory = ({ IDL }) => {
 		get_delegation: IDL.Func([GetDelegationArgs], [Result_1], ['query']),
 		get_proposal: IDL.Func([IDL.Nat], [IDL.Opt(Proposal)], ['query']),
 		get_storage_config: IDL.Func([], [StorageConfig], ['query']),
-		get_user_mission_control_center: IDL.Func([], [IDL.Opt(Account)], ['query']),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		http_request_streaming_callback: IDL.Func(
 			[StreamingCallbackToken],
@@ -470,11 +469,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], ['query']),
 		list_proposals: IDL.Func([ListProposalsParams], [ListProposalResults], ['query']),
-		list_user_mission_control_centers: IDL.Func(
-			[],
-			[IDL.Vec(IDL.Tuple(IDL.Principal, Account))],
-			['query']
-		),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -449,7 +449,6 @@ export const idlFactory = ({ IDL }) => {
 		get_delegation: IDL.Func([GetDelegationArgs], [Result_1], ['query']),
 		get_proposal: IDL.Func([IDL.Nat], [IDL.Opt(Proposal)], ['query']),
 		get_storage_config: IDL.Func([], [StorageConfig], ['query']),
-		get_user_mission_control_center: IDL.Func([], [IDL.Opt(Account)], ['query']),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		http_request_streaming_callback: IDL.Func(
 			[StreamingCallbackToken],
@@ -470,11 +469,6 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], ['query']),
 		list_proposals: IDL.Func([ListProposalsParams], [ListProposalResults], ['query']),
-		list_user_mission_control_centers: IDL.Func(
-			[],
-			[IDL.Vec(IDL.Tuple(IDL.Principal, Account))],
-			['query']
-		),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),

--- a/src/tests/specs/console/console.upgrade.spec.ts
+++ b/src/tests/specs/console/console.upgrade.spec.ts
@@ -2,6 +2,7 @@ import {
 	idlFactoryConsole,
 	idlFactoryConsole0014,
 	idlFactoryConsole008,
+	idlFactoryConsole015,
 	type ConsoleActor,
 	type ConsoleActor0014,
 	type ConsoleActor008,
@@ -262,7 +263,7 @@ describe('Console > Upgrade', () => {
 
 			await upgradeTo0_1_0();
 
-			const newActor = pic.createActor<ConsoleActor015>(idlFactoryConsole, canisterId);
+			const newActor = pic.createActor<ConsoleActor015>(idlFactoryConsole015, canisterId);
 			newActor.setIdentity(controller);
 
 			await assertControllers(newActor);
@@ -292,7 +293,7 @@ describe('Console > Upgrade', () => {
 
 					await upgradeTo0_1_0();
 
-					const newActor = pic.createActor<ConsoleActor015>(idlFactoryConsole, canisterId);
+					const newActor = pic.createActor<ConsoleActor015>(idlFactoryConsole015, canisterId);
 					newActor.setIdentity(controller);
 
 					await testUsers({ users: originalUsers, actor: newActor });
@@ -381,7 +382,7 @@ describe('Console > Upgrade', () => {
 	});
 
 	describe('v0.1.5 -> v0.2.0', () => {
-		let actor: Actor<ConsoleActor>;
+		let actor: Actor<ConsoleActor015>;
 
 		const upgradeCurrent = async () => {
 			await tick(pic);
@@ -398,8 +399,8 @@ describe('Console > Upgrade', () => {
 
 			const destination = await downloadConsole({ junoVersion: '0.0.61', version: '0.1.5' });
 
-			const { actor: c, canisterId: cId } = await pic.setupCanister<ConsoleActor>({
-				idlFactory: idlFactoryConsole,
+			const { actor: c, canisterId: cId } = await pic.setupCanister<ConsoleActor015>({
+				idlFactory: idlFactoryConsole015,
 				wasm: destination,
 				arg: controllersInitArgs(controller),
 				sender: controller.getPrincipal()

--- a/src/tests/specs/mission-control/mission-control.monitoring.notifications.spec.ts
+++ b/src/tests/specs/mission-control/mission-control.monitoring.notifications.spec.ts
@@ -96,10 +96,10 @@ describe('Mission Control > Notifications', () => {
 
 		consoleActor.setIdentity(user);
 
-		const { get_user_mission_control_center } = consoleActor;
-		const missionControl = await get_user_mission_control_center();
+		const { get_account } = consoleActor;
+		const account = await get_account();
 
-		const missionControlId = fromNullable(fromNullable(missionControl)?.mission_control_id ?? []);
+		const missionControlId = fromNullable(fromNullable(account)?.mission_control_id ?? []);
 
 		assertNonNullish(missionControlId);
 

--- a/src/tests/utils/console-tests.utils.ts
+++ b/src/tests/utils/console-tests.utils.ts
@@ -2,6 +2,7 @@ import {
 	type ConsoleActor,
 	type ConsoleActor0014,
 	type ConsoleActor008,
+	type ConsoleActor015,
 	type MissionControlActor,
 	idlFactoryConsole,
 	idlFactoryMissionControl
@@ -315,7 +316,7 @@ export const testSatelliteExists = async ({
 	pic
 }: {
 	users: Identity[];
-	actor: Actor<ConsoleActor | ConsoleActor008 | ConsoleActor0014>;
+	actor: Actor<ConsoleActor015 | ConsoleActor008 | ConsoleActor0014>;
 	pic: PocketIc;
 }) => {
 	const { list_user_mission_control_centers } = actor;

--- a/src/tests/utils/console-tests.utils.ts
+++ b/src/tests/utils/console-tests.utils.ts
@@ -77,7 +77,7 @@ const uploadSegment = async ({
 }: {
 	segment: 'satellite' | 'mission_control' | 'orbiter';
 	version: string;
-	actor: Actor<ConsoleActor | ConsoleActor0014>;
+	actor: Actor<ConsoleActor | ConsoleActor0014 | ConsoleActor015>;
 	proposalId: bigint;
 }) => {
 	const init_proposal_asset_upload =
@@ -196,7 +196,7 @@ export const deploySegments = async ({
 	withMissionControl = true,
 	withSatellite = true
 }: {
-	actor: Actor<ConsoleActor | ConsoleActor0014>;
+	actor: Actor<ConsoleActor | ConsoleActor0014 | ConsoleActor015>;
 	withOrbiter?: boolean;
 	withMissionControl?: boolean;
 	withSatellite?: boolean;
@@ -292,7 +292,7 @@ export const initMissionControls = async ({
 	pic,
 	length
 }: {
-	actor: Actor<ConsoleActor | ConsoleActor008 | ConsoleActor0014>;
+	actor: Actor<ConsoleActor | ConsoleActor008 | ConsoleActor0014 | ConsoleActor015>;
 	pic: PocketIc;
 	length: number;
 }): Promise<Identity[]> => {
@@ -489,7 +489,7 @@ export const assertAssetServed = async ({
 export const updateRateConfig = async ({
 	actor
 }: {
-	actor: Actor<ConsoleActor008 | ConsoleActor0014 | ConsoleActor>;
+	actor: Actor<ConsoleActor008 | ConsoleActor0014 | ConsoleActor015 | ConsoleActor>;
 }) => {
 	const { update_rate_config } = actor;
 


### PR DESCRIPTION
# Motivation

Follow-up of #2327
