### PR TITLE
feat(console): name option in create orbiter and satellite

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -80,12 +80,14 @@ type ControllerScope = variant { Write; Admin; Submit };
 type CreateOrbiterArgs = record {
   block_index : opt nat64;
   subnet_id : opt principal;
+  name : opt text;
   user : principal;
 };
 type CreateSatelliteArgs = record {
   block_index : opt nat64;
   subnet_id : opt principal;
   storage : opt InitStorageArgs;
+  name : opt text;
   user : principal;
 };
 type CustomDomain = record {

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -103,12 +103,14 @@ export type ControllerScope = { Write: null } | { Admin: null } | { Submit: null
 export interface CreateOrbiterArgs {
 	block_index: [] | [bigint];
 	subnet_id: [] | [Principal];
+	name: [] | [string];
 	user: Principal;
 }
 export interface CreateSatelliteArgs {
 	block_index: [] | [bigint];
 	subnet_id: [] | [Principal];
 	storage: [] | [InitStorageArgs];
+	name: [] | [string];
 	user: Principal;
 }
 export interface CustomDomain {

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -103,6 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	const CreateOrbiterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
+		name: IDL.Opt(IDL.Text),
 		user: IDL.Principal
 	});
 	const InitStorageMemory = IDL.Variant({
@@ -116,6 +117,7 @@ export const idlFactory = ({ IDL }) => {
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs),
+		name: IDL.Opt(IDL.Text),
 		user: IDL.Principal
 	});
 	const DeleteControllersArgs = IDL.Record({

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -103,6 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	const CreateOrbiterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
+		name: IDL.Opt(IDL.Text),
 		user: IDL.Principal
 	});
 	const InitStorageMemory = IDL.Variant({
@@ -116,6 +117,7 @@ export const idlFactory = ({ IDL }) => {
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs),
+		name: IDL.Opt(IDL.Text),
 		user: IDL.Principal
 	});
 	const DeleteControllersArgs = IDL.Record({

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -103,6 +103,7 @@ export const idlFactory = ({ IDL }) => {
 	const CreateOrbiterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
+		name: IDL.Opt(IDL.Text),
 		user: IDL.Principal
 	});
 	const InitStorageMemory = IDL.Variant({
@@ -116,6 +117,7 @@ export const idlFactory = ({ IDL }) => {
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
 		storage: IDL.Opt(InitStorageArgs),
+		name: IDL.Opt(IDL.Text),
 		user: IDL.Principal
 	});
 	const DeleteControllersArgs = IDL.Record({

--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -136,6 +136,7 @@ pub mod interface {
         pub user: UserId,
         pub block_index: Option<BlockIndex>,
         pub subnet_id: Option<SubnetId>,
+        pub name: Option<String>,
     }
 
     #[derive(CandidType, Deserialize)]
@@ -144,6 +145,7 @@ pub mod interface {
         pub block_index: Option<BlockIndex>,
         pub subnet_id: Option<SubnetId>,
         pub storage: Option<InitStorageArgs>,
+        pub name: Option<String>,
     }
 
     #[derive(CandidType, Deserialize)]

--- a/src/mission_control/src/factory/orbiter.rs
+++ b/src/mission_control/src/factory/orbiter.rs
@@ -82,6 +82,7 @@ async fn create_and_save_orbiter(
         user,
         block_index,
         subnet_id,
+        name: name.clone(),
     };
 
     let orbiter_id = Call::unbounded_wait(console, "create_orbiter")

--- a/src/mission_control/src/factory/satellite.rs
+++ b/src/mission_control/src/factory/satellite.rs
@@ -88,6 +88,7 @@ async fn create_and_save_satellite(
         block_index,
         subnet_id,
         storage,
+        name: name.clone(),
     };
 
     let satellite_id = Call::unbounded_wait(console, "create_satellite")


### PR DESCRIPTION
# Motivation

Even though it will only be use for backwards compatibility, we add the name to the create orbiter and satellite args optionally

Related to #2313