### PR TITLE
feat(console): use new field purchaser in payment stable map

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -193,6 +193,10 @@ type ListResults = record {
   items : vec record { text; AssetNoContent };
   items_length : nat64;
 };
+type ListSegmentsArgs = record {
+  segment_id : opt principal;
+  segment_type : opt SegmentType;
+};
 type Memory = variant { Heap; Stable };
 type OpenId = record { provider : OpenIdProvider; data : OpenIdData };
 type OpenIdData = record {
@@ -230,6 +234,7 @@ type Payment = record {
   mission_control_id : opt principal;
   created_at : nat64;
   block_index_refunded : opt nat64;
+  purchaser : opt principal;
 };
 type PaymentStatus = variant { Refunded; Acknowledged; Completed };
 type PrepareDelegationError = variant {
@@ -267,7 +272,19 @@ type Provider = variant { InternetIdentity; OpenId : OpenId };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type Result = variant { Ok : Authentication; Err : AuthenticationError };
 type Result_1 = variant { Ok : SignedDelegation; Err : GetDelegationError };
+type Segment = record {
+  updated_at : nat64;
+  metadata : vec record { text; text };
+  segment_id : principal;
+  created_at : nat64;
+};
+type SegmentKey = record {
+  user : principal;
+  segment_id : principal;
+  segment_type : SegmentType;
+};
 type SegmentKind = variant { Orbiter; MissionControl; Satellite };
+type SegmentType = variant { Orbiter; Satellite };
 type SegmentsDeploymentOptions = record {
   orbiter : opt text;
   mission_control_version : opt text;
@@ -385,6 +402,9 @@ service : () -> {
   list_custom_domains : () -> (vec record { text; CustomDomain }) query;
   list_payments : () -> (vec record { nat64; Payment }) query;
   list_proposals : (ListProposalsParams) -> (ListProposalResults) query;
+  list_segments : (ListSegmentsArgs) -> (
+      vec record { SegmentKey; Segment },
+    ) query;
   reject_proposal : (CommitProposal) -> (null);
   set_auth_config : (SetAuthenticationConfig) -> (AuthenticationConfig);
   set_controllers : (SetControllersArgs) -> ();

--- a/src/console/src/types.rs
+++ b/src/console/src/types.rs
@@ -212,13 +212,15 @@ pub mod interface {
 }
 
 pub mod ledger {
-    use candid::CandidType;
+    use candid::{CandidType, Principal};
     use ic_ledger_types::BlockIndex;
     use junobuild_shared::types::state::{MissionControlId, Timestamp};
     use serde::{Deserialize, Serialize};
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct Payment {
+        pub purchaser: Option<Principal>,
+        #[deprecated(note = "Deprecated. Use purchaser instead.")]
         pub mission_control_id: Option<MissionControlId>,
         pub block_index_payment: BlockIndex,
         pub block_index_refunded: Option<BlockIndex>,

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -233,6 +233,10 @@ export interface ListResults {
 	items: Array<[string, AssetNoContent]>;
 	items_length: bigint;
 }
+export interface ListSegmentsArgs {
+	segment_id: [] | [Principal];
+	segment_type: [] | [SegmentType];
+}
 export type Memory = { Heap: null } | { Stable: null };
 export interface OpenId {
 	provider: OpenIdProvider;
@@ -273,6 +277,7 @@ export interface Payment {
 	mission_control_id: [] | [Principal];
 	created_at: bigint;
 	block_index_refunded: [] | [bigint];
+	purchaser: [] | [Principal];
 }
 export type PaymentStatus = { Refunded: null } | { Acknowledged: null } | { Completed: null };
 export type PrepareDelegationError =
@@ -317,7 +322,19 @@ export interface RateConfig {
 }
 export type Result = { Ok: Authentication } | { Err: AuthenticationError };
 export type Result_1 = { Ok: SignedDelegation } | { Err: GetDelegationError };
+export interface Segment {
+	updated_at: bigint;
+	metadata: Array<[string, string]>;
+	segment_id: Principal;
+	created_at: bigint;
+}
+export interface SegmentKey {
+	user: Principal;
+	segment_id: Principal;
+	segment_type: SegmentType;
+}
 export type SegmentKind = { Orbiter: null } | { MissionControl: null } | { Satellite: null };
+export type SegmentType = { Orbiter: null } | { Satellite: null };
 export interface SegmentsDeploymentOptions {
 	orbiter: [] | [string];
 	mission_control_version: [] | [string];
@@ -446,6 +463,7 @@ export interface _SERVICE {
 	list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
 	list_payments: ActorMethod<[], Array<[bigint, Payment]>>;
 	list_proposals: ActorMethod<[ListProposalsParams], ListProposalResults>;
+	list_segments: ActorMethod<[ListSegmentsArgs], Array<[SegmentKey, Segment]>>;
 	reject_proposal: ActorMethod<[CommitProposal], null>;
 	set_auth_config: ActorMethod<[SetAuthenticationConfig], AuthenticationConfig>;
 	set_controllers: ActorMethod<[SetControllersArgs], undefined>;

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -376,7 +376,8 @@ export const idlFactory = ({ IDL }) => {
 		block_index_payment: IDL.Nat64,
 		mission_control_id: IDL.Opt(IDL.Principal),
 		created_at: IDL.Nat64,
-		block_index_refunded: IDL.Opt(IDL.Nat64)
+		block_index_refunded: IDL.Opt(IDL.Nat64),
+		purchaser: IDL.Opt(IDL.Principal)
 	});
 	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
@@ -392,6 +393,25 @@ export const idlFactory = ({ IDL }) => {
 		matches_length: IDL.Nat64,
 		items: IDL.Vec(IDL.Tuple(ProposalKey, Proposal)),
 		items_length: IDL.Nat64
+	});
+	const SegmentType = IDL.Variant({
+		Orbiter: IDL.Null,
+		Satellite: IDL.Null
+	});
+	const ListSegmentsArgs = IDL.Record({
+		segment_id: IDL.Opt(IDL.Principal),
+		segment_type: IDL.Opt(SegmentType)
+	});
+	const SegmentKey = IDL.Record({
+		user: IDL.Principal,
+		segment_id: IDL.Principal,
+		segment_type: SegmentType
+	});
+	const Segment = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		segment_id: IDL.Principal,
+		created_at: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
 		openid: IDL.Opt(AuthenticationConfigOpenId),
@@ -473,6 +493,7 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
 		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], []),
 		list_proposals: IDL.Func([ListProposalsParams], [ListProposalResults], []),
+		list_segments: IDL.Func([ListSegmentsArgs], [IDL.Vec(IDL.Tuple(SegmentKey, Segment))], []),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -376,7 +376,8 @@ export const idlFactory = ({ IDL }) => {
 		block_index_payment: IDL.Nat64,
 		mission_control_id: IDL.Opt(IDL.Principal),
 		created_at: IDL.Nat64,
-		block_index_refunded: IDL.Opt(IDL.Nat64)
+		block_index_refunded: IDL.Opt(IDL.Nat64),
+		purchaser: IDL.Opt(IDL.Principal)
 	});
 	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
@@ -392,6 +393,25 @@ export const idlFactory = ({ IDL }) => {
 		matches_length: IDL.Nat64,
 		items: IDL.Vec(IDL.Tuple(ProposalKey, Proposal)),
 		items_length: IDL.Nat64
+	});
+	const SegmentType = IDL.Variant({
+		Orbiter: IDL.Null,
+		Satellite: IDL.Null
+	});
+	const ListSegmentsArgs = IDL.Record({
+		segment_id: IDL.Opt(IDL.Principal),
+		segment_type: IDL.Opt(SegmentType)
+	});
+	const SegmentKey = IDL.Record({
+		user: IDL.Principal,
+		segment_id: IDL.Principal,
+		segment_type: SegmentType
+	});
+	const Segment = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		segment_id: IDL.Principal,
+		created_at: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
 		openid: IDL.Opt(AuthenticationConfigOpenId),
@@ -473,6 +493,11 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], ['query']),
 		list_proposals: IDL.Func([ListProposalsParams], [ListProposalResults], ['query']),
+		list_segments: IDL.Func(
+			[ListSegmentsArgs],
+			[IDL.Vec(IDL.Tuple(SegmentKey, Segment))],
+			['query']
+		),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -376,7 +376,8 @@ export const idlFactory = ({ IDL }) => {
 		block_index_payment: IDL.Nat64,
 		mission_control_id: IDL.Opt(IDL.Principal),
 		created_at: IDL.Nat64,
-		block_index_refunded: IDL.Opt(IDL.Nat64)
+		block_index_refunded: IDL.Opt(IDL.Nat64),
+		purchaser: IDL.Opt(IDL.Principal)
 	});
 	const ListProposalsOrder = IDL.Record({ desc: IDL.Bool });
 	const ListProposalsPaginate = IDL.Record({
@@ -392,6 +393,25 @@ export const idlFactory = ({ IDL }) => {
 		matches_length: IDL.Nat64,
 		items: IDL.Vec(IDL.Tuple(ProposalKey, Proposal)),
 		items_length: IDL.Nat64
+	});
+	const SegmentType = IDL.Variant({
+		Orbiter: IDL.Null,
+		Satellite: IDL.Null
+	});
+	const ListSegmentsArgs = IDL.Record({
+		segment_id: IDL.Opt(IDL.Principal),
+		segment_type: IDL.Opt(SegmentType)
+	});
+	const SegmentKey = IDL.Record({
+		user: IDL.Principal,
+		segment_id: IDL.Principal,
+		segment_type: SegmentType
+	});
+	const Segment = IDL.Record({
+		updated_at: IDL.Nat64,
+		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
+		segment_id: IDL.Principal,
+		created_at: IDL.Nat64
 	});
 	const SetAuthenticationConfig = IDL.Record({
 		openid: IDL.Opt(AuthenticationConfigOpenId),
@@ -473,6 +493,11 @@ export const idlFactory = ({ IDL }) => {
 		list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
 		list_payments: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Nat64, Payment))], ['query']),
 		list_proposals: IDL.Func([ListProposalsParams], [ListProposalResults], ['query']),
+		list_segments: IDL.Func(
+			[ListSegmentsArgs],
+			[IDL.Vec(IDL.Tuple(SegmentKey, Segment))],
+			['query']
+		),
 		reject_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		set_auth_config: IDL.Func([SetAuthenticationConfig], [AuthenticationConfig], []),
 		set_controllers: IDL.Func([SetControllersArgs], [], []),

--- a/src/tests/specs/console/upgrade/console.fees.upgrade-v0-3-0.spec.ts
+++ b/src/tests/specs/console/upgrade/console.fees.upgrade-v0-3-0.spec.ts
@@ -1,0 +1,115 @@
+import {
+	idlFactoryConsole,
+	idlFactoryConsole020,
+	idlFactoryMissionControl,
+	type ConsoleActor,
+	type ConsoleActor020,
+	type MissionControlActor
+} from '$declarations';
+import { PocketIc, type Actor } from '@dfinity/pic';
+import { assertNonNullish, fromNullable, toNullable } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
+import type { Principal } from '@icp-sdk/core/principal';
+import { inject } from 'vitest';
+import { CONSOLE_ID } from '../../../constants/console-tests.constants';
+import { deploySegments, updateRateConfig } from '../../../utils/console-tests.utils';
+import { tick } from '../../../utils/pic-tests.utils';
+import {
+	CONSOLE_WASM_PATH,
+	controllersInitArgs,
+	downloadConsole
+} from '../../../utils/setup-tests.utils';
+
+describe('Console > Upgrade > Fees > v0.2.0 -> v0.3.0', () => {
+	let pic: PocketIc;
+	let actor: Actor<ConsoleActor020>;
+	let canisterId: Principal;
+
+	const controller = Ed25519KeyIdentity.generate();
+
+	const user = Ed25519KeyIdentity.generate();
+
+	const upgradeCurrent = async () => {
+		await tick(pic);
+
+		await pic.upgradeCanister({
+			canisterId,
+			wasm: CONSOLE_WASM_PATH,
+			sender: controller.getPrincipal()
+		});
+	};
+
+	const createMissionControlAndSatellite = async ({ user }: { user: Identity }) => {
+		actor.setIdentity(user);
+
+		const { init_user_mission_control_center } = actor;
+		const missionControl = await init_user_mission_control_center();
+
+		const missionControlId = fromNullable(missionControl.mission_control_id);
+
+		assertNonNullish(missionControlId);
+
+		const micActor = pic.createActor<MissionControlActor>(
+			idlFactoryMissionControl,
+			missionControlId
+		);
+		micActor.setIdentity(user);
+
+		const { create_satellite } = micActor;
+		await create_satellite('test');
+	};
+
+	beforeEach(async () => {
+		pic = await PocketIc.create(inject('PIC_URL'));
+
+		const destination = await downloadConsole({ junoVersion: '0.0.62', version: '0.2.0' });
+
+		const { actor: c, canisterId: cId } = await pic.setupCanister<ConsoleActor020>({
+			idlFactory: idlFactoryConsole020,
+			wasm: destination,
+			arg: controllersInitArgs(controller),
+			sender: controller.getPrincipal(),
+			targetCanisterId: CONSOLE_ID
+		});
+
+		actor = c;
+		canisterId = cId;
+		actor.setIdentity(controller);
+
+		await updateRateConfig({ actor });
+
+		await deploySegments({ actor });
+
+		// Consumes starting credits otherwise get_create_fee will return None
+		await createMissionControlAndSatellite({ user });
+
+		// Create mission control requires the user to be a caller of the Console
+		actor.setIdentity(controller);
+	});
+
+	afterEach(async () => {
+		await pic?.tearDown();
+	});
+
+	it('should still provide fees', async () => {
+		const { set_fee } = actor;
+
+		await set_fee({ Satellite: null }, { e8s: 40_000_000n });
+		await set_fee({ Orbiter: null }, { e8s: 77_000_000n });
+
+		await upgradeCurrent();
+
+		const newActor = pic.createActor<ConsoleActor>(idlFactoryConsole, canisterId);
+		newActor.setIdentity(user);
+
+		const { get_create_fee } = newActor;
+
+		await expect(get_create_fee({ Satellite: null })).resolves.toEqual(
+			toNullable({ e8s: 40_000_000n })
+		);
+		await expect(get_create_fee({ Orbiter: null })).resolves.toEqual(
+			toNullable({ e8s: 77_000_000n })
+		);
+	});
+});

--- a/src/tests/specs/mission-control/mission-control.wallet.spec.ts
+++ b/src/tests/specs/mission-control/mission-control.wallet.spec.ts
@@ -11,7 +11,7 @@ import type { Principal } from '@icp-sdk/core/principal';
 import { inject } from 'vitest';
 import { LEDGER_ID } from '../../constants/ledger-tests.contants';
 import { MISSION_CONTROL_ADMIN_CONTROLLER_ERROR_MSG } from '../../constants/mission-control-tests.constants';
-import { setupLedger } from '../../utils/ledger-tests.utils';
+import { setupLedger, transferIcp } from '../../utils/ledger-tests.utils';
 import { missionControlUserInitArgs } from '../../utils/mission-control-tests.utils';
 import { MISSION_CONTROL_WASM_PATH } from '../../utils/setup-tests.utils';
 
@@ -164,15 +164,9 @@ describe('Mission Control > Wallet', () => {
 
 		describe('Transfer success', () => {
 			beforeAll(async () => {
-				const { icrc1_transfer } = ledgerActor;
-
-				await icrc1_transfer({
-					amount: 5_500_010_000n,
-					to: { owner: missionControlId, subaccount: [] },
-					fee: [],
-					memo: [],
-					from_subaccount: [],
-					created_at_time: []
+				await transferIcp({
+					ledgerActor,
+					owner: missionControlId
 				});
 			});
 

--- a/src/tests/utils/ledger-tests.utils.ts
+++ b/src/tests/utils/ledger-tests.utils.ts
@@ -1,10 +1,11 @@
 import { idlFactory, init } from '$declarations/ledger/icp/ledger.factory.did.js';
-import type { CanisterFixture, PocketIc } from '@dfinity/pic';
+import type { Actor, CanisterFixture, PocketIc } from '@dfinity/pic';
 import { assertNonNullish } from '@dfinity/utils';
 import { AccountIdentifier, type IcpLedgerCanisterOptions } from '@icp-sdk/canisters/ledger/icp';
 import type { Identity } from '@icp-sdk/core/agent';
 import { IDL } from '@icp-sdk/core/candid';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
+import type { Principal } from '@icp-sdk/core/principal';
 import { LEDGER_ID } from '../constants/ledger-tests.contants';
 import { download } from './setup-tests.utils';
 
@@ -73,4 +74,23 @@ export const setupLedger = async ({
 		actor,
 		...rest
 	};
+};
+
+export const transferIcp = async ({
+	ledgerActor,
+	owner
+}: {
+	ledgerActor: Actor<LedgerActor>;
+	owner: Principal;
+}) => {
+	const { icrc1_transfer } = ledgerActor;
+
+	await icrc1_transfer({
+		amount: 5_500_010_000n,
+		to: { owner, subaccount: [] },
+		fee: [],
+		memo: [],
+		from_subaccount: [],
+		created_at_time: []
+	});
 };


### PR DESCRIPTION
# Motivation

In #2313 we want to accept the Console UI to spin modules using ICRC transfer from hence the mission control not always being the purchaser anymore.
