### PR TITLE
build(core): bump ic-wasm v0.9.10

### DIFF
--- a/docker/bootstrap
+++ b/docker/bootstrap
@@ -51,7 +51,7 @@ install_tool() {
   fi
 }
 
-install_tool ic-wasm 0.8.5
+install_tool ic-wasm 0.9.10
 install_tool wasi2ic 0.2.16
 install_tool candid-extractor 0.1.6
 

--- a/docker/build-canister
+++ b/docker/build-canister
@@ -139,11 +139,11 @@ function build_canister() {
 function check_tools() {
   local target=$1
 
-  if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]
+  if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.9.10" ]]
   then
-      echo "could not find ic-wasm 0.8.5"
-      echo "ic-wasm version 0.8.5 is needed, please run the following command:"
-      echo "  cargo install ic-wasm --version 0.8.5"
+      echo "could not find ic-wasm 0.9.10"
+      echo "ic-wasm version 0.9.10 is needed, please run the following command:"
+      echo "  cargo install ic-wasm --version 0.9.10"
       exit 1
   fi
 


### PR DESCRIPTION
# Motivation

According the team the breaking change of [v0.9.0](https://github.com/dfinity/ic-wasm/releases/tag/0.9.0) only affected the `ic_wasm::instrumentation` module (see this [change](https://github.com/dfinity/ic-wasm/blob/main/CHANGELOG.md#090---2024-10-01)) and the corresponding `ic-wasm instrument` [command](https://github.com/dfinity/ic-wasm?tab=readme-ov-file#instrument-experimental).

Since we do not use the command, it should be safe to upgrade.

While I do not necessarely need to do so, I do it while the information is fresh.
