### PR TITLE
build(frontend): downgrade svelte

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
 				"prettier-plugin-toml": "^2.0.6",
 				"prompts": "^2.4.2",
 				"sass": "^1.94.2",
-				"svelte": "^5.45.5",
+				"svelte": "^5.39.2",
 				"svelte-check": "^4.3.4",
 				"tslib": "^2.8.1",
 				"typescript": "^5.9.3",
@@ -4903,6 +4903,7 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.5.0.tgz",
 			"integrity": "sha512-69sM5yrHfFLJt0AZ9QqZXGCPfJ7fQjvpln3Rq5+PS03LD32Ost1Q9N+eEnaQwGRIriKkMImXD56ocjQmfjbV3w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/doctrine": {
@@ -9119,9 +9120,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.45.5",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.45.5.tgz",
-			"integrity": "sha512-2074U+vObO5Zs8/qhxtBwdi6ZXNIhEBTzNmUFjiZexLxTdt9vq96D/0pnQELl6YcpLMD7pZ2dhXKByfGS8SAdg==",
+			"version": "5.39.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.39.2.tgz",
+			"integrity": "sha512-x4Me4TgiNprpLugcXyKbcGQhHdjWpITZzSeegv3jjIyA4jObVKBhNchGGDv257Eeolg3vUUSa4n2HGFMYNaPvg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -9133,9 +9134,8 @@
 				"aria-query": "^5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.5.0",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.1",
+				"esrap": "^2.1.0",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 		"prettier-plugin-toml": "^2.0.6",
 		"prompts": "^2.4.2",
 		"sass": "^1.94.2",
-		"svelte": "^5.45.5",
+		"svelte": "^5.39.2",
 		"svelte-check": "^4.3.4",
 		"tslib": "^2.8.1",
 		"typescript": "^5.9.3",


### PR DESCRIPTION
# Motivation

With latest version of Svelte I get zillions of warnings such as following that reference simple `$props()`. As far as I know those are reactive, so it does not seem to make sense.

> Warn: This reference only captures the initial value of `segment`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally (svelte)

Seems related to https://github.com/sveltejs/svelte/issues/17289
In this other thread they says it's a bug but, not sure if it's related or something else: https://github.com/sveltejs/svelte/issues/16343#issuecomment-3604483694

Long story short, I downgrade for now as I don't want to start updating hundred of components if not required.
