### PR TITLE
feat(shared): rename SetController interfaces to AccessKey

### DIFF
--- a/src/console/console.did
+++ b/src/console/console.did
@@ -310,20 +310,20 @@ type SegmentsDeploymentOptions = record {
   mission_control_version : opt text;
   satellite_version : opt text;
 };
+type SetAccessKey = record {
+  metadata : vec record { text; text };
+  kind : opt AccessKeyKind;
+  scope : AccessKeyScope;
+  expires_at : opt nat64;
+};
 type SetAuthenticationConfig = record {
   openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
   internet_identity : opt AuthenticationConfigInternetIdentity;
   rules : opt AuthenticationRules;
 };
-type SetController = record {
-  metadata : vec record { text; text };
-  kind : opt AccessKeyKind;
-  scope : AccessKeyScope;
-  expires_at : opt nat64;
-};
 type SetControllersArgs = record {
-  controller : SetController;
+  controller : SetAccessKey;
   controllers : vec principal;
 };
 type SetSegmentMetadataArgs = record {

--- a/src/console/src/store/heap/controllers.rs
+++ b/src/console/src/store/heap/controllers.rs
@@ -2,14 +2,14 @@ use crate::store::{mutate_heap_state, read_heap_state};
 use junobuild_shared::segments::access_keys::{
     delete_access_keys as delete_controllers_impl, set_access_keys as set_controllers_impl,
 };
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, AccessKeys};
 
 pub fn get_controllers() -> AccessKeys {
     read_heap_state(|heap| heap.controllers.clone())
 }
 
-pub fn set_controllers(new_controllers: &[AccessKeyId], controller: &SetController) {
+pub fn set_controllers(new_controllers: &[AccessKeyId], controller: &SetAccessKey) {
     mutate_heap_state(|heap| {
         set_controllers_impl(new_controllers, controller, &mut heap.controllers)
     })

--- a/src/declarations/console/console.did.d.ts
+++ b/src/declarations/console/console.did.d.ts
@@ -373,20 +373,20 @@ export interface SegmentsDeploymentOptions {
 	mission_control_version: [] | [string];
 	satellite_version: [] | [string];
 }
+export interface SetAccessKey {
+	metadata: Array<[string, string]>;
+	kind: [] | [AccessKeyKind];
+	scope: AccessKeyScope;
+	expires_at: [] | [bigint];
+}
 export interface SetAuthenticationConfig {
 	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
 	internet_identity: [] | [AuthenticationConfigInternetIdentity];
 	rules: [] | [AuthenticationRules];
 }
-export interface SetController {
-	metadata: Array<[string, string]>;
-	kind: [] | [AccessKeyKind];
-	scope: AccessKeyScope;
-	expires_at: [] | [bigint];
-}
 export interface SetControllersArgs {
-	controller: SetController;
+	controller: SetAccessKey;
 	controllers: Array<Principal>;
 }
 export interface SetSegmentMetadataArgs {

--- a/src/declarations/console/console.factory.certified.did.js
+++ b/src/declarations/console/console.factory.certified.did.js
@@ -457,14 +457,14 @@ export const idlFactory = ({ IDL }) => {
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const FeesArgs = IDL.Record({

--- a/src/declarations/console/console.factory.did.js
+++ b/src/declarations/console/console.factory.did.js
@@ -457,14 +457,14 @@ export const idlFactory = ({ IDL }) => {
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const FeesArgs = IDL.Record({

--- a/src/declarations/console/console.factory.did.mjs
+++ b/src/declarations/console/console.factory.did.mjs
@@ -457,14 +457,14 @@ export const idlFactory = ({ IDL }) => {
 		internet_identity: IDL.Opt(AuthenticationConfigInternetIdentity),
 		rules: IDL.Opt(AuthenticationRules)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const FeesArgs = IDL.Record({

--- a/src/declarations/mission_control/mission_control.did.d.ts
+++ b/src/declarations/mission_control/mission_control.did.d.ts
@@ -150,7 +150,7 @@ export interface SegmentsMonitoringStrategy {
 	ids: Array<Principal>;
 	strategy: CyclesMonitoringStrategy;
 }
-export interface SetController {
+export interface SetAccessKey {
 	metadata: Array<[string, string]>;
 	kind: [] | [AccessKeyKind];
 	scope: AccessKeyScope;
@@ -235,17 +235,17 @@ export interface _SERVICE {
 	list_satellites: ActorMethod<[], Array<[Principal, Satellite]>>;
 	set_config: ActorMethod<[[] | [Config]], undefined>;
 	set_metadata: ActorMethod<[Array<[string, string]>], undefined>;
-	set_mission_control_controllers: ActorMethod<[Array<Principal>, SetController], undefined>;
+	set_mission_control_controllers: ActorMethod<[Array<Principal>, SetAccessKey], undefined>;
 	set_orbiter: ActorMethod<[Principal, [] | [string]], Orbiter>;
 	set_orbiter_metadata: ActorMethod<[Principal, Array<[string, string]>], Orbiter>;
 	set_orbiters_controllers: ActorMethod<
-		[Array<Principal>, Array<Principal>, SetController],
+		[Array<Principal>, Array<Principal>, SetAccessKey],
 		undefined
 	>;
 	set_satellite: ActorMethod<[Principal, [] | [string]], Satellite>;
 	set_satellite_metadata: ActorMethod<[Principal, Array<[string, string]>], Satellite>;
 	set_satellites_controllers: ActorMethod<
-		[Array<Principal>, Array<Principal>, SetController],
+		[Array<Principal>, Array<Principal>, SetAccessKey],
 		undefined
 	>;
 	start_monitoring: ActorMethod<[], undefined>;

--- a/src/declarations/mission_control/mission_control.factory.certified.did.js
+++ b/src/declarations/mission_control/mission_control.factory.certified.did.js
@@ -180,7 +180,7 @@ export const idlFactory = ({ IDL }) => {
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
@@ -240,7 +240,7 @@ export const idlFactory = ({ IDL }) => {
 		list_satellites: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Satellite))], []),
 		set_config: IDL.Func([IDL.Opt(Config)], [], []),
 		set_metadata: IDL.Func([IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], [], []),
-		set_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal), SetController], [], []),
+		set_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal), SetAccessKey], [], []),
 		set_orbiter: IDL.Func([IDL.Principal, IDL.Opt(IDL.Text)], [Orbiter], []),
 		set_orbiter_metadata: IDL.Func(
 			[IDL.Principal, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],
@@ -248,7 +248,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_orbiters_controllers: IDL.Func(
-			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetController],
+			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetAccessKey],
 			[],
 			[]
 		),
@@ -259,7 +259,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_satellites_controllers: IDL.Func(
-			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetController],
+			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetAccessKey],
 			[],
 			[]
 		),

--- a/src/declarations/mission_control/mission_control.factory.did.js
+++ b/src/declarations/mission_control/mission_control.factory.did.js
@@ -180,7 +180,7 @@ export const idlFactory = ({ IDL }) => {
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
@@ -240,7 +240,7 @@ export const idlFactory = ({ IDL }) => {
 		list_satellites: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, Satellite))], ['query']),
 		set_config: IDL.Func([IDL.Opt(Config)], [], []),
 		set_metadata: IDL.Func([IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))], [], []),
-		set_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal), SetController], [], []),
+		set_mission_control_controllers: IDL.Func([IDL.Vec(IDL.Principal), SetAccessKey], [], []),
 		set_orbiter: IDL.Func([IDL.Principal, IDL.Opt(IDL.Text)], [Orbiter], []),
 		set_orbiter_metadata: IDL.Func(
 			[IDL.Principal, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],
@@ -248,7 +248,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_orbiters_controllers: IDL.Func(
-			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetController],
+			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetAccessKey],
 			[],
 			[]
 		),
@@ -259,7 +259,7 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		set_satellites_controllers: IDL.Func(
-			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetController],
+			[IDL.Vec(IDL.Principal), IDL.Vec(IDL.Principal), SetAccessKey],
 			[],
 			[]
 		),

--- a/src/declarations/observatory/observatory.did.d.ts
+++ b/src/declarations/observatory/observatory.did.d.ts
@@ -120,14 +120,14 @@ export interface Segment {
 	kind: SegmentKind;
 }
 export type SegmentKind = { Orbiter: null } | { MissionControl: null } | { Satellite: null };
-export interface SetController {
+export interface SetAccessKey {
 	metadata: Array<[string, string]>;
 	kind: [] | [AccessKeyKind];
 	scope: AccessKeyScope;
 	expires_at: [] | [bigint];
 }
 export interface SetControllersArgs {
-	controller: SetController;
+	controller: SetAccessKey;
 	controllers: Array<Principal>;
 }
 export interface _SERVICE {

--- a/src/declarations/observatory/observatory.factory.certified.did.js
+++ b/src/declarations/observatory/observatory.factory.certified.did.js
@@ -118,14 +118,14 @@ export const idlFactory = ({ IDL }) => {
 		user: IDL.Principal,
 		segment: Segment
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const Env = IDL.Record({ email_api_key: IDL.Opt(IDL.Text) });

--- a/src/declarations/observatory/observatory.factory.did.js
+++ b/src/declarations/observatory/observatory.factory.did.js
@@ -118,14 +118,14 @@ export const idlFactory = ({ IDL }) => {
 		user: IDL.Principal,
 		segment: Segment
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const Env = IDL.Record({ email_api_key: IDL.Opt(IDL.Text) });

--- a/src/declarations/observatory/observatory.factory.did.mjs
+++ b/src/declarations/observatory/observatory.factory.did.mjs
@@ -118,14 +118,14 @@ export const idlFactory = ({ IDL }) => {
 		user: IDL.Principal,
 		segment: Segment
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const Env = IDL.Record({ email_api_key: IDL.Opt(IDL.Text) });

--- a/src/declarations/orbiter/orbiter.did.d.ts
+++ b/src/declarations/orbiter/orbiter.did.d.ts
@@ -193,14 +193,14 @@ export type Result = { Ok: PageView } | { Err: string };
 export type Result_1 = { Ok: null } | { Err: Array<[AnalyticKey, string]> };
 export type Result_2 = { Ok: PerformanceMetric } | { Err: string };
 export type Result_3 = { Ok: TrackEvent } | { Err: string };
-export interface SetController {
+export interface SetAccessKey {
 	metadata: Array<[string, string]>;
 	kind: [] | [AccessKeyKind];
 	scope: AccessKeyScope;
 	expires_at: [] | [bigint];
 }
 export interface SetControllersArgs {
-	controller: SetController;
+	controller: SetAccessKey;
 	controllers: Array<Principal>;
 }
 export interface SetPageView {

--- a/src/declarations/orbiter/orbiter.factory.certified.did.js
+++ b/src/declarations/orbiter/orbiter.factory.certified.did.js
@@ -205,14 +205,14 @@ export const idlFactory = ({ IDL }) => {
 		version: IDL.Opt(IDL.Nat64)
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetPageView = IDL.Record({

--- a/src/declarations/orbiter/orbiter.factory.did.js
+++ b/src/declarations/orbiter/orbiter.factory.did.js
@@ -205,14 +205,14 @@ export const idlFactory = ({ IDL }) => {
 		version: IDL.Opt(IDL.Nat64)
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetPageView = IDL.Record({

--- a/src/declarations/orbiter/orbiter.factory.did.mjs
+++ b/src/declarations/orbiter/orbiter.factory.did.mjs
@@ -205,14 +205,14 @@ export const idlFactory = ({ IDL }) => {
 		version: IDL.Opt(IDL.Nat64)
 	});
 	const MemorySize = IDL.Record({ stable: IDL.Nat64, heap: IDL.Nat64 });
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetPageView = IDL.Record({

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -407,6 +407,12 @@ export interface SegmentsDeploymentOptions {
 	mission_control_version: [] | [string];
 	satellite_version: [] | [string];
 }
+export interface SetAccessKey {
+	metadata: Array<[string, string]>;
+	kind: [] | [AccessKeyKind];
+	scope: AccessKeyScope;
+	expires_at: [] | [bigint];
+}
 export interface SetAuthenticationConfig {
 	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
@@ -417,14 +423,8 @@ export interface SetAutomationConfig {
 	openid: [] | [AutomationConfigOpenId];
 	version: [] | [bigint];
 }
-export interface SetController {
-	metadata: Array<[string, string]>;
-	kind: [] | [AccessKeyKind];
-	scope: AccessKeyScope;
-	expires_at: [] | [bigint];
-}
 export interface SetControllersArgs {
-	controller: SetController;
+	controller: SetAccessKey;
 	controllers: Array<Principal>;
 }
 export interface SetDbConfig {

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -469,14 +469,14 @@ export const idlFactory = ({ IDL }) => {
 		openid: IDL.Opt(AutomationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetDbConfig = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -469,14 +469,14 @@ export const idlFactory = ({ IDL }) => {
 		openid: IDL.Opt(AutomationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetDbConfig = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -469,14 +469,14 @@ export const idlFactory = ({ IDL }) => {
 		openid: IDL.Opt(AutomationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetDbConfig = IDL.Record({

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -407,6 +407,12 @@ export interface SegmentsDeploymentOptions {
 	mission_control_version: [] | [string];
 	satellite_version: [] | [string];
 }
+export interface SetAccessKey {
+	metadata: Array<[string, string]>;
+	kind: [] | [AccessKeyKind];
+	scope: AccessKeyScope;
+	expires_at: [] | [bigint];
+}
 export interface SetAuthenticationConfig {
 	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
@@ -417,14 +423,8 @@ export interface SetAutomationConfig {
 	openid: [] | [AutomationConfigOpenId];
 	version: [] | [bigint];
 }
-export interface SetController {
-	metadata: Array<[string, string]>;
-	kind: [] | [AccessKeyKind];
-	scope: AccessKeyScope;
-	expires_at: [] | [bigint];
-}
 export interface SetControllersArgs {
-	controller: SetController;
+	controller: SetAccessKey;
 	controllers: Array<Principal>;
 }
 export interface SetDbConfig {

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -469,14 +469,14 @@ export const idlFactory = ({ IDL }) => {
 		openid: IDL.Opt(AutomationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetDbConfig = IDL.Record({

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -469,14 +469,14 @@ export const idlFactory = ({ IDL }) => {
 		openid: IDL.Opt(AutomationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetDbConfig = IDL.Record({

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -339,6 +339,12 @@ type SegmentsDeploymentOptions = record {
   mission_control_version : opt text;
   satellite_version : opt text;
 };
+type SetAccessKey = record {
+  metadata : vec record { text; text };
+  kind : opt AccessKeyKind;
+  scope : AccessKeyScope;
+  expires_at : opt nat64;
+};
 type SetAuthenticationConfig = record {
   openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
@@ -349,14 +355,8 @@ type SetAutomationConfig = record {
   openid : opt AutomationConfigOpenId;
   version : opt nat64;
 };
-type SetController = record {
-  metadata : vec record { text; text };
-  kind : opt AccessKeyKind;
-  scope : AccessKeyScope;
-  expires_at : opt nat64;
-};
 type SetControllersArgs = record {
-  controller : SetController;
+  controller : SetAccessKey;
   controllers : vec principal;
 };
 type SetDbConfig = record {

--- a/src/libs/satellite/src/access_keys/store.rs
+++ b/src/libs/satellite/src/access_keys/store.rs
@@ -3,14 +3,14 @@ use junobuild_shared::segments::access_keys::{
     delete_access_keys as delete_controllers_impl, filter_admin_access_keys,
     set_access_keys as set_controllers_impl,
 };
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, AccessKeys};
 
 // ---------------------------------------------------------
 // Access keys
 // ---------------------------------------------------------
 
-pub fn set_access_keys(new_controllers: &[AccessKeyId], controller: &SetController) {
+pub fn set_access_keys(new_controllers: &[AccessKeyId], controller: &SetAccessKey) {
     STATE.with(|state| {
         set_controllers_impl(
             new_controllers,

--- a/src/libs/satellite/src/automation/controllers/register.rs
+++ b/src/libs/satellite/src/automation/controllers/register.rs
@@ -3,7 +3,7 @@ use crate::automation::workflow::build_automation_workflow_key;
 use junobuild_auth::automation::types::PreparedAutomation;
 use junobuild_auth::openid::credentials::automation::types::interface::OpenIdAutomationCredential;
 use junobuild_auth::openid::types::provider::OpenIdAutomationProvider;
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, AccessKeyKind, Metadata};
 
 pub fn register_controller(
@@ -20,7 +20,7 @@ pub fn register_controller(
     let mut metadata: Metadata = Default::default();
     metadata.insert("workflow_key".to_string(), automation_workflow_key.to_key());
 
-    let controller: SetController = SetController {
+    let controller: SetAccessKey = SetAccessKey {
         scope: controller.scope.clone().into(),
         metadata,
         expires_at: Some(controller.expires_at),

--- a/src/libs/shared/src/segments/access_keys.rs
+++ b/src/libs/shared/src/segments/access_keys.rs
@@ -7,7 +7,7 @@ use crate::errors::{
     JUNO_ERROR_CONTROLLERS_REVOKED_NOT_ALLOWED,
 };
 use crate::ic::api::{id, is_canister_controller, time};
-use crate::types::interface::SetController;
+use crate::types::interface::SetAccessKey;
 use crate::types::state::{AccessKey, AccessKeyId, AccessKeyScope, AccessKeys, UserId};
 use crate::utils::{principal_anonymous, principal_equal, principal_not_anonymous};
 use candid::Principal;
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 pub fn init_admin_access_keys(new_access_keys: &[UserId]) -> AccessKeys {
     let mut access_keys: AccessKeys = AccessKeys::new();
 
-    let access_key_data: SetController = SetController {
+    let access_key_data: SetAccessKey = SetAccessKey {
         metadata: HashMap::new(),
         expires_at: None,
         scope: AccessKeyScope::Admin,
@@ -43,7 +43,7 @@ pub fn init_admin_access_keys(new_access_keys: &[UserId]) -> AccessKeys {
 /// - `access_keys`: Mutable reference to the current set of access keys to update.
 pub fn set_access_keys(
     new_access_keys: &[UserId],
-    access_key_data: &SetController,
+    access_key_data: &SetAccessKey,
     access_keys: &mut AccessKeys,
 ) {
     for access_key_id in new_access_keys {
@@ -308,7 +308,7 @@ fn assert_no_revoked_controller(access_keys_ids: &[AccessKeyId]) -> Result<(), S
 ///
 /// # Returns
 /// `Ok(())` if validation passes, or `Err(String)` with error message if validation fails
-pub fn assert_access_key_expiration(access_key: &SetController) -> Result<(), String> {
+pub fn assert_access_key_expiration(access_key: &SetAccessKey) -> Result<(), String> {
     if matches!(access_key.scope, AccessKeyScope::Admin) && access_key.expires_at.is_some() {
         return Err(JUNO_ERROR_CONTROLLERS_ADMIN_NO_EXPIRY.to_string());
     }
@@ -613,7 +613,7 @@ mod tests {
         let mut access_keys = AccessKeys::new();
         let principals = vec![test_principal(1)];
 
-        let access_key_data = SetController {
+        let access_key_data = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: Some(mock_time() + 1000),
             scope: AccessKeyScope::Write,
@@ -635,7 +635,7 @@ mod tests {
         let principal = test_principal(1);
 
         // First insert
-        let initial_data = SetController {
+        let initial_data = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: None,
             scope: AccessKeyScope::Write,
@@ -645,7 +645,7 @@ mod tests {
         let original_created_at = access_keys.get(&principal).unwrap().created_at;
 
         // Update
-        let update_data = SetController {
+        let update_data = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: Some(mock_time() + 1000),
             scope: AccessKeyScope::Admin,
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_assert_expiration_access_key_admin_with_expiry_rejected() {
-        let access_key = SetController {
+        let access_key = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: Some(time() + 1000),
             scope: AccessKeyScope::Admin,
@@ -795,7 +795,7 @@ mod tests {
 
     #[test]
     fn test_assert_expiration_access_key_admin_without_expiry_allowed() {
-        let access_key = SetController {
+        let access_key = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: None,
             scope: AccessKeyScope::Admin,
@@ -808,7 +808,7 @@ mod tests {
 
     #[test]
     fn test_assert_expiration_access_key_past_expiry_rejected() {
-        let access_key = SetController {
+        let access_key = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: Some(time() - 1000),
             scope: AccessKeyScope::Write,
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn test_assert_expiration_access_key_future_expiry_allowed() {
-        let access_key = SetController {
+        let access_key = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: Some(time() + 1000),
             scope: AccessKeyScope::Write,
@@ -838,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_assert_expiration_access_key_no_expiry_allowed() {
-        let access_key = SetController {
+        let access_key = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: None,
             scope: AccessKeyScope::Write,
@@ -851,7 +851,7 @@ mod tests {
 
     #[test]
     fn test_assert_expiration_access_key_submit_scope_with_future_expiry() {
-        let access_key = SetController {
+        let access_key = SetAccessKey {
             metadata: HashMap::new(),
             expires_at: Some(time() + 1000),
             scope: AccessKeyScope::Submit,

--- a/src/libs/shared/src/types.rs
+++ b/src/libs/shared/src/types.rs
@@ -172,7 +172,7 @@ pub mod interface {
     }
 
     #[derive(CandidType, Deserialize, Clone)]
-    pub struct SetController {
+    pub struct SetAccessKey {
         pub metadata: Metadata,
         pub expires_at: Option<Timestamp>,
         pub scope: AccessKeyScope,
@@ -180,11 +180,24 @@ pub mod interface {
     }
 
     #[derive(CandidType, Deserialize)]
-    pub struct SetControllersArgs {
-        pub controllers: Vec<AccessKeyId>,
-        pub controller: SetController,
+    pub struct SetAccessKeysArgs {
+        pub access_key_ids: Vec<AccessKeyId>,
+        pub access_key: SetAccessKey,
     }
 
+    #[deprecated(note = "use SetAccessKeysArgs instead")]
+    #[derive(CandidType, Deserialize)]
+    pub struct SetControllersArgs {
+        pub controllers: Vec<AccessKeyId>,
+        pub controller: SetAccessKey,
+    }
+
+    #[derive(CandidType, Deserialize)]
+    pub struct DeleteAccessKeysArgs {
+        pub access_key_ids: Vec<AccessKeyId>,
+    }
+
+    #[deprecated(note = "use DeleteAccessKeysArgs instead")]
     #[derive(CandidType, Deserialize)]
     pub struct DeleteControllersArgs {
         pub controllers: Vec<AccessKeyId>,

--- a/src/mission_control/mission_control.did
+++ b/src/mission_control/mission_control.did
@@ -113,7 +113,7 @@ type SegmentsMonitoringStrategy = record {
   ids : vec principal;
   strategy : CyclesMonitoringStrategy;
 };
-type SetController = record {
+type SetAccessKey = record {
   metadata : vec record { text; text };
   kind : opt AccessKeyKind;
   scope : AccessKeyScope;
@@ -191,14 +191,10 @@ service : (InitMissionControlArgs) -> {
   list_satellites : () -> (vec record { principal; Satellite }) query;
   set_config : (opt Config) -> ();
   set_metadata : (vec record { text; text }) -> ();
-  set_mission_control_controllers : (vec principal, SetController) -> ();
+  set_mission_control_controllers : (vec principal, SetAccessKey) -> ();
   set_orbiter : (principal, opt text) -> (Orbiter);
   set_orbiter_metadata : (principal, vec record { text; text }) -> (Orbiter);
-  set_orbiters_controllers : (
-      vec principal,
-      vec principal,
-      SetController,
-    ) -> ();
+  set_orbiters_controllers : (vec principal, vec principal, SetAccessKey) -> ();
   set_satellite : (principal, opt text) -> (Satellite);
   set_satellite_metadata : (principal, vec record { text; text }) -> (
       Satellite,
@@ -206,7 +202,7 @@ service : (InitMissionControlArgs) -> {
   set_satellites_controllers : (
       vec principal,
       vec principal,
-      SetController,
+      SetAccessKey,
     ) -> ();
   start_monitoring : () -> ();
   stop_monitoring : () -> ();

--- a/src/mission_control/src/api/controllers.rs
+++ b/src/mission_control/src/api/controllers.rs
@@ -6,11 +6,11 @@ use crate::controllers::store::get_controllers;
 use crate::guards::caller_is_user_or_admin_controller;
 use ic_cdk_macros::{query, update};
 use junobuild_shared::ic::UnwrapOrTrap;
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, AccessKeys};
 
 #[update(guard = "caller_is_user_or_admin_controller")]
-async fn set_mission_control_controllers(controllers: Vec<AccessKeyId>, controller: SetController) {
+async fn set_mission_control_controllers(controllers: Vec<AccessKeyId>, controller: SetAccessKey) {
     set_controllers_to_mission_control(&controllers, &controller)
         .await
         .unwrap_or_trap();

--- a/src/mission_control/src/api/orbiters.rs
+++ b/src/mission_control/src/api/orbiters.rs
@@ -10,7 +10,7 @@ use crate::types::interface::CreateCanisterConfig;
 use crate::types::state::{Orbiter, Orbiters};
 use ic_cdk_macros::{query, update};
 use junobuild_shared::ic::UnwrapOrTrap;
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, Metadata, OrbiterId, UserId};
 
 #[query(guard = "caller_is_user_or_admin_controller")]
@@ -49,7 +49,7 @@ fn set_orbiter_metadata(orbiter_id: OrbiterId, metadata: Metadata) -> Orbiter {
 async fn set_orbiters_controllers(
     orbiter_ids: Vec<OrbiterId>,
     controller_ids: Vec<AccessKeyId>,
-    controller: SetController,
+    controller: SetAccessKey,
 ) {
     for orbiter_id in orbiter_ids {
         set_orbiter_controllers(&orbiter_id, &controller_ids, &controller)

--- a/src/mission_control/src/api/satellites.rs
+++ b/src/mission_control/src/api/satellites.rs
@@ -12,7 +12,7 @@ use crate::types::interface::CreateSatelliteConfig;
 use crate::types::state::{Satellite, Satellites};
 use ic_cdk_macros::{query, update};
 use junobuild_shared::ic::UnwrapOrTrap;
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, SatelliteId};
 use junobuild_shared::types::state::{Metadata, UserId};
 
@@ -42,7 +42,7 @@ fn set_satellite_metadata(satellite_id: SatelliteId, metadata: Metadata) -> Sate
 async fn set_satellites_controllers(
     satellite_ids: Vec<SatelliteId>,
     controller_ids: Vec<AccessKeyId>,
-    controller: SetController,
+    controller: SetAccessKey,
 ) {
     for satellite_id in satellite_ids {
         set_satellite_controllers(&satellite_id, &controller_ids, &controller)

--- a/src/mission_control/src/controllers/mission_control.rs
+++ b/src/mission_control/src/controllers/mission_control.rs
@@ -10,12 +10,12 @@ use junobuild_shared::segments::access_keys::{
     assert_access_key_expiration, assert_controllers, assert_max_number_of_access_keys,
     into_access_key_ids,
 };
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, AccessKeys};
 
 pub async fn set_mission_control_controllers(
     controllers: &[AccessKeyId],
-    controller: &SetController,
+    controller: &SetAccessKey,
 ) -> Result<(), String> {
     assert_max_number_of_access_keys(
         &get_controllers(),

--- a/src/mission_control/src/controllers/orbiter.rs
+++ b/src/mission_control/src/controllers/orbiter.rs
@@ -1,11 +1,11 @@
 use crate::controllers::segment::{delete_segment_controllers, set_segment_controllers};
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, OrbiterId};
 
 pub async fn set_orbiter_controllers(
     orbiter_id: &OrbiterId,
     controllers: &[AccessKeyId],
-    controller: &SetController,
+    controller: &SetAccessKey,
 ) -> Result<(), String> {
     set_segment_controllers(orbiter_id, controllers, controller).await
 }

--- a/src/mission_control/src/controllers/satellite.rs
+++ b/src/mission_control/src/controllers/satellite.rs
@@ -1,11 +1,11 @@
 use crate::controllers::segment::{delete_segment_controllers, set_segment_controllers};
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, SatelliteId};
 
 pub async fn set_satellite_controllers(
     satellite_id: &SatelliteId,
     controllers: &[AccessKeyId],
-    controller: &SetController,
+    controller: &SetAccessKey,
 ) -> Result<(), String> {
     set_segment_controllers(satellite_id, controllers, controller).await
 }

--- a/src/mission_control/src/controllers/segment.rs
+++ b/src/mission_control/src/controllers/segment.rs
@@ -5,15 +5,13 @@ use junobuild_shared::mgmt::ic::update_canister_controllers;
 use junobuild_shared::segments::access_keys::{
     assert_access_key_expiration, assert_controllers, filter_admin_access_keys, into_access_key_ids,
 };
-use junobuild_shared::types::interface::{
-    DeleteControllersArgs, SetController, SetControllersArgs,
-};
+use junobuild_shared::types::interface::{DeleteControllersArgs, SetAccessKey, SetControllersArgs};
 use junobuild_shared::types::state::{AccessKeyId, AccessKeys};
 
 pub async fn set_segment_controllers(
     segment_id: &Principal,
     controllers: &[AccessKeyId],
-    controller: &SetController,
+    controller: &SetAccessKey,
 ) -> Result<(), String> {
     assert_controllers(controllers)?;
 
@@ -39,7 +37,7 @@ pub async fn delete_segment_controllers(
 async fn set_controllers(
     segment_id: &Principal,
     controllers: &[AccessKeyId],
-    controller: &SetController,
+    controller: &SetAccessKey,
 ) -> Result<Vec<AccessKeyId>, String> {
     let args = SetControllersArgs {
         controllers: controllers.to_owned(),

--- a/src/mission_control/src/controllers/store.rs
+++ b/src/mission_control/src/controllers/store.rs
@@ -3,14 +3,14 @@ use junobuild_shared::segments::access_keys::{
     delete_access_keys as delete_controllers_impl, filter_admin_access_keys,
     set_access_keys as set_controllers_impl,
 };
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, AccessKeys};
 
 // ---------------------------------------------------------
 // Controllers
 // ---------------------------------------------------------
 
-pub fn set_controllers(new_controllers: &[AccessKeyId], controller: &SetController) {
+pub fn set_controllers(new_controllers: &[AccessKeyId], controller: &SetAccessKey) {
     STATE.with(|state| {
         set_controllers_impl(
             new_controllers,

--- a/src/mission_control/src/lib.rs
+++ b/src/mission_control/src/lib.rs
@@ -36,7 +36,7 @@ use icrc_ledger_types::icrc1::transfer::TransferArg;
 use junobuild_shared::ledger::types::icrc::IcrcTransferResult;
 use junobuild_shared::types::interface::DepositCyclesArgs;
 use junobuild_shared::types::interface::InitMissionControlArgs;
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::Metadata;
 use junobuild_shared::types::state::SatelliteId;
 use junobuild_shared::types::state::UserId;

--- a/src/observatory/observatory.did
+++ b/src/observatory/observatory.did
@@ -79,14 +79,14 @@ type Segment = record {
   kind : SegmentKind;
 };
 type SegmentKind = variant { Orbiter; MissionControl; Satellite };
-type SetController = record {
+type SetAccessKey = record {
   metadata : vec record { text; text };
   kind : opt AccessKeyKind;
   scope : AccessKeyScope;
   expires_at : opt nat64;
 };
 type SetControllersArgs = record {
-  controller : SetController;
+  controller : SetAccessKey;
   controllers : vec principal;
 };
 service : () -> {

--- a/src/observatory/src/store/heap/controllers.rs
+++ b/src/observatory/src/store/heap/controllers.rs
@@ -2,10 +2,10 @@ use crate::memory::state::services::{mutate_heap_state, read_heap_state};
 use junobuild_shared::segments::access_keys::{
     delete_access_keys as delete_controllers_impl, set_access_keys as set_controllers_impl,
 };
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, AccessKeys};
 
-pub fn set_controllers(new_controllers: &[AccessKeyId], controller: &SetController) {
+pub fn set_controllers(new_controllers: &[AccessKeyId], controller: &SetAccessKey) {
     mutate_heap_state(|heap| {
         set_controllers_impl(new_controllers, controller, &mut heap.controllers)
     })

--- a/src/orbiter/orbiter.did
+++ b/src/orbiter/orbiter.did
@@ -152,14 +152,14 @@ type Result = variant { Ok : PageView; Err : text };
 type Result_1 = variant { Ok; Err : vec record { AnalyticKey; text } };
 type Result_2 = variant { Ok : PerformanceMetric; Err : text };
 type Result_3 = variant { Ok : TrackEvent; Err : text };
-type SetController = record {
+type SetAccessKey = record {
   metadata : vec record { text; text };
   kind : opt AccessKeyKind;
   scope : AccessKeyScope;
   expires_at : opt nat64;
 };
 type SetControllersArgs = record {
-  controller : SetController;
+  controller : SetAccessKey;
   controllers : vec principal;
 };
 type SetPageView = record {

--- a/src/orbiter/src/controllers/store.rs
+++ b/src/orbiter/src/controllers/store.rs
@@ -2,14 +2,14 @@ use crate::state::memory::manager::STATE;
 use junobuild_shared::segments::access_keys::{
     delete_access_keys as delete_controllers_impl, set_access_keys as set_controllers_impl,
 };
-use junobuild_shared::types::interface::SetController;
+use junobuild_shared::types::interface::SetAccessKey;
 use junobuild_shared::types::state::{AccessKeyId, AccessKeys};
 
 // ---------------------------------------------------------
 // Controllers
 // ---------------------------------------------------------
 
-pub fn set_controllers(new_controllers: &[AccessKeyId], controller: &SetController) {
+pub fn set_controllers(new_controllers: &[AccessKeyId], controller: &SetAccessKey) {
     STATE.with(|state| {
         set_controllers_impl(
             new_controllers,

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -341,6 +341,12 @@ type SegmentsDeploymentOptions = record {
   mission_control_version : opt text;
   satellite_version : opt text;
 };
+type SetAccessKey = record {
+  metadata : vec record { text; text };
+  kind : opt AccessKeyKind;
+  scope : AccessKeyScope;
+  expires_at : opt nat64;
+};
 type SetAuthenticationConfig = record {
   openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
@@ -351,14 +357,8 @@ type SetAutomationConfig = record {
   openid : opt AutomationConfigOpenId;
   version : opt nat64;
 };
-type SetController = record {
-  metadata : vec record { text; text };
-  kind : opt AccessKeyKind;
-  scope : AccessKeyScope;
-  expires_at : opt nat64;
-};
 type SetControllersArgs = record {
-  controller : SetController;
+  controller : SetAccessKey;
   controllers : vec principal;
 };
 type SetDbConfig = record {

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -341,6 +341,12 @@ type SegmentsDeploymentOptions = record {
   mission_control_version : opt text;
   satellite_version : opt text;
 };
+type SetAccessKey = record {
+  metadata : vec record { text; text };
+  kind : opt AccessKeyKind;
+  scope : AccessKeyScope;
+  expires_at : opt nat64;
+};
 type SetAuthenticationConfig = record {
   openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
@@ -351,14 +357,8 @@ type SetAutomationConfig = record {
   openid : opt AutomationConfigOpenId;
   version : opt nat64;
 };
-type SetController = record {
-  metadata : vec record { text; text };
-  kind : opt AccessKeyKind;
-  scope : AccessKeyScope;
-  expires_at : opt nat64;
-};
 type SetControllersArgs = record {
-  controller : SetController;
+  controller : SetAccessKey;
   controllers : vec principal;
 };
 type SetDbConfig = record {

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -408,6 +408,12 @@ export interface SegmentsDeploymentOptions {
 	mission_control_version: [] | [string];
 	satellite_version: [] | [string];
 }
+export interface SetAccessKey {
+	metadata: Array<[string, string]>;
+	kind: [] | [AccessKeyKind];
+	scope: AccessKeyScope;
+	expires_at: [] | [bigint];
+}
 export interface SetAuthenticationConfig {
 	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
@@ -418,14 +424,8 @@ export interface SetAutomationConfig {
 	openid: [] | [AutomationConfigOpenId];
 	version: [] | [bigint];
 }
-export interface SetController {
-	metadata: Array<[string, string]>;
-	kind: [] | [AccessKeyKind];
-	scope: AccessKeyScope;
-	expires_at: [] | [bigint];
-}
 export interface SetControllersArgs {
-	controller: SetController;
+	controller: SetAccessKey;
 	controllers: Array<Principal>;
 }
 export interface SetDbConfig {

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -469,14 +469,14 @@ export const idlFactory = ({ IDL }) => {
 		openid: IDL.Opt(AutomationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetDbConfig = IDL.Record({

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -469,14 +469,14 @@ export const idlFactory = ({ IDL }) => {
 		openid: IDL.Opt(AutomationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetDbConfig = IDL.Record({

--- a/src/tests/declarations/test_sputnik/test_sputnik.did.d.ts
+++ b/src/tests/declarations/test_sputnik/test_sputnik.did.d.ts
@@ -492,6 +492,12 @@ export interface SegmentsDeploymentOptions {
 	mission_control_version: [] | [string];
 	satellite_version: [] | [string];
 }
+export interface SetAccessKey {
+	metadata: Array<[string, string]>;
+	kind: [] | [AccessKeyKind];
+	scope: AccessKeyScope;
+	expires_at: [] | [bigint];
+}
 export interface SetAuthenticationConfig {
 	openid: [] | [AuthenticationConfigOpenId];
 	version: [] | [bigint];
@@ -502,14 +508,8 @@ export interface SetAutomationConfig {
 	openid: [] | [AutomationConfigOpenId];
 	version: [] | [bigint];
 }
-export interface SetController {
-	metadata: Array<[string, string]>;
-	kind: [] | [AccessKeyKind];
-	scope: AccessKeyScope;
-	expires_at: [] | [bigint];
-}
 export interface SetControllersArgs {
-	controller: SetController;
+	controller: SetAccessKey;
 	controllers: Array<Principal>;
 }
 export interface SetDbConfig {

--- a/src/tests/declarations/test_sputnik/test_sputnik.factory.did.js
+++ b/src/tests/declarations/test_sputnik/test_sputnik.factory.did.js
@@ -469,14 +469,14 @@ export const idlFactory = ({ IDL }) => {
 		openid: IDL.Opt(AutomationConfigOpenId),
 		version: IDL.Opt(IDL.Nat64)
 	});
-	const SetController = IDL.Record({
+	const SetAccessKey = IDL.Record({
 		metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
 		kind: IDL.Opt(AccessKeyKind),
 		scope: AccessKeyScope,
 		expires_at: IDL.Opt(IDL.Nat64)
 	});
 	const SetControllersArgs = IDL.Record({
-		controller: SetController,
+		controller: SetAccessKey,
 		controllers: IDL.Vec(IDL.Principal)
 	});
 	const SetDbConfig = IDL.Record({

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -341,6 +341,12 @@ type SegmentsDeploymentOptions = record {
   mission_control_version : opt text;
   satellite_version : opt text;
 };
+type SetAccessKey = record {
+  metadata : vec record { text; text };
+  kind : opt AccessKeyKind;
+  scope : AccessKeyScope;
+  expires_at : opt nat64;
+};
 type SetAuthenticationConfig = record {
   openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
@@ -351,14 +357,8 @@ type SetAutomationConfig = record {
   openid : opt AutomationConfigOpenId;
   version : opt nat64;
 };
-type SetController = record {
-  metadata : vec record { text; text };
-  kind : opt AccessKeyKind;
-  scope : AccessKeyScope;
-  expires_at : opt nat64;
-};
 type SetControllersArgs = record {
-  controller : SetController;
+  controller : SetAccessKey;
   controllers : vec principal;
 };
 type SetDbConfig = record {

--- a/src/tests/fixtures/test_sputnik/test_sputnik.did
+++ b/src/tests/fixtures/test_sputnik/test_sputnik.did
@@ -341,6 +341,12 @@ type SegmentsDeploymentOptions = record {
   mission_control_version : opt text;
   satellite_version : opt text;
 };
+type SetAccessKey = record {
+  metadata : vec record { text; text };
+  kind : opt AccessKeyKind;
+  scope : AccessKeyScope;
+  expires_at : opt nat64;
+};
 type SetAuthenticationConfig = record {
   openid : opt AuthenticationConfigOpenId;
   version : opt nat64;
@@ -351,14 +357,8 @@ type SetAutomationConfig = record {
   openid : opt AutomationConfigOpenId;
   version : opt nat64;
 };
-type SetController = record {
-  metadata : vec record { text; text };
-  kind : opt AccessKeyKind;
-  scope : AccessKeyScope;
-  expires_at : opt nat64;
-};
 type SetControllersArgs = record {
-  controller : SetController;
+  controller : SetAccessKey;
   controllers : vec principal;
 };
 type SetDbConfig = record {


### PR DESCRIPTION
# Motivation

We gonna keep the current interfaces as deprecated but still we also want to use "AccessKey" instead of "Controller" for setters
