### PR TITLE
fix(frontend): OpenChat memo leads to "Offset is outside the bounds of the DataView"

### DIFF
--- a/src/frontend/src/lib/types/ic-transaction.ts
+++ b/src/frontend/src/lib/types/ic-transaction.ts
@@ -23,5 +23,5 @@ export interface IcTransactionUi {
 	approveSpender?: string;
 	approveSpenderExplorerUrl?: string;
 	approveExpiresAt?: bigint;
-	memo: bigint;
+	memo: bigint | Uint8Array;
 }

--- a/src/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/src/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -1,5 +1,5 @@
 import type { IcTransactionUi } from '$lib/types/ic-transaction';
-import { fromNullable, jsonReplacer, nonNullish, uint8ArrayToBigInt } from '@dfinity/utils';
+import { fromNullable, jsonReplacer, nonNullish } from '@dfinity/utils';
 import type { AccountIdentifierHex, IcpIndexDid } from '@icp-sdk/canisters/ledger/icp';
 
 export const mapIcpTransaction = ({
@@ -18,7 +18,7 @@ export const mapIcpTransaction = ({
 			const icrc1Memo = fromNullable(icrc1_memo);
 
 			if (nonNullish(icrc1Memo)) {
-				return { memo: uint8ArrayToBigInt(icrc1Memo) };
+				return { memo: icrc1Memo };
 			}
 		}
 

--- a/src/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/src/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -5,8 +5,7 @@ import {
 	fromNullable,
 	fromNullishNullable,
 	jsonReplacer,
-	nonNullish,
-	uint8ArrayToBigInt
+	nonNullish
 } from '@dfinity/utils';
 import {
 	encodeIcrcAccount,
@@ -64,7 +63,7 @@ export const mapIcrcTransaction = ({
 		const icrc1Memo = fromNullable(data?.memo);
 
 		if (nonNullish(icrc1Memo)) {
-			return { memo: uint8ArrayToBigInt(icrc1Memo) };
+			return { memo: icrc1Memo };
 		}
 
 		return { memo: 0n };

--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -85,7 +85,8 @@ const icrcTransactionMemo = ({
 		}
 	};
 
-	// e.g. OpenChat uses 7 length memo like 4f435f53454e44
+	// ICRC memos can be 1–32 bytes, so they may not fit in a u64 (8 bytes).
+	// e.g. OpenChat sends 7-byte memos such as 4f435f53454e44 ("OC_SEND").
 	if (memo.length !== 8) {
 		return decodeIcrc1Memo();
 	}

--- a/src/frontend/src/lib/utils/wallet.utils.ts
+++ b/src/frontend/src/lib/utils/wallet.utils.ts
@@ -13,6 +13,7 @@ import type { IcTransactionUi } from '$lib/types/ic-transaction';
 import { emit } from '$lib/utils/events.utils';
 import { toAccountIdentifier } from '$lib/utils/icp-icrc-account.utils';
 import { waitForMilliseconds } from '$lib/utils/timeout.utils';
+import { uint8ArrayToBigInt, uint8ArrayToHexString } from '@dfinity/utils';
 import { encodeIcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
 import { get } from 'svelte/store';
 
@@ -40,6 +41,72 @@ export const transactionMemo = ({
 
 	const { memo, from } = transaction;
 
+	if (memo instanceof Uint8Array) {
+		return icrcTransactionMemo({ memo, walletId, from });
+	}
+
+	return icpTransactionMemo({ memo, walletId, from });
+};
+
+const icpTransactionMemo = ({
+	memo,
+	walletId,
+	from
+}: { memo: bigint; walletId: WalletId } & Pick<IcTransactionUi, 'from'>): string => {
+	const labels = get(i18n);
+
+	return knownTransactionMemo({
+		memo,
+		fallback: () => {
+			// TODO: likely not performant to encode on each matching transaction...
+			const walletIdText = encodeIcrcAccount(walletId);
+			const accountIdentifier = toAccountIdentifier(walletId);
+
+			if (from === walletIdText || from === accountIdentifier.toHex()) {
+				return labels.wallet.memo_sent;
+			}
+
+			return labels.wallet.memo_received;
+		}
+	});
+};
+
+const icrcTransactionMemo = ({
+	memo,
+	walletId,
+	from
+}: { memo: Uint8Array; walletId: WalletId } & Pick<IcTransactionUi, 'from'>): string => {
+	// Source NNS dapp
+	const decodeIcrc1Memo = (): string => {
+		try {
+			return new TextDecoder('utf-8', { fatal: true }).decode(memo);
+		} catch {
+			return uint8ArrayToHexString(memo);
+		}
+	};
+
+	// e.g. OpenChat uses 7 length memo like 4f435f53454e44
+	if (memo.length !== 8) {
+		return decodeIcrc1Memo();
+	}
+
+	const encodedMemo = uint8ArrayToBigInt(memo);
+
+	return knownTransactionMemo({
+		memo: encodedMemo,
+		fallback: decodeIcrc1Memo
+	});
+};
+
+const knownTransactionMemo = ({
+	memo,
+	fallback
+}: {
+	memo: bigint;
+	fallback: () => string;
+}): string => {
+	const labels = get(i18n);
+
 	switch (memo) {
 		case MEMO_CANISTER_CREATE:
 			return labels.wallet.memo_create;
@@ -54,15 +121,7 @@ export const transactionMemo = ({
 		case MEMO_CMC_MINT_CYCLES:
 			return labels.wallet.memo_convert_icp_to_cycles;
 		default: {
-			// TODO: likely not performant to encode on each matching transaction...
-			const walletIdText = encodeIcrcAccount(walletId);
-			const accountIdentifier = toAccountIdentifier(walletId);
-
-			if (from === walletIdText || from === accountIdentifier.toHex()) {
-				return labels.wallet.memo_sent;
-			}
-
-			return labels.wallet.memo_received;
+			return fallback();
 		}
 	}
 };


### PR DESCRIPTION
# Motivation

Someone reported an issue today as their wallet was displaying a balance of zero even though the transaction of ICP succeeded. The issue is likely the fact that OpenChat uses 7 length icrc memo which crashes the mapping of the memo which in turns crashes the worker that gather transactions and balance.

Source: https://discord.com/channels/1076791076544847982/1076791077308219414/1479496580951445725