### PR TITLE
feat(auth): use refs instead of branches in automation config

### DIFF
--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -311,7 +311,7 @@ export interface OpenIdAutomationProviderControllerConfig {
 	max_time_to_live: [] | [bigint];
 }
 export interface OpenIdAutomationRepositoryConfig {
-	branches: [] | [Array<string>];
+	refs: [] | [Array<string>];
 }
 export type OpenIdDelegationProvider = { GitHub: null } | { Google: null };
 export interface OpenIdGetDelegationArgs {

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const RepositoryKey = IDL.Record({ owner: IDL.Text, name: IDL.Text });
 	const OpenIdAutomationRepositoryConfig = IDL.Record({
-		branches: IDL.Opt(IDL.Vec(IDL.Text))
+		refs: IDL.Opt(IDL.Vec(IDL.Text))
 	});
 	const OpenIdAutomationProviderConfig = IDL.Record({
 		controller: IDL.Opt(OpenIdAutomationProviderControllerConfig),

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const RepositoryKey = IDL.Record({ owner: IDL.Text, name: IDL.Text });
 	const OpenIdAutomationRepositoryConfig = IDL.Record({
-		branches: IDL.Opt(IDL.Vec(IDL.Text))
+		refs: IDL.Opt(IDL.Vec(IDL.Text))
 	});
 	const OpenIdAutomationProviderConfig = IDL.Record({
 		controller: IDL.Opt(OpenIdAutomationProviderControllerConfig),

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const RepositoryKey = IDL.Record({ owner: IDL.Text, name: IDL.Text });
 	const OpenIdAutomationRepositoryConfig = IDL.Record({
-		branches: IDL.Opt(IDL.Vec(IDL.Text))
+		refs: IDL.Opt(IDL.Vec(IDL.Text))
 	});
 	const OpenIdAutomationProviderConfig = IDL.Record({
 		controller: IDL.Opt(OpenIdAutomationProviderControllerConfig),

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -311,7 +311,7 @@ export interface OpenIdAutomationProviderControllerConfig {
 	max_time_to_live: [] | [bigint];
 }
 export interface OpenIdAutomationRepositoryConfig {
-	branches: [] | [Array<string>];
+	refs: [] | [Array<string>];
 }
 export type OpenIdDelegationProvider = { GitHub: null } | { Google: null };
 export interface OpenIdGetDelegationArgs {

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const RepositoryKey = IDL.Record({ owner: IDL.Text, name: IDL.Text });
 	const OpenIdAutomationRepositoryConfig = IDL.Record({
-		branches: IDL.Opt(IDL.Vec(IDL.Text))
+		refs: IDL.Opt(IDL.Vec(IDL.Text))
 	});
 	const OpenIdAutomationProviderConfig = IDL.Record({
 		controller: IDL.Opt(OpenIdAutomationProviderControllerConfig),

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const RepositoryKey = IDL.Record({ owner: IDL.Text, name: IDL.Text });
 	const OpenIdAutomationRepositoryConfig = IDL.Record({
-		branches: IDL.Opt(IDL.Vec(IDL.Text))
+		refs: IDL.Opt(IDL.Vec(IDL.Text))
 	});
 	const OpenIdAutomationProviderConfig = IDL.Record({
 		controller: IDL.Opt(OpenIdAutomationProviderControllerConfig),

--- a/src/libs/auth/src/state/types.rs
+++ b/src/libs/auth/src/state/types.rs
@@ -156,8 +156,8 @@ pub mod automation {
 
     #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
     pub struct OpenIdAutomationRepositoryConfig {
-        // Optionally restrict to specific branches (e.g. ["main", "develop"])
-        pub branches: Option<Vec<String>>,
+        // Optionally restrict to specific references / branches (e.g. ["refs/heads/main", "refs/pull/74/merge"])
+        pub refs: Option<Vec<String>>,
     }
 
     #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -262,7 +262,7 @@ type OpenIdAutomationProviderControllerConfig = record {
   scope : opt AutomationScope;
   max_time_to_live : opt nat64;
 };
-type OpenIdAutomationRepositoryConfig = record { branches : opt vec text };
+type OpenIdAutomationRepositoryConfig = record { refs : opt vec text };
 type OpenIdDelegationProvider = variant { GitHub; Google };
 type OpenIdGetDelegationArgs = record {
   jwt : text;

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -264,7 +264,7 @@ type OpenIdAutomationProviderControllerConfig = record {
   scope : opt AutomationScope;
   max_time_to_live : opt nat64;
 };
-type OpenIdAutomationRepositoryConfig = record { branches : opt vec text };
+type OpenIdAutomationRepositoryConfig = record { refs : opt vec text };
 type OpenIdDelegationProvider = variant { GitHub; Google };
 type OpenIdGetDelegationArgs = record {
   jwt : text;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -264,7 +264,7 @@ type OpenIdAutomationProviderControllerConfig = record {
   scope : opt AutomationScope;
   max_time_to_live : opt nat64;
 };
-type OpenIdAutomationRepositoryConfig = record { branches : opt vec text };
+type OpenIdAutomationRepositoryConfig = record { refs : opt vec text };
 type OpenIdDelegationProvider = variant { GitHub; Google };
 type OpenIdGetDelegationArgs = record {
   jwt : text;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -311,7 +311,7 @@ export interface OpenIdAutomationProviderControllerConfig {
 	max_time_to_live: [] | [bigint];
 }
 export interface OpenIdAutomationRepositoryConfig {
-	branches: [] | [Array<string>];
+	refs: [] | [Array<string>];
 }
 export type OpenIdDelegationProvider = { GitHub: null } | { Google: null };
 export interface OpenIdGetDelegationArgs {

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const RepositoryKey = IDL.Record({ owner: IDL.Text, name: IDL.Text });
 	const OpenIdAutomationRepositoryConfig = IDL.Record({
-		branches: IDL.Opt(IDL.Vec(IDL.Text))
+		refs: IDL.Opt(IDL.Vec(IDL.Text))
 	});
 	const OpenIdAutomationProviderConfig = IDL.Record({
 		controller: IDL.Opt(OpenIdAutomationProviderControllerConfig),

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -237,7 +237,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const RepositoryKey = IDL.Record({ owner: IDL.Text, name: IDL.Text });
 	const OpenIdAutomationRepositoryConfig = IDL.Record({
-		branches: IDL.Opt(IDL.Vec(IDL.Text))
+		refs: IDL.Opt(IDL.Vec(IDL.Text))
 	});
 	const OpenIdAutomationProviderConfig = IDL.Record({
 		controller: IDL.Opt(OpenIdAutomationProviderControllerConfig),

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -264,7 +264,7 @@ type OpenIdAutomationProviderControllerConfig = record {
   scope : opt AutomationScope;
   max_time_to_live : opt nat64;
 };
-type OpenIdAutomationRepositoryConfig = record { branches : opt vec text };
+type OpenIdAutomationRepositoryConfig = record { refs : opt vec text };
 type OpenIdDelegationProvider = variant { GitHub; Google };
 type OpenIdGetDelegationArgs = record {
   jwt : text;

--- a/src/tests/utils/automation-assertions-authenticate-tests.utils.ts
+++ b/src/tests/utils/automation-assertions-authenticate-tests.utils.ts
@@ -123,7 +123,7 @@ export const testAutomationAuthenticate = ({
 								[
 									{ GitHub: null },
 									{
-										repositories: [[mockRepositoryKey, { branches: [] }]],
+										repositories: [[mockRepositoryKey, { refs: [] }]],
 										controller: []
 									}
 								]

--- a/src/tests/utils/automation-assertions-config-openid-tests.utils.ts
+++ b/src/tests/utils/automation-assertions-config-openid-tests.utils.ts
@@ -55,7 +55,7 @@ export const testAutomationConfigObservatory = ({
 							[
 								{ GitHub: null },
 								{
-									repositories: [[mockRepositoryKey, { branches: [] }]],
+									repositories: [[mockRepositoryKey, { refs: [] }]],
 									controller: []
 								}
 							]

--- a/src/tests/utils/automation-assertions-tests.utils.ts
+++ b/src/tests/utils/automation-assertions-tests.utils.ts
@@ -66,7 +66,7 @@ export const testAutomationOpenIdConfig = ({
 	const githubConfig: [OpenIdAutomationProvider, OpenIdAutomationProviderConfig] = [
 		{ GitHub: null },
 		{
-			repositories: [[mockRepositoryKey, { branches: [] }]],
+			repositories: [[mockRepositoryKey, { refs: [] }]],
 			controller: []
 		}
 	];
@@ -92,7 +92,7 @@ export const testAutomationOpenIdConfig = ({
 			([key]) => 'GitHub' in key
 		)?.[1];
 
-		expect(github?.repositories[0]).toEqual([mockRepositoryKey, { branches: [] }]);
+		expect(github?.repositories[0]).toEqual([mockRepositoryKey, { refs: [] }]);
 	});
 
 	it('should disable github', async () => {

--- a/src/tests/utils/automation-assertions-token-tests.utils.ts
+++ b/src/tests/utils/automation-assertions-token-tests.utils.ts
@@ -73,7 +73,7 @@ export const testAutomationToken = ({
 								[
 									{ GitHub: null },
 									{
-										repositories: [[mockRepositoryKey, { branches: [] }]],
+										repositories: [[mockRepositoryKey, { refs: [] }]],
 										controller: []
 									}
 								]

--- a/src/tests/utils/automation-tests.utils.ts
+++ b/src/tests/utils/automation-tests.utils.ts
@@ -103,7 +103,7 @@ const setupAutomation = async ({
 					[
 						{ GitHub: null },
 						{
-							repositories: [[mockRepositoryKey, { branches: [] }]],
+							repositories: [[mockRepositoryKey, { refs: [] }]],
 							controller: toNullable(controllerConfig)
 						}
 					]


### PR DESCRIPTION
# Motivation

While testing, among other mess, I ended having an issue because I allowed a branch "something" but, the JWT verification failed because my branch was referencing another branch (https://github.com/junobuild/juno-action/pull/74) and not main (https://github.com/junobuild/juno-action/actions/runs/21988152415/job/63527655846).

It's cleaner and easier to not parse the branch in the Satellite - and one might argue it's not its role anyway - therefore I switch "branches" in the config to "refs".

Means if dev want to allow only certain references, they will have to be explicit.
