### PR TITLE
chore(core): prevents npm from executing scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+ignore-scripts=true


### PR DESCRIPTION
# Motivation

We want to prevent npm from executing scripts for security reasons.

- https://x.com/sitnikcode/status/2001323549315969505
- https://www.nodejs-security.com/blog/npm-ignore-scripts-best-practices-as-security-mitigation-for-malicious-packages
- https://docs.npmjs.com/cli/v11/using-npm/config#ignore-scripts
