### PR TITLE
feat(console): add segment to list even when created from mission control

### DIFF
--- a/src/console/src/factory/canister.rs
+++ b/src/console/src/factory/canister.rs
@@ -54,15 +54,13 @@ where
         let creator: CanisterCreator =
             CanisterCreator::MissionControl((mission_control_id, account.owner));
 
-        return create_canister_with_account(
-            create,
-            increment_rate,
-            get_fee,
-            &account,
-            creator,
-            args,
-        )
-        .await;
+        let canister_id =
+            create_canister_with_account(create, increment_rate, get_fee, &account, creator, args)
+                .await?;
+
+        add_segment(&account.owner, &canister_id);
+
+        return Ok(canister_id);
     }
 
     Err("Unknown caller".to_string())


### PR DESCRIPTION
# Motivation

I'm not going, likely, to deprecate spinning Satellite and Orbiter through Mission Control at the same time as the next big release. Therefore, to get started, maybe I can allow devs to still spin those through their Mission Control but, still, we gonna list those from the Console list of segments because this will become to source list.
