### PR TITLE
feat(shared)!: limit access keys submit and editors to 20

### DIFF
--- a/src/console/src/api/controllers.rs
+++ b/src/console/src/api/controllers.rs
@@ -4,7 +4,9 @@ use crate::store::heap::{
 };
 use ic_cdk_macros::{query, update};
 use junobuild_shared::ic::UnwrapOrTrap;
-use junobuild_shared::segments::controllers::{assert_controller_expiration, assert_controllers};
+use junobuild_shared::segments::controllers::{
+    assert_controller_expiration, assert_controllers, assert_max_number_of_controllers,
+};
 use junobuild_shared::types::interface::{DeleteControllersArgs, SetControllersArgs};
 use junobuild_shared::types::state::Controllers;
 
@@ -15,6 +17,9 @@ fn set_controllers(
         controller,
     }: SetControllersArgs,
 ) {
+    assert_max_number_of_controllers(&get_controllers(), &controllers, &controller.scope, None)
+        .unwrap_or_trap();
+
     assert_controllers(&controllers).unwrap_or_trap();
 
     assert_controller_expiration(&controller).unwrap_or_trap();

--- a/src/libs/satellite/src/api/controllers.rs
+++ b/src/libs/satellite/src/api/controllers.rs
@@ -1,13 +1,11 @@
 use crate::controllers::store::{delete_controllers, set_controllers as set_controllers_store};
-use crate::{get_admin_controllers, get_controllers};
-use ic_cdk::trap;
-use junobuild_shared::constants::shared::MAX_NUMBER_OF_SATELLITE_CONTROLLERS;
+use crate::get_controllers;
 use junobuild_shared::ic::UnwrapOrTrap;
 use junobuild_shared::segments::controllers::{
     assert_controller_expiration, assert_controllers, assert_max_number_of_controllers,
 };
 use junobuild_shared::types::interface::{DeleteControllersArgs, SetControllersArgs};
-use junobuild_shared::types::state::{ControllerScope, Controllers};
+use junobuild_shared::types::state::Controllers;
 
 pub fn set_controllers(
     SetControllersArgs {
@@ -15,21 +13,8 @@ pub fn set_controllers(
         controller,
     }: SetControllersArgs,
 ) -> Controllers {
-    #[allow(clippy::single_match)]
-    match controller.scope {
-        ControllerScope::Admin => {
-            let max_controllers = assert_max_number_of_controllers(
-                &get_admin_controllers(),
-                &controllers,
-                MAX_NUMBER_OF_SATELLITE_CONTROLLERS,
-            );
-
-            if let Err(err) = max_controllers {
-                trap(&err)
-            }
-        }
-        _ => (),
-    }
+    assert_max_number_of_controllers(&get_controllers(), &controllers, &controller.scope, None)
+        .unwrap_or_trap();
 
     assert_controllers(&controllers).unwrap_or_trap();
 

--- a/src/libs/shared/src/constants/shared.rs
+++ b/src/libs/shared/src/constants/shared.rs
@@ -41,10 +41,13 @@ pub const MEMO_SATELLITE_CREATE_REFUND: Memo = Memo(0x44464552544153); // == 'SA
 pub const MEMO_ORBITER_CREATE_REFUND: Memo = Memo(0x4446455242524f); // == 'ORBREFD'
 
 // 10 controllers max on the IC - the canister itself and user of the console because these two are not added to the mission control state controllers
-pub const MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS: usize = 8;
+pub const MAX_NUMBER_OF_MISSION_CONTROL_ADMIN_CONTROLLERS: usize = 8;
 
 // 10 controllers max on the IC. User and mission control principals are copied in satellite state controllers
-pub const MAX_NUMBER_OF_SATELLITE_CONTROLLERS: usize = 10;
+pub const MAX_NUMBER_OF_ADMIN_CONTROLLERS: usize = 10;
+
+// 20 editor or submit access keys. We defined this value to prevent stacking way too way identities.
+pub const MAX_NUMBER_OF_ACCESS_KEYS: usize = 20;
 
 // Useful for filtering stable tree map ranges that use Principal in keys
 pub const PRINCIPAL_MIN: Principal = Principal::from_slice(&[]);

--- a/src/libs/shared/src/segments/controllers.rs
+++ b/src/libs/shared/src/segments/controllers.rs
@@ -11,7 +11,6 @@ use crate::types::interface::SetController;
 use crate::types::state::{Controller, ControllerId, ControllerScope, Controllers, UserId};
 use crate::utils::{principal_anonymous, principal_equal, principal_not_anonymous};
 use candid::Principal;
-use std::cmp::max_by;
 use std::collections::HashMap;
 
 /// Initializes a set of controllers with default administrative scope.

--- a/src/mission_control/src/controllers/mission_control.rs
+++ b/src/mission_control/src/controllers/mission_control.rs
@@ -1,30 +1,29 @@
-use crate::controllers::store::{delete_controllers, get_admin_controllers, set_controllers};
+use crate::controllers::store::{
+    delete_controllers, get_admin_controllers, get_controllers, set_controllers,
+};
 use crate::user::store::get_user;
-use junobuild_shared::constants::shared::MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS;
+use junobuild_shared::constants::shared::MAX_NUMBER_OF_MISSION_CONTROL_ADMIN_CONTROLLERS;
 use junobuild_shared::ic::api::id;
+use junobuild_shared::ic::UnwrapOrTrap;
 use junobuild_shared::mgmt::ic::update_canister_controllers;
 use junobuild_shared::segments::controllers::{
     assert_controller_expiration, assert_controllers, assert_max_number_of_controllers,
     into_controller_ids,
 };
 use junobuild_shared::types::interface::SetController;
-use junobuild_shared::types::state::{ControllerId, ControllerScope, Controllers};
+use junobuild_shared::types::state::{ControllerId, Controllers};
 
 pub async fn set_mission_control_controllers(
     controllers: &[ControllerId],
     controller: &SetController,
 ) -> Result<(), String> {
-    #[allow(clippy::single_match)]
-    match controller.scope {
-        ControllerScope::Admin => {
-            assert_max_number_of_controllers(
-                &get_admin_controllers(),
-                controllers,
-                MAX_NUMBER_OF_MISSION_CONTROL_CONTROLLERS,
-            )?;
-        }
-        _ => (),
-    }
+    assert_max_number_of_controllers(
+        &get_controllers(),
+        &controllers,
+        &controller.scope,
+        Some(MAX_NUMBER_OF_MISSION_CONTROL_ADMIN_CONTROLLERS),
+    )
+    .unwrap_or_trap();
 
     assert_controllers(controllers)?;
 

--- a/src/mission_control/src/controllers/segment.rs
+++ b/src/mission_control/src/controllers/segment.rs
@@ -2,9 +2,7 @@ use candid::Principal;
 use ic_cdk::call::Call;
 use junobuild_shared::ic::DecodeCandid;
 use junobuild_shared::mgmt::ic::update_canister_controllers;
-use junobuild_shared::segments::controllers::{
-    assert_controller_expiration, assert_controllers, filter_admin_controllers, into_controller_ids,
-};
+use junobuild_shared::segments::controllers::{assert_controller_expiration, assert_controllers, assert_max_number_of_controllers, filter_admin_controllers, into_controller_ids};
 use junobuild_shared::types::interface::{
     DeleteControllersArgs, SetController, SetControllersArgs,
 };

--- a/src/observatory/src/api/controllers.rs
+++ b/src/observatory/src/api/controllers.rs
@@ -4,7 +4,9 @@ use crate::store::heap::{
 };
 use ic_cdk_macros::{query, update};
 use junobuild_shared::ic::UnwrapOrTrap;
-use junobuild_shared::segments::controllers::{assert_controller_expiration, assert_controllers};
+use junobuild_shared::segments::controllers::{
+    assert_controller_expiration, assert_controllers, assert_max_number_of_controllers,
+};
 use junobuild_shared::types::interface::{DeleteControllersArgs, SetControllersArgs};
 use junobuild_shared::types::state::Controllers;
 
@@ -15,6 +17,9 @@ fn set_controllers(
         controller,
     }: SetControllersArgs,
 ) {
+    assert_max_number_of_controllers(&get_controllers(), &controllers, &controller.scope, None)
+        .unwrap_or_trap();
+
     assert_controllers(&controllers).unwrap_or_trap();
 
     assert_controller_expiration(&controller).unwrap_or_trap();

--- a/src/orbiter/src/api/controllers.rs
+++ b/src/orbiter/src/api/controllers.rs
@@ -1,17 +1,15 @@
 use crate::controllers::store::{
-    delete_controllers as delete_controllers_store, get_admin_controllers, get_controllers,
+    delete_controllers as delete_controllers_store, get_controllers,
     set_controllers as set_controllers_store,
 };
 use crate::guards::caller_is_admin_controller;
-use ic_cdk::trap;
 use ic_cdk_macros::{query, update};
-use junobuild_shared::constants::shared::MAX_NUMBER_OF_SATELLITE_CONTROLLERS;
 use junobuild_shared::ic::UnwrapOrTrap;
 use junobuild_shared::segments::controllers::{
     assert_controller_expiration, assert_controllers, assert_max_number_of_controllers,
 };
 use junobuild_shared::types::interface::{DeleteControllersArgs, SetControllersArgs};
-use junobuild_shared::types::state::{ControllerScope, Controllers};
+use junobuild_shared::types::state::Controllers;
 
 #[update(guard = "caller_is_admin_controller")]
 fn set_controllers(
@@ -20,21 +18,8 @@ fn set_controllers(
         controller,
     }: SetControllersArgs,
 ) -> Controllers {
-    #[allow(clippy::single_match)]
-    match controller.scope {
-        ControllerScope::Admin => {
-            let max_controllers = assert_max_number_of_controllers(
-                &get_admin_controllers(),
-                &controllers,
-                MAX_NUMBER_OF_SATELLITE_CONTROLLERS,
-            );
-
-            if let Err(err) = max_controllers {
-                trap(&err)
-            }
-        }
-        _ => (),
-    }
+    assert_max_number_of_controllers(&get_controllers(), &controllers, &controller.scope, None)
+        .unwrap_or_trap();
 
     assert_controllers(&controllers).unwrap_or_trap();
 

--- a/src/orbiter/src/controllers/store.rs
+++ b/src/orbiter/src/controllers/store.rs
@@ -1,6 +1,6 @@
 use crate::state::memory::manager::STATE;
 use junobuild_shared::segments::controllers::{
-    delete_controllers as delete_controllers_impl, filter_admin_controllers,
+    delete_controllers as delete_controllers_impl,
     set_controllers as set_controllers_impl,
 };
 use junobuild_shared::types::interface::SetController;

--- a/src/orbiter/src/controllers/store.rs
+++ b/src/orbiter/src/controllers/store.rs
@@ -1,7 +1,6 @@
 use crate::state::memory::manager::STATE;
 use junobuild_shared::segments::controllers::{
-    delete_controllers as delete_controllers_impl,
-    set_controllers as set_controllers_impl,
+    delete_controllers as delete_controllers_impl, set_controllers as set_controllers_impl,
 };
 use junobuild_shared::types::interface::SetController;
 use junobuild_shared::types::state::{ControllerId, Controllers};

--- a/src/orbiter/src/controllers/store.rs
+++ b/src/orbiter/src/controllers/store.rs
@@ -29,7 +29,3 @@ pub fn delete_controllers(remove_controllers: &[ControllerId]) {
 pub fn get_controllers() -> Controllers {
     STATE.with(|state| state.borrow().heap.controllers.clone())
 }
-
-pub fn get_admin_controllers() -> Controllers {
-    STATE.with(|state| filter_admin_controllers(&state.borrow().heap.controllers))
-}

--- a/src/tests/specs/mission-control/controllers/mission-control.controllers.orbiter.spec.ts
+++ b/src/tests/specs/mission-control/controllers/mission-control.controllers.orbiter.spec.ts
@@ -12,7 +12,8 @@ import type { Principal } from '@icp-sdk/core/principal';
 import {
 	JUNO_ERROR_CONTROLLERS_ADMIN_NO_EXPIRY,
 	JUNO_ERROR_CONTROLLERS_ANONYMOUS_NOT_ALLOWED,
-	JUNO_ERROR_CONTROLLERS_EXPIRY_IN_PAST
+	JUNO_ERROR_CONTROLLERS_EXPIRY_IN_PAST,
+	JUNO_ERROR_CONTROLLERS_MAX_NUMBER
 } from '@junobuild/errors';
 import { inject } from 'vitest';
 import { CONTROLLER_METADATA } from '../../../constants/controller-tests.constants';
@@ -29,6 +30,7 @@ describe('Mission Control > Controllers > Orbiter', () => {
 	let pic: PocketIc;
 	let actor: Actor<MissionControlActor>;
 
+	let missionControlId: Principal;
 	let orbiterId: Principal;
 
 	const controller = Ed25519KeyIdentity.generate();
@@ -38,16 +40,15 @@ describe('Mission Control > Controllers > Orbiter', () => {
 
 		const userInitArgs = (): Uint8Array => missionControlUserInitArgs(controller.getPrincipal());
 
-		const { actor: c, canisterId: missionControlId } = await pic.setupCanister<MissionControlActor>(
-			{
-				idlFactory: idlFactoryMissionControl,
-				wasm: MISSION_CONTROL_WASM_PATH,
-				arg: userInitArgs(),
-				sender: controller.getPrincipal()
-			}
-		);
+		const { actor: c, canisterId: mcId } = await pic.setupCanister<MissionControlActor>({
+			idlFactory: idlFactoryMissionControl,
+			wasm: MISSION_CONTROL_WASM_PATH,
+			arg: userInitArgs(),
+			sender: controller.getPrincipal()
+		});
 
 		actor = c;
+		missionControlId = mcId;
 
 		const { canisterId } = await pic.setupCanister<OrbiterActor>({
 			idlFactory: idlFactoryOrbiter,
@@ -73,58 +74,101 @@ describe('Mission Control > Controllers > Orbiter', () => {
 		);
 	});
 
-	describe('assert', () => {
-		it('should throw errors on creating admin controller with expiration date', async () => {
-			const { set_orbiters_controllers } = actor;
-
-			const controller = Ed25519KeyIdentity.generate();
-
-			await expect(
-				set_orbiters_controllers([orbiterId], [controller.getPrincipal()], {
-					...CONTROLLER_METADATA,
-					scope: { Admin: null },
-					expires_at: [1n]
-				})
-			).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_ADMIN_NO_EXPIRY);
+	describe('With Mission Control as effective controller', () => {
+		beforeEach(async () => {
+			await pic.updateCanisterSettings({
+				canisterId: orbiterId,
+				controllers: [controller.getPrincipal(), missionControlId],
+				sender: controller.getPrincipal()
+			});
 		});
 
-		it.each([
-			{ title: 'write', scope: { Write: null } },
-			{ title: 'submit', scope: { Submit: null } }
-		])(
-			'should throw errors on creating controller with expiry in the past for $title',
-			async ({ scope }) => {
+		it('should throw error when creating too many admin controllers', async () => {
+			const { set_orbiters_controllers } = actor;
+
+			const controllers = Array.from({ length: 11 }, () =>
+				Ed25519KeyIdentity.generate().getPrincipal()
+			);
+
+			await expect(
+				set_orbiters_controllers([orbiterId], controllers, {
+					...CONTROLLER_METADATA,
+					scope: { Admin: null }
+				})
+			).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_MAX_NUMBER);
+		});
+
+		describe('assert', () => {
+			it('should throw errors on creating admin controller with expiration date', async () => {
 				const { set_orbiters_controllers } = actor;
 
 				const controller = Ed25519KeyIdentity.generate();
 
-				const now = toBigIntNanoSeconds(new Date(await pic.getTime()));
+				await expect(
+					set_orbiters_controllers([orbiterId], [controller.getPrincipal()], {
+						...CONTROLLER_METADATA,
+						scope: { Admin: null },
+						expires_at: [1n]
+					})
+				).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_ADMIN_NO_EXPIRY);
+			});
 
-				await pic.advanceTime(10_000);
-				await tick(pic);
+			it.each([
+				{ title: 'write', scope: { Write: null } },
+				{ title: 'submit', scope: { Submit: null } }
+			])(
+				'should throw errors on creating controller with expiry in the past for $title',
+				async ({ scope }) => {
+					const { set_orbiters_controllers } = actor;
+
+					const controller = Ed25519KeyIdentity.generate();
+
+					const now = toBigIntNanoSeconds(new Date(await pic.getTime()));
+
+					await pic.advanceTime(10_000);
+					await tick(pic);
+
+					await expect(
+						set_orbiters_controllers([orbiterId], [controller.getPrincipal()], {
+							...CONTROLLER_METADATA,
+							scope,
+							expires_at: [now]
+						})
+					).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_EXPIRY_IN_PAST);
+				}
+			);
+
+			it('should throw errors on creating anonymous controller', async () => {
+				const { set_orbiters_controllers } = actor;
+
+				const controller = new AnonymousIdentity();
 
 				await expect(
 					set_orbiters_controllers([orbiterId], [controller.getPrincipal()], {
 						...CONTROLLER_METADATA,
-						scope,
-						expires_at: [now]
+						scope: { Admin: null },
+						expires_at: [1n]
 					})
-				).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_EXPIRY_IN_PAST);
-			}
-		);
+				).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_ANONYMOUS_NOT_ALLOWED);
+			});
 
-		it('should throw errors on creating anonymous controller', async () => {
-			const { set_orbiters_controllers } = actor;
+			it.each([
+				{ title: 'write', scope: { Write: null } },
+				{ title: 'submit', scope: { Submit: null } }
+			])('should throw error when creating too many controllers for $write', async ({ scope }) => {
+				const { set_orbiters_controllers } = actor;
 
-			const controller = new AnonymousIdentity();
+				const controllers = Array.from({ length: 21 }, () =>
+					Ed25519KeyIdentity.generate().getPrincipal()
+				);
 
-			await expect(
-				set_orbiters_controllers([orbiterId], [controller.getPrincipal()], {
-					...CONTROLLER_METADATA,
-					scope: { Admin: null },
-					expires_at: [1n]
-				})
-			).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_ANONYMOUS_NOT_ALLOWED);
+				await expect(
+					set_orbiters_controllers([orbiterId], controllers, {
+						...CONTROLLER_METADATA,
+						scope
+					})
+				).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_MAX_NUMBER);
+			});
 		});
 	});
 });

--- a/src/tests/specs/mission-control/controllers/mission-control.controllers.satellite.spec.ts
+++ b/src/tests/specs/mission-control/controllers/mission-control.controllers.satellite.spec.ts
@@ -13,7 +13,8 @@ import {
 	JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER,
 	JUNO_ERROR_CONTROLLERS_ADMIN_NO_EXPIRY,
 	JUNO_ERROR_CONTROLLERS_ANONYMOUS_NOT_ALLOWED,
-	JUNO_ERROR_CONTROLLERS_EXPIRY_IN_PAST
+	JUNO_ERROR_CONTROLLERS_EXPIRY_IN_PAST,
+	JUNO_ERROR_CONTROLLERS_MAX_NUMBER
 } from '@junobuild/errors';
 import { inject } from 'vitest';
 import { CONTROLLER_METADATA } from '../../../constants/controller-tests.constants';
@@ -29,6 +30,7 @@ describe('Mission Control > Controllers > Satellite', () => {
 	let pic: PocketIc;
 	let actor: Actor<MissionControlActor>;
 
+	let missionControlId: Principal;
 	let satelliteId: Principal;
 
 	const controller = Ed25519KeyIdentity.generate();
@@ -38,16 +40,15 @@ describe('Mission Control > Controllers > Satellite', () => {
 
 		const userInitArgs = (): Uint8Array => missionControlUserInitArgs(controller.getPrincipal());
 
-		const { actor: c, canisterId: missionControlId } = await pic.setupCanister<MissionControlActor>(
-			{
-				idlFactory: idlFactoryMissionControl,
-				wasm: MISSION_CONTROL_WASM_PATH,
-				arg: userInitArgs(),
-				sender: controller.getPrincipal()
-			}
-		);
+		const { actor: c, canisterId: mcId } = await pic.setupCanister<MissionControlActor>({
+			idlFactory: idlFactoryMissionControl,
+			wasm: MISSION_CONTROL_WASM_PATH,
+			arg: userInitArgs(),
+			sender: controller.getPrincipal()
+		});
 
 		actor = c;
+		missionControlId = mcId;
 
 		const { canisterId: cId } = await pic.setupCanister<SatelliteActor>({
 			idlFactory: idlFactorySatellite,
@@ -73,58 +74,101 @@ describe('Mission Control > Controllers > Satellite', () => {
 		);
 	});
 
-	describe('assert', () => {
-		it('should throw errors on creating admin controller with expiration date', async () => {
-			const { set_satellites_controllers } = actor;
-
-			const controller = Ed25519KeyIdentity.generate();
-
-			await expect(
-				set_satellites_controllers([satelliteId], [controller.getPrincipal()], {
-					...CONTROLLER_METADATA,
-					scope: { Admin: null },
-					expires_at: [1n]
-				})
-			).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_ADMIN_NO_EXPIRY);
+	describe('With Mission Control as effective controller', () => {
+		beforeEach(async () => {
+			await pic.updateCanisterSettings({
+				canisterId: satelliteId,
+				controllers: [controller.getPrincipal(), missionControlId],
+				sender: controller.getPrincipal()
+			});
 		});
 
-		it.each([
-			{ title: 'write', scope: { Write: null } },
-			{ title: 'submit', scope: { Submit: null } }
-		])(
-			'should throw errors on creating controller with expiry in the past for $title',
-			async ({ scope }) => {
+		it('should throw error when creating too many admin controllers', async () => {
+			const { set_satellites_controllers } = actor;
+
+			const controllers = Array.from({ length: 11 }, () =>
+				Ed25519KeyIdentity.generate().getPrincipal()
+			);
+
+			await expect(
+				set_satellites_controllers([satelliteId], controllers, {
+					...CONTROLLER_METADATA,
+					scope: { Admin: null }
+				})
+			).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_MAX_NUMBER);
+		});
+
+		describe('assert', () => {
+			it('should throw errors on creating admin controller with expiration date', async () => {
 				const { set_satellites_controllers } = actor;
 
 				const controller = Ed25519KeyIdentity.generate();
 
-				const now = toBigIntNanoSeconds(new Date(await pic.getTime()));
+				await expect(
+					set_satellites_controllers([satelliteId], [controller.getPrincipal()], {
+						...CONTROLLER_METADATA,
+						scope: { Admin: null },
+						expires_at: [1n]
+					})
+				).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_ADMIN_NO_EXPIRY);
+			});
 
-				await pic.advanceTime(10_000);
-				await tick(pic);
+			it.each([
+				{ title: 'write', scope: { Write: null } },
+				{ title: 'submit', scope: { Submit: null } }
+			])(
+				'should throw errors on creating controller with expiry in the past for $title',
+				async ({ scope }) => {
+					const { set_satellites_controllers } = actor;
+
+					const controller = Ed25519KeyIdentity.generate();
+
+					const now = toBigIntNanoSeconds(new Date(await pic.getTime()));
+
+					await pic.advanceTime(10_000);
+					await tick(pic);
+
+					await expect(
+						set_satellites_controllers([satelliteId], [controller.getPrincipal()], {
+							...CONTROLLER_METADATA,
+							scope,
+							expires_at: [now]
+						})
+					).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_EXPIRY_IN_PAST);
+				}
+			);
+
+			it('should throw errors on creating anonymous controller', async () => {
+				const { set_satellites_controllers } = actor;
+
+				const controller = new AnonymousIdentity();
 
 				await expect(
 					set_satellites_controllers([satelliteId], [controller.getPrincipal()], {
 						...CONTROLLER_METADATA,
-						scope,
-						expires_at: [now]
+						scope: { Admin: null },
+						expires_at: [1n]
 					})
-				).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_EXPIRY_IN_PAST);
-			}
-		);
+				).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_ANONYMOUS_NOT_ALLOWED);
+			});
 
-		it('should throw errors on creating anonymous controller', async () => {
-			const { set_satellites_controllers } = actor;
+			it.each([
+				{ title: 'write', scope: { Write: null } },
+				{ title: 'submit', scope: { Submit: null } }
+			])('should throw error when creating too many controllers for $write', async ({ scope }) => {
+				const { set_satellites_controllers } = actor;
 
-			const controller = new AnonymousIdentity();
+				const controllers = Array.from({ length: 21 }, () =>
+					Ed25519KeyIdentity.generate().getPrincipal()
+				);
 
-			await expect(
-				set_satellites_controllers([satelliteId], [controller.getPrincipal()], {
-					...CONTROLLER_METADATA,
-					scope: { Admin: null },
-					expires_at: [1n]
-				})
-			).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_ANONYMOUS_NOT_ALLOWED);
+				await expect(
+					set_satellites_controllers([satelliteId], controllers, {
+						...CONTROLLER_METADATA,
+						scope
+					})
+				).rejects.toThrowError(JUNO_ERROR_CONTROLLERS_MAX_NUMBER);
+			});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

It's a relatively high value. We want to prevent having zillion keys in memory.
