### PR TITLE
feat(satellite): keep system collection upgrades

### DIFF
--- a/src/libs/satellite/src/memory/lifecycle.rs
+++ b/src/libs/satellite/src/memory/lifecycle.rs
@@ -6,7 +6,7 @@ use crate::memory::internal::{get_memory_for_upgrade, init_stable_state};
 use crate::memory::state::STATE;
 use crate::memory::utils::init_storage_heap_state;
 use crate::random::init::defer_init_random_seed;
-use crate::rules::upgrade::init_automation_collections;
+use crate::rules::upgrade::init_system_collections;
 use crate::types::state::{HeapState, RuntimeState, State};
 use ciborium::{from_reader, into_writer};
 use junobuild_shared::memory::upgrade::{read_post_upgrade, write_pre_upgrade};
@@ -63,6 +63,5 @@ pub fn post_upgrade() {
 
     invoke_on_post_upgrade();
 
-    // TODO: to be removed - one time upgrade!
-    init_automation_collections();
+    init_system_collections();
 }

--- a/src/libs/satellite/src/rules/upgrade.rs
+++ b/src/libs/satellite/src/rules/upgrade.rs
@@ -4,7 +4,6 @@ use crate::assets::constants::{
 use crate::memory::state::services::{
     with_db_rules, with_db_rules_mut, with_storage_rules, with_storage_rules_mut,
 };
-use crate::memory::state::STATE;
 use ic_cdk::api::time;
 use junobuild_collections::constants::db::{
     COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE, COLLECTION_AUTOMATION_TOKEN_KEY,
@@ -18,7 +17,8 @@ use junobuild_collections::constants::db::{
 };
 use junobuild_collections::types::core::CollectionKey;
 use junobuild_collections::types::interface::SetRule;
-use junobuild_collections::types::rules::{Memory, Rule, Rules};
+use junobuild_collections::types::rules::Rule;
+
 // ---------------------------------------------------------
 // One time upgrade
 // ---------------------------------------------------------
@@ -115,7 +115,7 @@ fn init_db_collection(collection: &CollectionKey, default_rule: SetRule) {
 }
 
 fn init_juno_releases_collection() {
-    init_db_collection(
+    init_storage_collection(
         &CDN_JUNO_RELEASES_COLLECTION_KEY.to_string(),
         COLLECTION_RELEASES_DEFAULT_RULE,
     );

--- a/src/libs/satellite/src/rules/upgrade.rs
+++ b/src/libs/satellite/src/rules/upgrade.rs
@@ -1,4 +1,4 @@
-use crate::memory::state::STATE;
+use crate::memory::state::services::{with_db_rules, with_db_rules_mut};
 use ic_cdk::api::time;
 use junobuild_collections::constants::db::{
     COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE, COLLECTION_AUTOMATION_TOKEN_KEY,
@@ -74,15 +74,10 @@ fn init_automation_workflow_collection() {
 }
 
 fn init_collection(collection: &CollectionKey, default_rule: SetRule) {
-    let col = STATE.with(|state| {
-        let rules = &state.borrow_mut().heap.db.rules;
-        rules.get(collection).cloned()
-    });
+    let col = with_db_rules(|rules| rules.get(collection).cloned());
 
     if col.is_none() {
-        STATE.with(|state| {
-            let rules = &mut state.borrow_mut().heap.db.rules;
-
+        with_db_rules_mut(|rules| {
             let now = time();
 
             let rule = Rule {

--- a/src/libs/satellite/src/rules/upgrade.rs
+++ b/src/libs/satellite/src/rules/upgrade.rs
@@ -3,53 +3,80 @@ use ic_cdk::api::time;
 use junobuild_collections::constants::db::{
     COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE, COLLECTION_AUTOMATION_TOKEN_KEY,
     COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE, COLLECTION_AUTOMATION_WORKFLOW_KEY,
+    COLLECTION_LOG_DEFAULT_RULE, COLLECTION_LOG_KEY, COLLECTION_USER_USAGE_DEFAULT_RULE,
+    COLLECTION_USER_USAGE_KEY,
 };
+use junobuild_collections::constants::db::{
+    COLLECTION_USER_WEBAUTHN_DEFAULT_RULE, COLLECTION_USER_WEBAUTHN_INDEX_DEFAULT_RULE,
+    COLLECTION_USER_WEBAUTHN_INDEX_KEY, COLLECTION_USER_WEBAUTHN_KEY,
+};
+use junobuild_collections::types::core::CollectionKey;
+use junobuild_collections::types::interface::SetRule;
 use junobuild_collections::types::rules::Rule;
 
 // ---------------------------------------------------------
 // One time upgrade
 // ---------------------------------------------------------
 
-pub fn init_automation_collections() {
+pub fn init_system_collections() {
+    // Logs
+    init_log_collection();
+
+    // User usage
+    init_user_usage_collection();
+
+    // WebAuthn authentication
+    init_user_webauthn_collection();
+    init_user_webauthn_index_collection();
+
+    // Automation
     init_automation_token_collection();
     init_automation_workflow_collection();
 }
 
+fn init_log_collection() {
+    init_collection(&COLLECTION_LOG_KEY.to_string(), COLLECTION_LOG_DEFAULT_RULE);
+}
+
+fn init_user_usage_collection() {
+    init_collection(
+        &COLLECTION_USER_USAGE_KEY.to_string(),
+        COLLECTION_USER_USAGE_DEFAULT_RULE,
+    );
+}
+
+fn init_user_webauthn_collection() {
+    init_collection(
+        &COLLECTION_USER_WEBAUTHN_KEY.to_string(),
+        COLLECTION_USER_WEBAUTHN_DEFAULT_RULE,
+    );
+}
+
+fn init_user_webauthn_index_collection() {
+    init_collection(
+        &COLLECTION_USER_WEBAUTHN_INDEX_KEY.to_string(),
+        COLLECTION_USER_WEBAUTHN_INDEX_DEFAULT_RULE,
+    );
+}
+
 fn init_automation_token_collection() {
-    let col = STATE.with(|state| {
-        let rules = &state.borrow_mut().heap.db.rules;
-        rules.get(COLLECTION_AUTOMATION_TOKEN_KEY).cloned()
-    });
-
-    if col.is_none() {
-        STATE.with(|state| {
-            let rules = &mut state.borrow_mut().heap.db.rules;
-
-            let now = time();
-
-            let rule = Rule {
-                read: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.read,
-                write: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.write,
-                memory: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.memory,
-                mutable_permissions: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.mutable_permissions,
-                max_size: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.max_size,
-                max_capacity: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.max_capacity,
-                max_changes_per_user: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.max_changes_per_user,
-                created_at: now,
-                updated_at: now,
-                version: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.version,
-                rate_config: COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE.rate_config,
-            };
-
-            rules.insert(COLLECTION_AUTOMATION_TOKEN_KEY.to_string(), rule.clone());
-        });
-    }
+    init_collection(
+        &COLLECTION_AUTOMATION_TOKEN_KEY.to_string(),
+        COLLECTION_AUTOMATION_TOKEN_DEFAULT_RULE,
+    );
 }
 
 fn init_automation_workflow_collection() {
+    init_collection(
+        &COLLECTION_AUTOMATION_WORKFLOW_KEY.to_string(),
+        COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE,
+    );
+}
+
+fn init_collection(collection: &CollectionKey, default_rule: SetRule) {
     let col = STATE.with(|state| {
         let rules = &state.borrow_mut().heap.db.rules;
-        rules.get(COLLECTION_AUTOMATION_WORKFLOW_KEY).cloned()
+        rules.get(collection).cloned()
     });
 
     if col.is_none() {
@@ -59,22 +86,20 @@ fn init_automation_workflow_collection() {
             let now = time();
 
             let rule = Rule {
-                read: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE.read,
-                write: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE.write,
-                memory: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE.memory,
-                mutable_permissions: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE
-                    .mutable_permissions,
-                max_size: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE.max_size,
-                max_capacity: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE.max_capacity,
-                max_changes_per_user: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE
-                    .max_changes_per_user,
+                read: default_rule.read,
+                write: default_rule.write,
+                memory: default_rule.memory,
+                mutable_permissions: default_rule.mutable_permissions,
+                max_size: default_rule.max_size,
+                max_capacity: default_rule.max_capacity,
+                max_changes_per_user: default_rule.max_changes_per_user,
                 created_at: now,
                 updated_at: now,
-                version: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE.version,
-                rate_config: COLLECTION_AUTOMATION_WORKFLOW_DEFAULT_RULE.rate_config,
+                version: default_rule.version,
+                rate_config: default_rule.rate_config,
             };
 
-            rules.insert(COLLECTION_AUTOMATION_WORKFLOW_KEY.to_string(), rule.clone());
+            rules.insert(collection.to_string(), rule.clone());
         });
     }
 }


### PR DESCRIPTION
# Motivation

Instead of treating system init collection upgrades as one time shot that gets removed, we can keep those as they are guarded ("if collection not yet exist create it else do nothing"). This could be useful if a developer ever skip a version on upgrade (even though we do not recommend it).
