### PR TITLE
feat(auth): add support for preferred_username in open id data

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -231,6 +231,7 @@ type OpenIdData = record {
   email : opt text;
   picture : opt text;
   given_name : opt text;
+  preferred_username : opt text;
 };
 type OpenIdGetDelegationArgs = record {
   jwt : text;

--- a/src/console/src/accounts/impls.rs
+++ b/src/console/src/accounts/impls.rs
@@ -18,6 +18,9 @@ impl OpenIdProfile for OpenIdData {
     fn family_name(&self) -> Option<&str> {
         self.family_name.as_deref()
     }
+    fn preferred_username(&self) -> Option<&str> {
+        self.preferred_username.as_deref()
+    }
     fn picture(&self) -> Option<&str> {
         self.picture.as_deref()
     }
@@ -39,6 +42,10 @@ impl OpenIdData {
                 .family_name
                 .clone()
                 .or(existing.family_name.clone()),
+            preferred_username: credential
+                .preferred_username
+                .clone()
+                .or(existing.preferred_username.clone()),
             picture: credential.picture.clone().or(existing.picture.clone()),
             locale: credential.locale.clone().or(existing.locale.clone()),
         }
@@ -52,6 +59,7 @@ impl From<&OpenIdCredential> for OpenIdData {
             name: credential.name.clone(),
             given_name: credential.given_name.clone(),
             family_name: credential.family_name.clone(),
+            preferred_username: credential.preferred_username.clone(),
             picture: credential.picture.clone(),
             locale: credential.locale.clone(),
         }

--- a/src/console/src/segments/services.rs
+++ b/src/console/src/segments/services.rs
@@ -1,7 +1,7 @@
-use candid::Principal;
 use crate::segments::store::{try_add_segment, unset_segment};
 use crate::types::interface::{SetSegmentsArgs, UnsetSegmentsArgs};
 use crate::types::state::{Segment, SegmentKey};
+use candid::Principal;
 use junobuild_shared::ic::api::caller;
 
 pub fn attach_many_segments(args: Vec<SetSegmentsArgs>) -> Result<Vec<Segment>, String> {

--- a/src/console/src/types.rs
+++ b/src/console/src/types.rs
@@ -93,6 +93,7 @@ pub mod state {
         pub name: Option<String>,
         pub given_name: Option<String>,
         pub family_name: Option<String>,
+        pub preferred_username: Option<String>,
         pub picture: Option<String>,
         pub locale: Option<String>,
     }

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -287,6 +287,7 @@ export interface OpenIdData {
 	email: [] | [string];
 	picture: [] | [string];
 	given_name: [] | [string];
+	preferred_username: [] | [string];
 }
 export interface OpenIdGetDelegationArgs {
 	jwt: string;

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -31,7 +31,8 @@ export const idlFactory = ({ IDL }) => {
 		family_name: IDL.Opt(IDL.Text),
 		email: IDL.Opt(IDL.Text),
 		picture: IDL.Opt(IDL.Text),
-		given_name: IDL.Opt(IDL.Text)
+		given_name: IDL.Opt(IDL.Text),
+		preferred_username: IDL.Opt(IDL.Text)
 	});
 	const OpenId = IDL.Record({
 		provider: OpenIdProvider,

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -31,7 +31,8 @@ export const idlFactory = ({ IDL }) => {
 		family_name: IDL.Opt(IDL.Text),
 		email: IDL.Opt(IDL.Text),
 		picture: IDL.Opt(IDL.Text),
-		given_name: IDL.Opt(IDL.Text)
+		given_name: IDL.Opt(IDL.Text),
+		preferred_username: IDL.Opt(IDL.Text)
 	});
 	const OpenId = IDL.Record({
 		provider: OpenIdProvider,

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -31,7 +31,8 @@ export const idlFactory = ({ IDL }) => {
 		family_name: IDL.Opt(IDL.Text),
 		email: IDL.Opt(IDL.Text),
 		picture: IDL.Opt(IDL.Text),
-		given_name: IDL.Opt(IDL.Text)
+		given_name: IDL.Opt(IDL.Text),
+		preferred_username: IDL.Opt(IDL.Text)
 	});
 	const OpenId = IDL.Record({
 		provider: OpenIdProvider,

--- a/src/libs/auth/src/openid/impls.rs
+++ b/src/libs/auth/src/openid/impls.rs
@@ -17,6 +17,7 @@ impl From<TokenData<Claims>> for OpenIdCredential {
             name: token.claims.name,
             given_name: token.claims.given_name,
             family_name: token.claims.family_name,
+            preferred_username: token.claims.preferred_username,
             picture: token.claims.picture,
             locale: token.claims.locale,
         }

--- a/src/libs/auth/src/openid/jwt/kid.rs
+++ b/src/libs/auth/src/openid/jwt/kid.rs
@@ -58,6 +58,7 @@ mod unsafe_find_kid_tests {
             name: None,
             given_name: None,
             family_name: None,
+            preferred_username: None,
             picture: None,
             nonce: None,
             locale: None,

--- a/src/libs/auth/src/openid/jwt/types.rs
+++ b/src/libs/auth/src/openid/jwt/types.rs
@@ -17,6 +17,7 @@ pub(crate) mod token {
         pub name: Option<String>,
         pub given_name: Option<String>,
         pub family_name: Option<String>,
+        pub preferred_username: Option<String>,
         pub picture: Option<String>,
         pub locale: Option<String>,
     }

--- a/src/libs/auth/src/openid/jwt/verify.rs
+++ b/src/libs/auth/src/openid/jwt/verify.rs
@@ -155,6 +155,7 @@ mod verify_tests {
             name: None,
             given_name: None,
             family_name: None,
+            preferred_username: None,
             picture: None,
             nonce: nonce.map(|s| s.into()),
             locale: None,
@@ -497,6 +498,7 @@ mod verify_tests {
             name: Some("World".into()),
             given_name: Some("Hello".into()),
             family_name: Some("World".into()),
+            preferred_username: Some("hello_world".into()),
             picture: Some("https://example.com/world.png".into()),
             nonce: Some(NONCE_OK.into()),
             locale: Some("fr-CH".into()),
@@ -518,6 +520,7 @@ mod verify_tests {
         assert_eq!(claims.name.as_deref(), Some("World")); // unicode/emoji
         assert_eq!(claims.given_name.as_deref(), Some("Hello"));
         assert_eq!(claims.family_name.as_deref(), Some("World"));
+        assert_eq!(claims.preferred_username.as_deref(), Some("hello_world"));
         assert_eq!(
             claims.picture.as_deref(),
             Some("https://example.com/world.png")

--- a/src/libs/auth/src/openid/types.rs
+++ b/src/libs/auth/src/openid/types.rs
@@ -12,6 +12,7 @@ pub mod interface {
         pub name: Option<String>,
         pub given_name: Option<String>,
         pub family_name: Option<String>,
+        pub preferred_username: Option<String>,
         pub picture: Option<String>,
         pub locale: Option<String>,
     }

--- a/src/libs/auth/src/profile/errors.rs
+++ b/src/libs/auth/src/profile/errors.rs
@@ -10,6 +10,9 @@ pub const JUNO_AUTH_ERROR_PROFILE_GIVEN_NAME_INVALID_LENGTH: &str =
 // A family name must not be longer than 100 characters
 pub const JUNO_AUTH_ERROR_PROFILE_FAMILY_NAME_INVALID_LENGTH: &str =
     "juno.auth.error.profile.data.family_name_invalid_length";
+// A preferred_username (e.g. GitHub login) name must not be longer than 100 characters
+pub const JUNO_AUTH_ERROR_PROFILE_PREFERRED_USERNAME_INVALID_LENGTH: &str =
+    "juno.auth.error.profile.data.preferred_username_invalid_length";
 // Locale must not be longer than 35 characters
 pub const JUNO_AUTH_ERROR_PROFILE_LOCALE_INVALID_LENGTH: &str =
     "juno.auth.error.profile.data.locale_invalid_length";

--- a/src/libs/auth/src/profile/types.rs
+++ b/src/libs/auth/src/profile/types.rs
@@ -7,6 +7,7 @@ pub trait OpenIdProfile {
     fn name(&self) -> Option<&str>;
     fn given_name(&self) -> Option<&str>;
     fn family_name(&self) -> Option<&str>;
+    fn preferred_username(&self) -> Option<&str>;
     fn picture(&self) -> Option<&str>;
     fn locale(&self) -> Option<&str>;
 }

--- a/src/libs/satellite/src/user/core/impls.rs
+++ b/src/libs/satellite/src/user/core/impls.rs
@@ -40,6 +40,9 @@ impl OpenIdProfile for OpenIdData {
     fn family_name(&self) -> Option<&str> {
         self.family_name.as_deref()
     }
+    fn preferred_username(&self) -> Option<&str> {
+        self.preferred_username.as_deref()
+    }
     fn picture(&self) -> Option<&str> {
         self.picture.as_deref()
     }
@@ -131,6 +134,10 @@ impl OpenIdData {
                 .family_name
                 .clone()
                 .or(existing.family_name.clone()),
+            preferred_username: credential
+                .preferred_username
+                .clone()
+                .or(existing.preferred_username.clone()),
             picture: credential.picture.clone().or(existing.picture.clone()),
             locale: credential.locale.clone().or(existing.locale.clone()),
         }
@@ -144,6 +151,7 @@ impl From<&OpenIdCredential> for OpenIdData {
             name: credential.name.clone(),
             given_name: credential.given_name.clone(),
             family_name: credential.family_name.clone(),
+            preferred_username: credential.preferred_username.clone(),
             picture: credential.picture.clone(),
             locale: credential.locale.clone(),
         }
@@ -211,6 +219,7 @@ mod tests {
             name: Some("User".to_string()),
             given_name: None,
             family_name: None,
+            preferred_username: None,
             picture: Some("https://example.com/avatar.png".to_string()),
             locale: Some("en".to_string()),
         });
@@ -231,6 +240,7 @@ mod tests {
             name: Some("User".to_string()),
             given_name: None,
             family_name: None,
+            preferred_username: None,
             picture: Some("http://example.com/avatar.png".to_string()),
             locale: Some("en".to_string()),
         });

--- a/src/libs/satellite/src/user/core/types.rs
+++ b/src/libs/satellite/src/user/core/types.rs
@@ -50,6 +50,7 @@ pub mod state {
         pub name: Option<String>,
         pub given_name: Option<String>,
         pub family_name: Option<String>,
+        pub preferred_username: Option<String>,
         pub picture: Option<String>,
         pub locale: Option<String>,
     }

--- a/src/tests/specs/console/auth/console.auth.mission-control.spec.ts
+++ b/src/tests/specs/console/auth/console.auth.mission-control.spec.ts
@@ -23,6 +23,7 @@ describe('Satellite > Auth > Mission Control', () => {
 		name: toNullable('Hello World'),
 		given_name: toNullable('Hello'),
 		family_name: toNullable('World'),
+		preferred_username: toNullable('helloworld'),
 		picture: toNullable(),
 		locale: toNullable()
 	};

--- a/src/tests/specs/satellite/stock/auth/satellite.auth.user.spec.ts
+++ b/src/tests/specs/satellite/stock/auth/satellite.auth.user.spec.ts
@@ -27,6 +27,7 @@ describe('Satellite > Auth > User', () => {
 				name: 'Hello World',
 				givenName: 'Hello',
 				familyName: 'World',
+				preferredUsername: 'helloworld',
 				picture: null,
 				locale: null
 			}

--- a/src/tests/utils/jwt-tests.utils.ts
+++ b/src/tests/utils/jwt-tests.utils.ts
@@ -38,6 +38,7 @@ export const makeMockGoogleOpenIdJwt = async ({
 		name: 'Hello World',
 		given_name: 'Hello',
 		family_name: 'World',
+		preferred_username: 'helloworld',
 		aud: clientId,
 		iat: timestamp - 10,
 		exp: timestamp + 3600,


### PR DESCRIPTION
# Motivation

For the GitHub authentication we want to extend the open ID data with the usernam / login on Github.

We will save this information in the standadized `preferred_username` field. Feels like it's the feel that fits the best.

See "Standard Claims" specification: https://openid.net/specs/openid-connect-core-1_0.html
