### PR TITLE
feat(shared)!: rename is_controller to is_valid_controller

### DIFF
--- a/src/libs/satellite/src/assets/cdn/assert.rs
+++ b/src/libs/satellite/src/assets/cdn/assert.rs
@@ -7,12 +7,12 @@ use junobuild_collections::assert::stores::{
 use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::Permission;
-use junobuild_shared::segments::controllers::{controller_can_write, is_controller};
+use junobuild_shared::segments::controllers::{controller_can_write, is_valid_controller};
 use junobuild_shared::types::state::Controllers;
 
 pub fn assert_cdn_write_on_dapp_collection(caller: Principal, controllers: &Controllers) -> bool {
     // When using proposals, we allow any controllers to upload - submit - an asset to be served from #dapp collection
-    is_controller(caller, controllers)
+    is_valid_controller(caller, controllers)
 }
 
 pub fn assert_cdn_write_on_system_collection(
@@ -23,7 +23,7 @@ pub fn assert_cdn_write_on_system_collection(
     // Only controllers with scope "Admin" or "Write" can write in reserved collections starting with #
     // ...unless the collection is #_juno and the controller is "Submit".
     if collection == CDN_JUNO_RELEASES_COLLECTION_KEY {
-        return is_controller(caller, controllers);
+        return is_valid_controller(caller, controllers);
     }
 
     controller_can_write(caller, controllers)
@@ -37,7 +37,7 @@ pub fn assert_cdn_create_permission(
 ) -> bool {
     // Through a proposal, any controller - including "Submit" - can provide an asset for the #_juno or #dapp collections.
     if collection == CDN_JUNO_RELEASES_COLLECTION_KEY || collection == COLLECTION_ASSET_KEY {
-        return assert_create_permission_with(permission, caller, controllers, is_controller);
+        return assert_create_permission_with(permission, caller, controllers, is_valid_controller);
     }
 
     assert_create_permission(permission, caller, controllers)
@@ -52,7 +52,7 @@ pub fn assert_cdn_update_permission(
 ) -> bool {
     // Through a proposal, any controller - including "Submit" - can provide an update of an asset for the #_juno or #dapp collections.
     if collection == CDN_JUNO_RELEASES_COLLECTION_KEY || collection == COLLECTION_ASSET_KEY {
-        return assert_permission_with(permission, owner, caller, controllers, is_controller);
+        return assert_permission_with(permission, owner, caller, controllers, is_valid_controller);
     }
 
     assert_permission(permission, owner, caller, controllers)

--- a/src/libs/satellite/src/assets/storage/assert.rs
+++ b/src/libs/satellite/src/assets/storage/assert.rs
@@ -11,7 +11,7 @@ use junobuild_collections::constants::assets::COLLECTION_ASSET_KEY;
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::rules::Permission;
 use junobuild_shared::assert::assert_version;
-use junobuild_shared::segments::controllers::{controller_can_write, is_controller};
+use junobuild_shared::segments::controllers::{controller_can_write, is_valid_controller};
 use junobuild_shared::types::state::Controllers;
 use junobuild_storage::errors::{
     JUNO_STORAGE_ERROR_ASSET_NOT_FOUND, JUNO_STORAGE_ERROR_CANNOT_READ_ASSET,
@@ -67,7 +67,7 @@ pub fn assert_storage_list_permission(
     // because when used with the CLI, it needs to know which assets are currently deployed in order to only submit those
     // that are different.
     if collection == COLLECTION_ASSET_KEY {
-        return assert_permission_with(permission, owner, caller, controllers, is_controller);
+        return assert_permission_with(permission, owner, caller, controllers, is_valid_controller);
     }
 
     assert_permission(permission, owner, caller, controllers)

--- a/src/libs/satellite/src/guards.rs
+++ b/src/libs/satellite/src/guards.rs
@@ -5,7 +5,7 @@ use crate::errors::auth::{
 };
 use junobuild_shared::ic::api::caller;
 use junobuild_shared::segments::controllers::{
-    controller_can_write, is_admin_controller, is_controller,
+    controller_can_write, is_admin_controller, is_valid_controller,
 };
 use junobuild_shared::types::state::Controllers;
 
@@ -35,7 +35,7 @@ pub fn caller_is_controller() -> Result<(), String> {
     let caller = caller();
     let controllers: Controllers = get_controllers();
 
-    if is_controller(caller, &controllers) {
+    if is_valid_controller(caller, &controllers) {
         Ok(())
     } else {
         Err(JUNO_AUTH_ERROR_NOT_CONTROLLER.to_string())

--- a/src/libs/shared/src/segments/controllers.rs
+++ b/src/libs/shared/src/segments/controllers.rs
@@ -108,7 +108,7 @@ pub fn controller_can_write(caller: UserId, controllers: &Controllers) -> bool {
 ///
 /// # Returns
 /// `true` if the caller is a controller (not anonymous, calling itself or one of the known controllers), otherwise `false`.
-pub fn is_controller(caller: UserId, controllers: &Controllers) -> bool {
+pub fn is_valid_controller(caller: UserId, controllers: &Controllers) -> bool {
     principal_not_anonymous(caller)
         && (caller_is_self(caller)
             || controllers


### PR DESCRIPTION
# Motivation

Since we gonna support expiration date #2568, makes sense to rename `is_controller` to `is_valid_controller`
