### PR TITLE
feat(observatory): fetch github actions openid certificate

### DIFF
--- a/scripts/observatory.certificate.mjs
+++ b/scripts/observatory.certificate.mjs
@@ -12,7 +12,12 @@ const getGoogleCertificate = async ({ mainnet, provider: cmdProvider }) => {
 		? observatoryActorIC()
 		: observatoryActorLocal());
 
-	const provider = cmdProvider === 'github_auth' ? { GitHubAuth: null } : { Google: null };
+	const provider =
+		cmdProvider === 'gh_auth'
+			? { GitHubAuth: null }
+			: cmdProvider === 'gh_actions'
+				? { GitHubActions: null }
+				: { Google: null };
 
 	const certificate = await get_openid_certificate({ provider });
 
@@ -31,7 +36,7 @@ const mainnet = targetMainnet();
 const args = process.argv.slice(2);
 const provider = nextArg({ args, option: '-p' }) ?? nextArg({ args, option: '--provider' });
 
-if (!['google', 'github_auth'].includes(provider)) {
+if (!['google', 'gh_auth', 'gh_actions'].includes(provider)) {
 	console.log(`Provider ${provider} is not supported`);
 	process.exit(1);
 }

--- a/scripts/observatory.monitoring.mjs
+++ b/scripts/observatory.monitoring.mjs
@@ -9,7 +9,12 @@ const toggleOpenIdMonitoring = async ({ mainnet, provider, start }) => {
 		? observatoryActorIC()
 		: observatoryActorLocal());
 
-	const args = provider === 'github_auth' ? { GitHubAuth: null } : { Google: null };
+	const args =
+		provider === 'gh_auth'
+			? { GitHubAuth: null }
+			: provider === 'gh_actions'
+				? { GitHubActions: null }
+				: { Google: null };
 
 	if (start) {
 		await start_openid_monitoring(args);
@@ -39,7 +44,7 @@ if (start === true && stop === true) {
 
 const provider = nextArg({ args, option: '-p' }) ?? nextArg({ args, option: '--provider' });
 
-if (!['google', 'github_auth'].includes(provider)) {
+if (!['google', 'gh_auth', 'gh_actions'].includes(provider)) {
 	console.log(`Provider ${provider} is not supported`);
 	process.exit(1);
 }

--- a/src/declarations/observatory/observatory.did.d.ts
+++ b/src/declarations/observatory/observatory.did.d.ts
@@ -108,7 +108,7 @@ export interface OpenIdCertificate {
 	created_at: bigint;
 	version: [] | [bigint];
 }
-export type OpenIdProvider = { Google: null } | { GitHubAuth: null };
+export type OpenIdProvider = { GitHubActions: null } | { Google: null } | { GitHubAuth: null };
 export interface RateConfig {
 	max_tokens: bigint;
 	time_per_token_ns: bigint;

--- a/src/declarations/observatory/observatory.factory.certified.did.js
+++ b/src/declarations/observatory/observatory.factory.certified.did.js
@@ -21,6 +21,7 @@ export const idlFactory = ({ IDL }) => {
 		failed: IDL.Nat64
 	});
 	const OpenIdProvider = IDL.Variant({
+		GitHubActions: IDL.Null,
 		Google: IDL.Null,
 		GitHubAuth: IDL.Null
 	});

--- a/src/declarations/observatory/observatory.factory.did.js
+++ b/src/declarations/observatory/observatory.factory.did.js
@@ -21,6 +21,7 @@ export const idlFactory = ({ IDL }) => {
 		failed: IDL.Nat64
 	});
 	const OpenIdProvider = IDL.Variant({
+		GitHubActions: IDL.Null,
 		Google: IDL.Null,
 		GitHubAuth: IDL.Null
 	});

--- a/src/declarations/observatory/observatory.factory.did.mjs
+++ b/src/declarations/observatory/observatory.factory.did.mjs
@@ -21,6 +21,7 @@ export const idlFactory = ({ IDL }) => {
 		failed: IDL.Nat64
 	});
 	const OpenIdProvider = IDL.Variant({
+		GitHubActions: IDL.Null,
 		Google: IDL.Null,
 		GitHubAuth: IDL.Null
 	});

--- a/src/libs/auth/src/openid/impls.rs
+++ b/src/libs/auth/src/openid/impls.rs
@@ -1,8 +1,6 @@
 use crate::openid::jwt::types::cert::Jwks;
 use crate::openid::jwt::types::provider::JwtIssuers;
-use crate::openid::types::provider::{
-    OpenIdCertificate, OpenIdDelegationProvider, OpenIdProvider,
-};
+use crate::openid::types::provider::{OpenIdCertificate, OpenIdDelegationProvider, OpenIdProvider};
 use junobuild_shared::data::version::next_version;
 use junobuild_shared::ic::api::time;
 use junobuild_shared::types::state::{Version, Versioned};

--- a/src/observatory/observatory.did
+++ b/src/observatory/observatory.did
@@ -70,7 +70,7 @@ type OpenIdCertificate = record {
   created_at : nat64;
   version : opt nat64;
 };
-type OpenIdProvider = variant { Google; GitHubAuth };
+type OpenIdProvider = variant { GitHubActions; Google; GitHubAuth };
 type RateConfig = record { max_tokens : nat64; time_per_token_ns : nat64 };
 type RateKind = variant { OpenIdCertificateRequests };
 type Segment = record {

--- a/src/observatory/src/openid/scheduler.rs
+++ b/src/observatory/src/openid/scheduler.rs
@@ -9,10 +9,14 @@ use std::time::Duration;
 
 pub fn defer_restart_monitoring() {
     // Early spare one timer if no scheduler is enabled.
-    let enabled_count = [OpenIdProvider::Google, OpenIdProvider::GitHubAuth]
-        .into_iter()
-        .filter(is_scheduler_enabled)
-        .count();
+    let enabled_count = [
+        OpenIdProvider::Google,
+        OpenIdProvider::GitHubAuth,
+        OpenIdProvider::GitHubActions,
+    ]
+    .into_iter()
+    .filter(is_scheduler_enabled)
+    .count();
 
     if enabled_count == 0 {
         return;
@@ -24,7 +28,11 @@ pub fn defer_restart_monitoring() {
 }
 
 async fn restart_monitoring() {
-    for provider in [OpenIdProvider::Google, OpenIdProvider::GitHubAuth] {
+    for provider in [
+        OpenIdProvider::Google,
+        OpenIdProvider::GitHubAuth,
+        OpenIdProvider::GitHubActions,
+    ] {
         schedule_certificate_update(provider, None);
     }
 }

--- a/src/tests/constants/auth-tests.constants.ts
+++ b/src/tests/constants/auth-tests.constants.ts
@@ -7,4 +7,5 @@ export const LOG_SALT_INITIALIZED = 'Authentication salt initialized.';
 export const LOG_SALT_ALREADY_INITIALIZED = 'Authentication salt exists. Skipping initialization.';
 
 export const GOOGLE_OPEN_ID_PROVIDER = { Google: null };
-export const GITHUB_OPEN_ID_PROVIDER = { GitHubAuth: null };
+export const GITHUB_AUTH_OPEN_ID_PROVIDER = { GitHubAuth: null };
+export const GITHUB_ACTIONS_OPEN_ID_PROVIDER = { GitHubActions: null };

--- a/src/tests/specs/observatory/upgrade/observatory.upgrade-v0-5-0.openid-provider.spec.ts
+++ b/src/tests/specs/observatory/upgrade/observatory.upgrade-v0-5-0.openid-provider.spec.ts
@@ -9,7 +9,7 @@ import { fromNullable } from '@dfinity/utils';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import type { Principal } from '@icp-sdk/core/principal';
 import { inject } from 'vitest';
-import { GITHUB_OPEN_ID_PROVIDER } from '../../../constants/auth-tests.constants';
+import { GITHUB_AUTH_OPEN_ID_PROVIDER } from '../../../constants/auth-tests.constants';
 import { OBSERVATORY_ID } from '../../../constants/observatory-tests.constants';
 import { mockGitHubClientId } from '../../../mocks/jwt.mocks';
 import { generateNonce } from '../../../utils/auth-nonce-tests.utils';
@@ -74,7 +74,7 @@ describe('Observatory > Upgrade', () => {
 
 		const { jwks } = mockJwt;
 
-		await assertOpenIdHttpsOutcalls({ pic, jwks, method: 'github' });
+		await assertOpenIdHttpsOutcalls({ pic, jwks, method: 'github_auth' });
 	});
 
 	afterAll(async () => {
@@ -92,7 +92,7 @@ describe('Observatory > Upgrade', () => {
 		const { get_openid_certificate } = newActor;
 
 		const cert = await get_openid_certificate({
-			provider: GITHUB_OPEN_ID_PROVIDER
+			provider: GITHUB_AUTH_OPEN_ID_PROVIDER
 		});
 
 		expect(fromNullable(cert)).not.toBeUndefined();

--- a/src/tests/utils/auth-identity-tests.utils.ts
+++ b/src/tests/utils/auth-identity-tests.utils.ts
@@ -55,7 +55,11 @@ export const authenticateAndMakeIdentity = async <R>({
 
 	const { jwks, jwt } = mockJwt;
 
-	await assertOpenIdHttpsOutcalls({ pic, jwks, method });
+	await assertOpenIdHttpsOutcalls({
+		pic,
+		jwks,
+		method: method === 'github' ? 'github_auth' : 'google'
+	});
 
 	const { authenticate, get_delegation } = actor;
 

--- a/src/tests/utils/auth-tests.utils.ts
+++ b/src/tests/utils/auth-tests.utils.ts
@@ -14,7 +14,7 @@ import type { Actor, PocketIc } from '@dfinity/pic';
 import { ECDSAKeyIdentity, Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import type { Principal } from '@icp-sdk/core/principal';
 import {
-	GITHUB_OPEN_ID_PROVIDER,
+	GITHUB_AUTH_OPEN_ID_PROVIDER,
 	GOOGLE_OPEN_ID_PROVIDER
 } from '../constants/auth-tests.constants';
 import { OBSERVATORY_ID } from '../constants/observatory-tests.constants';
@@ -190,7 +190,7 @@ const setupAuth = async ({
 	await start_openid_monitoring(GOOGLE_OPEN_ID_PROVIDER);
 
 	if (withGitHub) {
-		await start_openid_monitoring(GITHUB_OPEN_ID_PROVIDER);
+		await start_openid_monitoring(GITHUB_AUTH_OPEN_ID_PROVIDER);
 	}
 
 	await updateRateConfigNoLimit({ actor: observatoryActor });

--- a/src/tests/utils/observatory-openid-tests.utils.ts
+++ b/src/tests/utils/observatory-openid-tests.utils.ts
@@ -13,7 +13,7 @@ export const assertOpenIdHttpsOutcalls = async ({
 }: {
 	pic: PocketIc;
 	jwks: MockOpenIdJwt['jwks'];
-	method?: 'google' | 'github';
+	method?: 'google' | 'github_auth' | 'github_actions';
 }) => {
 	await tick(pic);
 
@@ -23,9 +23,11 @@ export const assertOpenIdHttpsOutcalls = async ({
 	const pendingRequestedHttpOutCall = pendingHttpOutCalls.find(
 		({ url }) =>
 			url ===
-			(method === 'github'
+			(method === 'github_auth'
 				? 'https://api.juno.build/v1/auth/certs'
-				: 'https://www.googleapis.com/oauth2/v3/certs')
+				: method === 'github_actions'
+					? 'https://token.actions.githubusercontent.com/.well-known/jwks'
+					: 'https://www.googleapis.com/oauth2/v3/certs')
 	);
 
 	expect(pendingRequestedHttpOutCall).not.toBeUndefined();


### PR DESCRIPTION
# Motivation

As we do for Google and GitHub Auth, we need the observatory to get the OpenId certificate for GitHub Actions.
