### PR TITLE
feat(frontend): leftovers of using mission control satellites instead of global list

### DIFF
--- a/src/frontend/src/lib/components/changes/list/ChangesDockLoader.svelte
+++ b/src/frontend/src/lib/components/changes/list/ChangesDockLoader.svelte
@@ -3,8 +3,7 @@
 	import type { Snippet } from 'svelte';
 	import SpinnerParagraph from '$lib/components/ui/SpinnerParagraph.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { mctrlSatellitesNotLoaded } from '$lib/derived/mission-control/mission-control-satellites.derived';
-	import { satellitesStore } from '$lib/derived/satellites.derived';
+	import { satellitesNotLoaded, satellitesStore } from '$lib/derived/satellites.derived';
 	import { satellitesVersionNotLoaded } from '$lib/derived/version.derived';
 	import { loadProposals as loadProposalsServices } from '$lib/services/satellite/proposals/proposals.list.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
@@ -18,7 +17,7 @@
 	let loading: 'init' | 'in_progress' | 'done' | 'error' = $state('init');
 
 	const loadProposals = async () => {
-		if ($mctrlSatellitesNotLoaded) {
+		if ($satellitesNotLoaded) {
 			return;
 		}
 
@@ -43,7 +42,7 @@
 	const debounceLoadProposals = debounce(loadProposals);
 
 	$effect(() => {
-		$mctrlSatellitesNotLoaded;
+		$satellitesNotLoaded;
 		$satellitesVersionNotLoaded;
 
 		debounceLoadProposals();

--- a/src/frontend/src/lib/components/loaders/CanistersStatusLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/CanistersStatusLoader.svelte
@@ -2,8 +2,8 @@
 	import { debounce } from '@dfinity/utils';
 	import type { Principal } from '@icp-sdk/core/principal';
 	import { onDestroy, onMount, type Snippet } from 'svelte';
-	import { mctrlSatellitesNotLoaded } from '$lib/derived/mission-control/mission-control-satellites.derived';
 	import { orbiterNotLoaded } from '$lib/derived/orbiter.derived';
+	import { satellitesNotLoaded } from '$lib/derived/satellites.derived';
 	import { CyclesWorker } from '$lib/services/workers/worker.cycles.services';
 	import type { CanisterSegment } from '$lib/types/canister';
 	import type { Satellite } from '$lib/types/satellite';
@@ -30,7 +30,7 @@
 	$effect(() => {
 		worker?.stopCyclesTimer();
 
-		if ($mctrlSatellitesNotLoaded) {
+		if ($satellitesNotLoaded) {
 			return;
 		}
 

--- a/src/frontend/src/lib/components/loaders/RegistryLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/RegistryLoader.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { debounce } from '@dfinity/utils';
 	import { onDestroy, onMount, type Snippet } from 'svelte';
-	import { mctrlSatellitesNotLoaded } from '$lib/derived/mission-control/mission-control-satellites.derived';
 	import { orbiterNotLoaded } from '$lib/derived/orbiter.derived';
+	import { satellitesNotLoaded } from '$lib/derived/satellites.derived';
 	import { RegistryWorker } from '$lib/services/workers/worker.registry.services';
 	import type { CanisterSegment } from '$lib/types/canister';
 
@@ -25,7 +25,7 @@
 	);
 
 	$effect(() => {
-		if ($mctrlSatellitesNotLoaded) {
+		if ($satellitesNotLoaded) {
 			return;
 		}
 

--- a/src/frontend/src/lib/derived/satellites.derived.ts
+++ b/src/frontend/src/lib/derived/satellites.derived.ts
@@ -24,6 +24,16 @@ export const satellitesStore = derived(
 	}
 );
 
+export const satellitesLoaded = derived(
+	[satellitesStore],
+	([$satellitesStore]) => $satellitesStore !== undefined
+);
+
+export const satellitesNotLoaded = derived(
+	[satellitesLoaded],
+	([$satellitesLoaded]) => !$satellitesLoaded
+);
+
 export const sortedSatellites = derived([satellitesStore], ([$satellitesStore]) =>
 	($satellitesStore ?? []).sort((a, b) => satelliteName(a).localeCompare(satelliteName(b)))
 );

--- a/src/frontend/src/lib/derived/upgrade.derived.ts
+++ b/src/frontend/src/lib/derived/upgrade.derived.ts
@@ -1,6 +1,6 @@
 import { missionControlIdNotLoaded } from '$lib/derived/console/account.mission-control.derived';
-import { mctrlSatellitesNotLoaded } from '$lib/derived/mission-control/mission-control-satellites.derived';
 import { orbiterNotLoaded } from '$lib/derived/orbiter.derived';
+import { satellitesNotLoaded } from '$lib/derived/satellites.derived';
 import {
 	missionControlVersion,
 	orbiterVersion,
@@ -11,7 +11,7 @@ import { derived, type Readable } from 'svelte/store';
 export const hasPendingUpgrades: Readable<boolean | undefined> = derived(
 	[
 		missionControlIdNotLoaded,
-		mctrlSatellitesNotLoaded,
+		satellitesNotLoaded,
 		orbiterNotLoaded,
 		missionControlVersion,
 		orbiterVersion,


### PR DESCRIPTION
# Motivation

The list of Satellites is now a merge of what's in the Console and what's in the Mission Control (for backwards compatibility). There were few components and services that were not yet plugged to the new derived source.
