### PR TITLE
refactor(auth): redo name unsafe_find_jwt_provider

### DIFF
--- a/src/libs/auth/src/openid/credentials/delegation/verify.rs
+++ b/src/libs/auth/src/openid/credentials/delegation/verify.rs
@@ -2,7 +2,7 @@ use crate::openid::credentials::delegation::types::errors::VerifyOpenidCredentia
 use crate::openid::credentials::delegation::types::interface::OpenIdCredential;
 use crate::openid::jwkset::{get_jwks, get_or_refresh_jwks};
 use crate::openid::jwt::types::cert::Jwks;
-use crate::openid::jwt::{unsafe_find_jwt_delegation_provider, verify_openid_jwt};
+use crate::openid::jwt::{unsafe_find_jwt_provider, verify_openid_jwt};
 use crate::openid::types::provider::OpenIdDelegationProvider;
 use crate::openid::types::provider::OpenIdProvider;
 use crate::openid::utils::build_nonce;
@@ -19,7 +19,7 @@ pub async fn verify_openid_credentials_with_jwks_renewal(
     providers: &OpenIdAuthProviders,
     auth_heap: &impl AuthHeapStrategy,
 ) -> VerifyOpenIdCredentialsResult {
-    let (delegation_provider, config) = unsafe_find_jwt_delegation_provider(providers, jwt)
+    let (delegation_provider, config) = unsafe_find_jwt_provider(providers, jwt)
         .map_err(VerifyOpenidCredentialsError::JwtFindProvider)?;
 
     let provider: OpenIdProvider = (&delegation_provider).into();
@@ -37,7 +37,7 @@ pub fn verify_openid_credentials_with_cached_jwks(
     providers: &OpenIdAuthProviders,
     auth_heap: &impl AuthHeapStrategy,
 ) -> VerifyOpenIdCredentialsResult {
-    let (delegation_provider, config) = unsafe_find_jwt_delegation_provider(providers, jwt)
+    let (delegation_provider, config) = unsafe_find_jwt_provider(providers, jwt)
         .map_err(VerifyOpenidCredentialsError::JwtFindProvider)?;
 
     let provider: OpenIdProvider = (&delegation_provider).into();

--- a/src/libs/auth/src/openid/jwt/provider.rs
+++ b/src/libs/auth/src/openid/jwt/provider.rs
@@ -7,7 +7,7 @@ use jsonwebtoken::dangerous;
 
 /// ⚠️ **Warning:** This function decodes the JWT payload *without verifying its signature*.
 /// Use only to inspect claims (e.g., `iss`) before performing a verified decode.
-pub fn unsafe_find_jwt_delegation_provider<'a>(
+pub fn unsafe_find_jwt_provider<'a>(
     providers: &'a OpenIdAuthProviders,
     jwt: &str,
 ) -> Result<(OpenIdDelegationProvider, &'a OpenIdAuthProviderConfig), JwtFindProviderError> {
@@ -33,7 +33,7 @@ pub fn unsafe_find_jwt_delegation_provider<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::unsafe_find_jwt_delegation_provider;
+    use super::unsafe_find_jwt_provider;
     use crate::openid::jwt::types::errors::JwtFindProviderError;
     use crate::openid::types::provider::OpenIdDelegationProvider;
     use crate::state::types::config::{OpenIdAuthProviderConfig, OpenIdAuthProviders};
@@ -71,7 +71,7 @@ mod tests {
 
         let provs = providers_with_google();
         let (provider, cfg) =
-            unsafe_find_jwt_delegation_provider(&provs, &jwt).expect("should match provider");
+            unsafe_find_jwt_provider(&provs, &jwt).expect("should match provider");
 
         assert_eq!(provider, OpenIdDelegationProvider::Google);
         assert_eq!(cfg.client_id, "client-123");
@@ -83,8 +83,8 @@ mod tests {
         let jwt = jwt_with(json!({"alg":"RS256"}), json!({"iss": iss}));
 
         let provs = providers_with_google();
-        let (provider, _) = unsafe_find_jwt_delegation_provider(&provs, &jwt)
-            .expect("should match even without typ");
+        let (provider, _) =
+            unsafe_find_jwt_provider(&provs, &jwt).expect("should match even without typ");
         assert_eq!(provider, OpenIdDelegationProvider::Google);
     }
 
@@ -94,7 +94,7 @@ mod tests {
         let jwt = jwt_with(json!({"alg":"HS256","typ":"JWT"}), json!({"iss": iss}));
 
         let provs = providers_with_google();
-        let err = unsafe_find_jwt_delegation_provider(&provs, &jwt).unwrap_err();
+        let err = unsafe_find_jwt_provider(&provs, &jwt).unwrap_err();
 
         match err {
             JwtFindProviderError::BadClaim(f) => assert_eq!(f, "alg"),
@@ -111,7 +111,7 @@ mod tests {
         );
 
         let provs = providers_with_google();
-        let err = unsafe_find_jwt_delegation_provider(&provs, &jwt).unwrap_err();
+        let err = unsafe_find_jwt_provider(&provs, &jwt).unwrap_err();
 
         match err {
             JwtFindProviderError::BadClaim(f) => assert_eq!(f, "typ"),
@@ -123,7 +123,7 @@ mod tests {
     fn returns_no_matching_provider_when_issuer_missing() {
         let jwt = jwt_with(json!({"alg":"RS256","typ":"JWT"}), json!({}));
         let provs = providers_with_google();
-        let err = unsafe_find_jwt_delegation_provider(&provs, &jwt).unwrap_err();
+        let err = unsafe_find_jwt_provider(&provs, &jwt).unwrap_err();
         assert!(matches!(err, JwtFindProviderError::NoMatchingProvider));
     }
 
@@ -134,7 +134,7 @@ mod tests {
             json!({"iss":"https://unknown.example.com"}),
         );
         let provs = providers_with_google();
-        let err = unsafe_find_jwt_delegation_provider(&provs, &jwt).unwrap_err();
+        let err = unsafe_find_jwt_provider(&provs, &jwt).unwrap_err();
         assert!(matches!(err, JwtFindProviderError::NoMatchingProvider));
     }
 
@@ -142,7 +142,7 @@ mod tests {
     fn malformed_token_is_badsig() {
         let jwt = "definitely-not-a-jwt";
         let provs = providers_with_google();
-        let err = unsafe_find_jwt_delegation_provider(&provs, jwt).unwrap_err();
+        let err = unsafe_find_jwt_provider(&provs, jwt).unwrap_err();
         assert!(matches!(err, JwtFindProviderError::BadSig(_)));
     }
 
@@ -155,7 +155,7 @@ mod tests {
         let jwt = format!("{h}.{p}.{s}");
 
         let provs = providers_with_google();
-        let err = unsafe_find_jwt_delegation_provider(&provs, &jwt).unwrap_err();
+        let err = unsafe_find_jwt_provider(&provs, &jwt).unwrap_err();
         assert!(matches!(err, JwtFindProviderError::BadSig(_)));
     }
 
@@ -163,7 +163,7 @@ mod tests {
     fn empty_iss_is_no_match() {
         let jwt = jwt_with(json!({"alg":"RS256","typ":"JWT"}), json!({"iss": ""}));
         let provs = providers_with_google();
-        let err = unsafe_find_jwt_delegation_provider(&provs, &jwt).unwrap_err();
+        let err = unsafe_find_jwt_provider(&provs, &jwt).unwrap_err();
         assert!(matches!(err, JwtFindProviderError::NoMatchingProvider));
     }
 }


### PR DESCRIPTION
# Motivation

Ultimately we can make it generic in #2539
