### PR TITLE
feat(frontend): fetch kongswap for a single token

### DIFF
--- a/src/frontend/src/lib/rest/kongswap.rest.ts
+++ b/src/frontend/src/lib/rest/kongswap.rest.ts
@@ -1,22 +1,21 @@
-import { KongSwapTokensSchema } from '$lib/schemas/kongswap.schema';
-import type { KongSwapTokens } from '$lib/types/kongswap';
+import { KongSwapTokenSchema } from '$lib/schemas/kongswap.schema';
+import type { KongSwapToken } from '$lib/types/kongswap';
 import { assertResponseOk } from '$lib/utils/rest.utils';
 import { isEmptyString } from '@dfinity/utils';
+import type { PrincipalText } from '@junobuild/schema';
 
-export const fetchKongSwapTokens = async ({
-	page,
-	limit
+export const fetchKongSwapToken = async ({
+	ledgerId
 }: {
-	page: number;
-	limit: number;
-}): Promise<KongSwapTokens | undefined> => {
+	ledgerId: PrincipalText;
+}): Promise<KongSwapToken | undefined> => {
 	const KONGSWAP_API_URL = import.meta.env.VITE_KONGSWAP_API_URL;
 
 	if (isEmptyString(KONGSWAP_API_URL)) {
 		return undefined;
 	}
 
-	const response = await fetch(`${KONGSWAP_API_URL}/api/tokens?page=${page}&limit=${limit}`, {
+	const response = await fetch(`${KONGSWAP_API_URL}/api/tokens/${ledgerId}`, {
 		method: 'GET',
 		headers: {
 			'Content-Type': 'application/json'
@@ -27,5 +26,5 @@ export const fetchKongSwapTokens = async ({
 
 	const data = await response.json();
 
-	return KongSwapTokensSchema.parse(data);
+	return KongSwapTokenSchema.parse(data);
 };

--- a/src/frontend/src/lib/schemas/kongswap.schema.ts
+++ b/src/frontend/src/lib/schemas/kongswap.schema.ts
@@ -1,33 +1,29 @@
 import { PrincipalTextSchema } from '@junobuild/schema';
 import * as z from 'zod';
 
-const DateTimeSchema = z.string().refine(
-	(val) => {
-		const parsed = new Date(val);
-		return !isNaN(parsed.getTime());
-	},
-	{
-		message: 'Invalid ISO 8601 datetime string'
-	}
-);
+const DateTimeSchema = z
+	.string()
+	.refine((val) => !isNaN(new Date(val).getTime()), { message: 'Invalid ISO date' });
 
 const KongSwapTokenMetricsSchema = z.object({
-	price: z.number().nullable(),
 	token_id: z.number(),
 	total_supply: z.number().nullable(),
 	market_cap: z.number().nullable(),
-	updated_at: DateTimeSchema.nullable(),
+	price: z.number().nullable(),
+	updated_at: DateTimeSchema,
 	volume_24h: z.number().nullable(),
 	tvl: z.number().nullable(),
 	price_change_24h: z.number().nullable(),
 	previous_price: z.number().nullable(),
-	market_cap_rank: z.number().nullable(),
 	is_verified: z.boolean()
 });
 
-export const KongSwapTokenSchema = z.object({
-	address: z.string().nullable(),
+const KongSwapTokenBaseSchema = z.object({
+	token_id: z.number(),
+	name: z.string(),
+	symbol: z.string(),
 	canister_id: PrincipalTextSchema,
+	address: z.string().nullable(),
 	decimals: z.number(),
 	fee: z.number(),
 	fee_fixed: z.string().nullable(),
@@ -37,17 +33,11 @@ export const KongSwapTokenSchema = z.object({
 	icrc3: z.boolean(),
 	is_removed: z.boolean(),
 	logo_url: z.string().nullable(),
-	metrics: KongSwapTokenMetricsSchema,
-	name: z.string(),
-	symbol: z.string(),
-	token_id: z.number(),
+	logo_updated_at: DateTimeSchema.nullable(),
 	token_type: z.string()
 });
 
-export const KongSwapTokensSchema = z.object({
-	items: z.array(KongSwapTokenSchema),
-	total_pages: z.number(),
-	total_count: z.number(),
-	page: z.number(),
-	limit: z.number()
+export const KongSwapTokenSchema = z.object({
+	token: KongSwapTokenBaseSchema,
+	metrics: KongSwapTokenMetricsSchema
 });

--- a/src/frontend/src/lib/types/kongswap.ts
+++ b/src/frontend/src/lib/types/kongswap.ts
@@ -1,6 +1,4 @@
-import type { KongSwapTokenSchema, KongSwapTokensSchema } from '$lib/schemas/kongswap.schema';
+import type { KongSwapTokenSchema } from '$lib/schemas/kongswap.schema';
 import type * as z from 'zod';
 
 export type KongSwapToken = z.infer<typeof KongSwapTokenSchema>;
-
-export type KongSwapTokens = z.infer<typeof KongSwapTokensSchema>;

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -1,6 +1,6 @@
 import { ICP_LEDGER_CANISTER_ID, SYNC_TOKENS_TIMER_INTERVAL } from '$lib/constants/app.constants';
 import { PRICE_VALIDITY_TIMEFRAME } from '$lib/constants/exchange.constants';
-import { fetchKongSwapTokens } from '$lib/rest/kongswap.rest';
+import { fetchKongSwapToken } from '$lib/rest/kongswap.rest';
 import { exchangeIdbStore } from '$lib/stores/app/idb.store';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { ExchangePrice } from '$lib/types/exchange';
@@ -111,27 +111,8 @@ const exchangeRateICPToUsd = async (): Promise<ExchangePrice | undefined> => {
 	};
 };
 
-const findICPToken = async (page = 1): Promise<KongSwapToken | undefined> => {
-	const kongTokens = await fetchKongSwapTokens({ page, limit });
-
-	if (isNullish(kongTokens)) {
-		return undefined;
-	}
-
-	const { items, total_count } = kongTokens;
-
-	const icp = items.find(({ canister_id }) => canister_id === ICP_LEDGER_CANISTER_ID);
-
-	if (nonNullish(icp)) {
-		return icp;
-	}
-
-	if (page * limit < total_count) {
-		return await findICPToken(page + 1);
-	}
-
-	return undefined;
-};
+const findICPToken = async (): Promise<KongSwapToken | undefined> =>
+	await fetchKongSwapToken({ ledgerId: ICP_LEDGER_CANISTER_ID });
 
 const syncExchangePrice = async (exchangePrice: ExchangePrice) => {
 	// Save information in indexed-db as well to load previous values on navigation and refresh


### PR DESCRIPTION
# Motivation

Fetching the ICP details to get the conversion ICP<>USD on KongSwap currently fails or least forever on mainnet because we paginate two tokens after two tokens when we list those. We do so because the ICP token was listed first however, it has move to the position 252 in their list 😅.

Fortunately, I did not knew, there is an endpoint to get a single token. Therefore we can switch to this approach.
