### PR TITLE
chore(test): downgrade pic-js to v0.17.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 			},
 			"devDependencies": {
 				"@dfinity/eslint-config-oisy-wallet": "^0.2.4",
-				"@dfinity/pic": "^0.19.0",
+				"@dfinity/pic": "^0.17.2",
 				"@dfinity/response-verification": "^3.0.3",
 				"@icp-sdk/bindgen": "^0.2.1",
 				"@junobuild/cli-tools": "^0.12.2",
@@ -1206,16 +1206,16 @@
 			}
 		},
 		"node_modules/@dfinity/pic": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/pic/-/pic-0.19.0.tgz",
-			"integrity": "sha512-C866e6NTe3XmzI0bMASu7st8AjGbfYtZ67883BcgGeTMfGGeaRjzdYuykVTeMqB3bmk+ySwnjfKgu3FrGnhhxg==",
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/pic/-/pic-0.17.2.tgz",
+			"integrity": "sha512-jvzSn1XVaYnpCnvs5uh7dgGq2bSAAmKv8a1VkIk4ULm3Jli4yI4w2cyoxNEJRiLCc/I8G70flhCWTPTzVaAgZg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@icp-sdk/core": "^5.0.0",
 				"bip39": "^3.1.0",
-				"json-with-bigint": "3.5.7"
+				"json-with-bigint": "3.4.4"
 			}
 		},
 		"node_modules/@dfinity/response-verification": {
@@ -7504,9 +7504,9 @@
 			"peer": true
 		},
 		"node_modules/json-with-bigint": {
-			"version": "3.5.7",
-			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
-			"integrity": "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==",
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.4.4.tgz",
+			"integrity": "sha512-AhpYAAaZsPjU7smaBomDt1SOQshi9rEm6BlTbfVwsG1vNmeHKtEedJi62sHZzJTyKNtwzmNnrsd55kjwJ7054A==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 	},
 	"devDependencies": {
 		"@dfinity/eslint-config-oisy-wallet": "^0.2.4",
-		"@dfinity/pic": "^0.19.0",
+		"@dfinity/pic": "^0.17.2",
 		"@dfinity/response-verification": "^3.0.3",
 		"@icp-sdk/bindgen": "^0.2.1",
 		"@junobuild/cli-tools": "^0.12.2",


### PR DESCRIPTION
# Motivation

I'm not sure if it's related but, tests started to often fail with timeout.

e.g. https://github.com/junobuild/juno/actions/runs/23088589705/job/67071317699?pr=2666

So, trying to downgrade to see if it's related to PicJS that was bumped recently.
