### PR TITLE
chore(core): return Error::UNEXPECTED instead of new_custom(0)

### DIFF
--- a/src/libs/satellite/src/random/init.rs
+++ b/src/libs/satellite/src/random/init.rs
@@ -23,7 +23,7 @@ pub async fn init_random_seed() {
 unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
     with_runtime_rng_mut(|rng| {
         match rng {
-            None => Err(Error::new_custom(0)),
+            None => Err(Error::UNEXPECTED),
             Some(rng) => {
                 let buf: &mut [u8] = unsafe {
                     // fill the buffer with zeros

--- a/src/mission_control/src/random.rs
+++ b/src/mission_control/src/random.rs
@@ -26,7 +26,7 @@ unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Res
         let rng = &mut state.borrow_mut().rng;
 
         match rng {
-            None => Err(Error::new_custom(0)),
+            None => Err(Error::UNEXPECTED),
             Some(rng) => {
                 let buf: &mut [u8] = unsafe {
                     // fill the buffer with zeros

--- a/src/observatory/src/random.rs
+++ b/src/observatory/src/random.rs
@@ -22,7 +22,7 @@ async fn set_random_seed() {
 unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
     with_runtime_rng_mut(|rng| {
         match rng {
-            None => Err(Error::new_custom(0)),
+            None => Err(Error::UNEXPECTED),
             Some(rng) => {
                 let buf: &mut [u8] = unsafe {
                     // fill the buffer with zeros


### PR DESCRIPTION
# Motivation

Source: https://forum.dfinity.org/t/get-random-numbers-without-async-for-rust-getrandom/61671/8?u=peterparker
