### PR TITLE
feat(frontend): icp to cycles in total balance

### DIFF
--- a/src/frontend/src/lib/derived/wallet/balance.derived.ts
+++ b/src/frontend/src/lib/derived/wallet/balance.derived.ts
@@ -2,6 +2,8 @@ import { CYCLES_LEDGER_CANISTER_ID, ICP_LEDGER_CANISTER_ID } from '$lib/constant
 import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 import { devId } from '$lib/derived/dev.derived';
 import { balanceCertifiedStore } from '$lib/stores/wallet/balance.store';
+import { icpToCyclesRateStore } from '$lib/stores/wallet/icp-cycles-rate.store';
+import { icpToCycles } from '$lib/utils/cycles.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived } from 'svelte/store';
 
@@ -21,6 +23,14 @@ export const missionControlIcpBalance = derived(
 			: undefined
 );
 
+export const missionControlIcpToCyclesBalance = derived(
+	[missionControlIcpBalance, icpToCyclesRateStore],
+	([$missionControlIcpBalance, $icpToCyclesRateStore]) =>
+		nonNullish($missionControlIcpBalance) && nonNullish($icpToCyclesRateStore?.data)
+			? icpToCycles({ icp: $missionControlIcpBalance, trillionRatio: $icpToCyclesRateStore.data })
+			: undefined
+);
+
 export const missionControlCyclesBalance = derived(
 	[balanceCertifiedStore, missionControlId],
 	([$balanceStore, $missionControlId]) =>
@@ -30,13 +40,21 @@ export const missionControlCyclesBalance = derived(
 );
 
 export const balance = derived(
-	[devCyclesBalance, missionControlCyclesBalance],
-	([$devCyclesBalance, $missionControlCyclesBalance]) => {
-		if (isNullish($devCyclesBalance) && isNullish($missionControlCyclesBalance)) {
+	[devCyclesBalance, missionControlCyclesBalance, missionControlIcpToCyclesBalance],
+	([$devCyclesBalance, $missionControlCyclesBalance, $missionControlIcpToCyclesBalance]) => {
+		if (
+			isNullish($devCyclesBalance) &&
+			isNullish($missionControlCyclesBalance) &&
+			isNullish($missionControlIcpToCyclesBalance)
+		) {
 			return undefined;
 		}
 
-		return ($devCyclesBalance ?? 0n) + ($missionControlCyclesBalance ?? 0n);
+		return (
+			($devCyclesBalance ?? 0n) +
+			($missionControlCyclesBalance ?? 0n) +
+			($missionControlIcpToCyclesBalance ?? 0n)
+		);
 	}
 );
 


### PR DESCRIPTION
# Motivation

For backwards compatibility support, we want to sum the value in cycles of the icp of the mission control in the balance total.
