### PR TITLE
feat(console): create orbiter args

### DIFF
--- a/src/console/src/api/factory.rs
+++ b/src/console/src/api/factory.rs
@@ -4,7 +4,7 @@ use candid::Principal;
 use ic_cdk_macros::update;
 use junobuild_shared::ic::api::caller;
 use junobuild_shared::ic::UnwrapOrTrap;
-use junobuild_shared::types::interface::{CreateCanisterArgs, CreateSatelliteArgs};
+use junobuild_shared::types::interface::{CreateOrbiterArgs, CreateSatelliteArgs};
 
 #[update]
 async fn create_satellite(args: CreateSatelliteArgs) -> Principal {
@@ -16,7 +16,7 @@ async fn create_satellite(args: CreateSatelliteArgs) -> Principal {
 }
 
 #[update]
-async fn create_orbiter(args: CreateCanisterArgs) -> Principal {
+async fn create_orbiter(args: CreateOrbiterArgs) -> Principal {
     let caller = caller();
 
     create_orbiter_console(caller, args).await.unwrap_or_trap()

--- a/src/console/src/factory/canister.rs
+++ b/src/console/src/factory/canister.rs
@@ -3,6 +3,7 @@ use crate::accounts::{
     get_account_with_existing_mission_control,
 };
 use crate::factory::services::ledger::{refund_payment, verify_payment};
+use crate::factory::types::CreateCanisterArgs;
 use crate::store::stable::{
     insert_new_payment, is_known_payment, update_payment_completed, update_payment_refunded,
 };
@@ -10,7 +11,6 @@ use crate::types::ledger::Payment;
 use candid::Principal;
 use ic_ledger_types::{BlockIndex, Tokens};
 use junobuild_shared::mgmt::types::cmc::SubnetId;
-use junobuild_shared::types::interface::CreateCanisterArgs;
 use junobuild_shared::types::state::{MissionControlId, UserId};
 use std::future::Future;
 

--- a/src/console/src/factory/impls.rs
+++ b/src/console/src/factory/impls.rs
@@ -1,0 +1,22 @@
+use crate::factory::types::CreateCanisterArgs;
+use junobuild_shared::types::interface::{CreateOrbiterArgs, CreateSatelliteArgs};
+
+impl From<CreateOrbiterArgs> for CreateCanisterArgs {
+    fn from(args: CreateOrbiterArgs) -> Self {
+        Self {
+            user: args.user,
+            block_index: args.block_index,
+            subnet_id: args.subnet_id,
+        }
+    }
+}
+
+impl From<CreateSatelliteArgs> for CreateCanisterArgs {
+    fn from(args: CreateSatelliteArgs) -> Self {
+        Self {
+            user: args.user,
+            block_index: args.block_index,
+            subnet_id: args.subnet_id,
+        }
+    }
+}

--- a/src/console/src/factory/mod.rs
+++ b/src/console/src/factory/mod.rs
@@ -1,6 +1,8 @@
 mod canister;
+mod impls;
 pub mod mission_control;
 pub mod orbiter;
 pub mod satellite;
 mod services;
+mod types;
 mod utils;

--- a/src/console/src/factory/orbiter.rs
+++ b/src/console/src/factory/orbiter.rs
@@ -10,19 +10,19 @@ use junobuild_shared::mgmt::cmc::cmc_create_canister_install_code;
 use junobuild_shared::mgmt::ic::create_canister_install_code;
 use junobuild_shared::mgmt::types::cmc::SubnetId;
 use junobuild_shared::mgmt::types::ic::CreateCanisterInitSettingsArg;
-use junobuild_shared::types::interface::CreateCanisterArgs;
+use junobuild_shared::types::interface::CreateOrbiterArgs;
 use junobuild_shared::types::state::{MissionControlId, UserId};
 
 pub async fn create_orbiter(
     caller: Principal,
-    args: CreateCanisterArgs,
+    args: CreateOrbiterArgs,
 ) -> Result<Principal, String> {
     create_canister(
         create_orbiter_wasm,
         &increment_orbiters_rate,
         &get_orbiter_fee,
         caller,
-        args,
+        args.into(),
     )
     .await
 }

--- a/src/console/src/factory/types.rs
+++ b/src/console/src/factory/types.rs
@@ -1,0 +1,9 @@
+use ic_ledger_types::BlockIndex;
+use junobuild_shared::mgmt::types::cmc::SubnetId;
+use junobuild_shared::types::state::UserId;
+
+pub struct CreateCanisterArgs {
+    pub user: UserId,
+    pub block_index: Option<BlockIndex>,
+    pub subnet_id: Option<SubnetId>,
+}

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -41,10 +41,11 @@ use junobuild_shared::ic::response::ManualReply;
 use junobuild_shared::rate::types::RateConfig;
 use junobuild_shared::types::core::DomainName;
 use junobuild_shared::types::domain::CustomDomains;
+use junobuild_shared::types::interface::CreateOrbiterArgs;
 use junobuild_shared::types::interface::CreateSatelliteArgs;
 use junobuild_shared::types::interface::{
-    AssertMissionControlCenterArgs, CreateCanisterArgs, DeleteControllersArgs,
-    GetCreateCanisterFeeArgs, SetControllersArgs,
+    AssertMissionControlCenterArgs, DeleteControllersArgs, GetCreateCanisterFeeArgs,
+    SetControllersArgs,
 };
 use junobuild_shared::types::list::{ListParams, ListResults};
 use junobuild_shared::types::state::Controllers;

--- a/src/libs/shared/src/impls.rs
+++ b/src/libs/shared/src/impls.rs
@@ -1,5 +1,4 @@
 use crate::types::domain::CustomDomain;
-use crate::types::interface::{CreateCanisterArgs, CreateSatelliteArgs};
 use crate::types::state::{OrbiterSatelliteConfig, SegmentKind, Version, Versioned};
 use crate::types::utils::CalendarDate;
 use std::fmt::{Display, Formatter, Result};
@@ -34,15 +33,5 @@ impl Versioned for CustomDomain {
 impl Versioned for &OrbiterSatelliteConfig {
     fn version(&self) -> Option<Version> {
         self.version
-    }
-}
-
-impl From<CreateSatelliteArgs> for CreateCanisterArgs {
-    fn from(args: CreateSatelliteArgs) -> Self {
-        Self {
-            user: args.user,
-            block_index: args.block_index,
-            subnet_id: args.subnet_id,
-        }
     }
 }

--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -132,7 +132,7 @@ pub mod interface {
     use serde::{Deserialize, Serialize};
 
     #[derive(CandidType, Deserialize)]
-    pub struct CreateCanisterArgs {
+    pub struct CreateOrbiterArgs {
         pub user: UserId,
         pub block_index: Option<BlockIndex>,
         pub subnet_id: Option<SubnetId>,

--- a/src/mission_control/src/factory/orbiter.rs
+++ b/src/mission_control/src/factory/orbiter.rs
@@ -8,7 +8,7 @@ use ic_cdk::call::Call;
 use ic_ledger_types::BlockIndex;
 use junobuild_shared::env::CONSOLE;
 use junobuild_shared::ic::DecodeCandid;
-use junobuild_shared::types::interface::CreateCanisterArgs;
+use junobuild_shared::types::interface::CreateOrbiterArgs;
 use junobuild_shared::types::state::{OrbiterId, OrbiterSatelliteConfig, SatelliteId, UserId};
 use std::collections::HashMap;
 
@@ -78,7 +78,7 @@ async fn create_and_save_orbiter(
 ) -> Result<Orbiter, String> {
     let console = Principal::from_text(CONSOLE).unwrap();
 
-    let args = CreateCanisterArgs {
+    let args = CreateOrbiterArgs {
         user,
         block_index,
         subnet_id,


### PR DESCRIPTION
# Motivation

It's more consistent with create satellite args and this way we can more easily add an (unused) optional name field in #2313
