### PR TITLE
feat(frontend): cache config

### DIFF
--- a/src/frontend/src/lib/components/app/loaders/AppLoader.svelte
+++ b/src/frontend/src/lib/components/app/loaders/AppLoader.svelte
@@ -3,6 +3,7 @@
 	import { authNotSignedIn } from '$lib/derived/auth.derived';
 	import { syncSnapshots } from '$lib/services/ic-mgmt/snapshots.services';
 	import { syncSubnets } from '$lib/services/ic-mgmt/subnets.services';
+	import { syncSatellitesConfig } from '$lib/services/satellite/satellite-config.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
 
 	interface Props {
@@ -11,7 +12,8 @@
 
 	let { children }: Props = $props();
 
-	const syncIdbData = async () => await Promise.all([syncSubnets(), syncSnapshots()]);
+	const syncIdbData = async () =>
+		await Promise.all([syncSubnets(), syncSnapshots(), syncSatellitesConfig()]);
 
 	onMount(i18n.init);
 

--- a/src/frontend/src/lib/services/_idb-store.services.ts
+++ b/src/frontend/src/lib/services/_idb-store.services.ts
@@ -1,4 +1,5 @@
 import type { CanisterStore } from '$lib/stores/_canister.store';
+import type { CertifiedCanisterStore } from '$lib/stores/_certified-canister.store';
 import type { CanisterIdText } from '$lib/types/canister';
 import { clear, del, entries as idbEntries, set, type UseStore } from 'idb-keyval';
 
@@ -49,7 +50,7 @@ export const resetIdbStore = async <T>({
 	canisterId
 }: {
 	customStore: UseStore;
-	store: CanisterStore<T>;
+	store: CanisterStore<T> | CertifiedCanisterStore<T>;
 	canisterId: CanisterIdText;
 }) => {
 	store.reset(canisterId);
@@ -62,7 +63,7 @@ export const resetAllIdbStore = async <T>({
 	store
 }: {
 	customStore: UseStore;
-	store: CanisterStore<T>;
+	store: CanisterStore<T> | CertifiedCanisterStore<T>;
 }) => {
 	store.resetAll();
 

--- a/src/frontend/src/lib/services/_idb-store.uncertified.services.ts
+++ b/src/frontend/src/lib/services/_idb-store.uncertified.services.ts
@@ -1,0 +1,53 @@
+import type { CertifiedCanisterStore } from '$lib/stores/_certified-canister.store';
+import type { CanisterIdText } from '$lib/types/canister';
+import type { CertifiedData } from '$lib/types/store';
+import { entries as idbEntries, set, type UseStore } from 'idb-keyval';
+
+// We consider any data saved in IDB as not being certified. That's why we save those without any certified flags
+// but always read those with certified: false
+
+export const syncUncertifiedIdbStore = async <T>({
+	customStore,
+	store
+}: {
+	customStore: UseStore;
+	store: CertifiedCanisterStore<T>;
+}) => {
+	const entries = await idbEntries<CanisterIdText, T>(customStore);
+
+	store.setAll(
+		entries.length === 0
+			? undefined
+			: entries.reduce(
+					(acc, [key, data]) => ({
+						...acc,
+						[key]: {
+							data,
+							certified: undefined
+						}
+					}),
+					{}
+				)
+	);
+};
+
+export const setUncertifiedIdbStore = async <T>({
+	customStore,
+	store,
+	canisterId,
+	data: certifiedData
+}: {
+	customStore: UseStore;
+	store: CertifiedCanisterStore<T>;
+	canisterId: CanisterIdText;
+	data: CertifiedData<T>;
+}) => {
+	const { data, certified } = certifiedData;
+
+	store.set({
+		canisterId,
+		data: { data, certified }
+	});
+
+	await set(canisterId, data, customStore);
+};

--- a/src/frontend/src/lib/services/console/auth/auth.services.ts
+++ b/src/frontend/src/lib/services/console/auth/auth.services.ts
@@ -1,5 +1,6 @@
 import { resetSnapshots } from '$lib/services/ic-mgmt/snapshots.services';
 import { resetSubnets } from '$lib/services/ic-mgmt/subnets.services';
+import { resetSatellitesConfig } from '$lib/services/satellite/satellite-config.services';
 import { busy } from '$lib/stores/app/busy.store';
 import { i18n } from '$lib/stores/app/i18n.store';
 import {
@@ -89,7 +90,8 @@ const logout = async ({
 			clear(icpToCyclesRateIdbStore),
 			resetSnapshots(),
 			resetSubnets(),
-			resetLocalStorage()
+			resetLocalStorage(),
+			resetSatellitesConfig()
 		]);
 	}
 

--- a/src/frontend/src/lib/stores/app/idb.store.ts
+++ b/src/frontend/src/lib/stores/app/idb.store.ts
@@ -15,3 +15,7 @@ export const icpToCyclesRateIdbStore = createStore(
 // Loaded and set on the UI side
 export const snapshotsIdbStore = createStore('juno-snapshot', 'juno-snapshot-store');
 export const subnetsIdbStore = createStore('juno-subnet', 'juno-subnet-store');
+export const satellitesConfigIdbStore = createStore(
+	'juno-satellite-config',
+	'juno-satellite-config-store'
+);

--- a/src/frontend/src/lib/stores/satellite/satellites-configs.store.ts
+++ b/src/frontend/src/lib/stores/satellite/satellites-configs.store.ts
@@ -1,5 +1,4 @@
 import type { SatelliteDid } from '$declarations';
-import { initPerCertifiedCanisterStore } from '$lib/stores/_certified-canister.store';
+import { initCertifiedCanisterStore } from '$lib/stores/_certified-canister.store';
 
-export const uncertifiedSatellitesConfigsStore =
-	initPerCertifiedCanisterStore<SatelliteDid.Config>();
+export const uncertifiedSatellitesConfigsStore = initCertifiedCanisterStore<SatelliteDid.Config>();

--- a/src/frontend/src/lib/types/store.ts
+++ b/src/frontend/src/lib/types/store.ts
@@ -1,4 +1,4 @@
 export interface CertifiedData<T> {
 	data: T;
-	certified: boolean;
+	certified: boolean | undefined;
 }


### PR DESCRIPTION
# Motivation

We want to cache the config in IDB this way the "Loading your configuration..." spinner should be displayed less often. We keep reloading once per session this way the information is up-to-date in case the dev updated the config with the cli.
