### PR TITLE
feat(auth): support multi providers in authenticate / register

### DIFF
--- a/src/console/src/auth/authenticate.rs
+++ b/src/console/src/auth/authenticate.rs
@@ -19,10 +19,10 @@ pub async fn openid_authenticate(
     let prepared_delegation = delegation::openid_prepare_delegation(args, &providers).await;
 
     let result = match prepared_delegation {
-        Ok((delegation, credential)) => {
+        Ok((delegation, provider, credential)) => {
             let key = &delegation.user_key;
 
-            register_account(key, &credential)
+            register_account(key, &provider, &credential)
                 .await
                 .map(|account| Authentication {
                     delegation,

--- a/src/console/src/auth/delegation.rs
+++ b/src/console/src/auth/delegation.rs
@@ -5,11 +5,12 @@ use junobuild_auth::delegation::types::{
     PrepareDelegationError, PreparedDelegation,
 };
 use junobuild_auth::openid::types::interface::OpenIdCredential;
+use junobuild_auth::openid::types::provider::OpenIdProvider;
 use junobuild_auth::state::types::config::OpenIdProviders;
 use junobuild_auth::{delegation, openid};
 
 pub type OpenIdPrepareDelegationResult =
-    Result<(PreparedDelegation, OpenIdCredential), PrepareDelegationError>;
+    Result<(PreparedDelegation, OpenIdProvider, OpenIdCredential), PrepareDelegationError>;
 
 pub async fn openid_prepare_delegation(
     args: &OpenIdPrepareDelegationArgs,
@@ -32,7 +33,7 @@ pub async fn openid_prepare_delegation(
         &AuthCertificate,
     );
 
-    result.map(|prepared_delegation| (prepared_delegation, credential))
+    result.map(|prepared_delegation| (prepared_delegation, provider, credential))
 }
 
 pub fn openid_get_delegation(

--- a/src/console/src/auth/register.rs
+++ b/src/console/src/auth/register.rs
@@ -8,6 +8,7 @@ use junobuild_auth::openid::types::provider::OpenIdProvider;
 
 pub async fn register_account(
     public_key: &UserKey,
+    provider: &OpenIdProvider,
     credential: &OpenIdCredential,
 ) -> Result<Account, String> {
     let user_id = Principal::self_authenticating(public_key);
@@ -41,7 +42,7 @@ pub async fn register_account(
     };
 
     let provider = Provider::OpenId(OpenId {
-        provider: OpenIdProvider::Google,
+        provider: provider.clone(),
         data: provider_data,
     });
 

--- a/src/libs/satellite/src/auth/authenticate.rs
+++ b/src/libs/satellite/src/auth/authenticate.rs
@@ -21,10 +21,10 @@ pub async fn openid_authenticate(
     let prepared_delegation = delegation::openid_prepare_delegation(args, &providers).await;
 
     let result = match prepared_delegation {
-        Ok((delegation, credential)) => {
+        Ok((delegation, provider, credential)) => {
             let key = &delegation.user_key;
 
-            register_user(key, &credential)
+            register_user(key, &provider, &credential)
                 .map(|doc| Authentication { delegation, doc })
                 .map_err(AuthenticationError::RegisterUser)
         }

--- a/src/libs/satellite/src/auth/delegation.rs
+++ b/src/libs/satellite/src/auth/delegation.rs
@@ -5,11 +5,12 @@ use junobuild_auth::delegation::types::{
     PrepareDelegationError, PreparedDelegation,
 };
 use junobuild_auth::openid::types::interface::OpenIdCredential;
+use junobuild_auth::openid::types::provider::OpenIdProvider;
 use junobuild_auth::state::types::config::OpenIdProviders;
 use junobuild_auth::{delegation, openid};
 
 pub type OpenIdPrepareDelegationResult =
-    Result<(PreparedDelegation, OpenIdCredential), PrepareDelegationError>;
+    Result<(PreparedDelegation, OpenIdProvider, OpenIdCredential), PrepareDelegationError>;
 
 pub async fn openid_prepare_delegation(
     args: &OpenIdPrepareDelegationArgs,
@@ -32,7 +33,7 @@ pub async fn openid_prepare_delegation(
         &AuthCertificate,
     );
 
-    result.map(|prepared_delegation| (prepared_delegation, credential))
+    result.map(|prepared_delegation| (prepared_delegation, provider, credential))
 }
 
 pub fn openid_get_delegation(

--- a/src/libs/satellite/src/auth/register.rs
+++ b/src/libs/satellite/src/auth/register.rs
@@ -3,17 +3,22 @@ use crate::db::store::internal_set_doc_store;
 use crate::db::types::store::AssertSetDocOptions;
 use crate::errors::user::JUNO_DATASTORE_ERROR_USER_REGISTER_PROVIDER_INVALID_DATA;
 use crate::rules::store::get_rule_db;
-use crate::user::core::types::state::{AuthProvider, OpenIdData, ProviderData, UserData};
+use crate::user::core::types::state::{OpenIdData, ProviderData, UserData};
 use crate::Doc;
 use candid::Principal;
 use junobuild_auth::delegation::types::UserKey;
 use junobuild_auth::openid::types::interface::OpenIdCredential;
+use junobuild_auth::openid::types::provider::OpenIdProvider;
 use junobuild_collections::constants::db::COLLECTION_USER_KEY;
 use junobuild_collections::msg::msg_db_collection_not_found;
 use junobuild_shared::ic::api::id;
 use junobuild_utils::decode_doc_data;
 
-pub fn register_user(public_key: &UserKey, credential: &OpenIdCredential) -> Result<Doc, String> {
+pub fn register_user(
+    public_key: &UserKey,
+    provider: &OpenIdProvider,
+    credential: &OpenIdCredential,
+) -> Result<Doc, String> {
     let user_collection = COLLECTION_USER_KEY.to_string();
 
     let rule = get_rule_db(&user_collection)
@@ -78,7 +83,7 @@ pub fn register_user(public_key: &UserKey, credential: &OpenIdCredential) -> Res
     // Create or update the user.
     let user_data: UserData = UserData {
         banned,
-        provider: Some(AuthProvider::Google),
+        provider: Some(provider.into()),
         provider_data: Some(ProviderData::OpenId(provider_data)),
     };
 

--- a/src/libs/satellite/src/user/core/impls.rs
+++ b/src/libs/satellite/src/user/core/impls.rs
@@ -10,6 +10,7 @@ use crate::user::core::types::state::{
 };
 use crate::{Doc, SetDoc};
 use junobuild_auth::openid::types::interface::OpenIdCredential;
+use junobuild_auth::openid::types::provider::OpenIdProvider;
 use junobuild_auth::profile::types::{OpenIdProfile, Validated};
 use junobuild_utils::encode_doc_data;
 
@@ -154,6 +155,14 @@ impl From<&OpenIdCredential> for OpenIdData {
             preferred_username: credential.preferred_username.clone(),
             picture: credential.picture.clone(),
             locale: credential.locale.clone(),
+        }
+    }
+}
+
+impl From<&OpenIdProvider> for AuthProvider {
+    fn from(provider: &OpenIdProvider) -> Self {
+        match provider {
+            OpenIdProvider::Google => AuthProvider::Google,
         }
     }
 }


### PR DESCRIPTION
# Motivation

Parts of #2527. Instead of using the Google enum, which was the only OpenId provider that was supported so far, we use the resolved provider to finish the authentication flow.

# Notes

Kind of almost just refactoring.
