### PR TITLE
feat(macros): migrate usage of spawn_017_compat to spawn

### DIFF
--- a/src/libs/macros/src/parser.rs
+++ b/src/libs/macros/src/parser.rs
@@ -196,7 +196,7 @@ fn parse_on_hook(
     quote! {
         #[no_mangle]
         pub extern "Rust" fn #hook_fn(#hook_param: #hook_param_type) {
-            ic_cdk::futures::spawn_017_compat(async {
+            ic_cdk::futures::spawn(async {
                 let result = #function_call;
                 #hook_return
             });


### PR DESCRIPTION
# Motivation

Similar to #2637

I think we can likely now use the proper `spawn` function.
