### PR TITLE
feat(auth): use a standardized trait to read nonce instead of passing function

### DIFF
--- a/src/libs/auth/src/openid/credentials/delegation/impls.rs
+++ b/src/libs/auth/src/openid/credentials/delegation/impls.rs
@@ -34,4 +34,8 @@ impl JwtClaims for DelegationClaims {
     fn iat(&self) -> Option<u64> {
         self.iat
     }
+
+    fn nonce(&self) -> Option<&str> {
+        self.nonce.as_deref()
+    }
 }

--- a/src/libs/auth/src/openid/credentials/delegation/verify.rs
+++ b/src/libs/auth/src/openid/credentials/delegation/verify.rs
@@ -58,14 +58,6 @@ fn verify_openid_credentials(
     client_id: &OpenIdAuthProviderClientId,
     salt: &Salt,
 ) -> VerifyOpenIdDelegationCredentialsResult {
-    let assert_nonce = |claims: &DelegationClaims, nonce: &String| -> Result<(), JwtVerifyError> {
-        if claims.nonce.as_deref() != Some(nonce.as_str()) {
-            return Err(JwtVerifyError::BadClaim("nonce".to_string()));
-        }
-
-        Ok(())
-    };
-
     let assert_audience = |claims: &DelegationClaims| -> Result<(), JwtVerifyError> {
         if claims.aud != client_id.as_str() {
             return Err(JwtVerifyError::BadClaim("aud".to_string()));
@@ -74,15 +66,8 @@ fn verify_openid_credentials(
         Ok(())
     };
 
-    let token = verify_openid_jwt(
-        jwt,
-        provider.issuers(),
-        &jwks.keys,
-        salt,
-        assert_nonce,
-        assert_audience,
-    )
-    .map_err(VerifyOpenidCredentialsError::JwtVerify)?;
+    let token = verify_openid_jwt(jwt, provider.issuers(), &jwks.keys, salt, assert_audience)
+        .map_err(VerifyOpenidCredentialsError::JwtVerify)?;
 
     let credential = OpenIdDelegationCredential::from(token);
 

--- a/src/libs/auth/src/openid/jwt/types.rs
+++ b/src/libs/auth/src/openid/jwt/types.rs
@@ -3,6 +3,7 @@ pub(crate) mod token {
 
     pub trait JwtClaims {
         fn iat(&self) -> Option<u64>;
+        fn nonce(&self) -> Option<&str>;
     }
 
     #[derive(Clone, Deserialize)]


### PR DESCRIPTION
# Motivation

Makes #2539 cleaner
