### PR TITLE
feat(frontend): use id.ai instead of internetcomputer.org for identity sign-in

### DIFF
--- a/src/frontend/src/lib/services/console/auth/_internet-identity.services.ts
+++ b/src/frontend/src/lib/services/console/auth/_internet-identity.services.ts
@@ -18,7 +18,7 @@ export const signInWithII: SignInWithAuthClient = ({ authClient }) =>
 			? /apple/i.test(navigator?.vendor)
 				? `${LOCAL_REPLICA_HOST}?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
 				: `http://${INTERNET_IDENTITY_CANISTER_ID}.${new URL(LOCAL_REPLICA_HOST).host}`
-			: `https://identity.internetcomputer.org`;
+			: 'https://id.ai';
 
 		await authClient?.login({
 			maxTimeToLive: AUTH_MAX_TIME_TO_LIVE,


### PR DESCRIPTION
# Motivation

See https://github.com/junobuild/juno-js/releases/tag/v219
