### PR TITLE
feat(console): extract and make process payment generic

### DIFF
--- a/src/console/src/factory/mission_control.rs
+++ b/src/console/src/factory/mission_control.rs
@@ -1,6 +1,7 @@
 use crate::accounts::{get_existing_account, update_mission_control};
 use crate::constants::FREEZING_THRESHOLD_ONE_YEAR;
 use crate::factory::canister::create_canister_with_account;
+use crate::factory::services::payment::process_payment_icp;
 use crate::factory::types::CanisterCreator;
 use crate::factory::utils::controllers::update_mission_control_controllers;
 use crate::factory::utils::wasm::mission_control_wasm_arg;
@@ -28,6 +29,7 @@ pub async fn create_mission_control(
 
     let mission_control_id = create_canister_with_account(
         create_mission_control_wasm,
+        process_payment_icp,
         &increment_mission_controls_rate,
         &get_mission_control_fee,
         &account,

--- a/src/console/src/factory/services/ledger/mod.rs
+++ b/src/console/src/factory/services/ledger/mod.rs
@@ -1,2 +1,2 @@
 pub mod icp;
-pub mod icrc;
+pub(super) mod icrc;

--- a/src/console/src/factory/services/mod.rs
+++ b/src/console/src/factory/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod ledger;
+pub mod payment;

--- a/src/console/src/factory/services/payment.rs
+++ b/src/console/src/factory/services/payment.rs
@@ -1,0 +1,26 @@
+use crate::factory::services::ledger::icp::verify_payment;
+use crate::factory::services::ledger::icrc::transfer_from;
+use crate::store::stable::is_known_payment;
+use candid::Principal;
+use ic_ledger_types::{BlockIndex, Tokens};
+use junobuild_shared::env::ICP_LEDGER;
+
+pub async fn process_payment_icp(
+    purchaser: Principal,
+    block_index: Option<BlockIndex>,
+    fee: Tokens,
+) -> Result<(Principal, BlockIndex), String> {
+    let purchaser_payment_block_index = if let Some(block_index) = block_index {
+        if is_known_payment(&block_index) {
+            return Err("Payment has been or is being processed.".to_string());
+        }
+
+        verify_payment(&purchaser, &block_index, fee).await?
+    } else {
+        transfer_from(&purchaser, &fee).await?
+    };
+
+    let ledger_id = Principal::from_text(ICP_LEDGER).unwrap();
+
+    Ok((ledger_id, purchaser_payment_block_index))
+}


### PR DESCRIPTION
# Motivation

Relates to  #2407. We want to process payment in cycles for devs flow.

It's a feature but, closer to a refactoring therefore no new tests for now.
