### PR TITLE
feat(auth): make unsafe_find_jwt_provider generic

### DIFF
--- a/src/libs/auth/src/openid/impls.rs
+++ b/src/libs/auth/src/openid/impls.rs
@@ -1,4 +1,5 @@
 use crate::openid::jwt::types::cert::Jwks;
+use crate::openid::jwt::types::provider::JwtIssuers;
 use crate::openid::types::provider::{OpenIdCertificate, OpenIdDelegationProvider, OpenIdProvider};
 use ic_cdk::api::time;
 use junobuild_shared::data::version::next_version;
@@ -45,6 +46,12 @@ impl OpenIdDelegationProvider {
             Self::Google => OpenIdProvider::Google.issuers(),
             Self::GitHub => OpenIdProvider::GitHubAuth.issuers(),
         }
+    }
+}
+
+impl JwtIssuers for OpenIdDelegationProvider {
+    fn issuers(&self) -> &[&'static str] {
+        self.issuers()
     }
 }
 

--- a/src/libs/auth/src/openid/jwt/provider.rs
+++ b/src/libs/auth/src/openid/jwt/provider.rs
@@ -1,16 +1,19 @@
 use crate::openid::jwt::header::decode_jwt_header;
 use crate::openid::jwt::types::errors::JwtFindProviderError;
+use crate::openid::jwt::types::provider::JwtIssuers;
 use crate::openid::jwt::types::token::UnsafeClaims;
-use crate::openid::types::provider::OpenIdDelegationProvider;
-use crate::state::types::config::{OpenIdAuthProviderConfig, OpenIdAuthProviders};
 use jsonwebtoken::dangerous;
+use std::collections::BTreeMap;
 
 /// ⚠️ **Warning:** This function decodes the JWT payload *without verifying its signature*.
 /// Use only to inspect claims (e.g., `iss`) before performing a verified decode.
-pub fn unsafe_find_jwt_provider<'a>(
-    providers: &'a OpenIdAuthProviders,
+pub fn unsafe_find_jwt_provider<'a, Provider, Config>(
+    providers: &'a BTreeMap<Provider, Config>,
     jwt: &str,
-) -> Result<(OpenIdDelegationProvider, &'a OpenIdAuthProviderConfig), JwtFindProviderError> {
+) -> Result<(Provider, &'a Config), JwtFindProviderError>
+where
+    Provider: Clone + JwtIssuers,
+{
     // 1) Header sanity check
     decode_jwt_header(jwt).map_err(JwtFindProviderError::from)?;
 

--- a/src/libs/auth/src/openid/jwt/types.rs
+++ b/src/libs/auth/src/openid/jwt/types.rs
@@ -176,3 +176,9 @@ pub(crate) mod errors {
         BadClaim(String),
     }
 }
+
+pub mod provider {
+    pub trait JwtIssuers {
+        fn issuers(&self) -> &[&'static str];
+    }
+}


### PR DESCRIPTION
# Motivation

For #2539 we want to use `unsafe_find_jwt_provider` for both auth and automation providers, hence the need to make it generic. 
