### PR TITLE
feat(console): make factory more generic to support spinning modules from mission control or user (console ui)

### DIFF
--- a/src/console/src/factory/canister.rs
+++ b/src/console/src/factory/canister.rs
@@ -1,7 +1,7 @@
 use crate::accounts::credits::{has_credits, use_credits};
 use crate::accounts::get_account_with_existing_mission_control;
 use crate::factory::services::ledger::{refund_payment, verify_payment};
-use crate::factory::types::CreateCanisterArgs;
+use crate::factory::types::{CanisterCreator, CreateCanisterArgs};
 use crate::store::stable::{
     insert_new_payment, is_known_payment, update_payment_completed, update_payment_refunded,
 };
@@ -9,7 +9,7 @@ use crate::types::ledger::Payment;
 use candid::Principal;
 use ic_ledger_types::{BlockIndex, Tokens};
 use junobuild_shared::mgmt::types::cmc::SubnetId;
-use junobuild_shared::types::state::{MissionControlId, UserId};
+use junobuild_shared::types::state::UserId;
 use std::future::Future;
 
 pub async fn create_canister<F, Fut>(
@@ -17,14 +17,11 @@ pub async fn create_canister<F, Fut>(
     increment_rate: &dyn Fn() -> Result<(), String>,
     get_fee: &dyn Fn() -> Tokens,
     caller: Principal,
-    CreateCanisterArgs {
-        user,
-        block_index,
-        subnet_id,
-    }: CreateCanisterArgs,
+    user: UserId,
+    args: CreateCanisterArgs,
 ) -> Result<Principal, String>
 where
-    F: FnOnce(MissionControlId, UserId, Option<SubnetId>) -> Fut,
+    F: FnOnce(CanisterCreator, Option<SubnetId>) -> Fut,
     Fut: Future<Output = Result<Principal, String>>,
 {
     // User should have a mission control center
@@ -33,50 +30,42 @@ where
     match account.mission_control_id {
         None => Err("No mission control center found.".to_string()),
         Some(mission_control_id) => {
+            let creator: CanisterCreator =
+                CanisterCreator::MissionControl((mission_control_id, account.owner));
+
             let fee = get_fee();
 
             if has_credits(&account, &fee) {
                 // Guard too many requests
                 increment_rate()?;
 
-                return create_canister_with_credits(create, mission_control_id, user, subnet_id)
-                    .await;
+                return create_canister_with_credits(create, creator, args).await;
             }
 
-            create_canister_with_payment(
-                create,
-                caller,
-                mission_control_id,
-                CreateCanisterArgs {
-                    user,
-                    block_index,
-                    subnet_id,
-                },
-                fee,
-            )
-            .await
+            create_canister_with_payment(create, creator, args, fee).await
         }
     }
 }
 
 async fn create_canister_with_credits<F, Fut>(
     create: F,
-    mission_control_id: MissionControlId,
-    user: UserId,
-    subnet_id: Option<SubnetId>,
+    creator: CanisterCreator,
+    CreateCanisterArgs { subnet_id, .. }: CreateCanisterArgs,
 ) -> Result<Principal, String>
 where
-    F: FnOnce(MissionControlId, UserId, Option<SubnetId>) -> Fut,
+    F: FnOnce(CanisterCreator, Option<SubnetId>) -> Fut,
     Fut: Future<Output = Result<Principal, String>>,
 {
+    let account_owner = creator.account_owner().clone();
+
     // Create the satellite
-    let create_canister_result = create(mission_control_id, user, subnet_id).await;
+    let create_canister_result = create(creator, subnet_id).await;
 
     match create_canister_result {
         Err(_) => Err("Segment creation with credits failed.".to_string()),
         Ok(satellite_id) => {
-            // Satellite is created we can use the credits
-            let credits = use_credits(&user);
+            // Satellite or orbiter is created we can use the credits
+            let credits = use_credits(&account_owner);
 
             match credits {
                 Err(e) => Err(e.to_string()),
@@ -88,69 +77,60 @@ where
 
 async fn create_canister_with_payment<F, Fut>(
     create: F,
-    caller: Principal,
-    mission_control_id: MissionControlId,
+    creator: CanisterCreator,
     CreateCanisterArgs {
-        user,
         block_index,
         subnet_id,
     }: CreateCanisterArgs,
     fee: Tokens,
 ) -> Result<Principal, String>
 where
-    F: FnOnce(MissionControlId, UserId, Option<SubnetId>) -> Fut,
+    F: FnOnce(CanisterCreator, Option<SubnetId>) -> Fut,
     Fut: Future<Output = Result<Principal, String>>,
 {
+    let purchaser = creator.purchaser().clone();
+
     if block_index.is_none() {
         return Err("No block index provided to verify payment.".to_string());
     }
 
     // User should have processed a payment from the mission control center
-    let mission_control_payment_block_index: BlockIndex = block_index.unwrap();
-    let _ = verify_payment(&caller, &mission_control_payment_block_index, fee).await?;
+    let purchaser_payment_block_index: BlockIndex = block_index.unwrap();
+    let _ = verify_payment(&purchaser, &purchaser_payment_block_index, fee).await?;
 
-    if is_known_payment(&mission_control_payment_block_index) {
+    if is_known_payment(&purchaser_payment_block_index) {
         return Err("Payment has been or is being processed.".to_string());
     }
 
     // We acknowledge the new payment
-    insert_new_payment(&user, &mission_control_payment_block_index)?;
+    insert_new_payment(&purchaser, &purchaser_payment_block_index)?;
 
     // Create the canister (satellite or orbiter)
-    let create_canister_result = create(mission_control_id, user, subnet_id).await;
+    let create_canister_result = create(creator, subnet_id).await;
 
     match create_canister_result {
         Err(error) => {
-            refund_satellite_creation(
-                &mission_control_id,
-                &mission_control_payment_block_index,
-                fee,
-            )
-            .await?;
+            refund_canister_creation(&purchaser, &purchaser_payment_block_index, fee).await?;
 
-            Err([
-                "Satellite creation failed. Mission control center has been refunded.",
-                &error,
-            ]
-            .join(" - "))
+            Err(["Canister creation failed. Buyer has been refunded.", &error].join(" - "))
         }
         Ok(satellite_id) => {
-            // Satellite is created we can update the payment has being processed
-            update_payment_completed(&mission_control_payment_block_index)?;
+            // Satellite or orbiter is created, we can update the payment has being processed
+            update_payment_completed(&purchaser_payment_block_index)?;
 
             Ok(satellite_id)
         }
     }
 }
 
-async fn refund_satellite_creation(
-    mission_control_id: &MissionControlId,
-    mission_control_payment_block_index: &BlockIndex,
+async fn refund_canister_creation(
+    purchaser: &Principal,
+    purchaser_payment_block_index: &BlockIndex,
     fee: Tokens,
 ) -> Result<Payment, String> {
-    let refund_block_index = refund_payment(mission_control_id, fee).await?;
+    let refund_block_index = refund_payment(purchaser, fee).await?;
 
     // We record the refund in the payment list
-    update_payment_refunded(mission_control_payment_block_index, &refund_block_index)
+    update_payment_refunded(purchaser_payment_block_index, &refund_block_index)
         .map_err(|e| format!("Insert refund transaction error {e:?}"))
 }

--- a/src/console/src/factory/impls.rs
+++ b/src/console/src/factory/impls.rs
@@ -1,10 +1,37 @@
+use crate::factory::types::CanisterCreator;
 use crate::factory::types::CreateCanisterArgs;
+use candid::Principal;
 use junobuild_shared::types::interface::{CreateOrbiterArgs, CreateSatelliteArgs};
+use junobuild_shared::types::state::{ControllerId, UserId};
+
+impl CanisterCreator {
+    pub fn purchaser(&self) -> &Principal {
+        match self {
+            CanisterCreator::User(user) => user,
+            CanisterCreator::MissionControl((mission_control, _)) => mission_control,
+        }
+    }
+
+    pub fn account_owner(&self) -> &UserId {
+        match self {
+            CanisterCreator::User(user) => user,
+            CanisterCreator::MissionControl((_, user)) => user,
+        }
+    }
+
+    pub fn controllers(&self) -> Vec<ControllerId> {
+        match self {
+            CanisterCreator::User(user) => Vec::from([*user]),
+            CanisterCreator::MissionControl((mission_control, user)) => {
+                Vec::from([*user, *mission_control])
+            }
+        }
+    }
+}
 
 impl From<CreateOrbiterArgs> for CreateCanisterArgs {
     fn from(args: CreateOrbiterArgs) -> Self {
         Self {
-            user: args.user,
             block_index: args.block_index,
             subnet_id: args.subnet_id,
         }
@@ -14,7 +41,6 @@ impl From<CreateOrbiterArgs> for CreateCanisterArgs {
 impl From<CreateSatelliteArgs> for CreateCanisterArgs {
     fn from(args: CreateSatelliteArgs) -> Self {
         Self {
-            user: args.user,
             block_index: args.block_index,
             subnet_id: args.subnet_id,
         }

--- a/src/console/src/factory/types.rs
+++ b/src/console/src/factory/types.rs
@@ -1,9 +1,14 @@
 use ic_ledger_types::BlockIndex;
 use junobuild_shared::mgmt::types::cmc::SubnetId;
-use junobuild_shared::types::state::UserId;
+use junobuild_shared::types::state::{MissionControlId, UserId};
+
+#[derive(Clone)]
+pub enum CanisterCreator {
+    User(UserId), // The caller is the owner of the account. The caller comes from the Console UI.
+    MissionControl((MissionControlId, UserId)), // The caller is a mission control
+}
 
 pub struct CreateCanisterArgs {
-    pub user: UserId,
     pub block_index: Option<BlockIndex>,
     pub subnet_id: Option<SubnetId>,
 }

--- a/src/console/src/factory/utils/controllers.rs
+++ b/src/console/src/factory/utils/controllers.rs
@@ -1,6 +1,6 @@
 use candid::Principal;
 use junobuild_shared::mgmt::ic::update_canister_controllers;
-use junobuild_shared::types::state::MissionControlId;
+use junobuild_shared::types::state::ControllerId;
 use junobuild_shared::types::state::UserId;
 
 /// Once mission control is created:
@@ -19,25 +19,16 @@ pub async fn update_mission_control_controllers(
     }
 }
 
-// Satellite is ready - canister has been created and code has been installed once - we can remove the console of the list of the controllers of the satellite.
+// Satellite or Orbiter is ready - canister has been created and code has been installed once - we can remove the console of the list of the controllers of the satellite.
 // Note: we install the code the first time with the console as a controller to avoid to have to populate the satellite wasm in each mission control center.
 pub async fn remove_console_controller(
     canister_id: &Principal,
-    user: &UserId,
-    mission_control_id: &MissionControlId,
+    controllers: &Vec<ControllerId>,
 ) -> Result<(), String> {
-    let controllers = user_mission_control_controllers(user, mission_control_id);
     let result = update_canister_controllers(*canister_id, controllers.to_owned()).await;
 
     match result {
         Err(_) => Err("Failed to remove console from the controllers of the segment.".to_string()),
         Ok(_) => Ok(()),
     }
-}
-
-pub fn user_mission_control_controllers(
-    user: &UserId,
-    mission_control_id: &MissionControlId,
-) -> Vec<Principal> {
-    Vec::from([*user, *mission_control_id])
 }

--- a/src/console/src/factory/utils/wasm.rs
+++ b/src/console/src/factory/utils/wasm.rs
@@ -1,5 +1,4 @@
 use crate::cdn::helpers::heap::get_asset;
-use crate::factory::utils::controllers::user_mission_control_controllers;
 use crate::store::heap::{
     get_latest_mission_control_version, get_latest_orbiter_version, get_latest_satellite_version,
 };
@@ -9,7 +8,7 @@ use junobuild_shared::types::core::Blob;
 use junobuild_shared::types::interface::{
     InitMissionControlArgs, InitOrbiterArgs, InitSatelliteArgs, InitStorageArgs,
 };
-use junobuild_shared::types::state::{MissionControlId, UserId};
+use junobuild_shared::types::state::{ControllerId, UserId};
 use junobuild_storage::constants::ASSET_ENCODING_NO_COMPRESSION;
 use junobuild_storage::types::state::FullPath;
 
@@ -47,8 +46,7 @@ pub fn mission_control_wasm_arg(user: &UserId) -> Result<WasmArg, String> {
 }
 
 pub fn satellite_wasm_arg(
-    user: &UserId,
-    mission_control_id: &MissionControlId,
+    controllers: &Vec<ControllerId>,
     storage: Option<InitStorageArgs>,
 ) -> Result<WasmArg, String> {
     let latest_version =
@@ -56,22 +54,19 @@ pub fn satellite_wasm_arg(
     let full_path = format!("/releases/satellite-v{latest_version}.wasm.gz");
     let wasm: Blob = get_chunks(&full_path)?;
     let install_arg: Vec<u8> = Encode!(&InitSatelliteArgs {
-        controllers: user_mission_control_controllers(user, mission_control_id),
+        controllers: controllers.clone(),
         storage
     })
     .map_err(|e| e.to_string())?;
     Ok(WasmArg { wasm, install_arg })
 }
 
-pub fn orbiter_wasm_arg(
-    user: &UserId,
-    mission_control_id: &MissionControlId,
-) -> Result<WasmArg, String> {
+pub fn orbiter_wasm_arg(controllers: &Vec<ControllerId>) -> Result<WasmArg, String> {
     let latest_version = get_latest_orbiter_version().ok_or("No orbiter versions available.")?;
     let full_path = format!("/releases/orbiter-v{latest_version}.wasm.gz");
     let wasm: Blob = get_chunks(&full_path)?;
     let install_arg: Vec<u8> = Encode!(&InitOrbiterArgs {
-        controllers: user_mission_control_controllers(user, mission_control_id)
+        controllers: controllers.clone()
     })
     .map_err(|e| e.to_string())?;
     Ok(WasmArg { wasm, install_arg })


### PR DESCRIPTION
# Motivation

In #2313 we want to support spinning satellites and orbiters and mission controls from the console ui. the latter even only in the ui. that's why we refactor the factory to be more generic and already introduce an enum to get to know if the creator is mission control or user (aka user in the console ui frontend).

The PR does not contain yet the implementation so it's closer to a refactoring.
