### PR TITLE
feat(frontend): satellite config loader

### DIFF
--- a/src/frontend/src/lib/api/satellites.api.ts
+++ b/src/frontend/src/lib/api/satellites.api.ts
@@ -222,6 +222,14 @@ export const setAutomationConfig = async ({
 	return set_automation_config(config);
 };
 
+export const getConfig = async (params: {
+	satelliteId: Principal;
+	identity: OptionIdentity;
+}): Promise<SatelliteDid.Config> => {
+	const { get_config } = await getSatelliteActor(params);
+	return get_config();
+};
+
 export const deleteDoc = async ({
 	satelliteId,
 	collection,

--- a/src/frontend/src/lib/components/app/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/app/loaders/Loaders.svelte
@@ -4,19 +4,28 @@
 	import SegmentsLoader from '$lib/components/modules/loaders/SegmentsLoader.svelte';
 	import WalletLoader from '$lib/components/wallet/loaders/WalletLoader.svelte';
 	import { sortedSatellites } from '$lib/derived/satellites.derived';
+	import SatelliteConfigLoader from '$lib/components/satellites/loaders/SatelliteConfigLoader.svelte';
+	import NoSatelliteConfigLoader from '$lib/components/satellites/loaders/NoSatelliteConfigLoader.svelte';
 
 	interface Props {
 		children: Snippet;
 		monitoring?: boolean;
+		satelliteConfig?: boolean;
 	}
 
-	let { children, monitoring }: Props = $props();
+	let { children, monitoring, satelliteConfig = false }: Props = $props();
+
+	let SatelliteConfigLoaderComponent = $derived(
+		satelliteConfig ? SatelliteConfigLoader : NoSatelliteConfigLoader
+	);
 </script>
 
 <WalletLoader>
 	<SegmentsLoader>
 		<MetadataLoader {monitoring} satellites={$sortedSatellites}>
-			{@render children()}
+			<SatelliteConfigLoaderComponent>
+				{@render children()}
+			</SatelliteConfigLoaderComponent>
 		</MetadataLoader>
 	</SegmentsLoader>
 </WalletLoader>

--- a/src/frontend/src/lib/components/app/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/app/loaders/Loaders.svelte
@@ -2,10 +2,10 @@
 	import type { Snippet } from 'svelte';
 	import MetadataLoader from '$lib/components/modules/loaders/MetadataLoader.svelte';
 	import SegmentsLoader from '$lib/components/modules/loaders/SegmentsLoader.svelte';
+	import NoSatelliteConfigLoader from '$lib/components/satellites/loaders/NoSatelliteConfigLoader.svelte';
+	import SatelliteConfigLoader from '$lib/components/satellites/loaders/SatelliteConfigLoader.svelte';
 	import WalletLoader from '$lib/components/wallet/loaders/WalletLoader.svelte';
 	import { sortedSatellites } from '$lib/derived/satellites.derived';
-	import SatelliteConfigLoader from '$lib/components/satellites/loaders/SatelliteConfigLoader.svelte';
-	import NoSatelliteConfigLoader from '$lib/components/satellites/loaders/NoSatelliteConfigLoader.svelte';
 
 	interface Props {
 		children: Snippet;

--- a/src/frontend/src/lib/components/modules/loaders/SegmentsLoader.svelte
+++ b/src/frontend/src/lib/components/modules/loaders/SegmentsLoader.svelte
@@ -20,7 +20,8 @@
 
 		// I dislike those kind of "loading guard" pattern but, I don't really see another way
 		// for now to prevent loading twice the list of segments.
-		// // TODO(#767): in the future, remove the state and load segments with query+update
+		// TODO(#767): in the future, remove the state and load segments with query+update
+		// TODO: likewise in SatelliteConfigLoader
 		if (loading) {
 			return;
 		}

--- a/src/frontend/src/lib/components/satellites/loaders/NoSatelliteConfigLoader.svelte
+++ b/src/frontend/src/lib/components/satellites/loaders/NoSatelliteConfigLoader.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { type Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
+{@render children()}

--- a/src/frontend/src/lib/components/satellites/loaders/NoSatelliteConfigLoader.svelte
+++ b/src/frontend/src/lib/components/satellites/loaders/NoSatelliteConfigLoader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type Snippet } from 'svelte';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		children: Snippet;

--- a/src/frontend/src/lib/components/satellites/loaders/SatelliteConfigLoader.svelte
+++ b/src/frontend/src/lib/components/satellites/loaders/SatelliteConfigLoader.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { type Snippet, untrack } from 'svelte';
-	import type { Satellite } from '$lib/types/satellite';
-	import { loadSatelliteConfig } from '$lib/services/satellite/satellite-config.services';
-	import { satellite } from '$lib/derived/satellite.derived';
-	import type { Option } from '$lib/types/utils';
 	import { isNullish } from '@dfinity/utils';
+	import { type Snippet, untrack } from 'svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import { satellite } from '$lib/derived/satellite.derived';
+	import { loadSatelliteConfig } from '$lib/services/satellite/satellite-config.services';
+	import type { Satellite } from '$lib/types/satellite';
+	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		children: Snippet;

--- a/src/frontend/src/lib/components/satellites/loaders/SatelliteConfigLoader.svelte
+++ b/src/frontend/src/lib/components/satellites/loaders/SatelliteConfigLoader.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { type Snippet, untrack } from 'svelte';
+	import type { Satellite } from '$lib/types/satellite';
+	import { loadSatelliteConfig } from '$lib/services/satellite/satellite-config.services';
+	import { satellite } from '$lib/derived/satellite.derived';
+	import type { Option } from '$lib/types/utils';
+	import { isNullish } from '@dfinity/utils';
+	import { authIdentity } from '$lib/derived/auth.derived';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	let loading = $state(false);
+
+	const load = async (satellite: Option<Satellite>) => {
+		// Satellite is either not loaded or not found
+		if (isNullish(satellite)) {
+			return;
+		}
+
+		if (loading) {
+			return;
+		}
+
+		loading = true;
+
+		await loadSatelliteConfig({
+			satelliteId: satellite.satellite_id,
+			identity: $authIdentity
+		});
+
+		loading = false;
+	};
+
+	$effect(() => {
+		$satellite;
+
+		untrack(() => {
+			load($satellite);
+		});
+	});
+</script>
+
+{@render children()}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -681,6 +681,7 @@
 		"cannot_fetch_logs": "Unexpected error(s) while fetching the logs.",
 		"authentication_config_loading": "Unexpected error(s) while loading the configuration of the authentication.",
 		"automation_config_loading": "Unexpected error(s) while loading the configuration of the automation.",
+		"satellite_config_loading": "Unexpected error(s) while loading the configuration of the Satellite.",
 		"no_file_selected_for_upload": "No file was selected for the upload.",
 		"upload_error": "Unexpected error(s) while uploading the file.",
 		"set_asset_token_error": "Unexpected error(s) while updating the access token of the asset.",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -683,6 +683,7 @@
 		"cannot_fetch_logs": "获取日志时发生意外错误。",
 		"authentication_config_loading": "加载认证配置时发生意外错误。",
 		"automation_config_loading": "加载自动化配置时发生意外错误。",
+		"satellite_config_loading": "加载 Satellite 配置时发生意外错误。",
 		"no_file_selected_for_upload": "未选择上传文件。",
 		"upload_error": "上传文件时发生意外错误。",
 		"set_asset_token_error": "更新资产访问令牌时发生意外错误。",

--- a/src/frontend/src/lib/services/satellite/satellite-config.services.ts
+++ b/src/frontend/src/lib/services/satellite/satellite-config.services.ts
@@ -21,8 +21,6 @@ export const loadSatelliteConfig = async ({
 	const existingConfigs = get(uncertifiedSatellitesConfigsStore);
 	const existingConfig = existingConfigs?.[satelliteId.toText()];
 
-	console.log(existingConfig);
-
 	if (nonNullish(existingConfig) && !reload) {
 		return { result: 'skip' };
 	}

--- a/src/frontend/src/lib/services/satellite/satellite-config.services.ts
+++ b/src/frontend/src/lib/services/satellite/satellite-config.services.ts
@@ -1,0 +1,55 @@
+import { i18n } from '$lib/stores/app/i18n.store';
+import { toasts } from '$lib/stores/app/toasts.store';
+import { nonNullish } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+import { getConfig } from '$lib/api/satellites.api';
+import { uncertifiedSatellitesConfigsStore } from '$lib/stores/satellite/satellites-configs.store';
+import type { OptionIdentity } from '$lib/types/itentity';
+import type { SatelliteId } from '$lib/types/satellite';
+
+export const loadSatelliteConfig = async ({
+	satelliteId,
+	identity,
+	reload = false
+}: {
+	satelliteId: SatelliteId;
+	identity: OptionIdentity;
+	reload?: boolean;
+}): Promise<{ result: 'skip' | 'success' | 'error' }> => {
+	// We load only once per session or when required.
+	const existingConfigs = get(uncertifiedSatellitesConfigsStore);
+	const existingConfig = existingConfigs?.[satelliteId.toText()];
+
+	console.log(existingConfig);
+
+	if (nonNullish(existingConfig) && !reload) {
+		return { result: 'skip' };
+	}
+
+	try {
+		const config = await getConfig({
+			identity,
+			satelliteId
+		});
+
+		uncertifiedSatellitesConfigsStore.set({
+			canisterId: satelliteId.toText(),
+			data: {
+				data: config,
+				certified: false
+			}
+		});
+
+		return { result: 'success' };
+	} catch (err: unknown) {
+		const labels = get(i18n);
+
+		toasts.error({
+			text: labels.errors.satellite_config_loading,
+			detail: err
+		});
+
+		return { result: 'error' };
+	}
+};

--- a/src/frontend/src/lib/stores/satellite/satellites-configs.store.ts
+++ b/src/frontend/src/lib/stores/satellite/satellites-configs.store.ts
@@ -1,0 +1,5 @@
+import type { SatelliteDid } from '$declarations';
+import { initPerCertifiedCanisterStore } from '$lib/stores/_certified-canister.store';
+
+export const uncertifiedSatellitesConfigsStore =
+	initPerCertifiedCanisterStore<SatelliteDid.Config>();

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -699,6 +699,7 @@ interface I18nErrors {
 	cannot_fetch_logs: string;
 	authentication_config_loading: string;
 	automation_config_loading: string;
+	satellite_config_loading: string;
 	no_file_selected_for_upload: string;
 	upload_error: string;
 	set_asset_token_error: string;

--- a/src/frontend/src/routes/(split)/deployments/+page.svelte
+++ b/src/frontend/src/routes/(split)/deployments/+page.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <IdentityGuard>
-	<Loaders>
+	<Loaders satelliteConfig>
 		<SatelliteGuard>
 			{#snippet content(satellite)}
 				<Tabs>


### PR DESCRIPTION
# Motivation

- In the future we want to display GitHub deployments on more screen, therefore we need a store for the automation config and a loader
- On the automation screen, we need to display the tabs only when the config is loaded which is easier with a store
- We can load any configuration through a single endpoint which is cheaper than loading automation and authentication separatly
