### PR TITLE
feat(console): create mission control for user

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -77,6 +77,10 @@ type Controller = record {
   expires_at : opt nat64;
 };
 type ControllerScope = variant { Write; Admin; Submit };
+type CreateMissionControlArgs = record {
+  block_index : opt nat64;
+  subnet_id : opt principal;
+};
 type CreateOrbiterArgs = record {
   block_index : opt nat64;
   subnet_id : opt principal;
@@ -370,6 +374,7 @@ service : () -> {
   commit_proposal_asset_upload : (CommitBatch) -> ();
   commit_proposal_many_assets_upload : (vec CommitBatch) -> ();
   count_proposals : () -> (nat64) query;
+  create_mission_control : (CreateMissionControlArgs) -> (principal);
   create_orbiter : (CreateOrbiterArgs) -> (principal);
   create_satellite : (CreateSatelliteArgs) -> (principal);
   del_controllers : (DeleteControllersArgs) -> ();

--- a/src/console/console.did
+++ b/src/console/console.did
@@ -77,10 +77,7 @@ type Controller = record {
   expires_at : opt nat64;
 };
 type ControllerScope = variant { Write; Admin; Submit };
-type CreateMissionControlArgs = record {
-  block_index : opt nat64;
-  subnet_id : opt principal;
-};
+type CreateMissionControlArgs = record { subnet_id : opt principal };
 type CreateOrbiterArgs = record {
   block_index : opt nat64;
   subnet_id : opt principal;

--- a/src/console/src/api/factory.rs
+++ b/src/console/src/api/factory.rs
@@ -1,10 +1,22 @@
+use crate::factory::mission_control_new::create_mission_control as create_mission_control_console;
 use crate::factory::orbiter::create_orbiter as create_orbiter_console;
 use crate::factory::satellite::create_satellite as create_satellite_console;
 use candid::Principal;
 use ic_cdk_macros::update;
 use junobuild_shared::ic::api::caller;
 use junobuild_shared::ic::UnwrapOrTrap;
-use junobuild_shared::types::interface::{CreateOrbiterArgs, CreateSatelliteArgs};
+use junobuild_shared::types::interface::{
+    CreateMissionControlArgs, CreateOrbiterArgs, CreateSatelliteArgs,
+};
+
+#[update]
+async fn create_mission_control(args: CreateMissionControlArgs) -> Principal {
+    let caller = caller();
+
+    create_mission_control_console(caller, args)
+        .await
+        .unwrap_or_trap()
+}
 
 #[update]
 async fn create_satellite(args: CreateSatelliteArgs) -> Principal {

--- a/src/console/src/factory/impls.rs
+++ b/src/console/src/factory/impls.rs
@@ -52,7 +52,9 @@ impl From<CreateSatelliteArgs> for CreateCanisterArgs {
 impl From<CreateMissionControlArgs> for CreateCanisterArgs {
     fn from(args: CreateMissionControlArgs) -> Self {
         Self {
-            block_index: args.block_index,
+            // Unlike Satellite and Orbiter, Mission Control can only be
+            // spin using credits or ICRC-2 transfer from.
+            block_index: None,
             subnet_id: args.subnet_id,
         }
     }

--- a/src/console/src/factory/impls.rs
+++ b/src/console/src/factory/impls.rs
@@ -1,7 +1,9 @@
 use crate::factory::types::CanisterCreator;
 use crate::factory::types::CreateCanisterArgs;
 use candid::Principal;
-use junobuild_shared::types::interface::{CreateOrbiterArgs, CreateSatelliteArgs};
+use junobuild_shared::types::interface::{
+    CreateMissionControlArgs, CreateOrbiterArgs, CreateSatelliteArgs,
+};
 use junobuild_shared::types::state::{ControllerId, UserId};
 
 impl CanisterCreator {
@@ -40,6 +42,15 @@ impl From<CreateOrbiterArgs> for CreateCanisterArgs {
 
 impl From<CreateSatelliteArgs> for CreateCanisterArgs {
     fn from(args: CreateSatelliteArgs) -> Self {
+        Self {
+            block_index: args.block_index,
+            subnet_id: args.subnet_id,
+        }
+    }
+}
+
+impl From<CreateMissionControlArgs> for CreateCanisterArgs {
+    fn from(args: CreateMissionControlArgs) -> Self {
         Self {
             block_index: args.block_index,
             subnet_id: args.subnet_id,

--- a/src/console/src/factory/mission_control_new.rs
+++ b/src/console/src/factory/mission_control_new.rs
@@ -1,0 +1,83 @@
+use crate::accounts::{get_existing_account, update_mission_control};
+use crate::constants::FREEZING_THRESHOLD_ONE_YEAR;
+use crate::factory::canister::create_canister_with_account;
+use crate::factory::types::CanisterCreator;
+use crate::factory::utils::controllers::update_mission_control_controllers;
+use crate::factory::utils::wasm::mission_control_wasm_arg;
+use crate::store::heap::{get_mission_control_fee, increment_mission_controls_rate};
+use candid::{Nat, Principal};
+use junobuild_shared::constants_shared::CREATE_MISSION_CONTROL_CYCLES;
+use junobuild_shared::ic::api::id;
+use junobuild_shared::mgmt::cmc::cmc_create_canister_install_code;
+use junobuild_shared::mgmt::ic::create_canister_install_code;
+use junobuild_shared::mgmt::types::cmc::SubnetId;
+use junobuild_shared::mgmt::types::ic::CreateCanisterInitSettingsArg;
+use junobuild_shared::types::interface::CreateMissionControlArgs;
+
+pub async fn create_mission_control(
+    caller: Principal,
+    args: CreateMissionControlArgs,
+) -> Result<Principal, String> {
+    let account = get_existing_account(&caller)?;
+
+    if account.mission_control_id.is_some() {
+        return Err("Mission control center already exist.".to_string());
+    }
+
+    let creator: CanisterCreator = CanisterCreator::User(account.owner);
+
+    let mission_control_id = create_canister_with_account(
+        create_mission_control_wasm,
+        &increment_mission_controls_rate,
+        &get_mission_control_fee,
+        &account,
+        creator,
+        args.into(),
+    )
+    .await?;
+
+    update_mission_control(&account.owner, &mission_control_id)?;
+
+    Ok(mission_control_id)
+}
+
+async fn create_mission_control_wasm(
+    creator: CanisterCreator,
+    subnet_id: Option<SubnetId>,
+) -> Result<Principal, String> {
+    let CanisterCreator::User(user_id) = creator else {
+        return Err("Mission Control cannot create another Mission Control".to_string());
+    };
+
+    let wasm_arg = mission_control_wasm_arg(&user_id)?;
+
+    // We temporarily use the Console as a controller to create the canister but
+    // remove it as soon as it is spin.
+    let temporary_init_controllers = Vec::from([id(), user_id.clone()]);
+
+    let create_settings_arg = CreateCanisterInitSettingsArg {
+        controllers: temporary_init_controllers,
+        freezing_threshold: Nat::from(FREEZING_THRESHOLD_ONE_YEAR),
+    };
+
+    let mission_control_id = if let Some(subnet_id) = subnet_id {
+        cmc_create_canister_install_code(
+            &create_settings_arg,
+            &wasm_arg,
+            CREATE_MISSION_CONTROL_CYCLES,
+            &subnet_id,
+        )
+        .await
+    } else {
+        create_canister_install_code(
+            &create_settings_arg,
+            &wasm_arg,
+            CREATE_MISSION_CONTROL_CYCLES,
+        )
+        .await
+    }?;
+
+    update_mission_control_controllers(&mission_control_id, &user_id).await?;
+
+    Ok(mission_control_id)
+}

--- a/src/console/src/factory/mod.rs
+++ b/src/console/src/factory/mod.rs
@@ -1,6 +1,7 @@
 mod canister;
 mod impls;
 pub mod mission_control;
+pub mod mission_control_new;
 pub mod orbiter;
 pub mod satellite;
 mod services;

--- a/src/console/src/lib.rs
+++ b/src/console/src/lib.rs
@@ -45,6 +45,7 @@ use junobuild_shared::ic::response::ManualReply;
 use junobuild_shared::rate::types::RateConfig;
 use junobuild_shared::types::core::DomainName;
 use junobuild_shared::types::domain::CustomDomains;
+use junobuild_shared::types::interface::CreateMissionControlArgs;
 use junobuild_shared::types::interface::CreateOrbiterArgs;
 use junobuild_shared::types::interface::CreateSatelliteArgs;
 use junobuild_shared::types::interface::{

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -101,7 +101,6 @@ export interface Controller {
 }
 export type ControllerScope = { Write: null } | { Admin: null } | { Submit: null };
 export interface CreateMissionControlArgs {
-	block_index: [] | [bigint];
 	subnet_id: [] | [Principal];
 }
 export interface CreateOrbiterArgs {

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -100,6 +100,10 @@ export interface Controller {
 	expires_at: [] | [bigint];
 }
 export type ControllerScope = { Write: null } | { Admin: null } | { Submit: null };
+export interface CreateMissionControlArgs {
+	block_index: [] | [bigint];
+	subnet_id: [] | [Principal];
+}
 export interface CreateOrbiterArgs {
 	block_index: [] | [bigint];
 	subnet_id: [] | [Principal];
@@ -429,6 +433,7 @@ export interface _SERVICE {
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal_many_assets_upload: ActorMethod<[Array<CommitBatch>], undefined>;
 	count_proposals: ActorMethod<[], bigint>;
+	create_mission_control: ActorMethod<[CreateMissionControlArgs], Principal>;
 	create_orbiter: ActorMethod<[CreateOrbiterArgs], Principal>;
 	create_satellite: ActorMethod<[CreateSatelliteArgs], Principal>;
 	del_controllers: ActorMethod<[DeleteControllersArgs], undefined>;

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -101,7 +101,6 @@ export const idlFactory = ({ IDL }) => {
 		chunk_ids: IDL.Vec(IDL.Nat)
 	});
 	const CreateMissionControlArgs = IDL.Record({
-		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal)
 	});
 	const CreateOrbiterArgs = IDL.Record({

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -100,6 +100,10 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
 	});
+	const CreateMissionControlArgs = IDL.Record({
+		block_index: IDL.Opt(IDL.Nat64),
+		subnet_id: IDL.Opt(IDL.Principal)
+	});
 	const CreateOrbiterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
@@ -457,6 +461,7 @@ export const idlFactory = ({ IDL }) => {
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),
 		count_proposals: IDL.Func([], [IDL.Nat64], []),
+		create_mission_control: IDL.Func([CreateMissionControlArgs], [IDL.Principal], []),
 		create_orbiter: IDL.Func([CreateOrbiterArgs], [IDL.Principal], []),
 		create_satellite: IDL.Func([CreateSatelliteArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -100,6 +100,10 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
 	});
+	const CreateMissionControlArgs = IDL.Record({
+		block_index: IDL.Opt(IDL.Nat64),
+		subnet_id: IDL.Opt(IDL.Principal)
+	});
 	const CreateOrbiterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
@@ -457,6 +461,7 @@ export const idlFactory = ({ IDL }) => {
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),
 		count_proposals: IDL.Func([], [IDL.Nat64], ['query']),
+		create_mission_control: IDL.Func([CreateMissionControlArgs], [IDL.Principal], []),
 		create_orbiter: IDL.Func([CreateOrbiterArgs], [IDL.Principal], []),
 		create_satellite: IDL.Func([CreateSatelliteArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -101,7 +101,6 @@ export const idlFactory = ({ IDL }) => {
 		chunk_ids: IDL.Vec(IDL.Nat)
 	});
 	const CreateMissionControlArgs = IDL.Record({
-		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal)
 	});
 	const CreateOrbiterArgs = IDL.Record({

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -100,6 +100,10 @@ export const idlFactory = ({ IDL }) => {
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		chunk_ids: IDL.Vec(IDL.Nat)
 	});
+	const CreateMissionControlArgs = IDL.Record({
+		block_index: IDL.Opt(IDL.Nat64),
+		subnet_id: IDL.Opt(IDL.Principal)
+	});
 	const CreateOrbiterArgs = IDL.Record({
 		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal),
@@ -457,6 +461,7 @@ export const idlFactory = ({ IDL }) => {
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal_many_assets_upload: IDL.Func([IDL.Vec(CommitBatch)], [], []),
 		count_proposals: IDL.Func([], [IDL.Nat64], ['query']),
+		create_mission_control: IDL.Func([CreateMissionControlArgs], [IDL.Principal], []),
 		create_orbiter: IDL.Func([CreateOrbiterArgs], [IDL.Principal], []),
 		create_satellite: IDL.Func([CreateSatelliteArgs], [IDL.Principal], []),
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -101,7 +101,6 @@ export const idlFactory = ({ IDL }) => {
 		chunk_ids: IDL.Vec(IDL.Nat)
 	});
 	const CreateMissionControlArgs = IDL.Record({
-		block_index: IDL.Opt(IDL.Nat64),
 		subnet_id: IDL.Opt(IDL.Principal)
 	});
 	const CreateOrbiterArgs = IDL.Record({

--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -140,6 +140,12 @@ pub mod interface {
     }
 
     #[derive(CandidType, Deserialize)]
+    pub struct CreateMissionControlArgs {
+        pub block_index: Option<BlockIndex>,
+        pub subnet_id: Option<SubnetId>,
+    }
+
+    #[derive(CandidType, Deserialize)]
     pub struct CreateSatelliteArgs {
         pub user: UserId,
         pub block_index: Option<BlockIndex>,

--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -141,7 +141,6 @@ pub mod interface {
 
     #[derive(CandidType, Deserialize)]
     pub struct CreateMissionControlArgs {
-        pub block_index: Option<BlockIndex>,
         pub subnet_id: Option<SubnetId>,
     }
 

--- a/src/tests/specs/console/factory/console.factory.mission-control.spec.ts
+++ b/src/tests/specs/console/factory/console.factory.mission-control.spec.ts
@@ -1,0 +1,70 @@
+import type { ConsoleActor } from '$declarations';
+import type { Actor, PocketIc } from '@dfinity/pic';
+import { toNullable } from '@dfinity/utils';
+import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
+import type { Principal } from '@icp-sdk/core/principal';
+import { NO_ACCOUNT_ERROR_MSG } from '../../../constants/console-tests.constants';
+import { setupConsole } from '../../../utils/console-tests.utils';
+
+describe('Console > Factory > Mission Control', () => {
+	let pic: PocketIc;
+	let actor: Actor<ConsoleActor>;
+	let controller: Ed25519KeyIdentity;
+
+	beforeAll(async () => {
+		const {
+			pic: p,
+			actor: c,
+			controller: cO
+		} = await setupConsole({
+			withApplyRateTokens: true,
+			withLedger: true,
+			withSegments: true,
+			withFee: true
+		});
+
+		pic = p;
+
+		controller = cO;
+
+		actor = c;
+		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	const createMissionControlWithConsole = async (): Promise<Principal> => {
+		const { create_mission_control } = actor;
+
+		return await create_mission_control({
+			subnet_id: toNullable()
+		});
+	};
+
+	describe('Assertions', () => {
+		let user: Ed25519KeyIdentity;
+
+		beforeEach(() => {
+			user = Ed25519KeyIdentity.generate();
+			actor.setIdentity(user);
+		});
+
+		it('should fail with unknown account', async () => {
+			await expect(createMissionControlWithConsole()).rejects.toThrow(NO_ACCOUNT_ERROR_MSG);
+		});
+
+		it('should fail if mission control already exists', async () => {
+			const { init_user_mission_control_center } = actor;
+
+			await init_user_mission_control_center();
+
+			await expect(createMissionControlWithConsole()).rejects.toThrow(
+				'Mission control center already exist.'
+			);
+
+			actor.setIdentity(user);
+		});
+	});
+});

--- a/src/tests/specs/console/factory/console.factory.mission-control.spec.ts
+++ b/src/tests/specs/console/factory/console.factory.mission-control.spec.ts
@@ -1,15 +1,29 @@
 import type { ConsoleActor } from '$declarations';
 import type { Actor, PocketIc } from '@dfinity/pic';
-import { toNullable } from '@dfinity/utils';
+import { fromNullable, fromNullishNullable, toNullable } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import type { Principal } from '@icp-sdk/core/principal';
-import { NO_ACCOUNT_ERROR_MSG } from '../../../constants/console-tests.constants';
+import {
+	CONSOLE_ID,
+	NO_ACCOUNT_ERROR_MSG,
+	TEST_FEE
+} from '../../../constants/console-tests.constants';
 import { setupConsole } from '../../../utils/console-tests.utils';
+import { approveIcp, transferIcp } from '../../../utils/ledger-tests.utils';
+import { tick } from '../../../utils/pic-tests.utils';
 
 describe('Console > Factory > Mission Control', () => {
 	let pic: PocketIc;
 	let actor: Actor<ConsoleActor>;
 	let controller: Ed25519KeyIdentity;
+
+	let user: Ed25519KeyIdentity;
+
+	beforeEach(() => {
+		user = Ed25519KeyIdentity.generate();
+		actor.setIdentity(user);
+	});
 
 	beforeAll(async () => {
 		const {
@@ -35,6 +49,18 @@ describe('Console > Factory > Mission Control', () => {
 		await pic?.tearDown();
 	});
 
+	const createSatelliteWithConsole = async ({ user }: { user: Identity }): Promise<Principal> => {
+		const { create_satellite } = actor;
+
+		return await create_satellite({
+			user: user.getPrincipal(),
+			block_index: toNullable(),
+			name: toNullable(),
+			storage: toNullable(),
+			subnet_id: toNullable()
+		});
+	};
+
 	const createMissionControlWithConsole = async (): Promise<Principal> => {
 		const { create_mission_control } = actor;
 
@@ -44,13 +70,6 @@ describe('Console > Factory > Mission Control', () => {
 	};
 
 	describe('Assertions', () => {
-		let user: Ed25519KeyIdentity;
-
-		beforeEach(() => {
-			user = Ed25519KeyIdentity.generate();
-			actor.setIdentity(user);
-		});
-
 		it('should fail with unknown account', async () => {
 			await expect(createMissionControlWithConsole()).rejects.toThrow(NO_ACCOUNT_ERROR_MSG);
 		});
@@ -65,6 +84,103 @@ describe('Console > Factory > Mission Control', () => {
 			);
 
 			actor.setIdentity(user);
+		});
+	});
+
+	describe('User', () => {
+		it('should create for user', async () => {
+			const { get_or_init_account, get_account } = actor;
+			await get_or_init_account();
+
+			const id = await createMissionControlWithConsole();
+
+			expect(id).not.toBeUndefined();
+
+			const account = await get_account();
+
+			const missionControlId = fromNullishNullable(fromNullable(account)?.mission_control_id);
+
+			expect(missionControlId).not.toBeUndefined();
+		});
+
+		it('should fail with without credits and payment', async () => {
+			const { get_or_init_account } = actor;
+			await get_or_init_account();
+
+			// Create satellite to use credits
+			await createSatelliteWithConsole({ user });
+
+			await pic.advanceTime(60_000);
+			await tick(pic);
+
+			// Second requires payment
+			await expect(createMissionControlWithConsole()).rejects.toThrow('InsufficientAllowance');
+		});
+
+		it('should fail without enough payment', async () => {
+			const { get_or_init_account } = actor;
+			await get_or_init_account();
+
+			// Create satellite to use credits
+			await createSatelliteWithConsole({ user });
+
+			await pic.advanceTime(60_000);
+			await tick(pic);
+
+			await transferIcp({
+				pic,
+				owner: user.getPrincipal()
+			});
+
+			await approveIcp({
+				pic,
+				owner: user,
+				spender: CONSOLE_ID,
+				amount: TEST_FEE // Fees 10_000n are missing
+			});
+
+			await tick(pic);
+
+			// Second requires full payment
+			await expect(createMissionControlWithConsole()).rejects.toThrow('InsufficientAllowance');
+		});
+
+		it('should succeed with payment', async () => {
+			const { get_or_init_account } = actor;
+			await get_or_init_account();
+
+			// Create satellite to use credits
+			await createSatelliteWithConsole({ user });
+
+			await pic.advanceTime(60_000);
+			await tick(pic);
+
+			await transferIcp({
+				pic,
+				owner: user.getPrincipal()
+			});
+
+			await approveIcp({
+				pic,
+				owner: user,
+				spender: CONSOLE_ID,
+				amount: TEST_FEE + 10_000n
+			});
+
+			await tick(pic);
+
+			// Second uses payment
+			const secondId = await createMissionControlWithConsole();
+
+			expect(secondId).not.toBeUndefined();
+
+			const { get_account } = actor;
+
+			const account = await get_account();
+
+			const missionControlId = fromNullishNullable(fromNullable(account)?.mission_control_id);
+
+			expect(missionControlId).not.toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We want to make mission control an opt-in feature for user. They will be able to spin Mission Control in the frontend similarly as they do for Satellites or Orbiters. We gonna also merge the notion of Mission Control with Monitoring. That's why we expose a new create end point and implement the feature.

Spinning the Mission Control is close to a refactoring. To ease its introduction, I keep the module `mission_control.rs` for now and implement the feature in `mission_control_new.rs`. Later I'll remove the former. This will be a breaking change for the UI and tests.

Relates to #2313
