### PR TITLE
feat(frontend): certified get and init account

### DIFF
--- a/src/frontend/src/lib/api/console.api.ts
+++ b/src/frontend/src/lib/api/console.api.ts
@@ -5,8 +5,11 @@ import { getConsoleActor } from '$lib/api/actors/actor.juno.api';
 import type { OptionIdentity } from '$lib/types/itentity';
 import { fromNullable, isNullish } from '@dfinity/utils';
 
-export const getOrInitAccount = async (identity: OptionIdentity): Promise<ConsoleDid.Account> => {
-	const { get_or_init_account } = await getConsoleActor({ identity });
+export const getOrInitAccount = async (
+	actorParams: Omit<GetActorParams, 'certified'>
+): Promise<ConsoleDid.Account> => {
+	// update only endpoint
+	const { get_or_init_account } = await getConsoleActor({ ...actorParams, certified: true });
 
 	return await get_or_init_account();
 };

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -540,7 +540,7 @@
 	"errors": {
 		"no_identity": "Unexpected error. No identity provided.",
 		"stack_trace": "Stack trace of the error",
-		"initializing_mission_control": "Mission control center cannot be initialized.",
+		"initializing_account": "Failed to initialize account.",
 		"sign_in": "An error occurred during sign-in. Please check the error details and try again.",
 		"sign_in_openid": "Oops, docking sequence failed. Retry or reach out!",
 		"account_sign_out": "You have been signed out because your account could not be certified.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -540,7 +540,7 @@
 	"errors": {
 		"no_identity": "意外错误，未提供身份信息。",
 		"stack_trace": "错误堆栈追踪",
-		"initializing_mission_control": "控制中心初始化失败。",
+		"initializing_account": "账户初始化失败。",
 		"sign_in": "登录异常，请检查详细错误信息并重试。",
 		"sign_in_openid": "哎呀，对接失败。请重试或联系我们！",
 		"account_sign_out": "您的账户无法通过验证，因此已被登出。",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -557,7 +557,7 @@ interface I18nCli {
 interface I18nErrors {
 	no_identity: string;
 	stack_trace: string;
-	initializing_mission_control: string;
+	initializing_account: string;
 	sign_in: string;
 	sign_in_openid: string;
 	account_sign_out: string;

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
 	import Overlays from '$lib/components/core/Overlays.svelte';
 	import AuthBroadcastGuard from '$lib/components/guards/AuthBroadcastGuard.svelte';
 	import { layoutNavigationTitle } from '$lib/derived/app/layout-navigation.derived';
-	import { initAccountAndMissionControl } from '$lib/services/console/account.services';
+	import { initAccount } from '$lib/services/console/account.services';
 	import { displayAndCleanLogoutMsg } from '$lib/services/console/auth/auth.services';
 	import { syncSnapshots } from '$lib/services/ic-mgmt/snapshots.services';
 	import { syncSubnets } from '$lib/services/ic-mgmt/subnets.services';
@@ -52,7 +52,7 @@
 	};
 
 	$effect(() => {
-		initAccountAndMissionControl($authStore);
+		initAccount($authStore);
 	});
 
 	/**

--- a/src/frontend/tests/lib/services/account.services.test.ts
+++ b/src/frontend/tests/lib/services/account.services.test.ts
@@ -69,7 +69,7 @@ describe('initAccount', () => {
 		});
 
 		it('should trigger background certified account assertion', async () => {
-			vi.mocked(consoleApi.getAccount).mockImplementation(() => Promise.resolve(mockAccount));
+			vi.mocked(consoleApi.getAccount).mockResolvedValue(mockAccount);
 
 			await initAccount({ identity: mockIdentity });
 
@@ -155,7 +155,7 @@ describe('initAccount', () => {
 
 	describe('assertAccount background validation', () => {
 		it('should update store with certified account on successful assertion', async () => {
-			vi.mocked(consoleApi.getAccount).mockImplementation(() => Promise.resolve(mockAccount));
+			vi.mocked(consoleApi.getAccount).mockResolvedValue(mockAccount);
 
 			await initAccount({ identity: mockIdentity });
 

--- a/src/frontend/tests/lib/services/account.services.test.ts
+++ b/src/frontend/tests/lib/services/account.services.test.ts
@@ -1,0 +1,206 @@
+import type { ConsoleDid } from '$declarations';
+import * as consoleApi from '$lib/api/console.api';
+import { initAccount } from '$lib/services/console/account.services';
+import * as authServices from '$lib/services/console/auth/auth.services';
+import { accountCertifiedStore } from '$lib/stores/account.store';
+import { toasts } from '$lib/stores/app/toasts.store';
+import { nowInBigIntNanoSeconds } from '@dfinity/utils';
+import { get } from 'svelte/store';
+import { mockIdentity, mockPrincipal } from '../../mocks/identity.mock';
+
+vi.mock('$lib/api/console.api');
+vi.mock('$lib/services/console/auth/auth.services');
+
+describe('initAccount', () => {
+	const mockAccount: ConsoleDid.Account = {
+		owner: mockPrincipal,
+		mission_control_id: [],
+		created_at: nowInBigIntNanoSeconds(),
+		updated_at: nowInBigIntNanoSeconds(),
+		credits: { e8s: 0n },
+		provider: []
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		accountCertifiedStore.reset();
+
+		// we mock console.error just to avoid unnecessary logs when the error is toasted
+		vi.spyOn(console, 'error').mockImplementation(() => undefined);
+	});
+
+	describe('when identity is null', () => {
+		it('should skip initialization', async () => {
+			const result = await initAccount({ identity: null });
+
+			expect(result).toEqual({ result: 'skip' });
+			expect(consoleApi.getAccount).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('when identity is undefined', () => {
+		it('should skip initialization', async () => {
+			const result = await initAccount({ identity: undefined });
+
+			expect(result).toEqual({ result: 'skip' });
+			expect(consoleApi.getAccount).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Get uncertified account', () => {
+		it('should set uncertified account and return success', async () => {
+			vi.mocked(consoleApi.getAccount).mockResolvedValue(mockAccount);
+
+			const result = await initAccount({ identity: mockIdentity });
+
+			expect(consoleApi.getAccount).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				certified: false
+			});
+
+			const store = get(accountCertifiedStore);
+
+			expect(store).toEqual({
+				data: mockAccount,
+				certified: false
+			});
+
+			expect(result).toEqual({ result: 'success' });
+		});
+
+		it('should trigger background certified account assertion', async () => {
+			vi.mocked(consoleApi.getAccount).mockImplementation(async () => {
+				return mockAccount;
+			});
+
+			await initAccount({ identity: mockIdentity });
+
+			await vi.waitFor(() => {
+				expect(consoleApi.getAccount).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					certified: true
+				});
+			});
+
+			const store = get(accountCertifiedStore);
+
+			expect(store).toEqual({
+				data: mockAccount,
+				certified: true
+			});
+		});
+	});
+
+	describe('when no account exists', () => {
+		it('should create new account and return success', async () => {
+			vi.mocked(consoleApi.getAccount).mockResolvedValue(undefined);
+			vi.mocked(consoleApi.getOrInitAccount).mockResolvedValue(mockAccount);
+
+			const result = await initAccount({ identity: mockIdentity });
+
+			expect(consoleApi.getAccount).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				certified: false
+			});
+
+			expect(consoleApi.getOrInitAccount).toHaveBeenCalledWith({
+				identity: mockIdentity
+			});
+
+			const store = get(accountCertifiedStore);
+
+			expect(store).toEqual({
+				data: mockAccount,
+				certified: true
+			});
+
+			expect(result).toEqual({ result: 'success' });
+		});
+	});
+
+	describe('error handling', () => {
+		it('should show error toast and sign out on getAccount error', async () => {
+			const error = new Error('Network error');
+			vi.mocked(consoleApi.getAccount).mockRejectedValue(error);
+
+			const errorSpy = vi.spyOn(toasts, 'error');
+
+			const result = await initAccount({ identity: mockIdentity });
+
+			expect(errorSpy).toHaveBeenCalledWith({
+				text: 'Failed to initialize account.',
+				detail: error
+			});
+
+			expect(authServices.accountErrorSignOut).toHaveBeenCalled();
+			expect(result).toEqual({ result: 'error' });
+		});
+
+		it('should show error toast and sign out on getOrInitAccount error', async () => {
+			const error = new Error('Creation failed');
+			vi.mocked(consoleApi.getAccount).mockResolvedValue(undefined);
+			vi.mocked(consoleApi.getOrInitAccount).mockRejectedValue(error);
+
+			const errorSpy = vi.spyOn(toasts, 'error');
+
+			const result = await initAccount({ identity: mockIdentity });
+
+			expect(errorSpy).toHaveBeenCalledWith({
+				text: 'Failed to initialize account.',
+				detail: error
+			});
+
+			expect(authServices.accountErrorSignOut).toHaveBeenCalled();
+			expect(result).toEqual({ result: 'error' });
+		});
+	});
+
+	describe('assertAccount background validation', () => {
+		it('should update store with certified account on successful assertion', async () => {
+			vi.mocked(consoleApi.getAccount).mockImplementation(async ({ certified }) => {
+				return mockAccount;
+			});
+
+			await initAccount({ identity: mockIdentity });
+
+			await vi.waitFor(() => {
+				const store = get(accountCertifiedStore);
+
+				expect(store).toEqual({
+					data: mockAccount,
+					certified: true
+				});
+			});
+		});
+
+		it('should sign out if certified account is null', async () => {
+			vi.mocked(consoleApi.getAccount).mockImplementation(async ({ certified }) => {
+				if (certified) {
+					return undefined;
+				}
+				return mockAccount;
+			});
+
+			await initAccount({ identity: mockIdentity });
+
+			await vi.waitFor(() => {
+				expect(authServices.accountErrorSignOut).toHaveBeenCalled();
+			});
+		});
+
+		it('should sign out on assertion error', async () => {
+			vi.mocked(consoleApi.getAccount).mockImplementation(async ({ certified }) => {
+				if (certified) {
+					throw new Error('Certification failed');
+				}
+				return mockAccount;
+			});
+
+			await initAccount({ identity: mockIdentity });
+
+			await vi.waitFor(() => {
+				expect(authServices.accountErrorSignOut).toHaveBeenCalled();
+			});
+		});
+	});
+});

--- a/src/frontend/tests/lib/services/account.services.test.ts
+++ b/src/frontend/tests/lib/services/account.services.test.ts
@@ -69,9 +69,7 @@ describe('initAccount', () => {
 		});
 
 		it('should trigger background certified account assertion', async () => {
-			vi.mocked(consoleApi.getAccount).mockImplementation(async () => {
-				return mockAccount;
-			});
+			vi.mocked(consoleApi.getAccount).mockImplementation(() => Promise.resolve(mockAccount));
 
 			await initAccount({ identity: mockIdentity });
 
@@ -157,9 +155,7 @@ describe('initAccount', () => {
 
 	describe('assertAccount background validation', () => {
 		it('should update store with certified account on successful assertion', async () => {
-			vi.mocked(consoleApi.getAccount).mockImplementation(async ({ certified }) => {
-				return mockAccount;
-			});
+			vi.mocked(consoleApi.getAccount).mockImplementation(() => Promise.resolve(mockAccount));
 
 			await initAccount({ identity: mockIdentity });
 
@@ -174,6 +170,7 @@ describe('initAccount', () => {
 		});
 
 		it('should sign out if certified account is null', async () => {
+			// eslint-disable-next-line require-await
 			vi.mocked(consoleApi.getAccount).mockImplementation(async ({ certified }) => {
 				if (certified) {
 					return undefined;
@@ -189,6 +186,7 @@ describe('initAccount', () => {
 		});
 
 		it('should sign out on assertion error', async () => {
+			// eslint-disable-next-line require-await
 			vi.mocked(consoleApi.getAccount).mockImplementation(async ({ certified }) => {
 				if (certified) {
 					throw new Error('Certification failed');


### PR DESCRIPTION
# Motivation

We want to implement a safe sign-in - i.e. retrireving the account in an uncertified way but asynchronously certify it. 
Likewise, if no account is found, we do an update call their either get (in case the uncertified call was tempered) or init the account.
