### PR TITLE
fix(frontend): loading with certified new account stuck on launchpad

### DIFF
--- a/src/frontend/src/lib/components/loaders/SegmentsLoader.svelte
+++ b/src/frontend/src/lib/components/loaders/SegmentsLoader.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	import { debounce } from '@dfinity/utils';
 	import { type Snippet, untrack } from 'svelte';
 	import { missionControlCertifiedId } from '$lib/derived/console/account.mission-control.derived';
 	import { loadSegments } from '$lib/services/segments.services';
 	import type { MissionControlCertifiedId } from '$lib/types/mission-control';
-	import { debounce } from '@dfinity/utils';
 
 	interface Props {
 		children: Snippet;


### PR DESCRIPTION
# Motivation

Side effect of #2511 - new accounts are always certified
