### PR TITLE
feat(utils): serde with serializer and deserializer

### DIFF
--- a/src/libs/utils/src/lib.rs
+++ b/src/libs/utils/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod serializers;
+pub mod with;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{from_slice, to_string, to_vec};

--- a/src/libs/utils/src/with/bigint.rs
+++ b/src/libs/utils/src/with/bigint.rs
@@ -1,0 +1,50 @@
+use crate::serializers::types::DocDataBigInt;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+pub fn serialize<S>(value: &u64, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    DocDataBigInt { value: *value }.serialize(s)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    DocDataBigInt::deserialize(deserializer).map(|d| d.value)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct TestStruct {
+        #[serde(with = "crate::with::bigint")]
+        value: u64,
+    }
+
+    #[test]
+    fn serialize_bigint() {
+        let s = TestStruct { value: 42 };
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert_eq!(json, r#"{"value":{"__bigint__":"42"}}"#);
+    }
+
+    #[test]
+    fn deserialize_bigint() {
+        let json = r#"{"value":{"__bigint__":"42"}}"#;
+        let s: TestStruct = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(s.value, 42);
+    }
+
+    #[test]
+    fn round_trip() {
+        let original = TestStruct { value: u64::MAX };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: TestStruct = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.value, original.value);
+    }
+}

--- a/src/libs/utils/src/with/mod.rs
+++ b/src/libs/utils/src/with/mod.rs
@@ -1,0 +1,3 @@
+pub mod bigint;
+pub mod principal;
+pub mod uint8array;

--- a/src/libs/utils/src/with/principal.rs
+++ b/src/libs/utils/src/with/principal.rs
@@ -1,0 +1,60 @@
+use crate::serializers::types::DocDataPrincipal;
+use candid::Principal;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+pub fn serialize<S>(principal: &Principal, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    DocDataPrincipal { value: *principal }.serialize(s)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Principal, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    DocDataPrincipal::deserialize(deserializer).map(|d| d.value)
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::Principal;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct TestStruct {
+        #[serde(with = "super")]
+        value: Principal,
+    }
+
+    fn p(txt: &str) -> Principal {
+        Principal::from_text(txt).expect("principal text should parse")
+    }
+
+    #[test]
+    fn serialize_principal() {
+        let s = TestStruct {
+            value: p("aaaaa-aa"),
+        };
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert_eq!(json, r#"{"value":{"__principal__":"aaaaa-aa"}}"#);
+    }
+
+    #[test]
+    fn deserialize_principal() {
+        let json = r#"{"value":{"__principal__":"aaaaa-aa"}}"#;
+        let s: TestStruct = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(s.value, p("aaaaa-aa"));
+    }
+
+    #[test]
+    fn round_trip() {
+        let original = TestStruct {
+            value: p("ryjl3-tyaaa-aaaaa-aaaba-cai"),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: TestStruct = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.value, original.value);
+    }
+}

--- a/src/libs/utils/src/with/uint8array.rs
+++ b/src/libs/utils/src/with/uint8array.rs
@@ -1,0 +1,57 @@
+use crate::serializers::types::DocDataUint8Array;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+pub fn serialize<S>(value: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    DocDataUint8Array {
+        value: value.clone(),
+    }
+    .serialize(s)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    DocDataUint8Array::deserialize(deserializer).map(|d| d.value)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct TestStruct {
+        #[serde(with = "super")]
+        value: Vec<u8>,
+    }
+
+    #[test]
+    fn serialize_uint8array() {
+        let s = TestStruct {
+            value: vec![1, 2, 3],
+        };
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert_eq!(json, r#"{"value":{"__uint8array__":[1,2,3]}}"#);
+    }
+
+    #[test]
+    fn deserialize_uint8array() {
+        let json = r#"{"value":{"__uint8array__":[1,2,3]}}"#;
+        let s: TestStruct = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(s.value, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn round_trip() {
+        let original = TestStruct {
+            value: vec![0, 1, 2, 3, 255],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: TestStruct = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.value, original.value);
+    }
+}


### PR DESCRIPTION
# Motivation

Those `with` can be useful instead of declaring e.g. `DocDataPrincipal` but when using directly a `Principal` with a doc

```
#[derive(Serialize, Deserialize)]
struct MyDoc {
    #[serde(with = "junobuild_utils::with::principal")]
    owner: Principal,
}

let doc: MyDoc = decode_doc_data(&context.data.data.after.data)?;
```

