### PR TITLE
chore(toolchain): downgrade Rust v1.91.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.91.1"
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1"]


### PR DESCRIPTION
# Motivation

RustRover is buggy and does not support Rust v1.92.0.

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/fe4124b0-1d61-4a84-9a9f-70d2332dcae4" />



