### PR TITLE
feat(storage): support HEAD requests

### DIFF
--- a/src/libs/storage/src/http/response.rs
+++ b/src/libs/storage/src/http/response.rs
@@ -16,6 +16,7 @@ use junobuild_collections::types::rules::Memory;
 pub fn build_asset_response(
     requested_url: String,
     requested_headers: Vec<HeaderField>,
+    requested_method: String,
     certificate_version: Option<u16>,
     asset: Option<(Asset, Memory)>,
     rewrite_source: Option<String>,
@@ -40,10 +41,19 @@ pub fn build_asset_response(
                         certificate.get_pruned_labeled_sigs_root_hash_tree(),
                     );
 
-                    let Asset { key, .. } = &asset;
-
                     match headers {
                         Ok(headers) => {
+                            if requested_method == "HEAD" {
+                                return HttpResponse {
+                                    body: Vec::new(),
+                                    headers: headers.clone(),
+                                    status_code,
+                                    streaming_strategy: None,
+                                }
+                            }
+
+                            let Asset { key, .. } = &asset;
+
                             let body = storage_state.get_content_chunks(encoding, 0, &memory);
 
                             // TODO: support for HTTP response 304

--- a/src/libs/storage/src/http/response.rs
+++ b/src/libs/storage/src/http/response.rs
@@ -45,8 +45,8 @@ pub fn build_asset_response(
                     match headers {
                         Ok(headers) => {
                             // Note: We need to return the body regardless if the requested method is GET or HEAD.
-                            // It seems that the Boundary Nodes is expecting a body for HEAD request otherwise
-                            // some checks are failing on their side and reques ends in 503.
+                            // It seems that the Boundary Nodes are expecting a body for HEAD requests otherwise
+                            // some checks are failing on their side and requests end in 503.
                             let body = storage_state.get_content_chunks(encoding, 0, &memory);
 
                             // TODO: support for HTTP response 304

--- a/src/libs/storage/src/http_request.rs
+++ b/src/libs/storage/src/http_request.rs
@@ -28,7 +28,7 @@ pub fn http_request(
     storage_state: &impl StorageStateStrategy,
     certificate: &impl StorageCertificateStrategy,
 ) -> HttpResponse {
-    if method != "GET" {
+    if method != "GET" && method != "HEAD" {
         return error_response(RESPONSE_STATUS_CODE_405, "Method Not Allowed.".to_string());
     }
 
@@ -39,6 +39,7 @@ pub fn http_request(
             Routing::Default(RoutingDefault { url, asset }) => build_asset_response(
                 url,
                 req_headers,
+                method,
                 certificate_version,
                 asset,
                 None,
@@ -54,6 +55,7 @@ pub fn http_request(
             }) => build_asset_response(
                 url,
                 req_headers,
+                method,
                 certificate_version,
                 asset,
                 Some(source),

--- a/src/libs/storage/src/http_request.rs
+++ b/src/libs/storage/src/http_request.rs
@@ -39,7 +39,6 @@ pub fn http_request(
             Routing::Default(RoutingDefault { url, asset }) => build_asset_response(
                 url,
                 req_headers,
-                method,
                 certificate_version,
                 asset,
                 None,
@@ -55,7 +54,6 @@ pub fn http_request(
             }) => build_asset_response(
                 url,
                 req_headers,
-                method,
                 certificate_version,
                 asset,
                 Some(source),

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.head.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.head.spec.ts
@@ -1,0 +1,98 @@
+import type { SatelliteActor, SatelliteDid } from '$declarations';
+import type { Actor, PocketIc } from '@dfinity/pic';
+import { toNullable } from '@dfinity/utils';
+import type { Principal } from '@icp-sdk/core/principal';
+import { mockHtml } from '../../../../mocks/storage.mocks';
+import { assertCertification } from '../../../../utils/certification-tests.utils';
+import { uploadAsset } from '../../../../utils/satellite-storage-tests.utils';
+import { setupSatelliteStock } from '../../../../utils/satellite-tests.utils';
+
+describe('Satellite > Storage > Head', () => {
+	let pic: PocketIc;
+	let actor: Actor<SatelliteActor>;
+
+	let canisterId: Principal;
+	let currentDate: Date;
+
+	const name = `hello-world.html`;
+	const full_path = `/hello/${name}`;
+
+	const DAPP_COLLECTION = '#dapp';
+
+	beforeAll(async () => {
+		const { actor: a, pic: p, currentDate: cD, canisterId: cI } = await setupSatelliteStock();
+
+		pic = p;
+		actor = a;
+		currentDate = cD;
+		canisterId = cI;
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	it('should support head request', async () => {
+		const { http_request } = actor;
+
+		await uploadAsset({
+			full_path,
+			name,
+			collection: DAPP_COLLECTION,
+			actor
+		});
+
+		const request: SatelliteDid.HttpRequest = {
+			body: Uint8Array.from([]),
+			certificate_version: toNullable(2),
+			headers: [],
+			method: 'HEAD',
+			url: full_path
+		};
+
+		const response = await http_request(request);
+
+		const { body, status_code } = response;
+
+		const decoder = new TextDecoder();
+
+		expect(decoder.decode(body)).toEqual(mockHtml);
+		expect(status_code).toEqual(200);
+
+		await assertCertification({
+			canisterId,
+			pic,
+			request,
+			response,
+			currentDate,
+			statusCode: 200
+		});
+	});
+
+	it('should return body with head request', async () => {
+		const { http_request } = actor;
+
+		await uploadAsset({
+			full_path,
+			name,
+			collection: DAPP_COLLECTION,
+			actor
+		});
+
+		const request: SatelliteDid.HttpRequest = {
+			body: Uint8Array.from([]),
+			certificate_version: toNullable(2),
+			headers: [],
+			method: 'HEAD',
+			url: full_path
+		};
+
+		const response = await http_request(request);
+
+		const { body } = response;
+
+		const decoder = new TextDecoder();
+
+		expect(decoder.decode(body)).toEqual(mockHtml);
+	});
+});


### PR DESCRIPTION
# Motivation

Resolves #2384

And likely fixes the derivation origin support for Internet Identity which does not seem to work anymore for that reason.