### PR TITLE
feat(console): set and unset many segments at once

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -442,11 +442,13 @@ service : () -> {
   set_controllers : (SetControllersArgs) -> ();
   set_custom_domain : (text, opt text) -> ();
   set_fee : (SegmentKind, FeesArgs) -> ();
+  set_many_segments : (vec SetSegmentsArgs) -> (vec Segment);
   set_rate_config : (SegmentKind, RateConfig) -> ();
   set_segment : (SetSegmentsArgs) -> (Segment);
   set_segment_metadata : (SetSegmentMetadataArgs) -> (Segment);
   set_storage_config : (SetStorageConfig) -> (StorageConfig);
   submit_proposal : (nat) -> (nat, Proposal);
+  unset_many_segments : (vec UnsetSegmentsArgs) -> ();
   unset_segment : (UnsetSegmentsArgs) -> ();
   upload_proposal_asset_chunk : (UploadChunk) -> (UploadChunkResult);
 }

--- a/src/console/src/api/segments.rs
+++ b/src/console/src/api/segments.rs
@@ -1,5 +1,5 @@
 use crate::guards::caller_has_account;
-use crate::segments::{attach_segment, detach_segment};
+use crate::segments::{attach_many_segments, attach_segment, detach_many_segments, detach_segment};
 use crate::segments::{
     list_segments as list_segments_store, set_segment_metadata as set_segment_metadata_store,
 };
@@ -29,6 +29,16 @@ fn set_segment(args: SetSegmentsArgs) -> Segment {
 }
 
 #[update(guard = "caller_has_account")]
+fn set_many_segments(args: Vec<SetSegmentsArgs>) -> Vec<Segment> {
+    attach_many_segments(args).unwrap_or_trap()
+}
+
+#[update(guard = "caller_has_account")]
 fn unset_segment(args: UnsetSegmentsArgs) {
     detach_segment(args).unwrap_or_trap()
+}
+
+#[update(guard = "caller_has_account")]
+fn unset_many_segments(args: Vec<UnsetSegmentsArgs>) {
+    detach_many_segments(args).unwrap_or_trap()
 }

--- a/src/console/src/segments/services.rs
+++ b/src/console/src/segments/services.rs
@@ -1,10 +1,29 @@
+use candid::Principal;
 use crate::segments::store::{try_add_segment, unset_segment};
 use crate::types::interface::{SetSegmentsArgs, UnsetSegmentsArgs};
 use crate::types::state::{Segment, SegmentKey};
 use junobuild_shared::ic::api::caller;
 
+pub fn attach_many_segments(args: Vec<SetSegmentsArgs>) -> Result<Vec<Segment>, String> {
+    let caller = caller();
+
+    let mut results: Vec<Segment> = Vec::new();
+
+    for segment_args in args {
+        let result = try_attach_segment(&caller, segment_args)?;
+
+        results.push(result);
+    }
+
+    Ok(results)
+}
+
 pub fn attach_segment(args: SetSegmentsArgs) -> Result<Segment, String> {
-    let key = SegmentKey::from(&caller(), &args.segment_id, args.segment_kind);
+    try_attach_segment(&caller(), args)
+}
+
+fn try_attach_segment(caller: &Principal, args: SetSegmentsArgs) -> Result<Segment, String> {
+    let key = SegmentKey::from(caller, &args.segment_id, args.segment_kind);
     let segment = Segment::new(&args.segment_id, args.metadata);
 
     try_add_segment(&key, &segment)?;
@@ -12,8 +31,22 @@ pub fn attach_segment(args: SetSegmentsArgs) -> Result<Segment, String> {
     Ok(segment)
 }
 
+pub fn detach_many_segments(args: Vec<UnsetSegmentsArgs>) -> Result<(), String> {
+    let caller = caller();
+
+    for segment_args in args {
+        try_detach_segment(&caller, segment_args)?;
+    }
+
+    Ok(())
+}
+
 pub fn detach_segment(args: UnsetSegmentsArgs) -> Result<(), String> {
-    let key = SegmentKey::from(&caller(), &args.segment_id, args.segment_kind);
+    try_detach_segment(&caller(), args)
+}
+
+fn try_detach_segment(caller: &Principal, args: UnsetSegmentsArgs) -> Result<(), String> {
+    let key = SegmentKey::from(caller, &args.segment_id, args.segment_kind);
 
     unset_segment(&key)
 }

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -514,11 +514,13 @@ export interface _SERVICE {
 	set_controllers: ActorMethod<[SetControllersArgs], undefined>;
 	set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;
 	set_fee: ActorMethod<[SegmentKind, FeesArgs], undefined>;
+	set_many_segments: ActorMethod<[Array<SetSegmentsArgs>], Array<Segment>>;
 	set_rate_config: ActorMethod<[SegmentKind, RateConfig], undefined>;
 	set_segment: ActorMethod<[SetSegmentsArgs], Segment>;
 	set_segment_metadata: ActorMethod<[SetSegmentMetadataArgs], Segment>;
 	set_storage_config: ActorMethod<[SetStorageConfig], StorageConfig>;
 	submit_proposal: ActorMethod<[bigint], [bigint, Proposal]>;
+	unset_many_segments: ActorMethod<[Array<UnsetSegmentsArgs>], undefined>;
 	unset_segment: ActorMethod<[UnsetSegmentsArgs], undefined>;
 	upload_proposal_asset_chunk: ActorMethod<[UploadChunk], UploadChunkResult>;
 }

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -542,11 +542,13 @@ export const idlFactory = ({ IDL }) => {
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, FeesArgs], [], []),
+		set_many_segments: IDL.Func([IDL.Vec(SetSegmentsArgs)], [IDL.Vec(Segment)], []),
 		set_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
 		set_segment: IDL.Func([SetSegmentsArgs], [Segment], []),
 		set_segment_metadata: IDL.Func([SetSegmentMetadataArgs], [Segment], []),
 		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
+		unset_many_segments: IDL.Func([IDL.Vec(UnsetSegmentsArgs)], [], []),
 		unset_segment: IDL.Func([UnsetSegmentsArgs], [], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
 	});

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -546,11 +546,13 @@ export const idlFactory = ({ IDL }) => {
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, FeesArgs], [], []),
+		set_many_segments: IDL.Func([IDL.Vec(SetSegmentsArgs)], [IDL.Vec(Segment)], []),
 		set_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
 		set_segment: IDL.Func([SetSegmentsArgs], [Segment], []),
 		set_segment_metadata: IDL.Func([SetSegmentMetadataArgs], [Segment], []),
 		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
+		unset_many_segments: IDL.Func([IDL.Vec(UnsetSegmentsArgs)], [], []),
 		unset_segment: IDL.Func([UnsetSegmentsArgs], [], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
 	});

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -546,11 +546,13 @@ export const idlFactory = ({ IDL }) => {
 		set_controllers: IDL.Func([SetControllersArgs], [], []),
 		set_custom_domain: IDL.Func([IDL.Text, IDL.Opt(IDL.Text)], [], []),
 		set_fee: IDL.Func([SegmentKind, FeesArgs], [], []),
+		set_many_segments: IDL.Func([IDL.Vec(SetSegmentsArgs)], [IDL.Vec(Segment)], []),
 		set_rate_config: IDL.Func([SegmentKind, RateConfig], [], []),
 		set_segment: IDL.Func([SetSegmentsArgs], [Segment], []),
 		set_segment_metadata: IDL.Func([SetSegmentMetadataArgs], [Segment], []),
 		set_storage_config: IDL.Func([SetStorageConfig], [StorageConfig], []),
 		submit_proposal: IDL.Func([IDL.Nat], [IDL.Nat, Proposal], []),
+		unset_many_segments: IDL.Func([IDL.Vec(UnsetSegmentsArgs)], [], []),
 		unset_segment: IDL.Func([UnsetSegmentsArgs], [], []),
 		upload_proposal_asset_chunk: IDL.Func([UploadChunk], [UploadChunkResult], [])
 	});

--- a/src/tests/utils/console-factory-tests.utils.ts
+++ b/src/tests/utils/console-factory-tests.utils.ts
@@ -23,3 +23,22 @@ export const createSatelliteWithConsole = async ({
 		subnet_id: toNullable()
 	});
 };
+
+export const createOrbiterWithConsole = async ({
+	user,
+	actor
+}: {
+	user: Identity;
+	actor: Actor<ConsoleActor>;
+}): Promise<Principal> => {
+	actor.setIdentity(user);
+
+	const { create_orbiter } = actor;
+
+	return await create_orbiter({
+		user: user.getPrincipal(),
+		block_index: toNullable(),
+		name: toNullable(),
+		subnet_id: toNullable()
+	});
+};


### PR DESCRIPTION
# Motivation

I want to implement a feature that show a warning and provide the developers a function to reconcile the list of segments in the Console and their Mission Control. See #2499.

So, in the Console, I gonna add endpoints to make this at one, not multiple calls.


