### PR TITLE
feat(sputnik): migrate usage of spawn_017_compat to spawn

### DIFF
--- a/src/sputnik/src/hooks/db/on_delete_doc.rs
+++ b/src/sputnik/src/hooks/db/on_delete_doc.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_delete_doc_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnDeleteDocContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_delete_doc(context: OnDeleteDocContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {

--- a/src/sputnik/src/hooks/db/on_delete_filtered_docs.rs
+++ b/src/sputnik/src/hooks/db/on_delete_filtered_docs.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_delete_filtered_docs_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnDeleteFilteredDocsContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_delete_filtered_docs(context: OnDeleteFilteredDocsContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {

--- a/src/sputnik/src/hooks/db/on_delete_many_docs.rs
+++ b/src/sputnik/src/hooks/db/on_delete_many_docs.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_delete_many_docs_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnDeleteManyDocsContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_delete_many_docs(context: OnDeleteManyDocsContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {

--- a/src/sputnik/src/hooks/db/on_set_doc.rs
+++ b/src/sputnik/src/hooks/db/on_set_doc.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_set_doc_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnSetDocContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_set_doc(context: OnSetDocContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {

--- a/src/sputnik/src/hooks/db/on_set_many_docs.rs
+++ b/src/sputnik/src/hooks/db/on_set_many_docs.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_set_many_docs_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnSetManyDocsContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_set_many_docs(context: OnSetManyDocsContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {

--- a/src/sputnik/src/hooks/storage/on_delete_asset.rs
+++ b/src/sputnik/src/hooks/storage/on_delete_asset.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_delete_asset_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnDeleteAssetContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_delete_asset(context: OnDeleteAssetContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {

--- a/src/sputnik/src/hooks/storage/on_delete_filtered_assets.rs
+++ b/src/sputnik/src/hooks/storage/on_delete_filtered_assets.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_delete_filtered_assets_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnDeleteFilteredAssetsContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_delete_filtered_assets(context: OnDeleteFilteredAssetsContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {

--- a/src/sputnik/src/hooks/storage/on_delete_many_assets.rs
+++ b/src/sputnik/src/hooks/storage/on_delete_many_assets.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_delete_many_assets_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnDeleteManyAssetsContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_delete_many_assets(context: OnDeleteManyAssetsContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {

--- a/src/sputnik/src/hooks/storage/on_upload_asset.rs
+++ b/src/sputnik/src/hooks/storage/on_upload_asset.rs
@@ -3,14 +3,14 @@ use crate::hooks::js::runtime::types::OnJsHook;
 use crate::hooks::js::sdk::init_sdk;
 use crate::js::runtime::{execute_async_js, RunAsyncJsFn};
 use crate::state::store::get_on_upload_asset_collections;
-use ic_cdk::futures::spawn_017_compat;
+use ic_cdk::futures::spawn;
 use ic_cdk::trap;
 use junobuild_satellite::OnUploadAssetContext;
 use rquickjs::{Ctx, Error as JsError};
 
 #[no_mangle]
 pub extern "Rust" fn juno_on_upload_asset(context: OnUploadAssetContext) {
-    spawn_017_compat(async move {
+    spawn(async move {
         let execute_context = AsyncJsFnContext { context };
 
         if let Err(e) = execute_async_js(execute_context).await {


### PR DESCRIPTION
# Motivation

Since we are now using the `ic_cdk::set_timer` v1.0.0 (see #2273) it should actually be possible to use `spawn` and not the `spawn_017_compat` function.
