### PR TITLE
refactor(console): rename canister module to orchestrator

### DIFF
--- a/src/console/src/factory/mission_control.rs
+++ b/src/console/src/factory/mission_control.rs
@@ -1,6 +1,6 @@
 use crate::accounts::{get_existing_account, update_mission_control};
 use crate::constants::FREEZING_THRESHOLD_ONE_YEAR;
-use crate::factory::canister::create_canister_with_account;
+use crate::factory::orchestrator::create_canister_with_account;
 use crate::factory::services::payment::{process_payment_cycles, refund_payment_cycles};
 use crate::factory::types::CanisterCreator;
 use crate::factory::utils::controllers::update_mission_control_controllers;

--- a/src/console/src/factory/mod.rs
+++ b/src/console/src/factory/mod.rs
@@ -1,7 +1,7 @@
-mod canister;
 mod impls;
 pub mod mission_control;
 pub mod orbiter;
+mod orchestrator;
 pub mod satellite;
 mod services;
 mod types;

--- a/src/console/src/factory/orbiter.rs
+++ b/src/console/src/factory/orbiter.rs
@@ -1,5 +1,5 @@
 use crate::constants::FREEZING_THRESHOLD_THREE_MONTHS;
-use crate::factory::canister::create_canister;
+use crate::factory::orchestrator::create_segment_workflow;
 use crate::factory::types::CanisterCreator;
 use crate::factory::utils::controllers::remove_console_controller;
 use crate::factory::utils::wasm::orbiter_wasm_arg;
@@ -23,7 +23,7 @@ pub async fn create_orbiter(
     caller: Principal,
     args: CreateOrbiterArgs,
 ) -> Result<Principal, String> {
-    create_canister(
+    create_segment_workflow(
         create_orbiter_wasm,
         &increment_orbiters_rate,
         &get_fee,

--- a/src/console/src/factory/orchestrator.rs
+++ b/src/console/src/factory/orchestrator.rs
@@ -19,7 +19,7 @@ use junobuild_shared::types::state::UserId;
 use junobuild_shared::utils::principal_equal;
 use std::future::Future;
 
-pub async fn create_canister<F, Fut>(
+pub async fn create_segment_workflow<F, Fut>(
     create: F,
     increment_rate: &dyn Fn() -> Result<(), String>,
     get_fee: &dyn Fn(FeeKind) -> Result<Fee, String>,

--- a/src/console/src/factory/satellite.rs
+++ b/src/console/src/factory/satellite.rs
@@ -1,5 +1,5 @@
 use crate::constants::FREEZING_THRESHOLD_ONE_YEAR;
-use crate::factory::canister::create_canister;
+use crate::factory::orchestrator::create_segment_workflow;
 use crate::factory::types::CanisterCreator;
 use crate::factory::utils::controllers::remove_console_controller;
 use crate::factory::utils::wasm::satellite_wasm_arg;
@@ -26,7 +26,7 @@ pub async fn create_satellite(
     let storage = args.storage.clone();
     let name = args.name.clone();
 
-    create_canister(
+    create_segment_workflow(
         move |creator, subnet_id| async move {
             create_satellite_wasm(creator, subnet_id, storage).await
         },

--- a/src/observatory/src/api/rates.rs
+++ b/src/observatory/src/api/rates.rs
@@ -7,8 +7,6 @@ use junobuild_shared::rate::types::RateConfig;
 #[update(guard = "caller_is_admin_controller")]
 fn set_rate_config(kind: RateKind, config: RateConfig) {
     match kind {
-        RateKind::OpenIdCertificateRequests => {
-            set_openid_certificate_requests_rate_config(&config)
-        }
+        RateKind::OpenIdCertificateRequests => set_openid_certificate_requests_rate_config(&config),
     }
 }


### PR DESCRIPTION
# Motivation

`canister.create_canister` does more than "creating a canister". It's now more a workflow that checks for what flows to follow (user or mission control), payments etc.

So for clarity we should renamed it.
