### PR TITLE
chore(release): set module (console, satellite and sputnik) versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "candid",
  "ciborium",
@@ -1917,7 +1917,7 @@ checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "satellite"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "candid",
  "ic-cdk",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "sputnik"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "candid",

--- a/src/console/Cargo.toml
+++ b/src/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "console"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 publish = false
 

--- a/src/libs/satellite/Cargo.toml
+++ b/src/libs/satellite/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "MIT"
 
 [package.metadata.juno.satellite]
-version = "0.1.6"
+version = "0.2.0"
 
 [package.metadata.docs.rs]
 targets = ["wasm32-unknown-unknown"]

--- a/src/satellite/Cargo.toml
+++ b/src/satellite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satellite"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/src/sputnik/Cargo.toml
+++ b/src/sputnik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnik"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
# Notes

Not a breaking changes per sé but, we bump to v0.2.0 Satellite and Sputnik for making the introduction of automation support more obvious.
