### PR TITLE
refactor(shared): constant canister prefix

### DIFF
--- a/src/libs/shared/src/constants/shared.rs
+++ b/src/libs/shared/src/constants/shared.rs
@@ -13,7 +13,7 @@ pub const IC_TRANSACTION_FEE_CYCLES: CyclesTokens = CyclesTokens::from_e12s(100_
 // Cost for creating a canister have been increased by 400% in November 2024:
 // - https://forum.dfinity.org/t/evaluating-compute-pricing-in-response-to-increased-demand-on-the-internet-computer-protocol/36565
 // - https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=134032
-pub const CREATE_CANISTER_CYCLES: u128 = 500_000_000_000u128;
+pub const CREATE_RAW_CANISTER_CYCLES: u128 = 500_000_000_000u128;
 
 // Additional cycles allocated for creating different types of canisters to ensure operation beyond the minimum requirement.
 pub const CREATE_SATELLITE_CYCLES: u128 = 1_000_000_000_000;

--- a/src/libs/shared/src/constants/shared.rs
+++ b/src/libs/shared/src/constants/shared.rs
@@ -13,7 +13,7 @@ pub const IC_TRANSACTION_FEE_CYCLES: CyclesTokens = CyclesTokens::from_e12s(100_
 // Cost for creating a canister have been increased by 400% in November 2024:
 // - https://forum.dfinity.org/t/evaluating-compute-pricing-in-response-to-increased-demand-on-the-internet-computer-protocol/36565
 // - https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=134032
-pub const CREATE_RAW_CANISTER_CYCLES: u128 = 500_000_000_000u128;
+pub const IC_CREATE_CANISTER_CYCLES: u128 = 500_000_000_000u128;
 
 // Additional cycles allocated for creating different types of canisters to ensure operation beyond the minimum requirement.
 pub const CREATE_SATELLITE_CYCLES: u128 = 1_000_000_000_000;

--- a/src/libs/shared/src/mgmt/settings.rs
+++ b/src/libs/shared/src/mgmt/settings.rs
@@ -1,5 +1,5 @@
 use crate::constants::internal::WASM_MEMORY_LIMIT;
-use crate::constants::shared::CREATE_CANISTER_CYCLES;
+use crate::constants::shared::CREATE_RAW_CANISTER_CYCLES;
 use crate::mgmt::types::ic::CreateCanisterInitSettingsArg;
 use candid::Nat;
 use ic_cdk::management_canister::CanisterSettings;
@@ -24,5 +24,5 @@ pub fn create_canister_settings(
 }
 
 pub fn create_canister_cycles(cycles: u128) -> u128 {
-    CREATE_CANISTER_CYCLES + cycles
+    CREATE_RAW_CANISTER_CYCLES + cycles
 }

--- a/src/libs/shared/src/mgmt/settings.rs
+++ b/src/libs/shared/src/mgmt/settings.rs
@@ -1,5 +1,5 @@
 use crate::constants::internal::WASM_MEMORY_LIMIT;
-use crate::constants::shared::CREATE_RAW_CANISTER_CYCLES;
+use crate::constants::shared::IC_CREATE_CANISTER_CYCLES;
 use crate::mgmt::types::ic::CreateCanisterInitSettingsArg;
 use candid::Nat;
 use ic_cdk::management_canister::CanisterSettings;
@@ -24,5 +24,5 @@ pub fn create_canister_settings(
 }
 
 pub fn create_canister_cycles(cycles: u128) -> u128 {
-    CREATE_RAW_CANISTER_CYCLES + cycles
+    IC_CREATE_CANISTER_CYCLES + cycles
 }


### PR DESCRIPTION
# Motivation

We have `IC_TRANSACTION_FEE_ICP` or `IC_TRANSACTION_FEE_CYCLES` so makes sense to use `IC_` prefix and it's also useful for #2474
