### PR TITLE
feat(auth): make verify_openid_jwt generic

### DIFF
--- a/src/libs/auth/src/openid/credentials/delegation/impls.rs
+++ b/src/libs/auth/src/openid/credentials/delegation/impls.rs
@@ -1,11 +1,12 @@
 use crate::openid::credentials::delegation::types::interface::{
     OpenIdDelegationCredential, OpenIdDelegationCredentialKey,
 };
-use crate::openid::jwt::types::token::Claims;
+use crate::openid::credentials::delegation::types::token::DelegationClaims;
+use crate::openid::jwt::types::token::JwtClaims;
 use jsonwebtoken::TokenData;
 
-impl From<TokenData<Claims>> for OpenIdDelegationCredential {
-    fn from(token: TokenData<Claims>) -> Self {
+impl From<TokenData<DelegationClaims>> for OpenIdDelegationCredential {
+    fn from(token: TokenData<DelegationClaims>) -> Self {
         Self {
             sub: token.claims.sub,
             iss: token.claims.iss,
@@ -26,5 +27,11 @@ impl<'a> From<&'a OpenIdDelegationCredential> for OpenIdDelegationCredentialKey<
             sub: &credential.sub,
             iss: &credential.iss,
         }
+    }
+}
+
+impl JwtClaims for DelegationClaims {
+    fn iat(&self) -> Option<u64> {
+        self.iat
     }
 }

--- a/src/libs/auth/src/openid/credentials/delegation/types.rs
+++ b/src/libs/auth/src/openid/credentials/delegation/types.rs
@@ -4,9 +4,35 @@ pub mod interface {
         pub sub: &'a String,
     }
 
+    #[derive(Debug)]
     pub struct OpenIdDelegationCredential {
         pub iss: String,
         pub sub: String,
+
+        pub email: Option<String>,
+        pub name: Option<String>,
+        pub given_name: Option<String>,
+        pub family_name: Option<String>,
+        pub preferred_username: Option<String>,
+        pub picture: Option<String>,
+        pub locale: Option<String>,
+    }
+}
+
+pub(crate) mod token {
+    use candid::Deserialize;
+    use serde::Serialize;
+
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct DelegationClaims {
+        pub iss: String,
+        pub sub: String,
+        pub aud: String,
+        pub exp: Option<u64>,
+        pub nbf: Option<u64>,
+        pub iat: Option<u64>,
+
+        pub nonce: Option<String>,
 
         pub email: Option<String>,
         pub name: Option<String>,

--- a/src/libs/auth/src/openid/credentials/delegation/verify.rs
+++ b/src/libs/auth/src/openid/credentials/delegation/verify.rs
@@ -1,8 +1,10 @@
 use crate::openid::credentials::delegation::types::interface::OpenIdDelegationCredential;
+use crate::openid::credentials::delegation::types::token::DelegationClaims;
 use crate::openid::credentials::delegation::utils::nonce::build_nonce;
 use crate::openid::credentials::types::errors::VerifyOpenidCredentialsError;
 use crate::openid::jwkset::{get_jwks, get_or_refresh_jwks};
 use crate::openid::jwt::types::cert::Jwks;
+use crate::openid::jwt::types::errors::JwtVerifyError;
 use crate::openid::jwt::{unsafe_find_jwt_provider, verify_openid_jwt};
 use crate::openid::types::provider::OpenIdDelegationProvider;
 use crate::openid::types::provider::OpenIdProvider;
@@ -10,7 +12,7 @@ use crate::state::types::config::{OpenIdAuthProviderClientId, OpenIdAuthProvider
 use crate::state::types::state::Salt;
 use crate::strategies::AuthHeapStrategy;
 
-type VerifyOpenIdCredentialsResult =
+type VerifyOpenIdDelegationCredentialsResult =
     Result<(OpenIdDelegationCredential, OpenIdDelegationProvider), VerifyOpenidCredentialsError>;
 
 pub async fn verify_openid_credentials_with_jwks_renewal(
@@ -18,7 +20,7 @@ pub async fn verify_openid_credentials_with_jwks_renewal(
     salt: &Salt,
     providers: &OpenIdAuthProviders,
     auth_heap: &impl AuthHeapStrategy,
-) -> VerifyOpenIdCredentialsResult {
+) -> VerifyOpenIdDelegationCredentialsResult {
     let (delegation_provider, config) = unsafe_find_jwt_provider(providers, jwt)
         .map_err(VerifyOpenidCredentialsError::JwtFindProvider)?;
 
@@ -36,7 +38,7 @@ pub fn verify_openid_credentials_with_cached_jwks(
     salt: &Salt,
     providers: &OpenIdAuthProviders,
     auth_heap: &impl AuthHeapStrategy,
-) -> VerifyOpenIdCredentialsResult {
+) -> VerifyOpenIdDelegationCredentialsResult {
     let (delegation_provider, config) = unsafe_find_jwt_provider(providers, jwt)
         .map_err(VerifyOpenidCredentialsError::JwtFindProvider)?;
 
@@ -53,13 +55,257 @@ fn verify_openid_credentials(
     provider: &OpenIdDelegationProvider,
     client_id: &OpenIdAuthProviderClientId,
     salt: &Salt,
-) -> VerifyOpenIdCredentialsResult {
-    let nonce = build_nonce(salt);
+) -> VerifyOpenIdDelegationCredentialsResult {
+    let assert_audience = |claims: &DelegationClaims| -> Result<(), JwtVerifyError> {
+        if claims.aud != client_id.as_str() {
+            return Err(JwtVerifyError::BadClaim("aud".to_string()));
+        }
 
-    let token = verify_openid_jwt(jwt, provider.issuers(), client_id, &jwks.keys, &nonce)
-        .map_err(VerifyOpenidCredentialsError::JwtVerify)?;
+        Ok(())
+    };
+
+    let assert_no_replay = |claims: &DelegationClaims| -> Result<(), JwtVerifyError> {
+        let nonce = build_nonce(salt);
+
+        if claims.nonce.as_deref() != Some(nonce.as_str()) {
+            return Err(JwtVerifyError::BadClaim("nonce".to_string()));
+        }
+
+        Ok(())
+    };
+
+    let token = verify_openid_jwt(
+        jwt,
+        provider.issuers(),
+        &jwks.keys,
+        &assert_audience,
+        &assert_no_replay,
+    )
+    .map_err(VerifyOpenidCredentialsError::JwtVerify)?;
 
     let credential = OpenIdDelegationCredential::from(token);
 
     Ok((credential, provider.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openid::jwt::types::cert::{Jwk, JwkParams, JwkParamsRsa, JwkType, Jwks};
+    use crate::openid::types::provider::OpenIdDelegationProvider;
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const TEST_RSA_PEM: &str = include_str!("../../../../tests/keys/test_rsa.pem");
+    const N_B64URL: &str = "qtQHkWpyd489-_bWjRtrvlQX9CwiQreOsi6kNeeySznI8u-8sxyuO3spW1r2pRmu-rc4jnD9vY6eTGZ3WFNIMxe1geXsF_3nQc5fcNJUUZj19BZE4Ud3dCmUQ4ezkslTvBj8RgD-iBJL7BT7YpxpPgvmqQy_9IgYUkDW4I9_e6kME5kVpySvpRznlk73PfAaDkHWmUTN0j2WcxkW09SGJ_f-tStaYXtc4uH5J-PWMRjwsfL66A_sxLxAwUODJ0VUbeDxVFHGJa0L-58_6GYDTqeel1vH4XjezDL8lf53YRyva3aFxGrC_JeLuIUaJOJX1hXWQb2DruB4hVcQX9afrQ";
+    const E_B64URL: &str = "AQAB";
+    const KID: &str = "test-kid";
+    const ISS_GOOGLE: &str = "https://accounts.google.com";
+    const CLIENT_ID: &str = "test-client-id";
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    fn test_salt() -> Salt {
+        [42u8; 32]
+    }
+
+    fn test_jwks() -> Jwks {
+        Jwks {
+            keys: vec![Jwk {
+                kty: JwkType::Rsa,
+                alg: Some("RS256".into()),
+                kid: Some(KID.into()),
+                params: JwkParams::Rsa(JwkParamsRsa {
+                    n: N_B64URL.into(),
+                    e: E_B64URL.into(),
+                }),
+            }],
+        }
+    }
+
+    fn create_token(claims: &DelegationClaims) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(KID.into());
+        header.typ = Some("JWT".into());
+
+        let key = EncodingKey::from_rsa_pem(TEST_RSA_PEM.as_bytes()).unwrap();
+        encode(&header, claims, &key).unwrap()
+    }
+
+    #[test]
+    fn verifies_valid_delegation_credentials() {
+        let now = now_secs();
+        let salt = test_salt();
+        let nonce = build_nonce(&salt);
+
+        let claims = DelegationClaims {
+            iss: ISS_GOOGLE.into(),
+            sub: "user-123".into(),
+            aud: CLIENT_ID.into(),
+            iat: Some(now),
+            exp: Some(now + 600),
+            nbf: None,
+            nonce: Some(nonce),
+            email: Some("test@example.com".into()),
+            name: Some("Test User".into()),
+            given_name: None,
+            family_name: None,
+            preferred_username: None,
+            picture: None,
+            locale: None,
+        };
+
+        let jwt = create_token(&claims);
+        let jwks = test_jwks();
+
+        let result = verify_openid_credentials(
+            &jwt,
+            &jwks,
+            &OpenIdDelegationProvider::Google,
+            &CLIENT_ID.to_string(),
+            &salt,
+        );
+
+        assert!(result.is_ok());
+        let (credential, provider) = result.unwrap();
+        assert_eq!(provider, OpenIdDelegationProvider::Google);
+        assert_eq!(credential.email, Some("test@example.com".into()));
+    }
+
+    #[test]
+    fn rejects_wrong_audience() {
+        let now = now_secs();
+        let salt = test_salt();
+        let nonce = build_nonce(&salt);
+
+        let claims = DelegationClaims {
+            iss: ISS_GOOGLE.into(),
+            sub: "user-123".into(),
+            aud: "wrong-client-id".into(),
+            iat: Some(now),
+            exp: Some(now + 600),
+            nbf: None,
+            nonce: Some(nonce),
+            email: None,
+            name: None,
+            given_name: None,
+            family_name: None,
+            preferred_username: None,
+            picture: None,
+            locale: None,
+        };
+
+        let jwt = create_token(&claims);
+        let jwks = test_jwks();
+
+        let result = verify_openid_credentials(
+            &jwt,
+            &jwks,
+            &OpenIdDelegationProvider::Google,
+            &CLIENT_ID.to_string(),
+            &salt,
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifyOpenidCredentialsError::JwtVerify(JwtVerifyError::BadClaim(ref c)) if c == "aud"
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_nonce() {
+        let now = now_secs();
+        let salt = test_salt();
+
+        let claims = DelegationClaims {
+            iss: ISS_GOOGLE.into(),
+            sub: "user-123".into(),
+            aud: CLIENT_ID.into(),
+            iat: Some(now),
+            exp: Some(now + 600),
+            nbf: None,
+            nonce: Some("wrong-nonce".into()),
+            email: None,
+            name: None,
+            given_name: None,
+            family_name: None,
+            preferred_username: None,
+            picture: None,
+            locale: None,
+        };
+
+        let jwt = create_token(&claims);
+        let jwks = test_jwks();
+
+        let result = verify_openid_credentials(
+            &jwt,
+            &jwks,
+            &OpenIdDelegationProvider::Google,
+            &CLIENT_ID.to_string(),
+            &salt,
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifyOpenidCredentialsError::JwtVerify(JwtVerifyError::BadClaim(ref c)) if c == "nonce"
+        ));
+    }
+
+    #[test]
+    fn decodes_all_profile_fields() {
+        let now = now_secs();
+        let salt = test_salt();
+        let nonce = build_nonce(&salt);
+
+        let claims = DelegationClaims {
+            iss: ISS_GOOGLE.into(),
+            sub: "user-123".into(),
+            aud: CLIENT_ID.into(),
+            iat: Some(now),
+            exp: Some(now + 600),
+            nbf: None,
+            nonce: Some(nonce),
+            email: Some("hello@example.com".into()),
+            name: Some("Hello World".into()),
+            given_name: Some("Hello".into()),
+            family_name: Some("World".into()),
+            preferred_username: Some("hello_world".into()),
+            picture: Some("https://example.com/pic.png".into()),
+            locale: Some("en-US".into()),
+        };
+
+        let jwt = create_token(&claims);
+        let jwks = test_jwks();
+
+        let result = verify_openid_credentials(
+            &jwt,
+            &jwks,
+            &OpenIdDelegationProvider::Google,
+            &CLIENT_ID.to_string(),
+            &salt,
+        );
+
+        assert!(result.is_ok());
+        let (credential, _) = result.unwrap();
+        assert_eq!(credential.email.as_deref(), Some("hello@example.com"));
+        assert_eq!(credential.name.as_deref(), Some("Hello World"));
+        assert_eq!(credential.given_name.as_deref(), Some("Hello"));
+        assert_eq!(credential.family_name.as_deref(), Some("World"));
+        assert_eq!(
+            credential.preferred_username.as_deref(),
+            Some("hello_world")
+        );
+        assert_eq!(
+            credential.picture.as_deref(),
+            Some("https://example.com/pic.png")
+        );
+        assert_eq!(credential.locale.as_deref(), Some("en-US"));
+    }
 }

--- a/src/libs/auth/src/openid/jwt/kid.rs
+++ b/src/libs/auth/src/openid/jwt/kid.rs
@@ -21,8 +21,10 @@ pub fn unsafe_find_jwt_kid(jwt: &str) -> Result<String, JwtFindKidError> {
 #[cfg(test)]
 mod unsafe_find_kid_tests {
     use super::unsafe_find_jwt_kid;
-    use crate::openid::jwt::types::{errors::JwtFindKidError, token::Claims};
+    use crate::openid::jwt::types::errors::JwtFindKidError;
+    use candid::Deserialize;
     use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use serde::Serialize;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const TEST_RSA_PEM: &str = include_str!("../../../tests/keys/test_rsa.pem");
@@ -45,9 +47,29 @@ mod unsafe_find_kid_tests {
         h
     }
 
-    fn claims_basic() -> Claims {
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    pub struct GoogleClaims {
+        pub iss: String,
+        pub sub: String,
+        pub aud: String,
+        pub exp: Option<u64>,
+        pub nbf: Option<u64>,
+        pub iat: Option<u64>,
+
+        pub nonce: Option<String>,
+
+        pub email: Option<String>,
+        pub name: Option<String>,
+        pub given_name: Option<String>,
+        pub family_name: Option<String>,
+        pub preferred_username: Option<String>,
+        pub picture: Option<String>,
+        pub locale: Option<String>,
+    }
+
+    fn claims_basic() -> GoogleClaims {
         let now = now_secs();
-        Claims {
+        GoogleClaims {
             iss: ISS.into(),
             sub: "sub".into(),
             aud: AUD.into(),
@@ -65,7 +87,7 @@ mod unsafe_find_kid_tests {
         }
     }
 
-    fn sign_token(h: &Header, c: &Claims) -> String {
+    fn sign_token(h: &Header, c: &GoogleClaims) -> String {
         let enc = EncodingKey::from_rsa_pem(TEST_RSA_PEM.as_bytes()).expect("valid pem");
         encode(h, c, &enc).expect("jwt encode")
     }

--- a/src/libs/auth/src/openid/jwt/types.rs
+++ b/src/libs/auth/src/openid/jwt/types.rs
@@ -1,25 +1,8 @@
 pub(crate) mod token {
     use candid::Deserialize;
-    use serde::Serialize;
 
-    #[derive(Debug, Clone, Deserialize, Serialize)]
-    pub struct Claims {
-        pub iss: String,
-        pub sub: String,
-        pub aud: String,
-        pub exp: Option<u64>,
-        pub nbf: Option<u64>,
-        pub iat: Option<u64>,
-
-        pub nonce: Option<String>,
-
-        pub email: Option<String>,
-        pub name: Option<String>,
-        pub given_name: Option<String>,
-        pub family_name: Option<String>,
-        pub preferred_username: Option<String>,
-        pub picture: Option<String>,
-        pub locale: Option<String>,
+    pub trait JwtClaims {
+        fn iat(&self) -> Option<u64>;
     }
 
     #[derive(Clone, Deserialize)]


### PR DESCRIPTION
# Motivation

We make `verify_openid_jwt` generic for #2539. This way we can pass custom function to assert the audience and replay attack of the jwt
