### PR TITLE
feat(frontend): enable wallet picker only if mission control

### DIFF
--- a/src/frontend/src/lib/components/wallet/Wallet.svelte
+++ b/src/frontend/src/lib/components/wallet/Wallet.svelte
@@ -78,9 +78,7 @@
 
 		<div class="columns-3 fit-column-1">
 			<div>
-				<div class="picker">
-					<WalletPicker bind:selectedWallet />
-				</div>
+				<WalletPicker bind:selectedWallet />
 
 				<WalletTokenPicker {selectedWallet} bind:selectedToken />
 
@@ -113,8 +111,3 @@
 	<ReceiveTokens {selectedWallet} bind:visible={receiveVisible} />
 {/if}
 
-<style lang="scss">
-	.picker {
-		margin: 0 0 var(--padding-1_5x);
-	}
-</style>

--- a/src/frontend/src/lib/components/wallet/WalletPicker.svelte
+++ b/src/frontend/src/lib/components/wallet/WalletPicker.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { fade } from 'svelte/transition';
 	import { decodeIcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
-	import { untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { devId } from '$lib/derived/dev.derived';
@@ -17,7 +18,7 @@
 	let { selectedWallet = $bindable(undefined), filterMissionControlZeroBalance = false }: Props =
 		$props();
 
-	let walletIdText = $state<WalletIdText | undefined>(undefined);
+	let walletIdText = $state<WalletIdText | undefined>($devId?.toText());
 
 	$effect(() => {
 		walletIdText;
@@ -32,19 +33,23 @@
 				: undefined;
 		});
 	});
+
+	let pickerEnabled = $derived($missionControlId !== null);
 </script>
 
-<div>
-	<Value ref="wallet-id">
-		{#snippet label()}
-			{$i18n.wallet.title}
-		{/snippet}
+{#if pickerEnabled}
+	<div in:fade>
+		<Value ref="wallet-id">
+			{#snippet label()}
+				{$i18n.wallet.title}
+			{/snippet}
 
-		<select id="wallet-id" name="wallet-id" bind:value={walletIdText}>
-			{#if nonNullish($devId)}<option value={$devId.toText()}>{$i18n.wallet.dev}</option>{/if}
-			{#if nonNullish($missionControlId) && (!filterMissionControlZeroBalance || $missionControlHasIcp)}<option
-					value={$missionControlId.toText()}>{$i18n.mission_control.title}</option
-				>{/if}
-		</select>
-	</Value>
-</div>
+			<select id="wallet-id" name="wallet-id" bind:value={walletIdText}>
+				{#if nonNullish($devId)}<option value={$devId.toText()}>{$i18n.wallet.dev}</option>{/if}
+				{#if nonNullish($missionControlId) && (!filterMissionControlZeroBalance || $missionControlHasIcp)}<option
+						value={$missionControlId.toText()}>{$i18n.mission_control.title}</option
+					>{/if}
+			</select>
+		</Value>
+	</div>
+{/if}


### PR DESCRIPTION
# Motivation

We want to simplify the UI/UX as much as possible therefore if not monitoring/mission control activated, no need to display the wallet picker.
