### PR TITLE
feat(console): if user has mission control, make it controller too

### DIFF
--- a/src/console/src/factory/canister.rs
+++ b/src/console/src/factory/canister.rs
@@ -33,7 +33,8 @@ where
 
     if principal_equal(caller, account.owner) {
         // Caller is user
-        let creator: CanisterCreator = CanisterCreator::User(account.owner);
+        let creator: CanisterCreator =
+            CanisterCreator::User((account.owner, account.mission_control_id));
 
         let canister_id =
             create_canister_with_account(create, increment_rate, get_fee, &account, creator, args)

--- a/src/console/src/factory/impls.rs
+++ b/src/console/src/factory/impls.rs
@@ -9,21 +9,25 @@ use junobuild_shared::types::state::{ControllerId, UserId};
 impl CanisterCreator {
     pub fn purchaser(&self) -> &Principal {
         match self {
-            CanisterCreator::User(user) => user,
+            CanisterCreator::User((user, _)) => user,
             CanisterCreator::MissionControl((mission_control, _)) => mission_control,
         }
     }
 
     pub fn account_owner(&self) -> &UserId {
         match self {
-            CanisterCreator::User(user) => user,
+            CanisterCreator::User((user, _)) => user,
             CanisterCreator::MissionControl((_, user)) => user,
         }
     }
 
     pub fn controllers(&self) -> Vec<ControllerId> {
         match self {
-            CanisterCreator::User(user) => Vec::from([*user]),
+            CanisterCreator::User((user, mission_control)) => {
+                let mut controllers = Vec::from([*user]);
+                controllers.extend(mission_control);
+                controllers
+            }
             CanisterCreator::MissionControl((mission_control, user)) => {
                 Vec::from([*user, *mission_control])
             }

--- a/src/console/src/factory/mission_control.rs
+++ b/src/console/src/factory/mission_control.rs
@@ -24,7 +24,7 @@ pub async fn create_mission_control(
         return Err("Mission control center already exist.".to_string());
     }
 
-    let creator: CanisterCreator = CanisterCreator::User(account.owner);
+    let creator: CanisterCreator = CanisterCreator::User((account.owner, None));
 
     let mission_control_id = create_canister_with_account(
         create_mission_control_wasm,
@@ -45,7 +45,7 @@ async fn create_mission_control_wasm(
     creator: CanisterCreator,
     subnet_id: Option<SubnetId>,
 ) -> Result<Principal, String> {
-    let CanisterCreator::User(user_id) = creator else {
+    let CanisterCreator::User((user_id, _)) = creator else {
         return Err("Mission Control cannot create another Mission Control".to_string());
     };
 

--- a/src/console/src/factory/types.rs
+++ b/src/console/src/factory/types.rs
@@ -4,7 +4,7 @@ use junobuild_shared::types::state::{MissionControlId, UserId};
 
 #[derive(Clone)]
 pub enum CanisterCreator {
-    User(UserId), // The caller is the owner of the account. The caller comes from the Console UI.
+    User((UserId, Option<MissionControlId>)), // The caller is the owner of the account. The caller comes from the Console UI.
     MissionControl((MissionControlId, UserId)), // The caller is a mission control
 }
 

--- a/src/tests/specs/console/factory/console.factory.controllers.spec.ts
+++ b/src/tests/specs/console/factory/console.factory.controllers.spec.ts
@@ -1,0 +1,157 @@
+import type { ConsoleActor } from '$declarations';
+import type { Actor, PocketIc } from '@dfinity/pic';
+import { toNullable } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
+import type { Principal } from '@icp-sdk/core/principal';
+import { setupConsole } from '../../../utils/console-tests.utils';
+import { canisterStatus } from '../../../utils/ic-management-tests.utils';
+
+describe('Console > Factory > Controllers', () => {
+	let pic: PocketIc;
+	let actor: Actor<ConsoleActor>;
+	let controller: Ed25519KeyIdentity;
+
+	beforeAll(async () => {
+		const {
+			pic: p,
+			actor: c,
+			controller: cO
+		} = await setupConsole({
+			withApplyRateTokens: true,
+			withLedger: true,
+			withSegments: true,
+			withFee: true
+		});
+
+		pic = p;
+
+		controller = cO;
+
+		actor = c;
+		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	const assertController = async ({
+		user,
+		canisterId,
+		controllers
+	}: {
+		user: Identity;
+		canisterId: Principal;
+		controllers: Principal[];
+	}) => {
+		const result = await canisterStatus({
+			sender: user,
+			pic,
+			canisterId
+		});
+
+		const settings = result?.settings;
+
+		expect(settings?.controllers).toHaveLength(controllers.length);
+
+		for (const controller of controllers) {
+			expect(
+				settings?.controllers.find((c) => c.toText() === controller.toText())
+			).not.toBeUndefined();
+		}
+	};
+
+	const createSatelliteWithConsole = async ({ user }: { user: Identity }): Promise<Principal> => {
+		const { create_satellite } = actor;
+
+		return await create_satellite({
+			user: user.getPrincipal(),
+			block_index: toNullable(),
+			name: toNullable(),
+			storage: toNullable(),
+			subnet_id: toNullable()
+		});
+	};
+
+	const createOrbiterWithConsole = async ({ user }: { user: Identity }): Promise<Principal> => {
+		const { create_orbiter } = actor;
+
+		return await create_orbiter({
+			user: user.getPrincipal(),
+			block_index: toNullable(),
+			name: toNullable(),
+			subnet_id: toNullable()
+		});
+	};
+
+	const addCredits = async ({ user }: { user: Identity }) => {
+		actor.setIdentity(controller);
+
+		// Spinning mission control requires credits or ICP as well
+		const { add_credits } = actor;
+		await add_credits(user.getPrincipal(), { e8s: 100_000_000n });
+
+		actor.setIdentity(user);
+	};
+
+	describe.each([
+		{
+			title: 'Satellite',
+			createFn: createSatelliteWithConsole
+		},
+		{
+			title: 'Orbiter',
+			createFn: createOrbiterWithConsole
+		}
+	])('$title', ({ title, createFn }) => {
+		let user: Ed25519KeyIdentity;
+
+		beforeEach(() => {
+			user = Ed25519KeyIdentity.generate();
+			actor.setIdentity(user);
+		});
+
+		it('should have user as sole controller', async () => {
+			const { get_or_init_account } = actor;
+			await get_or_init_account();
+
+			const id = await createFn({
+				user
+			});
+
+			expect(id).not.toBeUndefined();
+
+			await assertController({
+				canisterId: id,
+				controllers: [user.getPrincipal()],
+				user
+			});
+		});
+
+		it('should have user and mission control as controllers', async () => {
+			const { get_or_init_account, create_mission_control } = actor;
+
+			await get_or_init_account();
+
+			const missionControlId = await create_mission_control({
+				subnet_id: []
+			});
+
+			// Spinning mission control requires credits or ICP as well
+			await addCredits({ user });
+
+			const id = await createFn({
+				user
+			});
+
+			expect(id).not.toBeUndefined();
+
+			await assertController({
+				canisterId: id,
+				controllers: [user.getPrincipal(), missionControlId],
+				user
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We do a big change in #2313 that removes the need for a mission control but, in a first step at leat, we still move forward with the mission control being a controller of the satellites or orbiters if used. We can potentially do not use this approach and just make the modules allow that canisters to read the cycles for for now, we just move this way. That would add a big breaking change at the top.

Long story short, if a use spin a modules and already has a mission control, then we can set it as a controller at the same time, this way it's done.
