### PR TITLE
feat(utils): keep but duplicate/rename doc data to json data

### DIFF
--- a/src/libs/utils/src/doc.rs
+++ b/src/libs/utils/src/doc.rs
@@ -1,0 +1,121 @@
+use crate::{decode_json_data, encode_json_data, encode_json_data_to_string};
+use serde::{Deserialize, Serialize};
+
+/// Decodes serialized document data into a Rust struct, tailored for use with Juno hooks.
+///
+/// This function is a utility for developers working with Juno hooks, particularly
+/// when receiving document data that needs to be processed. It uses Serde's deserialization to
+/// convert a byte slice into a specified Rust data structure, allowing for direct manipulation
+/// of document data within hook functions.
+///
+/// # Parameters
+/// - `data`: A byte slice (`&[u8]`) containing the serialized document data.
+///
+/// # Returns
+/// - `Ok(T)`: Successfully deserialized data of type `T`.
+/// - `Err(String)`: An error string if deserialization fails.
+///
+/// # Examples
+/// Within a Juno hook, you might receive document data that needs to be decoded:
+/// ```rust
+/// #[derive(Serialize, Deserialize)]
+/// struct Person {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// #[on_set_doc(collections = ["people"])]
+/// async fn handle_set_person_doc(context: OnSetDocContext) -> Result<(), String> {
+///     let person: Person = decode_doc_data(&context.data.data.after.data)
+///         .expect("Failed to decode document data");
+///
+///     // Proceed with custom logic for the decoded `Person` instance
+///     println!("Received document for person: {}", person.name);
+///
+///     Ok(())
+/// }
+/// ```
+pub fn decode_doc_data<T: for<'a> Deserialize<'a>>(data: &[u8]) -> Result<T, String> {
+    decode_json_data::<T>(data)
+}
+
+/// Encodes a Rust struct into serialized document data, designed for use with Juno hooks.
+///
+/// When preparing document data to be stored, this function facilitates the serialization
+/// of a Rust data structure into a byte vector. It leverages Serde's serialization capabilities,
+/// ensuring that any Rust type implementing the `Serialize` trait can be efficiently converted
+/// into a format compatible with Juno's document requirements.
+///
+/// # Parameters
+/// - `data`: A reference to the Rust data structure to be serialized.
+///
+/// # Returns
+/// - `Ok(Vec<u8>)`: A byte vector containing the serialized data.
+/// - `Err(String)`: An error string if serialization fails.
+///
+/// # Examples
+/// In a Juno hook, you might want to modify and then store updated document data:
+/// ```rust
+/// #[derive(Serialize, Deserialize)]
+/// struct Person {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// #[on_set_doc(collections = ["people"])]
+/// async fn handle_set_person_doc(context: OnSetDocContext) -> Result<(), String> {
+///     let mut person: Person = decode_doc_data(&context.data.data.after.data)?;
+///     person.age += 1; // Increment the person's age
+///
+///     let updated_data = encode_doc_data(&person)
+///         .expect("Failed to serialize updated document data");
+///
+///     // Use `updated_data` to store the modified document
+///
+///     Ok(())
+/// }
+/// ```
+pub fn encode_doc_data<T: Serialize>(data: &T) -> Result<Vec<u8>, String> {
+    encode_json_data::<T>(data)
+}
+
+/// Encodes a Rust struct into a JSON string, designed for use with Juno hooks.
+///
+/// This function facilitates the serialization
+/// of a Rust data structure representing a document data into a JSON string.
+/// It leverages Serde's serialization capabilities,
+/// ensuring that any Rust type implementing the `Serialize` trait can be efficiently converted
+/// into a format compatible with Juno's document requirements.
+///
+/// # Parameters
+/// - `data`: A reference to the Rust data structure to be serialized.
+///
+/// # Returns
+/// - `Ok(String)`: A JSON string containing the serialized data.
+/// - `Err(String)`: An error string if serialization fails.
+///
+/// # Examples
+/// In a Juno hook, you might want to modify and then store updated document data:
+/// ```rust
+/// #[derive(Serialize, Deserialize)]
+/// struct Person {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// #[on_set_doc(collections = ["people"])]
+/// async fn handle_set_person_doc(context: OnSetDocContext) -> Result<(), String> {
+///     let mut person: Person = decode_doc_data(&context.data.data.after.data)?;
+///     person.age += 1; // Increment the person's age
+///
+///     let updated_data = encode_doc_data_to_string(&person)
+///         .expect("Failed to serialize updated document data");
+///
+///     // Use `updated_data` to store the modified document
+///
+///     Ok(())
+/// }
+/// ```
+pub fn encode_doc_data_to_string<T: Serialize>(data: &T) -> Result<String, String> {
+    encode_json_data_to_string::<T>(data)
+}

--- a/src/libs/utils/src/json.rs
+++ b/src/libs/utils/src/json.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{from_slice, to_string, to_vec};
+
+/// Decodes JSON data into a Rust struct.
+///
+/// Deserializes a byte slice into the specified type using Serde and `serde_json`.
+/// Supports Juno's extended JSON conventions for IC types such as `Principal`, `u64` (bigint),
+/// and `Vec<u8>` (Uint8Array), which are encoded using `@dfinity/utils` compatible markers.
+///
+/// # Parameters
+/// - `data`: A byte slice (`&[u8]`) containing the JSON-encoded data.
+///
+/// # Returns
+/// - `Ok(T)`: Successfully deserialized data of type `T`.
+/// - `Err(String)`: An error string if deserialization fails.
+///
+/// # Example
+///
+/// ```rust
+/// #[derive(Deserialize)]
+/// struct MyData {
+///     name: String,
+/// }
+///
+/// let data: MyData = decode_json_data(bytes)?;
+/// ```
+pub fn decode_json_data<T: for<'a> Deserialize<'a>>(data: &[u8]) -> Result<T, String> {
+    from_slice::<T>(data).map_err(|e| e.to_string())
+}
+
+/// Encodes a Rust struct into JSON bytes.
+///
+/// Serializes the provided data into a byte vector using Serde and `serde_json`.
+/// Supports Juno's extended JSON conventions for IC types such as `Principal`, `u64` (bigint),
+/// and `Vec<u8>` (Uint8Array), which are encoded using `@dfinity/utils` compatible markers.
+///
+/// # Parameters
+/// - `data`: A reference to the Rust data structure to be serialized.
+///
+/// # Returns
+/// - `Ok(Vec<u8>)`: A byte vector containing the JSON-encoded data.
+/// - `Err(String)`: An error string if serialization fails.
+///
+/// # Example
+///
+/// ```rust
+/// #[derive(Serialize)]
+/// struct MyData {
+///     name: String,
+/// }
+///
+/// let bytes = encode_json_data(&my_data)?;
+/// ```
+pub fn encode_json_data<T: Serialize>(data: &T) -> Result<Vec<u8>, String> {
+    to_vec(data).map_err(|e| e.to_string())
+}
+
+/// Encodes a Rust struct into a JSON string.
+///
+/// Serializes the provided data into a `String` using Serde and `serde_json`.
+/// Supports Juno's extended JSON conventions for IC types such as `Principal`, `u64` (bigint),
+/// and `Vec<u8>` (Uint8Array), which are encoded using `@dfinity/utils` compatible markers.
+///
+/// # Parameters
+/// - `data`: A reference to the Rust data structure to be serialized.
+///
+/// # Returns
+/// - `Ok(String)`: A JSON string containing the serialized data.
+/// - `Err(String)`: An error string if serialization fails.
+///
+/// # Example
+///
+/// ```rust
+/// #[derive(Serialize)]
+/// struct MyData {
+///     name: String,
+/// }
+///
+/// let json = encode_json_data_to_string(&my_data)?;
+/// ```
+pub fn encode_json_data_to_string<T: Serialize>(data: &T) -> Result<String, String> {
+    to_string(data).map_err(|e| e.to_string())
+}

--- a/src/libs/utils/src/lib.rs
+++ b/src/libs/utils/src/lib.rs
@@ -1,128 +1,14 @@
 #![doc = include_str!("../README.md")]
 
+mod doc;
+mod json;
 mod serializers;
 pub mod with;
 
-use serde::{Deserialize, Serialize};
-use serde_json::{from_slice, to_string, to_vec};
+pub use doc::*;
+pub use json::*;
 
-pub use crate::serializers::types::{DocDataBigInt, DocDataPrincipal, DocDataUint8Array};
-
-/// Decodes serialized document data into a Rust struct, tailored for use with Juno hooks.
-///
-/// This function is a utility for developers working with Juno hooks, particularly
-/// when receiving document data that needs to be processed. It uses Serde's deserialization to
-/// convert a byte slice into a specified Rust data structure, allowing for direct manipulation
-/// of document data within hook functions.
-///
-/// # Parameters
-/// - `data`: A byte slice (`&[u8]`) containing the serialized document data.
-///
-/// # Returns
-/// - `Ok(T)`: Successfully deserialized data of type `T`.
-/// - `Err(String)`: An error string if deserialization fails.
-///
-/// # Examples
-/// Within a Juno hook, you might receive document data that needs to be decoded:
-/// ```rust
-/// #[derive(Serialize, Deserialize)]
-/// struct Person {
-///     name: String,
-///     age: u32,
-/// }
-///
-/// #[on_set_doc(collections = ["people"])]
-/// async fn handle_set_person_doc(context: OnSetDocContext) -> Result<(), String> {
-///     let person: Person = decode_doc_data(&context.data.data.after.data)
-///         .expect("Failed to decode document data");
-///
-///     // Proceed with custom logic for the decoded `Person` instance
-///     println!("Received document for person: {}", person.name);
-///
-///     Ok(())
-/// }
-/// ```
-pub fn decode_doc_data<T: for<'a> Deserialize<'a>>(data: &[u8]) -> Result<T, String> {
-    from_slice::<T>(data).map_err(|e| e.to_string())
-}
-
-/// Encodes a Rust struct into serialized document data, designed for use with Juno hooks.
-///
-/// When preparing document data to be stored, this function facilitates the serialization
-/// of a Rust data structure into a byte vector. It leverages Serde's serialization capabilities,
-/// ensuring that any Rust type implementing the `Serialize` trait can be efficiently converted
-/// into a format compatible with Juno's document requirements.
-///
-/// # Parameters
-/// - `data`: A reference to the Rust data structure to be serialized.
-///
-/// # Returns
-/// - `Ok(Vec<u8>)`: A byte vector containing the serialized data.
-/// - `Err(String)`: An error string if serialization fails.
-///
-/// # Examples
-/// In a Juno hook, you might want to modify and then store updated document data:
-/// ```rust
-/// #[derive(Serialize, Deserialize)]
-/// struct Person {
-///     name: String,
-///     age: u32,
-/// }
-///
-/// #[on_set_doc(collections = ["people"])]
-/// async fn handle_set_person_doc(context: OnSetDocContext) -> Result<(), String> {
-///     let mut person: Person = decode_doc_data(&context.data.data.after.data)?;
-///     person.age += 1; // Increment the person's age
-///
-///     let updated_data = encode_doc_data(&person)
-///         .expect("Failed to serialize updated document data");
-///
-///     // Use `updated_data` to store the modified document
-///
-///     Ok(())
-/// }
-/// ```
-pub fn encode_doc_data<T: Serialize>(data: &T) -> Result<Vec<u8>, String> {
-    to_vec(data).map_err(|e| e.to_string())
-}
-
-/// Encodes a Rust struct into a JSON string, designed for use with Juno hooks.
-///
-/// This function facilitates the serialization
-/// of a Rust data structure representing a document data into a JSON string.
-/// It leverages Serde's serialization capabilities,
-/// ensuring that any Rust type implementing the `Serialize` trait can be efficiently converted
-/// into a format compatible with Juno's document requirements.
-///
-/// # Parameters
-/// - `data`: A reference to the Rust data structure to be serialized.
-///
-/// # Returns
-/// - `Ok(String)`: A JSON string containing the serialized data.
-/// - `Err(String)`: An error string if serialization fails.
-///
-/// # Examples
-/// In a Juno hook, you might want to modify and then store updated document data:
-/// ```rust
-/// #[derive(Serialize, Deserialize)]
-/// struct Person {
-///     name: String,
-///     age: u32,
-/// }
-///
-/// #[on_set_doc(collections = ["people"])]
-/// async fn handle_set_person_doc(context: OnSetDocContext) -> Result<(), String> {
-///     let mut person: Person = decode_doc_data(&context.data.data.after.data)?;
-///     person.age += 1; // Increment the person's age
-///
-///     let updated_data = encode_doc_data_to_string(&person)
-///         .expect("Failed to serialize updated document data");
-///
-///     // Use `updated_data` to store the modified document
-///
-///     Ok(())
-/// }
-/// ```
-pub fn encode_doc_data_to_string<T: Serialize>(data: &T) -> Result<String, String> {
-    to_string(data).map_err(|e| e.to_string())
-}
+pub use crate::serializers::types::{
+    DocDataBigInt, DocDataPrincipal, DocDataUint8Array, JsonDataBigInt, JsonDataPrincipal,
+    JsonDataUint8Array,
+};

--- a/src/libs/utils/src/serializers/bigint.rs
+++ b/src/libs/utils/src/serializers/bigint.rs
@@ -1,16 +1,16 @@
-use crate::serializers::types::DocDataBigInt;
+use crate::serializers::types::JsonDataBigInt;
 use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
-impl fmt::Display for DocDataBigInt {
+impl fmt::Display for JsonDataBigInt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.value)
     }
 }
 
-impl Serialize for DocDataBigInt {
+impl Serialize for JsonDataBigInt {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -21,7 +21,7 @@ impl Serialize for DocDataBigInt {
     }
 }
 
-impl<'de> Deserialize<'de> for DocDataBigInt {
+impl<'de> Deserialize<'de> for JsonDataBigInt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -33,13 +33,13 @@ impl<'de> Deserialize<'de> for DocDataBigInt {
 struct DocDataBigIntVisitor;
 
 impl<'de> Visitor<'de> for DocDataBigIntVisitor {
-    type Value = DocDataBigInt;
+    type Value = JsonDataBigInt;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("an object with a key __bigint__")
     }
 
-    fn visit_map<V>(self, mut map: V) -> Result<DocDataBigInt, V::Error>
+    fn visit_map<V>(self, mut map: V) -> Result<JsonDataBigInt, V::Error>
     where
         V: MapAccess<'de>,
     {
@@ -56,7 +56,7 @@ impl<'de> Visitor<'de> for DocDataBigIntVisitor {
         let bigint_value = value_str
             .parse::<u64>()
             .map_err(|_| de::Error::custom("Invalid format for __bigint__"))?;
-        Ok(DocDataBigInt {
+        Ok(JsonDataBigInt {
             value: bigint_value,
         })
     }
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn serialize_doc_data_bigint() {
-        let data = DocDataBigInt {
+        let data = JsonDataBigInt {
             value: 12345678901234,
         };
         let s = serde_json::to_string(&data).expect("serialize");
@@ -79,21 +79,21 @@ mod tests {
     #[test]
     fn deserialize_doc_data_bigint() {
         let s = r#"{"__bigint__":"12345678901234"}"#;
-        let data: DocDataBigInt = serde_json::from_str(s).expect("deserialize");
+        let data: JsonDataBigInt = serde_json::from_str(s).expect("deserialize");
         assert_eq!(data.value, 12345678901234);
     }
 
     #[test]
     fn round_trip() {
-        let original = DocDataBigInt { value: u64::MAX };
+        let original = JsonDataBigInt { value: u64::MAX };
         let json = serde_json::to_string(&original).unwrap();
-        let decoded: DocDataBigInt = serde_json::from_str(&json).unwrap();
+        let decoded: JsonDataBigInt = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.value, original.value);
     }
 
     #[test]
     fn error_on_missing_field() {
-        let err = serde_json::from_str::<DocDataBigInt>(r#"{}"#).unwrap_err();
+        let err = serde_json::from_str::<JsonDataBigInt>(r#"{}"#).unwrap_err();
         assert!(
             err.to_string().contains("missing field `__bigint__`"),
             "got: {err}"
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn error_on_duplicate_field() {
         let s = r#"{"__bigint__":"123","__bigint__":"456"}"#;
-        let err = serde_json::from_str::<DocDataBigInt>(s).unwrap_err();
+        let err = serde_json::from_str::<JsonDataBigInt>(s).unwrap_err();
         assert!(
             err.to_string().contains("duplicate field `__bigint__`"),
             "got: {err}"
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn error_on_invalid_bigint_format() {
         let s = r#"{"__bigint__":"not-a-number"}"#;
-        let err = serde_json::from_str::<DocDataBigInt>(s).unwrap_err();
+        let err = serde_json::from_str::<JsonDataBigInt>(s).unwrap_err();
         assert!(
             err.to_string().contains("Invalid format for __bigint__"),
             "got: {err}"
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn test_display_implementation() {
-        let data = DocDataBigInt {
+        let data = JsonDataBigInt {
             value: 12345678901234,
         };
         assert_eq!(format!("{}", data), "12345678901234");

--- a/src/libs/utils/src/serializers/principal.rs
+++ b/src/libs/utils/src/serializers/principal.rs
@@ -1,11 +1,11 @@
-use crate::serializers::types::DocDataPrincipal;
+use crate::serializers::types::JsonDataPrincipal;
 use candid::Principal as CandidPrincipal;
 use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
-impl Serialize for DocDataPrincipal {
+impl Serialize for JsonDataPrincipal {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -16,7 +16,7 @@ impl Serialize for DocDataPrincipal {
     }
 }
 
-impl<'de> Deserialize<'de> for DocDataPrincipal {
+impl<'de> Deserialize<'de> for JsonDataPrincipal {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -32,13 +32,13 @@ impl<'de> Deserialize<'de> for DocDataPrincipal {
 struct DocDataPrincipalVisitor;
 
 impl<'de> Visitor<'de> for DocDataPrincipalVisitor {
-    type Value = DocDataPrincipal;
+    type Value = JsonDataPrincipal;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("an object with a key __principal__")
     }
 
-    fn visit_map<V>(self, mut map: V) -> Result<DocDataPrincipal, V::Error>
+    fn visit_map<V>(self, mut map: V) -> Result<JsonDataPrincipal, V::Error>
     where
         V: MapAccess<'de>,
     {
@@ -54,7 +54,7 @@ impl<'de> Visitor<'de> for DocDataPrincipalVisitor {
         let value_str = value.ok_or_else(|| de::Error::missing_field("__principal__"))?;
         let principal = CandidPrincipal::from_text(value_str)
             .map_err(|_| de::Error::custom("Invalid format for __principal__"))?;
-        Ok(DocDataPrincipal { value: principal })
+        Ok(JsonDataPrincipal { value: principal })
     }
 }
 
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn serialize_doc_data_principal() {
-        let ddp = DocDataPrincipal {
+        let ddp = JsonDataPrincipal {
             value: p("aaaaa-aa"),
         };
         let s = serde_json::to_string(&ddp).expect("serialize");
@@ -80,23 +80,23 @@ mod tests {
     #[test]
     fn deserialize_doc_data_principal() {
         let s = r#"{"__principal__":"aaaaa-aa"}"#;
-        let ddp: DocDataPrincipal = serde_json::from_str(s).expect("deserialize");
+        let ddp: JsonDataPrincipal = serde_json::from_str(s).expect("deserialize");
         assert_eq!(ddp.value, p("aaaaa-aa"));
     }
 
     #[test]
     fn round_trip() {
-        let original = DocDataPrincipal {
+        let original = JsonDataPrincipal {
             value: p("ryjl3-tyaaa-aaaaa-aaaba-cai"),
         };
         let json = serde_json::to_string(&original).unwrap();
-        let decoded: DocDataPrincipal = serde_json::from_str(&json).unwrap();
+        let decoded: JsonDataPrincipal = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.value, original.value);
     }
 
     #[test]
     fn error_on_missing_field() {
-        let err = serde_json::from_str::<DocDataPrincipal>(r#"{}"#).unwrap_err();
+        let err = serde_json::from_str::<JsonDataPrincipal>(r#"{}"#).unwrap_err();
         assert!(
             err.to_string().contains("missing field `__principal__`"),
             "got: {err}"
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn error_on_duplicate_field() {
         let s = r#"{"__principal__":"aaaaa-aa","__principal__":"aaaaa-aa"}"#;
-        let err = serde_json::from_str::<DocDataPrincipal>(s).unwrap_err();
+        let err = serde_json::from_str::<JsonDataPrincipal>(s).unwrap_err();
         assert!(
             err.to_string().contains("duplicate field `__principal__`"),
             "got: {err}"
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn error_on_invalid_principal_format() {
         let s = r#"{"__principal__":"not-a-principal"}"#;
-        let err = serde_json::from_str::<DocDataPrincipal>(s).unwrap_err();
+        let err = serde_json::from_str::<JsonDataPrincipal>(s).unwrap_err();
         assert!(
             err.to_string().contains("Invalid format for __principal__"),
             "got: {err}"

--- a/src/libs/utils/src/serializers/types.rs
+++ b/src/libs/utils/src/serializers/types.rs
@@ -8,7 +8,7 @@ use candid::Principal as CandidPrincipal;
 /// # Fields
 /// - `value`: The `Principal` this struct wraps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DocDataPrincipal {
+pub struct JsonDataPrincipal {
     pub value: CandidPrincipal,
 }
 
@@ -18,7 +18,7 @@ pub struct DocDataPrincipal {
 /// # Fields
 /// - `value`: A `u64` integer representing the large numeric value encapsulated by this struct.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DocDataBigInt {
+pub struct JsonDataBigInt {
     pub value: u64,
 }
 
@@ -30,6 +30,14 @@ pub struct DocDataBigInt {
 /// # Fields
 /// - `value`: The underlying bytes.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DocDataUint8Array {
+pub struct JsonDataUint8Array {
     pub value: Vec<u8>,
 }
+/// Alias for [`JsonDataPrincipal`].
+pub type DocDataPrincipal = JsonDataPrincipal;
+
+/// Alias for [`JsonDataBigInt`].
+pub type DocDataBigInt = JsonDataBigInt;
+
+/// Alias for [`JsonDataUint8Array`].
+pub type DocDataUint8Array = JsonDataUint8Array;

--- a/src/libs/utils/src/serializers/uint8array.rs
+++ b/src/libs/utils/src/serializers/uint8array.rs
@@ -1,16 +1,16 @@
-use crate::serializers::types::DocDataUint8Array;
+use crate::serializers::types::JsonDataUint8Array;
 use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
-impl fmt::Display for DocDataUint8Array {
+impl fmt::Display for JsonDataUint8Array {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.value)
     }
 }
 
-impl Serialize for DocDataUint8Array {
+impl Serialize for JsonDataUint8Array {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -21,7 +21,7 @@ impl Serialize for DocDataUint8Array {
     }
 }
 
-impl<'de> Deserialize<'de> for DocDataUint8Array {
+impl<'de> Deserialize<'de> for JsonDataUint8Array {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -37,13 +37,13 @@ impl<'de> Deserialize<'de> for DocDataUint8Array {
 struct DocDataUint8ArrayVisitor;
 
 impl<'de> Visitor<'de> for DocDataUint8ArrayVisitor {
-    type Value = DocDataUint8Array;
+    type Value = JsonDataUint8Array;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("an object with a key __uint8array__")
     }
 
-    fn visit_map<V>(self, mut map: V) -> Result<DocDataUint8Array, V::Error>
+    fn visit_map<V>(self, mut map: V) -> Result<JsonDataUint8Array, V::Error>
     where
         V: MapAccess<'de>,
     {
@@ -59,7 +59,7 @@ impl<'de> Visitor<'de> for DocDataUint8ArrayVisitor {
         }
 
         let bytes = value.ok_or_else(|| de::Error::missing_field("__uint8array__"))?;
-        Ok(DocDataUint8Array { value: bytes })
+        Ok(JsonDataUint8Array { value: bytes })
     }
 }
 
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn serialize_doc_data_uint8array() {
-        let data = DocDataUint8Array {
+        let data = JsonDataUint8Array {
             value: vec![1, 2, 3, 5],
         };
         let s = serde_json::to_string(&data).expect("serialize");
@@ -80,23 +80,23 @@ mod tests {
     #[test]
     fn deserialize_doc_data_uint8array() {
         let s = r#"{"__uint8array__":[1,2,3,5]}"#;
-        let data: DocDataUint8Array = serde_json::from_str(s).expect("deserialize");
+        let data: JsonDataUint8Array = serde_json::from_str(s).expect("deserialize");
         assert_eq!(data.value, vec![1, 2, 3, 5]);
     }
 
     #[test]
     fn round_trip() {
-        let original = DocDataUint8Array {
+        let original = JsonDataUint8Array {
             value: vec![0, 1, 2, 3, 5],
         };
         let json = serde_json::to_string(&original).unwrap();
-        let decoded: DocDataUint8Array = serde_json::from_str(&json).unwrap();
+        let decoded: JsonDataUint8Array = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.value, original.value);
     }
 
     #[test]
     fn error_on_missing_field() {
-        let err = serde_json::from_str::<DocDataUint8Array>(r#"{}"#).unwrap_err();
+        let err = serde_json::from_str::<JsonDataUint8Array>(r#"{}"#).unwrap_err();
         assert!(
             err.to_string().contains("missing field `__uint8array__`"),
             "got: {err}"
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn error_on_duplicate_field() {
         let s = r#"{"__uint8array__":[1,2],"__uint8array__":[3,4]}"#;
-        let err = serde_json::from_str::<DocDataUint8Array>(s).unwrap_err();
+        let err = serde_json::from_str::<JsonDataUint8Array>(s).unwrap_err();
         assert!(
             err.to_string().contains("duplicate field `__uint8array__`"),
             "got: {err}"
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn error_on_invalid_uint8array_format() {
         let s = r#"{"__uint8array__":"not-a-uint8array"}"#;
-        let err = serde_json::from_str::<DocDataUint8Array>(s).unwrap_err();
+        let err = serde_json::from_str::<JsonDataUint8Array>(s).unwrap_err();
         assert!(
             err.to_string()
                 .contains("invalid type: string \"not-a-uint8array\""),
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_display_implementation() {
-        let data = DocDataUint8Array {
+        let data = JsonDataUint8Array {
             value: vec![1, 2, 3],
         };
         assert_eq!(format!("{}", data), "[1, 2, 3]");

--- a/src/libs/utils/src/with/bigint.rs
+++ b/src/libs/utils/src/with/bigint.rs
@@ -1,18 +1,18 @@
-use crate::serializers::types::DocDataBigInt;
+use crate::serializers::types::JsonDataBigInt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub fn serialize<S>(value: &u64, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    DocDataBigInt { value: *value }.serialize(s)
+    JsonDataBigInt { value: *value }.serialize(s)
 }
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
 where
     D: Deserializer<'de>,
 {
-    DocDataBigInt::deserialize(deserializer).map(|d| d.value)
+    JsonDataBigInt::deserialize(deserializer).map(|d| d.value)
 }
 
 #[cfg(test)]

--- a/src/libs/utils/src/with/principal.rs
+++ b/src/libs/utils/src/with/principal.rs
@@ -1,4 +1,4 @@
-use crate::serializers::types::DocDataPrincipal;
+use crate::serializers::types::JsonDataPrincipal;
 use candid::Principal;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -6,14 +6,14 @@ pub fn serialize<S>(principal: &Principal, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    DocDataPrincipal { value: *principal }.serialize(s)
+    JsonDataPrincipal { value: *principal }.serialize(s)
 }
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Principal, D::Error>
 where
     D: Deserializer<'de>,
 {
-    DocDataPrincipal::deserialize(deserializer).map(|d| d.value)
+    JsonDataPrincipal::deserialize(deserializer).map(|d| d.value)
 }
 
 #[cfg(test)]

--- a/src/libs/utils/src/with/uint8array.rs
+++ b/src/libs/utils/src/with/uint8array.rs
@@ -1,11 +1,11 @@
-use crate::serializers::types::DocDataUint8Array;
+use crate::serializers::types::JsonDataUint8Array;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub fn serialize<S>(value: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    DocDataUint8Array {
+    JsonDataUint8Array {
         value: value.clone(),
     }
     .serialize(s)
@@ -15,7 +15,7 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    DocDataUint8Array::deserialize(deserializer).map(|d| d.value)
+    JsonDataUint8Array::deserialize(deserializer).map(|d| d.value)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Motivation

In custom functions we want to use the encoder and decoder for data but those are not "doc". So it makes sense to introduce a more generic name while preserving backwards compatibility.
