### PR TITLE
feat(observatory): expose endpoint to query monitoring enabled or not

### DIFF
--- a/src/declarations/observatory/observatory.did.d.ts
+++ b/src/declarations/observatory/observatory.did.d.ts
@@ -131,6 +131,7 @@ export interface _SERVICE {
 	del_controllers: ActorMethod<[DeleteControllersArgs], undefined>;
 	get_notify_status: ActorMethod<[GetNotifications], NotifyStatus>;
 	get_openid_certificate: ActorMethod<[GetOpenIdCertificateArgs], [] | [OpenIdCertificate]>;
+	is_openid_monitoring_enabled: ActorMethod<[], boolean>;
 	list_controllers: ActorMethod<[], Array<[Principal, Controller]>>;
 	notify: ActorMethod<[NotifyArgs], undefined>;
 	ping: ActorMethod<[NotifyArgs], undefined>;

--- a/src/declarations/observatory/observatory.factory.certified.did.js
+++ b/src/declarations/observatory/observatory.factory.certified.did.js
@@ -129,6 +129,7 @@ export const idlFactory = ({ IDL }) => {
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		get_notify_status: IDL.Func([GetNotifications], [NotifyStatus], []),
 		get_openid_certificate: IDL.Func([GetOpenIdCertificateArgs], [IDL.Opt(OpenIdCertificate)], []),
+		is_openid_monitoring_enabled: IDL.Func([], [IDL.Bool], []),
 		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], []),
 		notify: IDL.Func([NotifyArgs], [], []),
 		ping: IDL.Func([NotifyArgs], [], []),

--- a/src/declarations/observatory/observatory.factory.did.js
+++ b/src/declarations/observatory/observatory.factory.did.js
@@ -129,6 +129,7 @@ export const idlFactory = ({ IDL }) => {
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		get_notify_status: IDL.Func([GetNotifications], [NotifyStatus], ['query']),
 		get_openid_certificate: IDL.Func([GetOpenIdCertificateArgs], [IDL.Opt(OpenIdCertificate)], []),
+		is_openid_monitoring_enabled: IDL.Func([], [IDL.Bool], []),
 		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], ['query']),
 		notify: IDL.Func([NotifyArgs], [], []),
 		ping: IDL.Func([NotifyArgs], [], []),

--- a/src/declarations/observatory/observatory.factory.did.mjs
+++ b/src/declarations/observatory/observatory.factory.did.mjs
@@ -129,6 +129,7 @@ export const idlFactory = ({ IDL }) => {
 		del_controllers: IDL.Func([DeleteControllersArgs], [], []),
 		get_notify_status: IDL.Func([GetNotifications], [NotifyStatus], ['query']),
 		get_openid_certificate: IDL.Func([GetOpenIdCertificateArgs], [IDL.Opt(OpenIdCertificate)], []),
+		is_openid_monitoring_enabled: IDL.Func([], [IDL.Bool], []),
 		list_controllers: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))], ['query']),
 		notify: IDL.Func([NotifyArgs], [], []),
 		ping: IDL.Func([NotifyArgs], [], []),

--- a/src/observatory/observatory.did
+++ b/src/observatory/observatory.did
@@ -92,6 +92,7 @@ service : () -> {
   get_openid_certificate : (GetOpenIdCertificateArgs) -> (
       opt OpenIdCertificate,
     );
+  is_openid_monitoring_enabled : () -> (bool);
   list_controllers : () -> (vec record { principal; Controller }) query;
   notify : (NotifyArgs) -> ();
   ping : (NotifyArgs) -> ();

--- a/src/observatory/src/api/openid.rs
+++ b/src/observatory/src/api/openid.rs
@@ -2,7 +2,7 @@ use crate::guards::{
     caller_is_admin_controller, caller_is_not_admin_controller, caller_is_not_anonymous,
     increment_openid_certificate_requests,
 };
-use crate::openid::scheduler::{start_openid_scheduler, stop_openid_scheduler};
+use crate::openid::scheduler::{is_openid_scheduler_enabled, start_openid_scheduler, stop_openid_scheduler};
 use crate::store::heap::get_certificate;
 use ic_cdk_macros::update;
 use junobuild_auth::openid::jwkset::types::interface::GetOpenIdCertificateArgs;
@@ -17,6 +17,11 @@ fn start_openid_monitoring() {
 #[update(guard = "caller_is_admin_controller")]
 fn stop_openid_monitoring() {
     stop_openid_scheduler().unwrap_or_trap()
+}
+
+#[update(guard = "caller_is_admin_controller")]
+fn is_openid_monitoring_enabled() -> bool {
+    is_openid_scheduler_enabled()
 }
 
 #[update(guard = "caller_is_not_anonymous")]

--- a/src/observatory/src/openid/scheduler.rs
+++ b/src/observatory/src/openid/scheduler.rs
@@ -1,7 +1,5 @@
 use crate::openid::certificate::schedule_certificate_update;
-use crate::store::heap::{
-    assert_scheduler_running, assert_scheduler_stopped, disable_scheduler, enable_scheduler,
-};
+use crate::store::heap::{assert_scheduler_running, assert_scheduler_stopped, disable_scheduler, enable_scheduler, is_scheduler_enabled};
 use ic_cdk_timers::set_timer;
 use junobuild_auth::openid::types::provider::OpenIdProvider;
 use std::time::Duration;
@@ -39,4 +37,10 @@ pub fn stop_openid_scheduler() -> Result<(), String> {
     assert_scheduler_running(&provider)?;
 
     disable_scheduler(&provider)
+}
+
+pub fn is_openid_scheduler_enabled() -> bool {
+    let provider = OpenIdProvider::Google;
+
+    is_scheduler_enabled(&provider)
 }

--- a/src/observatory/src/store/heap/openid.rs
+++ b/src/observatory/src/store/heap/openid.rs
@@ -23,6 +23,10 @@ pub fn disable_scheduler(provider: &OpenIdProvider) -> Result<(), String> {
     with_openid_mut(|openid| disable_scheduler_impl(provider, openid))
 }
 
+pub fn is_scheduler_enabled(provider: &OpenIdProvider) -> bool {
+    with_openid(|openid| scheduler_enabled(openid, provider))
+}
+
 pub fn set_openid_certificate(provider: &OpenIdProvider, jwks: &Jwks) {
     with_openid_mut(|openid| set_openid_certificate_impl(provider, jwks, openid))
 }

--- a/src/tests/specs/observatory/observatory.openid.spec.ts
+++ b/src/tests/specs/observatory/observatory.openid.spec.ts
@@ -53,6 +53,12 @@ describe('Observatory > OpenId', async () => {
 			await assertOpenIdHttpsOutcalls({ pic, jwks: mockJwks });
 		});
 
+		it('should get openid monitoring enabled', async () => {
+			const { is_openid_monitoring_enabled } = actor;
+
+			await expect(is_openid_monitoring_enabled()).resolves.toBeTruthy();
+		});
+
 		it('should provide certificate', async () => {
 			await assertGetCertificate({ version: 1n, actor, jwks: mockJwks });
 		});
@@ -87,6 +93,12 @@ describe('Observatory > OpenId', async () => {
 			const { stop_openid_monitoring } = actor;
 
 			await expect(stop_openid_monitoring()).resolves.toBeNull();
+		});
+
+		it('should get openid monitoring disabled', async () => {
+			const { is_openid_monitoring_enabled } = actor;
+
+			await expect(is_openid_monitoring_enabled()).resolves.toBeFalsy();
 		});
 
 		it('should still provide certificate', async () => {

--- a/src/tests/specs/observatory/observatory.spec.ts
+++ b/src/tests/specs/observatory/observatory.spec.ts
@@ -129,6 +129,14 @@ describe('Observatory', () => {
 				CALLER_NOT_CONTROLLER_OBSERVATORY_MSG
 			);
 		});
+
+		it('should throw errors on getting openid enabled', async () => {
+			const { is_openid_monitoring_enabled } = actor;
+
+			await expect(is_openid_monitoring_enabled()).rejects.toThrowError(
+				CALLER_NOT_CONTROLLER_OBSERVATORY_MSG
+			);
+		});
 	};
 
 	describe('anonymous', () => {


### PR DESCRIPTION
# Motivation

Backend for #2461 - i.e. we want to expose a new endpoint, this way the emulator can check the status of the monitoring to perform a start or stop or not.
