### PR TITLE
refactor(frontend): derived $authStore.identity

### DIFF
--- a/src/frontend/src/lib/components/analytics/Analytics.svelte
+++ b/src/frontend/src/lib/components/analytics/Analytics.svelte
@@ -14,6 +14,7 @@
 	import NoAnalytics from '$lib/components/analytics/NoAnalytics.svelte';
 	import SpinnerParagraph from '$lib/components/ui/SpinnerParagraph.svelte';
 	import Warning from '$lib/components/ui/Warning.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { orbiterFeatures } from '$lib/derived/orbiter/orbiter-satellites.derived';
 	import { orbitersStore, orbiterStore } from '$lib/derived/orbiter.derived';
 	import { satelliteStore } from '$lib/derived/satellite/satellite.derived';
@@ -23,7 +24,6 @@
 	import { loadOrbiterConfigs } from '$lib/services/orbiter/orbiters.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { analyticsFiltersStore } from '$lib/stores/orbiter/analytics-filters.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import type {
@@ -59,7 +59,7 @@
 			const params: PageViewsParams = {
 				satelliteId: $satelliteStore?.satellite_id,
 				orbiterId: $orbiterStore.orbiter_id,
-				identity: $authStore.identity,
+				identity: $authIdentity,
 				from,
 				...restPeriod
 			};

--- a/src/frontend/src/lib/components/analytics/AnalyticsControllers.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsControllers.svelte
@@ -4,8 +4,8 @@
 	import { deleteOrbitersController, setOrbitersController } from '$lib/api/mission-control.api';
 	import { listOrbiterControllers } from '$lib/api/orbiter.api';
 	import Controllers from '$lib/components/controllers/Controllers.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { SetControllerParams } from '$lib/types/controllers';
 	import type { MissionControlId } from '$lib/types/mission-control';
 
@@ -16,7 +16,7 @@
 	let { orbiterId }: Props = $props();
 
 	const list = (): Promise<[Principal, MissionControlDid.Controller][]> =>
-		listOrbiterControllers({ orbiterId, identity: $authStore.identity });
+		listOrbiterControllers({ orbiterId, identity: $authIdentity });
 
 	const remove = (params: {
 		missionControlId: MissionControlId;
@@ -25,7 +25,7 @@
 		deleteOrbitersController({
 			...params,
 			orbiterIds: [orbiterId],
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 	const add = (
@@ -36,7 +36,7 @@
 		setOrbitersController({
 			...params,
 			orbiterIds: [orbiterId],
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 </script>
 

--- a/src/frontend/src/lib/components/analytics/AnalyticsEventsExport.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsEventsExport.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import type { MissionControlDid } from '$declarations';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { satelliteStore } from '$lib/derived/satellite/satellite.derived';
 	import { exportTrackEvents } from '$lib/services/orbiter/orbiter.export.services';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { analyticsFiltersStore } from '$lib/stores/orbiter/analytics-filters.store';
 	import type { PageViewsParams } from '$lib/types/orbiter';
 
@@ -29,7 +29,7 @@
 		const params: PageViewsParams = {
 			satelliteId: $satelliteStore?.satellite_id,
 			orbiterId: orbiter.orbiter_id,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			from,
 			...restPeriod
 		};

--- a/src/frontend/src/lib/components/analytics/AnalyticsNew.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsNew.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { testIds } from '$lib/constants/test-ids.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { initOrbiterWizard } from '$lib/services/factory/factory-wizard.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { testId } from '$lib/utils/test.utils';
 
 	const createOrbiter = async () => {
 		await initOrbiterWizard({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId: $missionControlId
 		});
 	};

--- a/src/frontend/src/lib/components/analytics/AnalyticsPagesExport.svelte
+++ b/src/frontend/src/lib/components/analytics/AnalyticsPagesExport.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import type { MissionControlDid } from '$declarations';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { satelliteStore } from '$lib/derived/satellite/satellite.derived';
 	import { exportPageViews } from '$lib/services/orbiter/orbiter.export.services';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { analyticsFiltersStore } from '$lib/stores/orbiter/analytics-filters.store';
 	import type { PageViewsParams } from '$lib/types/orbiter';
 
@@ -29,7 +29,7 @@
 		const params: PageViewsParams = {
 			satelliteId: $satelliteStore?.satellite_id,
 			orbiterId: orbiter.orbiter_id,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			from,
 			...restPeriod
 		};

--- a/src/frontend/src/lib/components/assets/Asset.svelte
+++ b/src/frontend/src/lib/components/assets/Asset.svelte
@@ -11,9 +11,9 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { DATA_CONTEXT_KEY, type DataContext } from '$lib/types/data.context';
 	import { PAGINATION_CONTEXT_KEY, type PaginationContext } from '$lib/types/pagination.context';
 	import { RULES_CONTEXT_KEY, type RulesContext } from '$lib/types/rules.context';
@@ -67,7 +67,7 @@
 		await deleteAsset({
 			...params,
 			full_path,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		resetData();

--- a/src/frontend/src/lib/components/assets/AssetToken.svelte
+++ b/src/frontend/src/lib/components/assets/AssetToken.svelte
@@ -7,10 +7,10 @@
 	import InputGenerate from '$lib/components/ui/InputGenerate.svelte';
 	import Popover from '$lib/components/ui/Popover.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { busy, isBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { RULES_CONTEXT_KEY, type RulesContext } from '$lib/types/rules.context';
 	import { container } from '$lib/utils/juno.utils';
 
@@ -35,7 +35,7 @@
 	const generateToken = () => (token = window.crypto.randomUUID());
 
 	const apply = async () => {
-		if (isNullish($authStore.identity)) {
+		if (isNullish($authIdentity)) {
 			toasts.error({
 				text: $i18n.authentication.not_signed_in
 			});
@@ -51,7 +51,7 @@
 				token: token ?? null,
 				satellite: {
 					satelliteId: satelliteId.toText(),
-					identity: $authStore.identity,
+					identity: $authIdentity,
 					...container()
 				}
 			});

--- a/src/frontend/src/lib/components/assets/AssetUpload.svelte
+++ b/src/frontend/src/lib/components/assets/AssetUpload.svelte
@@ -9,10 +9,10 @@
 	import InputGenerate from '$lib/components/ui/InputGenerate.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { COLLECTION_DAPP } from '$lib/constants/storage.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { RULES_CONTEXT_KEY, type RulesContext } from '$lib/types/rules.context';
 	import { container } from '$lib/utils/juno.utils';
 
@@ -55,7 +55,7 @@
 			return;
 		}
 
-		if (isNullish($authStore.identity)) {
+		if (isNullish($authIdentity)) {
 			toasts.error({
 				text: $i18n.authentication.not_signed_in
 			});
@@ -98,7 +98,7 @@
 				data: file,
 				satellite: {
 					satelliteId: satelliteId.toText(),
-					identity: $authStore.identity,
+					identity: $authIdentity,
 					...container()
 				}
 			});

--- a/src/frontend/src/lib/components/assets/Assets.svelte
+++ b/src/frontend/src/lib/components/assets/Assets.svelte
@@ -12,8 +12,8 @@
 	import DataPaginator from '$lib/components/data/DataPaginator.svelte';
 	import IconRefresh from '$lib/components/icons/IconRefresh.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import { type DataContext, DATA_CONTEXT_KEY } from '$lib/types/data.context';
 	import { type ListParamsContext, LIST_PARAMS_CONTEXT_KEY } from '$lib/types/list-params.context';
@@ -74,7 +74,7 @@
 	 */
 
 	const deleteData = async (params: { collection: string; satelliteId: Principal }) => {
-		await deleteAssets({ ...params, identity: $authStore.identity });
+		await deleteAssets({ ...params, identity: $authIdentity });
 		resetData();
 	};
 

--- a/src/frontend/src/lib/components/auth/AuthSettingsLoader.svelte
+++ b/src/frontend/src/lib/components/auth/AuthSettingsLoader.svelte
@@ -3,10 +3,10 @@
 	import { fade } from 'svelte/transition';
 	import SpinnerParagraph from '$lib/components/ui/SpinnerParagraph.svelte';
 	import Warning from '$lib/components/ui/Warning.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { getAuthConfig } from '$lib/services/console/auth/auth.config.services';
 	import { getRuleUser } from '$lib/services/satellite/collection.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import { AUTH_CONFIG_CONTEXT_KEY, type AuthConfigContext } from '$lib/types/auth.context';
 	import type { Satellite } from '$lib/types/satellite';
@@ -24,14 +24,14 @@
 	const { setConfig, setRule, state } = getContext<AuthConfigContext>(AUTH_CONFIG_CONTEXT_KEY);
 
 	const loadRule = async () => {
-		const result = await getRuleUser({ satelliteId, identity: $authStore.identity });
+		const result = await getRuleUser({ satelliteId, identity: $authIdentity });
 		setRule(result);
 	};
 
 	const loadConfig = async () => {
 		const result = await getAuthConfig({
 			satelliteId,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		setConfig(result);

--- a/src/frontend/src/lib/components/auth/UserBan.svelte
+++ b/src/frontend/src/lib/components/auth/UserBan.svelte
@@ -3,9 +3,9 @@
 	import { getContext } from 'svelte';
 	import ButtonTableAction from '$lib/components/ui/ButtonTableAction.svelte';
 	import Popover from '$lib/components/ui/Popover.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { banUser, unbanUser } from '$lib/services/satellite/user/user.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { PAGINATION_CONTEXT_KEY, type PaginationContext } from '$lib/types/pagination.context';
 	import type { User } from '$lib/types/user';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
@@ -37,7 +37,7 @@
 		const fn = isBanned ? unbanUser : banUser;
 
 		const { success } = await fn({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			satelliteId,
 			user,
 			setItem

--- a/src/frontend/src/lib/components/auth/UserRow.svelte
+++ b/src/frontend/src/lib/components/auth/UserRow.svelte
@@ -6,9 +6,9 @@
 	import UserProvider from '$lib/components/auth/UserProvider.svelte';
 	import ButtonTableAction from '$lib/components/ui/ButtonTableAction.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { openUserDetail } from '$lib/services/satellite/user/user.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { User } from '$lib/types/user';
 	import { formatToDate } from '$lib/utils/date.utils';
 
@@ -25,7 +25,7 @@
 		await openUserDetail({
 			user,
 			satelliteId,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 	};
 </script>

--- a/src/frontend/src/lib/components/auth/Users.svelte
+++ b/src/frontend/src/lib/components/auth/Users.svelte
@@ -9,12 +9,12 @@
 	import DataOrder from '$lib/components/data/DataOrder.svelte';
 	import DataPaginator from '$lib/components/data/DataPaginator.svelte';
 	import IconRefresh from '$lib/components/icons/IconRefresh.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { listUsers } from '$lib/services/satellite/user/users.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { initListParamsContext } from '$lib/stores/app/list-params.context.store';
 	import { initPaginationContext } from '$lib/stores/app/pagination.context.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import {
 		LIST_PARAMS_CONTEXT_KEY,
@@ -50,7 +50,7 @@
 				startAfter: $startAfter,
 				filter: $listParams.filter,
 				order: $listParams.order,
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 
 			setItems({ items: users, matches_length, items_length });

--- a/src/frontend/src/lib/components/canister/lifecycle/CanisterStart.svelte
+++ b/src/frontend/src/lib/components/canister/lifecycle/CanisterStart.svelte
@@ -5,13 +5,12 @@
 	import Confirmation from '$lib/components/core/Confirmation.svelte';
 	import IconStart from '$lib/components/icons/IconStart.svelte';
 	import Text from '$lib/components/ui/Text.svelte';
-	import { authSignedOut } from '$lib/derived/auth.derived';
+	import { authSignedOut, authIdentity } from '$lib/derived/auth.derived';
 	import { reloadOrbiterVersion } from '$lib/services/version/version.orbiter.services';
 	import { reloadSatelliteVersion } from '$lib/services/version/version.satellite.services';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { CanisterSyncData } from '$lib/types/canister';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nCapitalize, i18nFormat } from '$lib/utils/i18n.utils';
@@ -41,9 +40,9 @@
 		try {
 			const canisterId = Principal.fromText(canister.id);
 
-			assertNonNullish($authStore.identity);
+			assertNonNullish($authIdentity);
 
-			await canisterStart({ canisterId, identity: $authStore.identity });
+			await canisterStart({ canisterId, identity: $authIdentity });
 
 			emit({ message: 'junoRestartCycles', detail: { canisterId } });
 

--- a/src/frontend/src/lib/components/canister/lifecycle/CanisterStop.svelte
+++ b/src/frontend/src/lib/components/canister/lifecycle/CanisterStop.svelte
@@ -5,11 +5,10 @@
 	import Confirmation from '$lib/components/core/Confirmation.svelte';
 	import IconStop from '$lib/components/icons/IconStop.svelte';
 	import Text from '$lib/components/ui/Text.svelte';
-	import { authSignedOut } from '$lib/derived/auth.derived';
+	import { authSignedOut, authIdentity } from '$lib/derived/auth.derived';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { CanisterSyncData } from '$lib/types/canister';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nCapitalize, i18nFormat } from '$lib/utils/i18n.utils';
@@ -45,9 +44,9 @@
 		try {
 			const canisterId = Principal.fromText(canister.id);
 
-			assertNonNullish($authStore.identity);
+			assertNonNullish($authIdentity);
 
-			await canisterStop({ canisterId, identity: $authStore.identity });
+			await canisterStop({ canisterId, identity: $authIdentity });
 
 			emit({ message: 'junoRestartCycles', detail: { canisterId } });
 

--- a/src/frontend/src/lib/components/cdn/list/Cdn.svelte
+++ b/src/frontend/src/lib/components/cdn/list/Cdn.svelte
@@ -5,12 +5,12 @@
 	import CdnAsset from '$lib/components/cdn/list/CdnAsset.svelte';
 	import DataCount from '$lib/components/data/DataCount.svelte';
 	import DataPaginator from '$lib/components/data/DataPaginator.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { listWasmAssets } from '$lib/services/satellite/proposals/proposals.cdn.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { initListParamsContext } from '$lib/stores/app/list-params.context.store';
 	import { initPaginationContext } from '$lib/stores/app/pagination.context.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import {
 		LIST_PARAMS_CONTEXT_KEY,
@@ -39,7 +39,7 @@
 			return;
 		}
 
-		if (isNullish($authStore.identity)) {
+		if (isNullish($authIdentity)) {
 			setItems({ items: undefined, matches_length: undefined, items_length: undefined });
 
 			toasts.error({
@@ -52,7 +52,7 @@
 			const { items, matches_length, items_length } = await listWasmAssets({
 				satelliteId: satellite.satellite_id,
 				startAfter: $startAfter,
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 
 			setItems({ items, matches_length, items_length });

--- a/src/frontend/src/lib/components/cdn/wizard/UpgradeCdnWizard.svelte
+++ b/src/frontend/src/lib/components/cdn/wizard/UpgradeCdnWizard.svelte
@@ -11,13 +11,13 @@
 	import Html from '$lib/components/ui/Html.svelte';
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
 	import CanisterUpgradeOptions from '$lib/components/upgrade/wizard/CanisterUpgradeOptions.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { prepareWasmUpgrade } from '$lib/services/upgrade/upgrade.cdn.services';
 	import { reloadSatelliteVersion } from '$lib/services/version/version.satellite.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { Satellite } from '$lib/types/satellite';
 	import type { Wasm } from '$lib/types/upgrade';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
@@ -52,7 +52,7 @@
 		await upgradeSatellite({
 			satellite: {
 				satelliteId,
-				identity: $authStore.identity ?? new AnonymousIdentity(),
+				identity: $authIdentity ?? new AnonymousIdentity(),
 				...container()
 			},
 			...params,
@@ -104,7 +104,7 @@
 		const result = await prepareWasmUpgrade({
 			asset,
 			satelliteId: satellite.satellite_id,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		if (result.result === 'error') {

--- a/src/frontend/src/lib/components/changes/list/ChangesDockLoader.svelte
+++ b/src/frontend/src/lib/components/changes/list/ChangesDockLoader.svelte
@@ -2,12 +2,12 @@
 	import { debounce } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import SpinnerParagraph from '$lib/components/ui/SpinnerParagraph.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { satellitesNotLoaded } from '$lib/derived/mission-control/satellites.derived';
 	import { satellitesStore } from '$lib/derived/satellites.derived';
 	import { satellitesVersionNotLoaded } from '$lib/derived/version.derived';
 	import { loadProposals as loadProposalsServices } from '$lib/services/satellite/proposals/proposals.list.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 
 	interface Props {
 		children: Snippet;
@@ -34,7 +34,7 @@
 
 		const { result } = await loadProposalsServices({
 			satellites: $satellitesStore ?? [],
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		loading = result === 'loaded' ? 'done' : 'error';

--- a/src/frontend/src/lib/components/changes/list/ChangesMore.svelte
+++ b/src/frontend/src/lib/components/changes/list/ChangesMore.svelte
@@ -3,10 +3,10 @@
 	import IconMore from '$lib/components/icons/IconMore.svelte';
 	import IconRefresh from '$lib/components/icons/IconRefresh.svelte';
 	import Popover from '$lib/components/ui/Popover.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { reloadSatelliteProposals } from '$lib/services/satellite/proposals/proposals.list.satellite.services';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 
 	interface Props {
 		satelliteId: Principal;
@@ -26,7 +26,7 @@
 		await reloadSatelliteProposals({
 			satelliteId,
 			skipReload: false,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		busy.stop();

--- a/src/frontend/src/lib/components/changes/wizard/ApplyChangeWizard.svelte
+++ b/src/frontend/src/lib/components/changes/wizard/ApplyChangeWizard.svelte
@@ -4,8 +4,8 @@
 	import ApplyChangeDone from '$lib/components/changes/wizard/ApplyChangeDone.svelte';
 	import ConfirmApplyChange from '$lib/components/changes/wizard/ConfirmApplyChange.svelte';
 	import ProgressApplyChange from '$lib/components/changes/wizard/ProgressApplyChange.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { applyProposal } from '$lib/services/satellite/proposals/proposals.services';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { ProposalRecord } from '$lib/types/proposals';
 	import type { SatelliteIdText } from '$lib/types/satellite';
 
@@ -47,7 +47,7 @@
 		await applyProposal({
 			satelliteId,
 			proposal: proposalRecord,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			clearProposalAssets,
 			takeSnapshot,
 			nextSteps: (next) => (step = next),

--- a/src/frontend/src/lib/components/changes/wizard/UpgradeChangeWizard.svelte
+++ b/src/frontend/src/lib/components/changes/wizard/UpgradeChangeWizard.svelte
@@ -3,8 +3,8 @@
 	import { onMount } from 'svelte';
 	import type { SatelliteDid } from '$declarations';
 	import UpgradeCdnWizard from '$lib/components/cdn/wizard/UpgradeCdnWizard.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { findWasmAssetForProposal } from '$lib/services/satellite/proposals/proposals.cdn.services';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { ProposalRecord } from '$lib/types/proposals';
 	import type { Satellite } from '$lib/types/satellite';
 
@@ -24,7 +24,7 @@
 		const result = await findWasmAssetForProposal({
 			satelliteId,
 			proposal,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		if (isNullish(result)) {

--- a/src/frontend/src/lib/components/cli/CliAdd.svelte
+++ b/src/frontend/src/lib/components/cli/CliAdd.svelte
@@ -7,11 +7,11 @@
 	import Html from '$lib/components/ui/Html.svelte';
 	import Warning from '$lib/components/ui/Warning.svelte';
 	import { REVOKED_CONTROLLERS } from '$lib/constants/app.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { setCliControllers } from '$lib/services/cli.services';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import type { Satellite } from '$lib/types/satellite';
 	import type { Option } from '$lib/types/utils';
@@ -53,7 +53,7 @@
 			return;
 		}
 
-		if (isNullish($authStore.identity)) {
+		if (isNullish($authIdentity)) {
 			toasts.error({
 				text: $i18n.authentication.not_signed_in
 			});
@@ -67,7 +67,7 @@
 			missionControlId,
 			controllerId: principal,
 			profile,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			selectedSatellites,
 			selectedOrbiters
 		});

--- a/src/frontend/src/lib/components/collections/CollectionDelete.svelte
+++ b/src/frontend/src/lib/components/collections/CollectionDelete.svelte
@@ -5,10 +5,10 @@
 	import { deleteRule } from '$lib/api/satellites.api';
 	import Confirmation from '$lib/components/core/Confirmation.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { RULES_CONTEXT_KEY, type RulesContext } from '$lib/types/rules.context';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 
@@ -44,10 +44,10 @@
 				collection,
 				type,
 				rule,
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 
-			await reload({ identity: $authStore.identity });
+			await reload({ identity: $authIdentity });
 
 			toasts.success({
 				text: i18nFormat($i18n.collections.deleted, [

--- a/src/frontend/src/lib/components/collections/CollectionEdit.svelte
+++ b/src/frontend/src/lib/components/collections/CollectionEdit.svelte
@@ -14,11 +14,11 @@
 		type MemoryText,
 		type PermissionText
 	} from '$lib/constants/rules.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { setRule } from '$lib/services/satellite/collection.services';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { RULES_CONTEXT_KEY, type RulesContext } from '$lib/types/rules.context';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 	import { memoryToText, permissionToText } from '$lib/utils/rules.utils';
@@ -127,7 +127,7 @@
 				maxTokens,
 				maxChanges,
 				mutablePermissions: !immutable,
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 
 			toasts.success({
@@ -139,7 +139,7 @@
 				])
 			});
 
-			await reload({ identity: $authStore.identity });
+			await reload({ identity: $authIdentity });
 
 			onsuccess();
 		} catch (err: unknown) {

--- a/src/frontend/src/lib/components/controllers/Controllers.svelte
+++ b/src/frontend/src/lib/components/controllers/Controllers.svelte
@@ -8,10 +8,10 @@
 	import ControllerInfo from '$lib/components/controllers/ControllerInfo.svelte';
 	import ButtonTableAction from '$lib/components/ui/ButtonTableAction.svelte';
 	import Identifier from '$lib/components/ui/Identifier.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { CanisterSegmentWithLabel } from '$lib/types/canister';
 	import type { SetControllerParams } from '$lib/types/controllers';
 	import type { MissionControlId } from '$lib/types/mission-control';
@@ -63,8 +63,7 @@
 	const isMissionControl = (controllerId: Principal): boolean =>
 		nonNullish($missionControlId) && $missionControlId.toText() === controllerId.toText();
 	const isDev = (controllerId: Principal): boolean =>
-		nonNullish($authStore.identity) &&
-		$authStore.identity.getPrincipal().toText() === controllerId.toText();
+		nonNullish($authIdentity) && $authIdentity.getPrincipal().toText() === controllerId.toText();
 </script>
 
 <div class="table-container">

--- a/src/frontend/src/lib/components/db/Db.svelte
+++ b/src/frontend/src/lib/components/db/Db.svelte
@@ -4,8 +4,8 @@
 	import DbCollections from '$lib/components/db/DbCollections.svelte';
 	import DbData from '$lib/components/db/DbData.svelte';
 	import { DbCollectionType } from '$lib/constants/rules.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { initListParamsContext } from '$lib/stores/app/list-params.context.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { initRulesContext } from '$lib/stores/satellite/rules.context.store';
 	import {
 		type ListParamsContext,
@@ -28,7 +28,7 @@
 	});
 
 	$effect(() => {
-		context.init({ satelliteId, identity: $authStore.identity });
+		context.init({ satelliteId, identity: $authIdentity });
 	});
 
 	setContext<RulesContext>(RULES_CONTEXT_KEY, context);

--- a/src/frontend/src/lib/components/db/DbData.svelte
+++ b/src/frontend/src/lib/components/db/DbData.svelte
@@ -13,10 +13,10 @@
 	import DocForm from '$lib/components/docs/DocHeader.svelte';
 	import Docs from '$lib/components/docs/Docs.svelte';
 	import { SATELLITE_v0_0_9 } from '$lib/constants/version.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { initPaginationContext } from '$lib/stores/app/pagination.context.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import { DATA_CONTEXT_KEY, type DataContext, type DataStoreData } from '$lib/types/data.context';
 	import type { ListParams } from '$lib/types/list';
@@ -57,7 +57,7 @@
 					// prettier-ignore parenthesis required for Webstorm Svelte plugin
 					...$listParams
 				} as ListParams,
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 			setItems({ items, matches_length, items_length });
 		} catch (err: unknown) {

--- a/src/frontend/src/lib/components/docs/DocHeader.svelte
+++ b/src/frontend/src/lib/components/docs/DocHeader.svelte
@@ -10,9 +10,9 @@
 	import DocUpload from '$lib/components/docs/DocUpload.svelte';
 	import IconDownload from '$lib/components/icons/IconDownload.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { DATA_CONTEXT_KEY, type DataContext } from '$lib/types/data.context';
 	import { RULES_CONTEXT_KEY, type RulesContext } from '$lib/types/rules.context';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
@@ -44,7 +44,7 @@
 			...params,
 			key,
 			doc,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		resetData();
@@ -78,7 +78,7 @@
 		});
 	};
 
-	const reloadRules = async () => await reload({ identity: $authStore.identity });
+	const reloadRules = async () => await reload({ identity: $authIdentity });
 </script>
 
 <div class="title doc">

--- a/src/frontend/src/lib/components/docs/DocUpload.svelte
+++ b/src/frontend/src/lib/components/docs/DocUpload.svelte
@@ -14,10 +14,10 @@
 	import DataUpload from '$lib/components/data/DataUpload.svelte';
 	import InputGenerate from '$lib/components/ui/InputGenerate.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { RULES_CONTEXT_KEY, type RulesContext } from '$lib/types/rules.context';
 	import { fileToDocData } from '$lib/utils/doc.utils';
 	import { container } from '$lib/utils/juno.utils';
@@ -84,7 +84,7 @@
 			return;
 		}
 
-		if (isNullish($authStore.identity)) {
+		if (isNullish($authIdentity)) {
 			toasts.error({
 				text: $i18n.authentication.not_signed_in
 			});
@@ -104,7 +104,7 @@
 				},
 				satellite: {
 					satelliteId: satelliteId.toText(),
-					identity: $authStore.identity,
+					identity: $authIdentity,
 					...container()
 				}
 			});

--- a/src/frontend/src/lib/components/docs/Docs.svelte
+++ b/src/frontend/src/lib/components/docs/Docs.svelte
@@ -12,9 +12,9 @@
 	import DocUpload from '$lib/components/docs/DocUpload.svelte';
 	import IconRefresh from '$lib/components/icons/IconRefresh.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { initListParamsContext } from '$lib/stores/app/list-params.context.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import { DATA_CONTEXT_KEY, type DataContext } from '$lib/types/data.context';
 	import {
@@ -69,7 +69,7 @@
 	 */
 
 	const deleteData = async (params: { collection: string; satelliteId: Principal }) => {
-		await deleteDocs({ ...params, identity: $authStore.identity });
+		await deleteDocs({ ...params, identity: $authIdentity });
 
 		resetData();
 	};

--- a/src/frontend/src/lib/components/guards/IdentityGuard.svelte
+++ b/src/frontend/src/lib/components/guards/IdentityGuard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 
 	interface Props {
 		children: Snippet;
@@ -10,7 +10,7 @@
 	let { children }: Props = $props();
 </script>
 
-{#if $authStore.identity === null}
+{#if $authIdentity === null}
 	<p>{$i18n.core.not_logged_in}</p>
 
 	<a class="button" href="/">{$i18n.not_found.go_home}</a>

--- a/src/frontend/src/lib/components/hosting/CustomDomainActions.svelte
+++ b/src/frontend/src/lib/components/hosting/CustomDomainActions.svelte
@@ -8,11 +8,11 @@
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import Popover from '$lib/components/ui/Popover.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { deleteCustomDomain as deleteCustomDomainService } from '$lib/services/satellite/custom-domain.services';
 	import { busy, isBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { CustomDomain } from '$lib/types/custom-domain';
 	import type { JunoModalCustomDomainDetail } from '$lib/types/modal';
 	import type { Satellite } from '$lib/types/satellite';
@@ -67,7 +67,7 @@
 				...updateConfig,
 				version: config.version
 			},
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 	};
 
@@ -87,7 +87,7 @@
 				domainName: customDomain[0],
 				customDomain: customDomain[1],
 				deleteCustomDomain: !skipDeleteDomain,
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 
 			await updateConfig();

--- a/src/frontend/src/lib/components/hosting/Hosting.svelte
+++ b/src/frontend/src/lib/components/hosting/Hosting.svelte
@@ -8,11 +8,11 @@
 		type SelectedCustomDomain
 	} from '$lib/components/hosting/CustomDomainInfo.svelte';
 	import HostingCount from '$lib/components/hosting/HostingCount.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { sortedSatelliteCustomDomains } from '$lib/derived/satellite/satellite-custom-domains.derived';
 	import { getAuthConfig } from '$lib/services/console/auth/auth.config.services';
 	import { listCustomDomains } from '$lib/services/satellite/custom-domain.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { Satellite } from '$lib/types/satellite';
 	import { satelliteUrl } from '$lib/utils/satellite.utils';
 
@@ -34,7 +34,7 @@
 			}),
 			getAuthConfig({
 				satelliteId: satellite.satellite_id,
-				identity: $authStore.identity
+				identity: $authIdentity
 			})
 		]);
 

--- a/src/frontend/src/lib/components/hosting/HostingCount.svelte
+++ b/src/frontend/src/lib/components/hosting/HostingCount.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { countHostingAssets } from '$lib/services/satellite/hosting.storage.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import type { Satellite } from '$lib/types/satellite';
 
@@ -18,7 +18,7 @@
 	const load = async () => {
 		const result = await countHostingAssets({
 			satellite,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		assets = result.result === 'success' ? result.count : 0n;

--- a/src/frontend/src/lib/components/hosting/HostingSettings.svelte
+++ b/src/frontend/src/lib/components/hosting/HostingSettings.svelte
@@ -6,9 +6,9 @@
 	import HostingSwitchMemory from '$lib/components/hosting/HostingSwitchMemory.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { getRuleDapp } from '$lib/services/satellite/collection.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { Satellite } from '$lib/types/satellite';
 
 	interface Props {
@@ -26,7 +26,7 @@
 	let memory = $derived(fromNullable(rule?.memory ?? []));
 
 	const loadRule = async () => {
-		const result = await getRuleDapp({ satelliteId, identity: $authStore.identity });
+		const result = await getRuleDapp({ satelliteId, identity: $authIdentity });
 		rule = result?.rule;
 		supportSettings = result?.result === 'success';
 

--- a/src/frontend/src/lib/components/hosting/HostingSwitchMemory.svelte
+++ b/src/frontend/src/lib/components/hosting/HostingSwitchMemory.svelte
@@ -2,9 +2,9 @@
 	import { nonNullish } from '@dfinity/utils';
 	import type { SatelliteDid } from '$declarations';
 	import Confirmation from '$lib/components/core/Confirmation.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { switchHostingMemory } from '$lib/services/satellite/hosting.storage.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { Satellite } from '$lib/types/satellite';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 
@@ -23,7 +23,7 @@
 	const switchMemory = async () => {
 		const { result } = await switchHostingMemory({
 			satellite,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		if (result === 'error') {

--- a/src/frontend/src/lib/components/logs/Logs.svelte
+++ b/src/frontend/src/lib/components/logs/Logs.svelte
@@ -9,10 +9,10 @@
 	import LogsOrder from '$lib/components/logs/LogsOrder.svelte';
 	import LogsRefresh from '$lib/components/logs/LogsRefresh.svelte';
 	import SpinnerParagraph from '$lib/components/ui/SpinnerParagraph.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { listLogs } from '$lib/services/satellite/logs.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { initPaginationContext } from '$lib/stores/app/pagination.context.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { Log as LogType, LogLevel as LogLevelType } from '$lib/types/log';
 	import { PAGINATION_CONTEXT_KEY, type PaginationContext } from '$lib/types/pagination.context';
 
@@ -28,7 +28,7 @@
 	const list = async () => {
 		const { results, error } = await listLogs({
 			satelliteId,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			desc,
 			levels
 		});

--- a/src/frontend/src/lib/components/mission-control/MissionControlControllers.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlControllers.svelte
@@ -8,8 +8,8 @@
 		setMissionControlController
 	} from '$lib/api/mission-control.api';
 	import Controllers from '$lib/components/controllers/Controllers.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { SetControllerParams } from '$lib/types/controllers';
 	import type { MissionControlId } from '$lib/types/mission-control';
 
@@ -20,18 +20,18 @@
 	let { missionControlId }: Props = $props();
 
 	const list = (): Promise<[Principal, MissionControlDid.Controller][]> =>
-		listMissionControlControllers({ missionControlId, identity: $authStore.identity });
+		listMissionControlControllers({ missionControlId, identity: $authIdentity });
 
 	const remove = (params: {
 		missionControlId: MissionControlId;
 		controller: Principal;
-	}): Promise<void> => deleteMissionControlController({ ...params, identity: $authStore.identity });
+	}): Promise<void> => deleteMissionControlController({ ...params, identity: $authIdentity });
 
 	const add = (
 		params: {
 			missionControlId: MissionControlId;
 		} & SetControllerParams
-	): Promise<void> => setMissionControlController({ ...params, identity: $authStore.identity });
+	): Promise<void> => setMissionControlController({ ...params, identity: $authIdentity });
 
 	const pseudoAdminController: MissionControlDid.Controller = {
 		created_at: 0n,
@@ -43,9 +43,9 @@
 
 	let extraControllers = $derived<[Principal, MissionControlDid.Controller][]>([
 		[missionControlId, pseudoAdminController],
-		...(nonNullish($authStore.identity)
+		...(nonNullish($authIdentity)
 			? [
-					[$authStore.identity.getPrincipal(), pseudoAdminController] as [
+					[$authIdentity.getPrincipal(), pseudoAdminController] as [
 						Principal,
 						MissionControlDid.Controller
 					]

--- a/src/frontend/src/lib/components/mission-control/MissionControlDataLoader.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlDataLoader.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { onMount, type Snippet, untrack } from 'svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlVersion } from '$lib/derived/version.derived';
 	import {
 		loadSettings,
 		loadUserData
 	} from '$lib/services/mission-control/mission-control.services';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
 
 	interface Props {
@@ -25,12 +25,12 @@
 		await Promise.all([
 			loadSettings({
 				missionControlId,
-				identity: $authStore.identity,
+				identity: $authIdentity,
 				reload
 			}),
 			loadUserData({
 				missionControlId,
-				identity: $authStore.identity,
+				identity: $authIdentity,
 				reload
 			})
 		]);

--- a/src/frontend/src/lib/components/mission-control/MissionControlEmail.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlEmail.svelte
@@ -6,6 +6,7 @@
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { EMAIL_PLACEHOLDER } from '$lib/constants/monitoring.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import {
 		missionControlEmail,
@@ -15,7 +16,6 @@
 	import { setMetadataEmail } from '$lib/services/mission-control/mission-control.services';
 	import { busy, isBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 
 	let email = $state('');
 	let visible: boolean = $state(false);
@@ -35,7 +35,7 @@
 		busy.start();
 
 		const { success } = await setMetadataEmail({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId: $missionControlId,
 			metadata: $missionControlMetadata ?? [],
 			email

--- a/src/frontend/src/lib/components/mission-control/MissionControlNew.svelte
+++ b/src/frontend/src/lib/components/mission-control/MissionControlNew.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { initMissionControlWizard } from '$lib/services/factory/factory-wizard.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 
 	const createMissionControl = async () => {
 		await initMissionControlWizard({
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 	};
 </script>

--- a/src/frontend/src/lib/components/modals/AuthConfigModal.svelte
+++ b/src/frontend/src/lib/components/modals/AuthConfigModal.svelte
@@ -7,6 +7,7 @@
 	import AuthConfigFormII from '$lib/components/auth/AuthConfigFormII.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { isSkylab } from '$lib/env/app.env';
 	import {
 		updateAuthConfigRules,
@@ -17,7 +18,6 @@
 	import { emulatorToggleOpenIdMonitoring } from '$lib/services/emulator.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail, JunoModalEditAuthConfigDetail } from '$lib/types/modal';
 	import { emit } from '$lib/utils/events.utils';
 
@@ -64,7 +64,7 @@
 		const update = (): Promise<UpdateAuthConfigResult> => {
 			const commonPayload = {
 				satellite,
-				identity: $authStore.identity,
+				identity: $authIdentity,
 				config
 			};
 

--- a/src/frontend/src/lib/components/modals/CanisterEditSettingsModal.svelte
+++ b/src/frontend/src/lib/components/modals/CanisterEditSettingsModal.svelte
@@ -15,10 +15,10 @@
 		THREE_MONTHS,
 		TWO_YEARS
 	} from '$lib/constants/canister.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { updateSettings as updateSettingsServices } from '$lib/services/ic-mgmt/settings.services';
 	import { isBusy, wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { CanisterLogVisibility } from '$lib/types/canister';
 	import type { JunoModalDetail, JunoModalEditCanisterSettingsDetail } from '$lib/types/modal';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
@@ -116,7 +116,7 @@
 				memoryAllocation: BigInt(memoryAllocation),
 				computeAllocation: BigInt(computeAllocation)
 			},
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		wizardBusy.stop();

--- a/src/frontend/src/lib/components/modals/CanisterRestoreSnapshotModal.svelte
+++ b/src/frontend/src/lib/components/modals/CanisterRestoreSnapshotModal.svelte
@@ -5,10 +5,10 @@
 	import Html from '$lib/components/ui/Html.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import Warning from '$lib/components/ui/Warning.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { restoreSnapshot } from '$lib/services/ic-mgmt/snapshots.services';
 	import { isBusy, wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail, JunoModalRestoreSnapshotDetail } from '$lib/types/modal';
 	import type { SnapshotProgress } from '$lib/types/progress-snapshot';
 	import { formatToDate } from '$lib/utils/date.utils';
@@ -41,7 +41,7 @@
 		const { success } = await restoreSnapshot({
 			canisterId,
 			snapshot: $state.snapshot(snapshot),
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			onProgress
 		});
 

--- a/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
+++ b/src/frontend/src/lib/components/modals/CreateMonitoringStrategyModal.svelte
@@ -11,13 +11,13 @@
 	import MonitoringSelectSegments from '$lib/components/monitoring/MonitoringSelectSegments.svelte';
 	import ProgressMonitoring from '$lib/components/monitoring/ProgressMonitoring.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
 		applyMonitoringCyclesStrategy,
 		type ApplyMonitoringCyclesStrategyOptions
 	} from '$lib/services/mission-control/monitoring.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail, JunoModalCreateMonitoringStrategyDetail } from '$lib/types/modal';
 	import type { MonitoringStrategyProgress } from '$lib/types/progress-strategy';
 	import type { Option } from '$lib/types/utils';
@@ -150,7 +150,7 @@
 		next('in_progress');
 
 		const { success } = await applyMonitoringCyclesStrategy({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId,
 			satellites: selectedSatellites.map(([id, _]) => id),
 			orbiters: selectedOrbiters.map(([id, _]) => id),

--- a/src/frontend/src/lib/components/modals/CreateSnapshotModal.svelte
+++ b/src/frontend/src/lib/components/modals/CreateSnapshotModal.svelte
@@ -6,11 +6,11 @@
 	import Html from '$lib/components/ui/Html.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import Warning from '$lib/components/ui/Warning.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { createSnapshot } from '$lib/services/ic-mgmt/snapshots.services';
 	import { isBusy, wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { snapshotStore } from '$lib/stores/ic-mgmt/snapshot.store';
 	import type { JunoModalDetail, JunoModalSegmentDetail } from '$lib/types/modal';
 	import type { SnapshotProgress } from '$lib/types/progress-snapshot';
@@ -49,7 +49,7 @@
 		const { success } = await createSnapshot({
 			canisterId,
 			snapshotId: $snapshotStore?.[segment.canisterId]?.[0]?.id,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			onProgress
 		});
 

--- a/src/frontend/src/lib/components/modals/CustomDomainModal.svelte
+++ b/src/frontend/src/lib/components/modals/CustomDomainModal.svelte
@@ -6,11 +6,11 @@
 	import AddCustomDomainForm from '$lib/components/hosting/AddCustomDomainForm.svelte';
 	import IconVerified from '$lib/components/icons/IconVerified.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { configHosting } from '$lib/services/satellite/hosting.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { CustomDomainDns } from '$lib/types/custom-domain';
 	import type { JunoModalCustomDomainDetail, JunoModalDetail } from '$lib/types/modal';
 	import type { HostingProgress } from '$lib/types/progress-hosting';
@@ -77,7 +77,7 @@
 			domainName: dns.hostname,
 			config,
 			useDomainForDerivationOrigin,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			onProgress
 		});
 

--- a/src/frontend/src/lib/components/modals/MissionControlTransferCyclesModal.svelte
+++ b/src/frontend/src/lib/components/modals/MissionControlTransferCyclesModal.svelte
@@ -3,9 +3,9 @@
 	import type { Principal } from '@icp-sdk/core/principal';
 	import { depositCycles } from '$lib/api/mission-control.api';
 	import CanisterTransferCyclesModal from '$lib/components/modals/CanisterTransferCyclesModal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalCycles, JunoModalDetail } from '$lib/types/modal';
 
 	interface Props {
@@ -26,7 +26,7 @@
 					// We know for sure that the mission control is defined at this point.
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					missionControlId: $missionControlId!,
-					identity: $authStore.identity
+					identity: $authIdentity
 				})
 		);
 </script>

--- a/src/frontend/src/lib/components/modals/MissionControlUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/MissionControlUpgradeModal.svelte
@@ -4,10 +4,10 @@
 	import { type UpgradeCodeParams, upgradeMissionControl } from '@junobuild/admin';
 	import CanisterUpgradeModal from '$lib/components/modals/CanisterUpgradeModal.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { reloadMissionControlVersion } from '$lib/services/version/version.mission-control.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail, JunoModalUpgradeDetail } from '$lib/types/modal';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 	import { container } from '$lib/utils/juno.utils';
@@ -30,7 +30,7 @@
 				// We know for sure that the mission control is defined at this point.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				missionControlId: $missionControlId!.toText(),
-				identity: $authStore.identity ?? new AnonymousIdentity(),
+				identity: $authIdentity ?? new AnonymousIdentity(),
 				...container()
 			},
 			...params

--- a/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterConfigModal.svelte
@@ -10,11 +10,11 @@
 	import SpinnerModal from '$lib/components/ui/SpinnerModal.svelte';
 	import { DEFAULT_FEATURES } from '$lib/constants/analytics.constants';
 	import { ORBITER_v0_0_8 } from '$lib/constants/version.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { setOrbiterSatelliteConfigs } from '$lib/services/orbiter/orbiters.services';
 	import { isBusy, wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { orbitersConfigsStore } from '$lib/stores/orbiter/orbiter-configs.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import type { JunoModalDetail, JunoModalEditOrbiterConfigDetail } from '$lib/types/modal';
@@ -112,7 +112,7 @@
 				orbiterId,
 				config,
 				features,
-				identity: $authStore.identity,
+				identity: $authIdentity,
 				orbiterVersion: $versionStore.orbiter.current
 			});
 

--- a/src/frontend/src/lib/components/modals/OrbiterDeleteModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterDeleteModal.svelte
@@ -3,8 +3,8 @@
 	import { deleteOrbiter } from '$lib/api/mission-control.api';
 	import CanisterDeleteWizard from '$lib/components/canister/lifecycle/CanisterDeleteWizard.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import type { JunoModalCycles, JunoModalDetail } from '$lib/types/modal';
 
@@ -28,7 +28,7 @@
 				// We know for sure that the orbiter is defined at this point.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				orbiterId: $orbiterStore!.orbiter_id,
-				identity: $authStore.identity
+				identity: $authIdentity
 			})
 	);
 </script>

--- a/src/frontend/src/lib/components/modals/OrbiterTransferCyclesModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterTransferCyclesModal.svelte
@@ -3,9 +3,9 @@
 	import type { Principal } from '@icp-sdk/core/principal';
 	import { depositCycles } from '$lib/api/orbiter.api';
 	import CanisterTransferCyclesModal from '$lib/components/modals/CanisterTransferCyclesModal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalCycles, JunoModalDetail } from '$lib/types/modal';
 
 	interface Props {
@@ -26,7 +26,7 @@
 					// We know for sure that the orbiter is defined at this point.
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					orbiterId: $orbiterStore!.orbiter_id,
-					identity: $authStore.identity
+					identity: $authIdentity
 				})
 		);
 </script>

--- a/src/frontend/src/lib/components/modals/OrbiterUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/OrbiterUpgradeModal.svelte
@@ -7,10 +7,10 @@
 	import Html from '$lib/components/ui/Html.svelte';
 	import type { IgnoreCanUpgradeErrorFn } from '$lib/components/upgrade/wizard/SelectUpgradeVersion.svelte';
 	import { ORBITER_v0_0_8, ORBITER_v0_2_0 } from '$lib/constants/version.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { orbiterStore } from '$lib/derived/orbiter.derived';
 	import { reloadOrbiterVersion } from '$lib/services/version/version.orbiter.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail, JunoModalUpgradeDetail } from '$lib/types/modal';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 	import { container } from '$lib/utils/juno.utils';
@@ -31,7 +31,7 @@
 				// We know for sure that the orbiter is defined at this point.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				orbiterId: $orbiterStore!.orbiter_id.toText(),
-				identity: $authStore.identity ?? new AnonymousIdentity(),
+				identity: $authIdentity ?? new AnonymousIdentity(),
 				...container()
 			},
 			...params

--- a/src/frontend/src/lib/components/modals/RejectChangeModal.svelte
+++ b/src/frontend/src/lib/components/modals/RejectChangeModal.svelte
@@ -4,9 +4,9 @@
 	import ConfirmRejectChange from '$lib/components/changes/wizard/ConfirmRejectChange.svelte';
 	import ProgressRejectChange from '$lib/components/changes/wizard/ProgressRejectChange.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { rejectProposal } from '$lib/services/satellite/proposals/proposals.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalChangeDetail, JunoModalDetail } from '$lib/types/modal';
 
 	interface Props {
@@ -43,7 +43,7 @@
 		await rejectProposal({
 			satelliteId,
 			proposal: proposalRecord,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			clearProposalAssets,
 			nextSteps: (next) => (step = next),
 			onProgress

--- a/src/frontend/src/lib/components/modals/SatelliteDeleteModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteDeleteModal.svelte
@@ -3,9 +3,9 @@
 	import CanisterDeleteWizard from '$lib/components/canister/lifecycle/CanisterDeleteWizard.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { satelliteCustomDomains } from '$lib/derived/satellite/satellite-custom-domains.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import type { JunoModalDeleteSatelliteDetail, JunoModalDetail } from '$lib/types/modal';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
@@ -28,7 +28,7 @@
 			await deleteSatellite({
 				...params,
 				satelliteId: satellite.satellite_id,
-				identity: $authStore.identity
+				identity: $authIdentity
 			})
 	);
 </script>

--- a/src/frontend/src/lib/components/modals/SatelliteTransferCyclesModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteTransferCyclesModal.svelte
@@ -2,7 +2,7 @@
 	import type { Principal } from '@icp-sdk/core/principal';
 	import { depositCycles } from '$lib/api/satellites.api';
 	import CanisterTransferCyclesModal from '$lib/components/modals/CanisterTransferCyclesModal.svelte';
-	import { authStore } from '$lib/stores/auth.store';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import type { JunoModalCyclesSatelliteDetail, JunoModalDetail } from '$lib/types/modal';
 	import { satelliteName } from '$lib/utils/satellite.utils';
 
@@ -21,7 +21,7 @@
 				await depositCycles({
 					...params,
 					satelliteId: satellite.satellite_id,
-					identity: $authStore.identity
+					identity: $authIdentity
 				})
 		);
 </script>

--- a/src/frontend/src/lib/components/modals/SatelliteUpgradeModal.svelte
+++ b/src/frontend/src/lib/components/modals/SatelliteUpgradeModal.svelte
@@ -6,10 +6,10 @@
 	import CanisterUpgradeModal from '$lib/components/modals/CanisterUpgradeModal.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import { SATELLITE_v0_0_7, SATELLITE_v0_0_9 } from '$lib/constants/version.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { reloadSatelliteVersion } from '$lib/services/version/version.satellite.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail, JunoModalUpgradeSatelliteDetail } from '$lib/types/modal';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 	import { container } from '$lib/utils/juno.utils';
@@ -32,7 +32,7 @@
 		await upgradeSatellite({
 			satellite: {
 				satelliteId: satellite.satellite_id.toText(),
-				identity: $authStore.identity ?? new AnonymousIdentity(),
+				identity: $authIdentity ?? new AnonymousIdentity(),
 				...container()
 			},
 			...params,

--- a/src/frontend/src/lib/components/modals/StopMonitoringStrategyModal.svelte
+++ b/src/frontend/src/lib/components/modals/StopMonitoringStrategyModal.svelte
@@ -7,10 +7,10 @@
 	import MonitoringStopReview from '$lib/components/monitoring/MonitoringStopReview.svelte';
 	import ProgressMonitoring from '$lib/components/monitoring/ProgressMonitoring.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { stopMonitoringCyclesStrategy } from '$lib/services/mission-control/monitoring.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail, JunoModalCreateMonitoringStrategyDetail } from '$lib/types/modal';
 	import type { MonitoringStrategyProgress } from '$lib/types/progress-strategy';
 
@@ -55,7 +55,7 @@
 		step = 'in_progress';
 
 		const { success } = await stopMonitoringCyclesStrategy({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId,
 			satellites: selectedSatellites.map(([id, _]) => id),
 			orbiters: selectedOrbiters.map(([id, _]) => id),

--- a/src/frontend/src/lib/components/modals/factory/MissionControlCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/factory/MissionControlCreateModal.svelte
@@ -6,12 +6,11 @@
 	import FactoryProgressCreate from '$lib/components/factory/FactoryProgressCreate.svelte';
 	import Confetti from '$lib/components/ui/Confetti.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
-	import { authSignedOut } from '$lib/derived/auth.derived';
+	import { authSignedOut, authIdentity } from '$lib/derived/auth.derived';
 	import type { SelectedWallet } from '$lib/schemas/wallet.schema';
 	import { createMissionControlWizard } from '$lib/services/factory/factory-wizard.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { WizardCreateProgress } from '$lib/types/progress-wizard';
 	import type { Option } from '$lib/types/utils';
@@ -47,7 +46,7 @@
 
 		const { success } = await createMissionControlWizard({
 			selectedWallet,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			subnetId,
 			withFee,
 			onProgress,

--- a/src/frontend/src/lib/components/modals/factory/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/factory/OrbiterCreateModal.svelte
@@ -8,13 +8,12 @@
 	import Confetti from '$lib/components/ui/Confetti.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import { testIds } from '$lib/constants/test-ids.constants';
-	import { authSignedOut } from '$lib/derived/auth.derived';
+	import { authSignedOut, authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import type { SelectedWallet } from '$lib/schemas/wallet.schema';
 	import { createOrbiterWizard } from '$lib/services/factory/factory-wizard.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { WizardCreateProgress } from '$lib/types/progress-wizard';
 	import type { Option } from '$lib/types/utils';
@@ -48,7 +47,7 @@
 
 		const { success } = await createOrbiterWizard({
 			selectedWallet,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId: $missionControlId,
 			subnetId,
 			monitoringStrategy,

--- a/src/frontend/src/lib/components/modals/factory/SatelliteCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/factory/SatelliteCreateModal.svelte
@@ -9,13 +9,12 @@
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { testIds } from '$lib/constants/test-ids.constants';
-	import { authSignedOut } from '$lib/derived/auth.derived';
+	import { authSignedOut, authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import type { SelectedWallet } from '$lib/schemas/wallet.schema';
 	import { createSatelliteWizard } from '$lib/services/factory/factory-wizard.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { WizardCreateProgress } from '$lib/types/progress-wizard';
 	import type { SatelliteId } from '$lib/types/satellite';
@@ -52,7 +51,7 @@
 
 		const result = await createSatelliteWizard({
 			selectedWallet,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId: $missionControlId,
 			subnetId,
 			monitoringStrategy,

--- a/src/frontend/src/lib/components/modals/top-up/CanisterTopUpModal.svelte
+++ b/src/frontend/src/lib/components/modals/top-up/CanisterTopUpModal.svelte
@@ -7,11 +7,11 @@
 	import CanisterTopUpReview from '$lib/components/canister/top-up/CanisterTopUpReview.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import { CYCLES } from '$lib/constants/token.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import type { SelectedToken, SelectedWallet } from '$lib/schemas/wallet.schema';
 	import { topUp } from '$lib/services/top-up/top-up.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { CanisterSegmentWithLabel } from '$lib/types/canister';
 	import type { TopUpProgress } from '$lib/types/progress-topup';
 
@@ -44,7 +44,7 @@
 			canisterId: Principal.fromText(segment.canisterId),
 			selectedWallet,
 			selectedToken,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			balance,
 			amount,
 			onProgress

--- a/src/frontend/src/lib/components/modals/wallet/SendTokensModal.svelte
+++ b/src/frontend/src/lib/components/modals/wallet/SendTokensModal.svelte
@@ -6,6 +6,7 @@
 	import ProgressSendTokens from '$lib/components/wallet/tokens/ProgressSendTokens.svelte';
 	import SendTokensForm from '$lib/components/wallet/tokens/SendTokensForm.svelte';
 	import SendTokensReview from '$lib/components/wallet/tokens/SendTokensReview.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
 		devCyclesBalance,
 		devIcpBalance,
@@ -15,7 +16,6 @@
 	import { sendTokens } from '$lib/services/wallet/wallet.send.services';
 	import { wizardBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { JunoModalDetail, JunoModalWalletDetail } from '$lib/types/modal';
 	import type { SendTokensProgress } from '$lib/types/progress-send-tokens';
 	import { isTokenIcp } from '$lib/utils/token.utils';
@@ -67,7 +67,7 @@
 		const { success } = await sendTokens({
 			selectedWallet,
 			selectedToken,
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			destination,
 			token,
 			onProgress

--- a/src/frontend/src/lib/components/monitoring/MonitoringNotifications.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringNotifications.svelte
@@ -4,13 +4,13 @@
 	import { fade } from 'svelte/transition';
 	import Toggle from '$lib/components/ui/Toggle.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { missionControlSettingsLoaded } from '$lib/derived/mission-control/mission-control-settings.derived';
 	import { missionControlConfigMonitoring } from '$lib/derived/mission-control/mission-control-user.derived';
 	import { setMonitoringNotification } from '$lib/services/mission-control/monitoring.services';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 
 	let enabled = $state(false);
 
@@ -32,7 +32,7 @@
 		busy.start();
 
 		await setMonitoringNotification({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId: $missionControlId,
 			monitoringConfig: $missionControlConfigMonitoring,
 			enabled

--- a/src/frontend/src/lib/components/satellites/SatelliteControllers.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteControllers.svelte
@@ -7,8 +7,8 @@
 	} from '$lib/api/mission-control.api';
 	import { listControllers } from '$lib/api/satellites.api';
 	import Controllers from '$lib/components/controllers/Controllers.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import type { SetControllerParams } from '$lib/types/controllers';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import type { Satellite } from '$lib/types/satellite';
@@ -20,7 +20,7 @@
 	let { satellite }: Props = $props();
 
 	const list = (): Promise<[Principal, MissionControlDid.Controller][]> =>
-		listControllers({ satelliteId: satellite.satellite_id, identity: $authStore.identity });
+		listControllers({ satelliteId: satellite.satellite_id, identity: $authIdentity });
 
 	const remove = (params: {
 		missionControlId: MissionControlId;
@@ -29,7 +29,7 @@
 		deleteSatellitesController({
 			...params,
 			satelliteIds: [satellite.satellite_id],
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 	const add = (
@@ -40,7 +40,7 @@
 		setSatellitesController({
 			...params,
 			satelliteIds: [satellite.satellite_id],
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 </script>
 

--- a/src/frontend/src/lib/components/satellites/SatelliteNewButton.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteNewButton.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { testIds } from '$lib/constants/test-ids.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { initSatelliteWizard } from '$lib/services/factory/factory-wizard.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { testId } from '$lib/utils/test.utils';
 
 	const createSatellite = async () => {
 		await initSatelliteWizard({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId: $missionControlId
 		});
 	};

--- a/src/frontend/src/lib/components/satellites/SatelliteNewLaunchButton.svelte
+++ b/src/frontend/src/lib/components/satellites/SatelliteNewLaunchButton.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import IconRocket from '$lib/components/icons/IconRocket.svelte';
 	import { testIds } from '$lib/constants/test-ids.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
 	import { initSatelliteWizard } from '$lib/services/factory/factory-wizard.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { testId } from '$lib/utils/test.utils';
 
 	const createSatellite = async () => {
 		await initSatelliteWizard({
-			identity: $authStore.identity,
+			identity: $authIdentity,
 			missionControlId: $missionControlId
 		});
 	};

--- a/src/frontend/src/lib/components/snapshot/SnapshotDelete.svelte
+++ b/src/frontend/src/lib/components/snapshot/SnapshotDelete.svelte
@@ -4,11 +4,11 @@
 	import type { Principal } from '@icp-sdk/core/principal';
 	import type { ICDid } from '$declarations';
 	import Popover from '$lib/components/ui/Popover.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { deleteSnapshot } from '$lib/services/ic-mgmt/snapshots.services';
 	import { busy, isBusy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 
@@ -34,7 +34,7 @@
 		const { success } = await deleteSnapshot({
 			canisterId,
 			snapshot: existingSnapshot,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		busy.stop();

--- a/src/frontend/src/lib/components/snapshot/SnapshotsLoader.svelte
+++ b/src/frontend/src/lib/components/snapshot/SnapshotsLoader.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import type { Principal } from '@icp-sdk/core/principal';
 	import { onMount, type Snippet } from 'svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { loadSnapshots } from '$lib/services/ic-mgmt/snapshots.services';
-	import { authStore } from '$lib/stores/auth.store';
 
 	interface Props {
 		canisterId: Principal;
@@ -14,7 +14,7 @@
 	onMount(() => {
 		loadSnapshots({
 			canisterId,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 	});
 </script>

--- a/src/frontend/src/lib/components/snapshot/SnapshotsRefresh.svelte
+++ b/src/frontend/src/lib/components/snapshot/SnapshotsRefresh.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import type { Principal } from '@icp-sdk/core/principal';
 	import IconAutoRenew from '$lib/components/icons/IconAutoRenew.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { reloadSnapshots } from '$lib/services/ic-mgmt/snapshots.services';
 	import { busy } from '$lib/stores/app/busy.store';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 
 	interface Props {
 		canisterId: Principal;
@@ -17,7 +17,7 @@
 
 		await reloadSnapshots({
 			canisterId,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 
 		busy.stop();

--- a/src/frontend/src/lib/components/storage/Storage.svelte
+++ b/src/frontend/src/lib/components/storage/Storage.svelte
@@ -4,8 +4,8 @@
 	import StorageCollections from '$lib/components/storage/StorageCollections.svelte';
 	import StorageData from '$lib/components/storage/StorageData.svelte';
 	import { StorageCollectionType } from '$lib/constants/rules.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { initListParamsContext } from '$lib/stores/app/list-params.context.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { initRulesContext } from '$lib/stores/satellite/rules.context.store';
 	import {
 		type ListParamsContext,
@@ -28,7 +28,7 @@
 	});
 
 	$effect(() => {
-		context.init({ satelliteId, identity: $authStore.identity });
+		context.init({ satelliteId, identity: $authIdentity });
 	});
 
 	setContext<RulesContext>(RULES_CONTEXT_KEY, context);

--- a/src/frontend/src/lib/components/storage/StorageData.svelte
+++ b/src/frontend/src/lib/components/storage/StorageData.svelte
@@ -12,9 +12,9 @@
 	import DataCollectionsHeaderWithFilter from '$lib/components/data/DataCollectionsHeaderWithFilter.svelte';
 	import DataCount from '$lib/components/data/DataCount.svelte';
 	import { SATELLITE_v0_0_10, SATELLITE_v0_0_9 } from '$lib/constants/version.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { initPaginationContext } from '$lib/stores/app/pagination.context.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { versionStore } from '$lib/stores/version.store';
 	import { DATA_CONTEXT_KEY, type DataContext, type DataStoreData } from '$lib/types/data.context';
 	import type { ListParams } from '$lib/types/list';
@@ -65,7 +65,7 @@
 					// prettier-ignore parenthesis required for Webstorm Svelte plugin
 					...$listParams
 				} as ListParams,
-				identity: $authStore.identity
+				identity: $authIdentity
 			});
 			setItems({ items, matches_length, items_length });
 		} catch (err: unknown) {

--- a/src/frontend/src/lib/components/upgrade/wizard/ReviewUpgradeVersion.svelte
+++ b/src/frontend/src/lib/components/upgrade/wizard/ReviewUpgradeVersion.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import Html from '$lib/components/ui/Html.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
 		upgrade as upgradeServices,
 		type UpgradeParams
 	} from '$lib/services/upgrade/upgrade.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 
 	type Props = {
@@ -37,7 +37,7 @@
 			nextSteps,
 			takeSnapshot,
 			canisterId,
-			identity: $authStore.identity
+			identity: $authIdentity
 		});
 	};
 </script>

--- a/src/frontend/src/lib/components/wallet/tokens/ReceiveTokensSignerForm.svelte
+++ b/src/frontend/src/lib/components/wallet/tokens/ReceiveTokensSignerForm.svelte
@@ -7,9 +7,9 @@
 	import Input from '$lib/components/ui/Input.svelte';
 	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
-	import { authStore } from '$lib/stores/auth.store';
 	import { formatICP } from '$lib/utils/icp.utils';
 
 	interface Props {
@@ -30,7 +30,7 @@
 				? base64ToUint8Array(account.subaccount)
 				: undefined;
 
-			balance = await getBalance({ account: { owner, subaccount }, identity: $authStore.identity });
+			balance = await getBalance({ account: { owner, subaccount }, identity: $authIdentity });
 		} catch (err: unknown) {
 			toasts.error({
 				text: $i18n.errors.wallet_load_balance,

--- a/src/frontend/src/lib/derived/auth.derived.ts
+++ b/src/frontend/src/lib/derived/auth.derived.ts
@@ -1,17 +1,11 @@
 import { authStore } from '$lib/stores/auth.store';
 import { nonNullish } from '@dfinity/utils';
-import { derived, type Readable } from 'svelte/store';
+import { derived } from 'svelte/store';
 
-export const authSignedIn: Readable<boolean> = derived(authStore, ({ identity }) =>
-	nonNullish(identity)
-);
+export const authSignedIn = derived(authStore, ({ identity }) => nonNullish(identity));
 
-export const authNotSignedIn: Readable<boolean> = derived(
-	authSignedIn,
-	($authSignedIn) => !$authSignedIn
-);
+export const authNotSignedIn = derived(authSignedIn, ($authSignedIn) => !$authSignedIn);
 
-export const authSignedOut: Readable<boolean> = derived(
-	[authSignedIn],
-	([$authSignedIn]) => !$authSignedIn
-);
+export const authSignedOut = derived([authSignedIn], ([$authSignedIn]) => !$authSignedIn);
+
+export const authIdentity = derived(authStore, ({ identity }) => identity);


### PR DESCRIPTION
# Motivation

Tired of typing `$authStore.identity` particularly with my Jetbrains IDE which is still buggy and cannot auto-import stores when prefixed with `$`.
