### PR TITLE
fix(console): typo in ICP price (1_500_000_000 is 15 not 1.5)

### DIFF
--- a/src/console/src/constants.rs
+++ b/src/console/src/constants.rs
@@ -2,8 +2,8 @@ use ic_ledger_types::Tokens;
 use junobuild_shared::ledger::types::cycles::CyclesTokens;
 
 // 1.5 ICP roughly 3 T Cycles on Dec. 31, 2025
-pub const SATELLITE_CREATION_FEE_ICP: Tokens = Tokens::from_e8s(1_500_000_000);
-pub const ORBITER_CREATION_FEE_ICP: Tokens = Tokens::from_e8s(1_500_000_000);
+pub const SATELLITE_CREATION_FEE_ICP: Tokens = Tokens::from_e8s(150_000_000);
+pub const ORBITER_CREATION_FEE_ICP: Tokens = Tokens::from_e8s(150_000_000);
 
 // We create canister with CREATE_CANISTER_CYCLES + e.g. CREATE_SATELLITE_CYCLES
 // 0.5 + 1 = 1.5 T Cycles (minus what's get consumed along the way)

--- a/src/tests/specs/console/console.fees.spec.ts
+++ b/src/tests/specs/console/console.fees.spec.ts
@@ -80,7 +80,7 @@ describe('Console > Fees', () => {
 			const { get_fee } = randomIdentityActor;
 
 			const defaultFees = {
-				fee_icp: toNullable({ e8s: 1_500_000_000n }),
+				fee_icp: toNullable({ e8s: 150_000_000n }),
 				fee_cycles: { e12s: 3_000_000_000_000n },
 				updated_at: expect.any(BigInt)
 			};

--- a/src/tests/specs/console/upgrade/console.upgrade-v0-3-0.fees.spec.ts
+++ b/src/tests/specs/console/upgrade/console.upgrade-v0-3-0.fees.spec.ts
@@ -107,13 +107,13 @@ describe('Console > Upgrade > Fees > v0.2.0 -> v0.3.0', () => {
 
 		await expect(get_fee({ Satellite: null })).resolves.toEqual(
 			expect.objectContaining({
-				fee_icp: toNullable({ e8s: 1_500_000_000n }),
+				fee_icp: toNullable({ e8s: 150_000_000n }),
 				fee_cycles: { e12s: 3_000_000_000_000n }
 			})
 		);
 		await expect(get_fee({ Orbiter: null })).resolves.toEqual(
 			expect.objectContaining({
-				fee_icp: toNullable({ e8s: 1_500_000_000n }),
+				fee_icp: toNullable({ e8s: 150_000_000n }),
 				fee_cycles: { e12s: 3_000_000_000_000n }
 			})
 		);


### PR DESCRIPTION
# Motivation

Fix #2433. We want 1.5 ICP as price.
