### PR TITLE
chore(fix): run npm prepare after install

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -24,7 +24,7 @@ Before you begin developing and contributing to Juno, ensure the following tools
 ```bash
 git clone https://github.com/junobuild/juno
 cd juno
-npm ci
+npm run bootstrap:ci
 ```
 
 ### Running the Development Environment

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"format": "prettier --write './**/*.{ts,js,mjs,json,scss,css,svelte,html,md,toml}' && npm run format-imports",
 		"prebuild": "npm run generate",
 		"bootstrap:ci": "npm ci && npm run prepare",
-		"bootstrap:i": "npm install && npm run prepare",
+		"bootstrap:install": "npm install && npm run prepare",
 		"postinstall:trusted": "node node_modules/@dfinity/pic/postinstall.mjs",
 		"postinstall": "npm run copy:did && npm run postinstall:trusted",
 		"generate": "scripts/did.sh && scripts/did.idl.sh && node scripts/did.update.types.mjs && scripts/did.idl.certified.sh && npm run copy:did && npm run format",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
 		"format-imports": "eslint --fix --rule 'import/no-duplicates: [error, { prefer-inline: true }]' ./src/frontend/src/**/*.svelte",
 		"format": "prettier --write './**/*.{ts,js,mjs,json,scss,css,svelte,html,md,toml}' && npm run format-imports",
 		"prebuild": "npm run generate",
+		"bootstrap:ci": "npm ci && npm run prepare",
+		"bootstrap:i": "npm install && npm run prepare",
 		"postinstall:trusted": "node node_modules/@dfinity/pic/postinstall.mjs",
 		"postinstall": "npm run copy:did && npm run postinstall:trusted",
 		"generate": "scripts/did.sh && scripts/did.idl.sh && node scripts/did.update.types.mjs && scripts/did.idl.certified.sh && npm run copy:did && npm run format",


### PR DESCRIPTION
# Motivation

Since I added `ignore-scripts=true` for security reason, `prepare` and `postinstall` are not run anymore after `npm i` or `npm ci`. As a result, building the Docker image using this repo failed (see https://github.com/junobuild/juno-docker/actions/runs/20722039458/job/59488058750`.

I can add an explicit prepare there but then, dev that fork the repo will face the same issue. That's why I add two scripts for the installation.
