### PR TITLE
fix(frontend): Use StorageCollectionType instead of DbCollectionType 

### DIFF
--- a/src/frontend/src/lib/services/satellite/user/user.services.ts
+++ b/src/frontend/src/lib/services/satellite/user/user.services.ts
@@ -107,7 +107,7 @@ const loadUserUsages = async ({
 			: listRules0022({ satelliteId, type: DbCollectionType, identity }),
 		newestListRules
 			? modernListRules(StorageCollectionType)
-			: listRules0022({ satelliteId, type: DbCollectionType, identity })
+			: listRules0022({ satelliteId, type: StorageCollectionType, identity })
 	]);
 
 	const loadUsage = async ({


### PR DESCRIPTION


# Motivation

<!-- Describe the motivation that lead to the PR -->
Fixes the `loadUserUsages` service to correctly use `StorageCollectionType` for storage rule lookups in the legacy path.
