### PR TITLE
feat(storage,cdn): allow 0kb chunk assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"@dfinity/pic": "^0.21.0",
 				"@dfinity/response-verification": "^3.0.3",
 				"@icp-sdk/bindgen": "^0.2.1",
-				"@junobuild/cli-tools": "^0.12.4-next-2026-03-20.3",
+				"@junobuild/cli-tools": "^0.12.4-next-2026-03-22",
 				"@junobuild/config-loader": "^0.4.9-next-2026-03-20.3",
 				"@junobuild/errors": "^0.2.4-next-2026-03-20.3",
 				"@junobuild/functions": "^0.7.2-next-2026-03-20.3",
@@ -1871,9 +1871,9 @@
 			}
 		},
 		"node_modules/@junobuild/cli-tools": {
-			"version": "0.12.4-next-2026-03-20.3",
-			"resolved": "https://registry.npmjs.org/@junobuild/cli-tools/-/cli-tools-0.12.4-next-2026-03-20.3.tgz",
-			"integrity": "sha512-AeSF9ktq0HzBDPkC9uRl6jfAb4fDt+zcjWX3tj4KQgzmNajwEOyQuuSFRX1NGRq2U23QCk2XELDxk497P3Od+A==",
+			"version": "0.12.4-next-2026-03-22",
+			"resolved": "https://registry.npmjs.org/@junobuild/cli-tools/-/cli-tools-0.12.4-next-2026-03-22.tgz",
+			"integrity": "sha512-DSM7dknxMAYMPdg9hCKvJY2VmrVCbf8+ukx60sSA+mZaZb0BwzUKAAMqY5g4xcEaq69nUjnZ5nwYUDelyp1BSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5998,9 +5998,9 @@
 			}
 		},
 		"node_modules/file-type": {
-			"version": "21.3.3",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
-			"integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9390,9 +9390,9 @@
 			}
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"@dfinity/pic": "^0.21.0",
 		"@dfinity/response-verification": "^3.0.3",
 		"@icp-sdk/bindgen": "^0.2.1",
-		"@junobuild/cli-tools": "^0.12.4-next-2026-03-20.3",
+		"@junobuild/cli-tools": "^0.12.4-next-2026-03-22",
 		"@junobuild/config-loader": "^0.4.9-next-2026-03-20.3",
 		"@junobuild/errors": "^0.2.4-next-2026-03-20.3",
 		"@junobuild/functions": "^0.7.2-next-2026-03-20.3",

--- a/src/console/src/cdn/strategies_impls/storage.rs
+++ b/src/console/src/cdn/strategies_impls/storage.rs
@@ -116,8 +116,7 @@ impl StorageStateStrategy for StorageState {
         chunk_index: usize,
         _memory: &Memory,
     ) -> Option<Blob> {
-        let content_chunks = clone_asset_encoding_content_chunks(encoding, chunk_index);
-        Some(content_chunks)
+        clone_asset_encoding_content_chunks(encoding, chunk_index)
     }
 
     fn get_public_asset(

--- a/src/libs/cdn/src/proposals/errors.rs
+++ b/src/libs/cdn/src/proposals/errors.rs
@@ -22,9 +22,6 @@ pub const JUNO_CDN_PROPOSALS_ERROR_INVALID_HASH: &str = "juno.cdn.proposals.erro
 // Proposal type is not supported.
 pub const JUNO_CDN_PROPOSALS_ERROR_UNKNOWN_TYPE: &str = "juno.cdn.proposals.error.unknown_type";
 
-// Empty content chunks for encoding
-pub const JUNO_CDN_PROPOSALS_ERROR_EMPTY_CONTENT_CHUNKS: &str =
-    "juno.cdn.proposals.error.empty_content_chunks";
 // No content chunks found for encoding {} at index {}
 pub const JUNO_CDN_PROPOSALS_ERROR_NOT_CONTENT_CHUNKS_AT_INDEX: &str =
     "juno.cdn.proposals.error.no_content_chunks_at_index";

--- a/src/libs/cdn/src/proposals/workflows/commit.rs
+++ b/src/libs/cdn/src/proposals/workflows/commit.rs
@@ -1,7 +1,7 @@
 use crate::proposals::errors::{
     JUNO_CDN_PROPOSALS_ERROR_CANNOT_COMMIT, JUNO_CDN_PROPOSALS_ERROR_CANNOT_COMMIT_INVALID_STATUS,
-    JUNO_CDN_PROPOSALS_ERROR_EMPTY_ASSETS, JUNO_CDN_PROPOSALS_ERROR_EMPTY_CONTENT_CHUNKS,
-    JUNO_CDN_PROPOSALS_ERROR_INVALID_HASH, JUNO_CDN_PROPOSALS_ERROR_NOT_CONTENT_CHUNKS_AT_INDEX,
+    JUNO_CDN_PROPOSALS_ERROR_EMPTY_ASSETS, JUNO_CDN_PROPOSALS_ERROR_INVALID_HASH,
+    JUNO_CDN_PROPOSALS_ERROR_NOT_CONTENT_CHUNKS_AT_INDEX,
 };
 use crate::proposals::workflows::assert::assert_known_proposal_type;
 use crate::proposals::{get_proposal, insert_proposal};
@@ -144,12 +144,6 @@ fn copy_committed_assets(
                 })?;
 
                 content_chunks.push(chunks);
-            }
-
-            if content_chunks.is_empty() {
-                return Err(format!(
-                    "{JUNO_CDN_PROPOSALS_ERROR_EMPTY_CONTENT_CHUNKS} ({encoding_type})"
-                ));
             }
 
             let encoding_with_content = AssetEncoding {

--- a/src/libs/satellite/src/assets/storage/state.rs
+++ b/src/libs/satellite/src/assets/storage/state.rs
@@ -105,10 +105,7 @@ pub fn get_content_chunks(
     memory: &Memory,
 ) -> Option<Blob> {
     match memory {
-        Memory::Heap => {
-            let content_chunks = clone_asset_encoding_content_chunks(encoding, chunk_index);
-            Some(content_chunks)
-        }
+        Memory::Heap => clone_asset_encoding_content_chunks(encoding, chunk_index),
         Memory::Stable => STATE.with(|state| {
             get_content_chunks_stable(encoding, chunk_index, &state.borrow().stable.content_chunks)
         }),
@@ -188,8 +185,9 @@ fn get_content_chunks_stable(
     chunk_index: usize,
     content_chunks: &ContentChunksStable,
 ) -> Option<Blob> {
-    let key: StableEncodingChunkKey =
-        deserialize_from_bytes(Cow::Owned(encoding.content_chunks[chunk_index].clone()));
+    let key: StableEncodingChunkKey = deserialize_from_bytes(Cow::Owned(
+        encoding.content_chunks.get(chunk_index)?.clone(),
+    ));
     content_chunks.get(&key)
 }
 

--- a/src/libs/storage/src/errors.rs
+++ b/src/libs/storage/src/errors.rs
@@ -14,8 +14,6 @@ pub const JUNO_STORAGE_ERROR_BATCH_NOT_FOUND: &str = "juno.storage.error.batch_n
 pub const JUNO_STORAGE_ERROR_CHUNK_NOT_FOUND: &str = "juno.storage.error.chunk_not_found";
 pub const JUNO_STORAGE_ERROR_CHUNK_NOT_INCLUDED_IN_BATCH: &str =
     "juno.storage.error.chunk_not_included_in_batch";
-pub const JUNO_STORAGE_ERROR_CHUNK_TO_COMMIT_NOT_FOUND: &str =
-    "juno.storage.error.chunk_to_commit_not_found";
 // Asset exceed max allowed size
 pub const JUNO_STORAGE_ERROR_ASSET_MAX_ALLOWED_SIZE: &str =
     "juno.storage.error.asset_max_allowed_size";

--- a/src/libs/storage/src/http/response.rs
+++ b/src/libs/storage/src/http/response.rs
@@ -70,10 +70,12 @@ pub fn build_asset_response(
                                     }
                                 }
                                 None => {
-                                    error_response(
-                                        RESPONSE_STATUS_CODE_500,
-                                        "No chunks found.".to_string(),
-                                    );
+                                    return HttpResponse {
+                                        body: vec![],
+                                        headers: headers.clone(),
+                                        status_code,
+                                        streaming_strategy: None,
+                                    }
                                 }
                             }
                         }

--- a/src/libs/storage/src/store.rs
+++ b/src/libs/storage/src/store.rs
@@ -6,7 +6,7 @@ use crate::constants::{ASSET_ENCODING_NO_COMPRESSION, ENCODING_CERTIFICATION_ORD
 use crate::errors::{
     JUNO_STORAGE_ERROR_ASSET_MAX_ALLOWED_SIZE, JUNO_STORAGE_ERROR_BATCH_NOT_FOUND,
     JUNO_STORAGE_ERROR_CANNOT_COMMIT_BATCH, JUNO_STORAGE_ERROR_CHUNK_NOT_FOUND,
-    JUNO_STORAGE_ERROR_CHUNK_NOT_INCLUDED_IN_BATCH, JUNO_STORAGE_ERROR_CHUNK_TO_COMMIT_NOT_FOUND,
+    JUNO_STORAGE_ERROR_CHUNK_NOT_INCLUDED_IN_BATCH,
 };
 use crate::runtime::{
     clear_batch as clear_runtime_batch, clear_expired_batches as clear_expired_runtime_batches,
@@ -329,10 +329,6 @@ fn commit_chunks(
     // Collect content
     for c in chunks.iter() {
         content_chunks.push(c.content.clone());
-    }
-
-    if content_chunks.is_empty() {
-        return Err(JUNO_STORAGE_ERROR_CHUNK_TO_COMMIT_NOT_FOUND.to_string());
     }
 
     // We clone the key with the new information provided by the upload (name, full_path, token, etc.) to set the new key.

--- a/src/libs/storage/src/utils.rs
+++ b/src/libs/storage/src/utils.rs
@@ -161,8 +161,11 @@ pub fn create_asset_with_content(
     (asset, encoding)
 }
 
-pub fn clone_asset_encoding_content_chunks(encoding: &AssetEncoding, chunk_index: usize) -> Blob {
-    encoding.content_chunks[chunk_index].clone()
+pub fn clone_asset_encoding_content_chunks(
+    encoding: &AssetEncoding,
+    chunk_index: usize,
+) -> Option<Blob> {
+    encoding.content_chunks.get(chunk_index).cloned()
 }
 
 /// With heap memory the encodings are part of the asset struct.

--- a/src/tests/specs/console/cdn/console.cdn.batch.spec.ts
+++ b/src/tests/specs/console/cdn/console.cdn.batch.spec.ts
@@ -3,7 +3,10 @@ import { PocketIc, type Actor } from '@dfinity/pic';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import type { Principal } from '@icp-sdk/core/principal';
 import { inject } from 'vitest';
-import { testUploadProposalEmptyAsset, testUploadProposalManyAssets } from '../../../utils/cdn-assertions-tests.utils';
+import {
+	testUploadProposalEmptyAsset,
+	testUploadProposalManyAssets
+} from '../../../utils/cdn-assertions-tests.utils';
 import { CONSOLE_WASM_PATH } from '../../../utils/setup-tests.utils';
 
 describe('Console > Cdn > Batch', () => {

--- a/src/tests/specs/console/cdn/console.cdn.batch.spec.ts
+++ b/src/tests/specs/console/cdn/console.cdn.batch.spec.ts
@@ -3,7 +3,7 @@ import { PocketIc, type Actor } from '@dfinity/pic';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import type { Principal } from '@icp-sdk/core/principal';
 import { inject } from 'vitest';
-import { testUploadProposalManyAssets } from '../../../utils/cdn-assertions-tests.utils';
+import { testUploadProposalEmptyAsset, testUploadProposalManyAssets } from '../../../utils/cdn-assertions-tests.utils';
 import { CONSOLE_WASM_PATH } from '../../../utils/setup-tests.utils';
 
 describe('Console > Cdn > Batch', () => {
@@ -48,6 +48,14 @@ describe('Console > Cdn > Batch', () => {
 			currentDate,
 			canisterId: () => canisterId,
 			caller: () => controller,
+			pic: () => pic
+		});
+
+		testUploadProposalEmptyAsset({
+			expectedProposalId: 2n,
+			actor: () => actor,
+			currentDate,
+			canisterId: () => canisterId,
 			pic: () => pic
 		});
 	});

--- a/src/tests/specs/satellite/stock/cdn/satellite.cdn.batch.spec.ts
+++ b/src/tests/specs/satellite/stock/cdn/satellite.cdn.batch.spec.ts
@@ -4,7 +4,10 @@ import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import type { Principal } from '@icp-sdk/core/principal';
 import { inject } from 'vitest';
 import { CONTROLLER_METADATA } from '../../../../constants/controller-tests.constants';
-import { testUploadProposalManyAssets } from '../../../../utils/cdn-assertions-tests.utils';
+import {
+	testUploadProposalEmptyAsset,
+	testUploadProposalManyAssets
+} from '../../../../utils/cdn-assertions-tests.utils';
 import { controllersInitArgs, SATELLITE_WASM_PATH } from '../../../../utils/setup-tests.utils';
 
 describe('Satellite > Cdn > Batch', () => {
@@ -57,6 +60,14 @@ describe('Satellite > Cdn > Batch', () => {
 			caller: () => controller,
 			pic: () => pic
 		});
+
+		testUploadProposalEmptyAsset({
+			expectedProposalId: 2n,
+			actor: () => actor,
+			currentDate,
+			canisterId: () => canisterId,
+			pic: () => pic
+		});
 	});
 
 	describe('Read+write controller', () => {
@@ -81,11 +92,19 @@ describe('Satellite > Cdn > Batch', () => {
 		});
 
 		testUploadProposalManyAssets({
-			expectedProposalId: 2n,
+			expectedProposalId: 3n,
 			actor: () => actor,
 			currentDate,
 			canisterId: () => canisterId,
 			caller: () => controllerReadWrite,
+			pic: () => pic
+		});
+
+		testUploadProposalEmptyAsset({
+			expectedProposalId: 4n,
+			actor: () => actor,
+			currentDate,
+			canisterId: () => canisterId,
 			pic: () => pic
 		});
 	});

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.spec.ts
@@ -1568,9 +1568,9 @@ describe.each([{ title: 'Heap (default)', memory: null }, ...MEMORIES])(
 			});
 		});
 
-		describe("More admin", () => {
+		describe('More admin', () => {
 			it('should deploy empty asset to dapp', async () => {
-				const { http_request, commit_asset_upload, upload_asset_chunk, init_asset_upload } = actor;
+				const { http_request, commit_asset_upload, init_asset_upload } = actor;
 
 				const full_path = '/hello-empty.html';
 
@@ -1621,6 +1621,6 @@ describe.each([{ title: 'Heap (default)', memory: null }, ...MEMORIES])(
 				expect(decoder.decode(body)).toEqual('');
 				expect(body).toHaveLength(0);
 			});
-		})
+		});
 	}
 );

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.spec.ts
@@ -1567,5 +1567,60 @@ describe.each([{ title: 'Heap (default)', memory: null }, ...MEMORIES])(
 				);
 			});
 		});
+
+		describe("More admin", () => {
+			it('should deploy empty asset to dapp', async () => {
+				const { http_request, commit_asset_upload, upload_asset_chunk, init_asset_upload } = actor;
+
+				const full_path = '/hello-empty.html';
+
+				const file = await init_asset_upload({
+					collection: '#dapp',
+					description: toNullable(),
+					encoding_type: [],
+					full_path,
+					name: 'hello-empty.html',
+					token: toNullable()
+				});
+
+				await commit_asset_upload({
+					batch_id: file.batch_id,
+					chunk_ids: [],
+					headers: []
+				});
+
+				const request: SatelliteDid.HttpRequest = {
+					body: Uint8Array.from([]),
+					certificate_version: toNullable(2),
+					headers: [],
+					method: 'GET',
+					url: full_path
+				};
+
+				const response = await http_request(request);
+
+				const { headers, body, status_code } = response;
+
+				expect(status_code).toBe(200);
+
+				assertHeaders({
+					headers,
+					etag: '"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"'
+				});
+
+				await assertCertification({
+					canisterId,
+					pic,
+					request,
+					response,
+					currentDate
+				});
+
+				const decoder = new TextDecoder();
+
+				expect(decoder.decode(body)).toEqual('');
+				expect(body).toHaveLength(0);
+			});
+		})
 	}
 );

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -1537,4 +1537,126 @@ export const testUploadProposalManyAssets = ({
 	});
 };
 
+export const testUploadProposalEmptyAsset = ({
+	actor,
+	pic,
+	canisterId,
+	currentDate,
+	expectedProposalId
+}: {
+	actor: (params?: { requireController: boolean }) => Actor<SatelliteActor | ConsoleActor>;
+	pic: () => PocketIc;
+	canisterId: () => Principal;
+	currentDate: Date;
+	expectedProposalId: bigint;
+}) => {
+	const collection = '#dapp';
+
+	const name = `hello-batch-empty-${nanoid()}.html`;
+	const full_path = `/hello/${name}`;
+
+	const key: ConsoleDid.InitAssetKey = {
+		collection,
+		description: toNullable(),
+		encoding_type: [],
+		full_path,
+		name,
+		token: toNullable()
+	}
+
+	const uploadProposalEmptyAsset = async (proposalId: bigint) => {
+		const {
+			init_proposal_many_assets_upload,
+			commit_proposal_many_assets_upload
+		} = actor();
+
+		const files = await init_proposal_many_assets_upload([key], proposalId);
+
+		const [_, { batch_id }] = files[0];
+
+		await commit_proposal_many_assets_upload([
+			{
+				batch_id,
+				// No chunks
+				chunk_ids: [],
+				// Expected by assertHeads in serve test
+				headers: [['cache-control', 'no-cache']]
+			}
+		]);
+	};
+
+	const proposal_type: ConsoleDid.ProposalType = {
+		AssetsUpgrade: {
+			clear_existing_assets: toNullable()
+		}
+	};
+
+	it('should upload an empty asset', async () => {
+		const { init_proposal, submit_proposal } = actor();
+
+		const [proposalId, proposal] = await init_proposal(proposal_type);
+
+		expect(proposalId).toEqual(expectedProposalId);
+
+		expect(proposal.status).toEqual({ Initialized: null });
+
+		await uploadProposalEmptyAsset(proposalId);
+
+		const [_, submittedProposal] = await submit_proposal(proposalId);
+
+		expect(submittedProposal.status).toEqual({ Open: null });
+
+		const { commit_proposal } = actor({ requireController: true });
+
+		const sha = fromNullable(submittedProposal.sha256);
+
+		assertNonNullish(sha);
+
+		await expect(
+			commit_proposal({
+				sha256: sha,
+				proposal_id: proposalId
+			})
+		).resolves.not.toThrow();
+	});
+
+	it('should serve asset with empty content', async () => {
+		const { http_request } = actor();
+
+		await tick(pic());
+
+		const request: ConsoleDid.HttpRequest = {
+			body: Uint8Array.from([]),
+			certificate_version: toNullable(2),
+			headers: [],
+			method: 'GET',
+			url: full_path
+		};
+
+		const response = await http_request(request);
+
+		const { status_code, headers, body } = response;
+
+		expect(status_code).toBe(200);
+
+		assertHeaders({
+			headers,
+			etag: '"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"'
+		});
+
+		await assertCertification({
+			canisterId: canisterId(),
+			pic: pic(),
+			request,
+			response,
+			currentDate
+		});
+
+		const decoder = new TextDecoder();
+
+		expect(decoder.decode(body)).toEqual("");
+		expect(body).toHaveLength(0);
+	});
+};
+
 /* eslint-enable */

--- a/src/tests/utils/cdn-assertions-tests.utils.ts
+++ b/src/tests/utils/cdn-assertions-tests.utils.ts
@@ -1562,17 +1562,14 @@ export const testUploadProposalEmptyAsset = ({
 		full_path,
 		name,
 		token: toNullable()
-	}
+	};
 
 	const uploadProposalEmptyAsset = async (proposalId: bigint) => {
-		const {
-			init_proposal_many_assets_upload,
-			commit_proposal_many_assets_upload
-		} = actor();
+		const { init_proposal_many_assets_upload, commit_proposal_many_assets_upload } = actor();
 
 		const files = await init_proposal_many_assets_upload([key], proposalId);
 
-		const [_, { batch_id }] = files[0];
+		const [[_, { batch_id }]] = files;
 
 		await commit_proposal_many_assets_upload([
 			{
@@ -1654,7 +1651,7 @@ export const testUploadProposalEmptyAsset = ({
 
 		const decoder = new TextDecoder();
 
-		expect(decoder.decode(body)).toEqual("");
+		expect(decoder.decode(body)).toEqual('');
 		expect(body).toHaveLength(0);
 	});
 };

--- a/src/tests/utils/storage-tests.utils.ts
+++ b/src/tests/utils/storage-tests.utils.ts
@@ -1,4 +1,4 @@
-export const assertHeaders = ({ headers }: { headers: [string, string][] }) => {
+export const assertHeaders = ({ headers, etag }: { headers: [string, string][], etag?: string }) => {
 	const rest = headers.filter(([header, _]) => header !== 'IC-Certificate');
 
 	const sortHeaders = (headers: [string, string][]): [string, string][] =>
@@ -6,7 +6,7 @@ export const assertHeaders = ({ headers }: { headers: [string, string][] }) => {
 
 	const expectedHeaders: [string, string][] = [
 		['accept-ranges', 'bytes'],
-		['etag', '"03ee66f1452916b4f91a504c1e9babfa201b6d64c26a82b2cf03c3ed49d91585"'],
+		['etag', etag ?? '"03ee66f1452916b4f91a504c1e9babfa201b6d64c26a82b2cf03c3ed49d91585"'],
 		['x-content-type-options', 'nosniff'],
 		['strict-transport-security', 'max-age=31536000 ; includeSubDomains'],
 		['referrer-policy', 'same-origin'],

--- a/src/tests/utils/storage-tests.utils.ts
+++ b/src/tests/utils/storage-tests.utils.ts
@@ -1,4 +1,10 @@
-export const assertHeaders = ({ headers, etag }: { headers: [string, string][], etag?: string }) => {
+export const assertHeaders = ({
+	headers,
+	etag
+}: {
+	headers: [string, string][];
+	etag?: string;
+}) => {
 	const rest = headers.filter(([header, _]) => header !== 'IC-Certificate');
 
 	const sortHeaders = (headers: [string, string][]): [string, string][] =>


### PR DESCRIPTION
# Motivation

While I still think it's a Vite v8 bug (see #2695), allowing 0kb chunk - since it's not an issue for the certification or serving content on the web - can be allowed which per extension would prevent issues.
