### PR TITLE
test(e2e): adapt for new creation flow with cycles and updated launchpad

### DIFF
--- a/src/e2e/create-second-satellite.spec.ts
+++ b/src/e2e/create-second-satellite.spec.ts
@@ -13,7 +13,7 @@ testWithII('should not allow creating a second satellite', async () => {
 	await consolePage.goto();
 
 	// Open Create Satellite wizard again
-	await consolePage.openCreateSatelliteWizard();
+	await consolePage.openCreateAdditionalSatelliteWizard();
 
 	// Assert no create button is available
 	await consolePage.failedAtCreatingSatellite();

--- a/src/e2e/page-objects/console.page.ts
+++ b/src/e2e/page-objects/console.page.ts
@@ -37,11 +37,9 @@ export class ConsolePage extends IdentityPage {
 	}
 
 	async createSatellite({ kind }: { kind: 'website' | 'application' }): Promise<void> {
-		await expect(this.page.getByTestId(testIds.createSatellite.launch)).toBeVisible(
-			TIMEOUT_AVERAGE
-		);
+		await expect(this.page.getByTestId(testIds.launchpad.launch)).toBeVisible(TIMEOUT_AVERAGE);
 
-		await this.page.getByTestId(testIds.createSatellite.launch).click();
+		await this.page.getByTestId(testIds.launchpad.launch).click();
 
 		await expect(this.page.getByTestId(testIds.createSatellite.create)).toBeVisible();
 
@@ -103,12 +101,16 @@ export class ConsolePage extends IdentityPage {
 		await expect(this.page.getByRole('menu')).toContainText(expected.balance, TIMEOUT_LONG);
 	}
 
-	async openCreateSatelliteWizard(): Promise<void> {
-		await expect(this.page.getByTestId(testIds.createSatellite.launch)).toBeVisible(
+	async openCreateAdditionalSatelliteWizard(): Promise<void> {
+		await expect(this.page.getByTestId(testIds.launchpad.actions)).toBeVisible(TIMEOUT_AVERAGE);
+
+		await this.page.getByTestId(testIds.launchpad.actions).click();
+
+		await expect(this.page.getByTestId(testIds.launchpad.launchExtraSatellite)).toBeVisible(
 			TIMEOUT_AVERAGE
 		);
 
-		await this.page.getByTestId(testIds.createSatellite.launch).click();
+		await this.page.getByTestId(testIds.launchpad.launchExtraSatellite).click();
 	}
 
 	async failedAtCreatingSatellite(): Promise<void> {
@@ -116,8 +118,8 @@ export class ConsolePage extends IdentityPage {
 		await expect(this.page.getByTestId(testIds.createSatellite.create)).not.toBeVisible();
 
 		const expectedText = i18n.satellites.create_satellite_price
-			.replace('{0}', '0.5000 ICP')
-			.replace('{1}', '0.0000 ICP');
+			.replace('{0}', '3.000 T Cycles')
+			.replace('{1}', '0.000 T Cycles');
 
 		await expect(this.page.getByText(expectedText)).toBeVisible();
 	}

--- a/src/frontend/src/lib/components/launchpad/Launchpad.svelte
+++ b/src/frontend/src/lib/components/launchpad/Launchpad.svelte
@@ -2,8 +2,8 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { run } from 'svelte/legacy';
 	import { fade } from 'svelte/transition';
-	import LaunchpadSegments from '$lib/components/launchpad/LaunchpadSegments.svelte';
 	import LaunchpadFirstSatellite from '$lib/components/launchpad/LaunchpadFirstSatellite.svelte';
+	import LaunchpadSegments from '$lib/components/launchpad/LaunchpadSegments.svelte';
 	import ContainerCentered from '$lib/components/ui/ContainerCentered.svelte';
 	import Message from '$lib/components/ui/Message.svelte';
 	import Spinner from '$lib/components/ui/Spinner.svelte';

--- a/src/frontend/src/lib/components/launchpad/LaunchpadFirstSatellite.svelte
+++ b/src/frontend/src/lib/components/launchpad/LaunchpadFirstSatellite.svelte
@@ -15,7 +15,7 @@
 	};
 </script>
 
-<button class="primary" onclick={createSatellite} {...testId(testIds.createSatellite.launch)}>
+<button class="primary" onclick={createSatellite} {...testId(testIds.launchpad.launch)}>
 	{$i18n.satellites.launch}
 	<IconRocket />
 </button>

--- a/src/frontend/src/lib/components/launchpad/LaunchpadNewActions.svelte
+++ b/src/frontend/src/lib/components/launchpad/LaunchpadNewActions.svelte
@@ -59,7 +59,7 @@
 	bind:this={button}
 	class="primary"
 	onclick={() => (visible = true)}
-	{...testId(testIds.createSatellite.launch)}
+	{...testId(testIds.launchpad.actions)}
 >
 	<span>{$i18n.core.launch}&nbsp;</span>
 	<IconRocket size="16px" />
@@ -67,7 +67,10 @@
 
 <Popover anchor={button} direction="rtl" bind:visible>
 	<div class="container">
-		<button class="menu" onclick={createSatellite}
+		<button
+			class="menu"
+			onclick={createSatellite}
+			{...testId(testIds.launchpad.launchExtraSatellite)}
 			><IconSatellite /> {$i18n.satellites.launch}</button
 		>
 

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -4,8 +4,12 @@ export const testIds = {
 	auth: {
 		signInII: 'btn-sign-in-ii'
 	},
+	launchpad: {
+		launch: 'btn-launch-first-satellite',
+		launchExtraSatellite: 'btn-launch-extra-satellite',
+		actions: 'btn-open-actions'
+	},
 	createSatellite: {
-		launch: 'btn-launch-satellite',
 		create: 'btn-create-satellite',
 		input: 'input-satellite-name',
 		website: 'input-radio-satellite-website',


### PR DESCRIPTION
# Motivation

The E2E tests are failing because:

1. They need a new version of the emulator for spinning modules with the new flow with cycles or getting cycles with the wallet
2. And also need to be update to the new flows and reviewed launchpad
