### PR TITLE
feat(satellite): certify assets chunk

### DIFF
--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -115,7 +115,10 @@ export type CertifyAssetsCursor =
 export interface CertifyAssetsResult {
 	next_cursor: [] | [CertifyAssetsCursor];
 }
-export type CertifyAssetsStrategy = { Reset: null } | { Accumulate: null };
+export type CertifyAssetsStrategy =
+	| { Append: null }
+	| { Clear: null }
+	| { AppendWithRouting: null };
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -104,6 +104,16 @@ export interface AutomationController {
 	expires_at: bigint;
 }
 export type AutomationScope = { Write: null } | { Submit: null };
+export interface CertifyAssetsArgs {
+	cursor: CertifyAssetsCursor;
+	chunk_size: [] | [number];
+}
+export type CertifyAssetsCursor =
+	| { Heap: { offset: bigint } }
+	| { Stable: { key: [] | [AssetKey] } };
+export interface CertifyAssetsResult {
+	next_cursor: [] | [CertifyAssetsCursor];
+}
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;
@@ -515,6 +525,7 @@ export interface _SERVICE {
 		[AuthenticateAutomationArgs],
 		AuthenticateAutomationResultResponse
 	>;
+	certify_assets_chunk: ActorMethod<[CertifyAssetsArgs], CertifyAssetsResult>;
 	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;

--- a/src/declarations/satellite/satellite.did.d.ts
+++ b/src/declarations/satellite/satellite.did.d.ts
@@ -106,6 +106,7 @@ export interface AutomationController {
 export type AutomationScope = { Write: null } | { Submit: null };
 export interface CertifyAssetsArgs {
 	cursor: CertifyAssetsCursor;
+	strategy: CertifyAssetsStrategy;
 	chunk_size: [] | [number];
 }
 export type CertifyAssetsCursor =
@@ -114,6 +115,7 @@ export type CertifyAssetsCursor =
 export interface CertifyAssetsResult {
 	next_cursor: [] | [CertifyAssetsCursor];
 }
+export type CertifyAssetsStrategy = { Reset: null } | { Accumulate: null };
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -123,8 +123,13 @@ export const idlFactory = ({ IDL }) => {
 		Heap: IDL.Record({ offset: IDL.Nat64 }),
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
+	const CertifyAssetsStrategy = IDL.Variant({
+		Reset: IDL.Null,
+		Accumulate: IDL.Null
+	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,
+		strategy: CertifyAssetsStrategy,
 		chunk_size: IDL.Opt(IDL.Nat32)
 	});
 	const CertifyAssetsResult = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -124,8 +124,9 @@ export const idlFactory = ({ IDL }) => {
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
 	const CertifyAssetsStrategy = IDL.Variant({
-		Reset: IDL.Null,
-		Accumulate: IDL.Null
+		Append: IDL.Null,
+		Clear: IDL.Null,
+		AppendWithRouting: IDL.Null
 	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,

--- a/src/declarations/satellite/satellite.factory.certified.did.js
+++ b/src/declarations/satellite/satellite.factory.certified.did.js
@@ -111,6 +111,25 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Tuple(IDL.Principal, AutomationController),
 		Err: AuthenticationAutomationError
 	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const CertifyAssetsCursor = IDL.Variant({
+		Heap: IDL.Record({ offset: IDL.Nat64 }),
+		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
+	});
+	const CertifyAssetsArgs = IDL.Record({
+		cursor: CertifyAssetsCursor,
+		chunk_size: IDL.Opt(IDL.Nat32)
+	});
+	const CertifyAssetsResult = IDL.Record({
+		next_cursor: IDL.Opt(CertifyAssetsCursor)
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -177,14 +196,6 @@ export const idlFactory = ({ IDL }) => {
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
-	});
-	const AssetKey = IDL.Record({
-		token: IDL.Opt(IDL.Text),
-		collection: IDL.Text,
-		owner: IDL.Principal,
-		name: IDL.Text,
-		description: IDL.Opt(IDL.Text),
-		full_path: IDL.Text
 	});
 	const AssetEncodingNoContent = IDL.Record({
 		modified: IDL.Nat64,
@@ -522,6 +533,7 @@ export const idlFactory = ({ IDL }) => {
 			[AuthenticateAutomationResultResponse],
 			[]
 		),
+		certify_assets_chunk: IDL.Func([CertifyAssetsArgs], [CertifyAssetsResult], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -123,8 +123,13 @@ export const idlFactory = ({ IDL }) => {
 		Heap: IDL.Record({ offset: IDL.Nat64 }),
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
+	const CertifyAssetsStrategy = IDL.Variant({
+		Reset: IDL.Null,
+		Accumulate: IDL.Null
+	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,
+		strategy: CertifyAssetsStrategy,
 		chunk_size: IDL.Opt(IDL.Nat32)
 	});
 	const CertifyAssetsResult = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -124,8 +124,9 @@ export const idlFactory = ({ IDL }) => {
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
 	const CertifyAssetsStrategy = IDL.Variant({
-		Reset: IDL.Null,
-		Accumulate: IDL.Null
+		Append: IDL.Null,
+		Clear: IDL.Null,
+		AppendWithRouting: IDL.Null
 	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,

--- a/src/declarations/satellite/satellite.factory.did.js
+++ b/src/declarations/satellite/satellite.factory.did.js
@@ -111,6 +111,25 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Tuple(IDL.Principal, AutomationController),
 		Err: AuthenticationAutomationError
 	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const CertifyAssetsCursor = IDL.Variant({
+		Heap: IDL.Record({ offset: IDL.Nat64 }),
+		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
+	});
+	const CertifyAssetsArgs = IDL.Record({
+		cursor: CertifyAssetsCursor,
+		chunk_size: IDL.Opt(IDL.Nat32)
+	});
+	const CertifyAssetsResult = IDL.Record({
+		next_cursor: IDL.Opt(CertifyAssetsCursor)
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -177,14 +196,6 @@ export const idlFactory = ({ IDL }) => {
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
-	});
-	const AssetKey = IDL.Record({
-		token: IDL.Opt(IDL.Text),
-		collection: IDL.Text,
-		owner: IDL.Principal,
-		name: IDL.Text,
-		description: IDL.Opt(IDL.Text),
-		full_path: IDL.Text
 	});
 	const AssetEncodingNoContent = IDL.Record({
 		modified: IDL.Nat64,
@@ -522,6 +533,7 @@ export const idlFactory = ({ IDL }) => {
 			[AuthenticateAutomationResultResponse],
 			[]
 		),
+		certify_assets_chunk: IDL.Func([CertifyAssetsArgs], [CertifyAssetsResult], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -123,8 +123,13 @@ export const idlFactory = ({ IDL }) => {
 		Heap: IDL.Record({ offset: IDL.Nat64 }),
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
+	const CertifyAssetsStrategy = IDL.Variant({
+		Reset: IDL.Null,
+		Accumulate: IDL.Null
+	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,
+		strategy: CertifyAssetsStrategy,
 		chunk_size: IDL.Opt(IDL.Nat32)
 	});
 	const CertifyAssetsResult = IDL.Record({

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -124,8 +124,9 @@ export const idlFactory = ({ IDL }) => {
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
 	const CertifyAssetsStrategy = IDL.Variant({
-		Reset: IDL.Null,
-		Accumulate: IDL.Null
+		Append: IDL.Null,
+		Clear: IDL.Null,
+		AppendWithRouting: IDL.Null
 	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,

--- a/src/declarations/satellite/satellite.factory.did.mjs
+++ b/src/declarations/satellite/satellite.factory.did.mjs
@@ -111,6 +111,25 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Tuple(IDL.Principal, AutomationController),
 		Err: AuthenticationAutomationError
 	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const CertifyAssetsCursor = IDL.Variant({
+		Heap: IDL.Record({ offset: IDL.Nat64 }),
+		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
+	});
+	const CertifyAssetsArgs = IDL.Record({
+		cursor: CertifyAssetsCursor,
+		chunk_size: IDL.Opt(IDL.Nat32)
+	});
+	const CertifyAssetsResult = IDL.Record({
+		next_cursor: IDL.Opt(CertifyAssetsCursor)
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -177,14 +196,6 @@ export const idlFactory = ({ IDL }) => {
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
-	});
-	const AssetKey = IDL.Record({
-		token: IDL.Opt(IDL.Text),
-		collection: IDL.Text,
-		owner: IDL.Principal,
-		name: IDL.Text,
-		description: IDL.Opt(IDL.Text),
-		full_path: IDL.Text
 	});
 	const AssetEncodingNoContent = IDL.Record({
 		modified: IDL.Nat64,
@@ -522,6 +533,7 @@ export const idlFactory = ({ IDL }) => {
 			[AuthenticateAutomationResultResponse],
 			[]
 		),
+		certify_assets_chunk: IDL.Func([CertifyAssetsArgs], [CertifyAssetsResult], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -115,7 +115,10 @@ export type CertifyAssetsCursor =
 export interface CertifyAssetsResult {
 	next_cursor: [] | [CertifyAssetsCursor];
 }
-export type CertifyAssetsStrategy = { Reset: null } | { Accumulate: null };
+export type CertifyAssetsStrategy =
+	| { Append: null }
+	| { Clear: null }
+	| { AppendWithRouting: null };
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -104,6 +104,16 @@ export interface AutomationController {
 	expires_at: bigint;
 }
 export type AutomationScope = { Write: null } | { Submit: null };
+export interface CertifyAssetsArgs {
+	cursor: CertifyAssetsCursor;
+	chunk_size: [] | [number];
+}
+export type CertifyAssetsCursor =
+	| { Heap: { offset: bigint } }
+	| { Stable: { key: [] | [AssetKey] } };
+export interface CertifyAssetsResult {
+	next_cursor: [] | [CertifyAssetsCursor];
+}
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;
@@ -515,6 +525,7 @@ export interface _SERVICE {
 		[AuthenticateAutomationArgs],
 		AuthenticateAutomationResultResponse
 	>;
+	certify_assets_chunk: ActorMethod<[CertifyAssetsArgs], CertifyAssetsResult>;
 	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;

--- a/src/declarations/sputnik/sputnik.did.d.ts
+++ b/src/declarations/sputnik/sputnik.did.d.ts
@@ -106,6 +106,7 @@ export interface AutomationController {
 export type AutomationScope = { Write: null } | { Submit: null };
 export interface CertifyAssetsArgs {
 	cursor: CertifyAssetsCursor;
+	strategy: CertifyAssetsStrategy;
 	chunk_size: [] | [number];
 }
 export type CertifyAssetsCursor =
@@ -114,6 +115,7 @@ export type CertifyAssetsCursor =
 export interface CertifyAssetsResult {
 	next_cursor: [] | [CertifyAssetsCursor];
 }
+export type CertifyAssetsStrategy = { Reset: null } | { Accumulate: null };
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -123,8 +123,13 @@ export const idlFactory = ({ IDL }) => {
 		Heap: IDL.Record({ offset: IDL.Nat64 }),
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
+	const CertifyAssetsStrategy = IDL.Variant({
+		Reset: IDL.Null,
+		Accumulate: IDL.Null
+	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,
+		strategy: CertifyAssetsStrategy,
 		chunk_size: IDL.Opt(IDL.Nat32)
 	});
 	const CertifyAssetsResult = IDL.Record({

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -124,8 +124,9 @@ export const idlFactory = ({ IDL }) => {
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
 	const CertifyAssetsStrategy = IDL.Variant({
-		Reset: IDL.Null,
-		Accumulate: IDL.Null
+		Append: IDL.Null,
+		Clear: IDL.Null,
+		AppendWithRouting: IDL.Null
 	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,

--- a/src/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/src/declarations/sputnik/sputnik.factory.certified.did.js
@@ -111,6 +111,25 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Tuple(IDL.Principal, AutomationController),
 		Err: AuthenticationAutomationError
 	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const CertifyAssetsCursor = IDL.Variant({
+		Heap: IDL.Record({ offset: IDL.Nat64 }),
+		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
+	});
+	const CertifyAssetsArgs = IDL.Record({
+		cursor: CertifyAssetsCursor,
+		chunk_size: IDL.Opt(IDL.Nat32)
+	});
+	const CertifyAssetsResult = IDL.Record({
+		next_cursor: IDL.Opt(CertifyAssetsCursor)
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -177,14 +196,6 @@ export const idlFactory = ({ IDL }) => {
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
-	});
-	const AssetKey = IDL.Record({
-		token: IDL.Opt(IDL.Text),
-		collection: IDL.Text,
-		owner: IDL.Principal,
-		name: IDL.Text,
-		description: IDL.Opt(IDL.Text),
-		full_path: IDL.Text
 	});
 	const AssetEncodingNoContent = IDL.Record({
 		modified: IDL.Nat64,
@@ -522,6 +533,7 @@ export const idlFactory = ({ IDL }) => {
 			[AuthenticateAutomationResultResponse],
 			[]
 		),
+		certify_assets_chunk: IDL.Func([CertifyAssetsArgs], [CertifyAssetsResult], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -123,8 +123,13 @@ export const idlFactory = ({ IDL }) => {
 		Heap: IDL.Record({ offset: IDL.Nat64 }),
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
+	const CertifyAssetsStrategy = IDL.Variant({
+		Reset: IDL.Null,
+		Accumulate: IDL.Null
+	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,
+		strategy: CertifyAssetsStrategy,
 		chunk_size: IDL.Opt(IDL.Nat32)
 	});
 	const CertifyAssetsResult = IDL.Record({

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -124,8 +124,9 @@ export const idlFactory = ({ IDL }) => {
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
 	const CertifyAssetsStrategy = IDL.Variant({
-		Reset: IDL.Null,
-		Accumulate: IDL.Null
+		Append: IDL.Null,
+		Clear: IDL.Null,
+		AppendWithRouting: IDL.Null
 	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,

--- a/src/declarations/sputnik/sputnik.factory.did.js
+++ b/src/declarations/sputnik/sputnik.factory.did.js
@@ -111,6 +111,25 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Tuple(IDL.Principal, AutomationController),
 		Err: AuthenticationAutomationError
 	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const CertifyAssetsCursor = IDL.Variant({
+		Heap: IDL.Record({ offset: IDL.Nat64 }),
+		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
+	});
+	const CertifyAssetsArgs = IDL.Record({
+		cursor: CertifyAssetsCursor,
+		chunk_size: IDL.Opt(IDL.Nat32)
+	});
+	const CertifyAssetsResult = IDL.Record({
+		next_cursor: IDL.Opt(CertifyAssetsCursor)
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -177,14 +196,6 @@ export const idlFactory = ({ IDL }) => {
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
-	});
-	const AssetKey = IDL.Record({
-		token: IDL.Opt(IDL.Text),
-		collection: IDL.Text,
-		owner: IDL.Principal,
-		name: IDL.Text,
-		description: IDL.Opt(IDL.Text),
-		full_path: IDL.Text
 	});
 	const AssetEncodingNoContent = IDL.Record({
 		modified: IDL.Nat64,
@@ -522,6 +533,7 @@ export const idlFactory = ({ IDL }) => {
 			[AuthenticateAutomationResultResponse],
 			[]
 		),
+		certify_assets_chunk: IDL.Func([CertifyAssetsArgs], [CertifyAssetsResult], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -98,7 +98,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
-type CertifyAssetsStrategy = variant { Reset; Accumulate };
+type CertifyAssetsStrategy = variant { Append; Clear; AppendWithRouting };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -90,6 +90,7 @@ type AutomationController = record {
 type AutomationScope = variant { Write; Submit };
 type CertifyAssetsArgs = record {
   cursor : CertifyAssetsCursor;
+  strategy : CertifyAssetsStrategy;
   chunk_size : opt nat32;
 };
 type CertifyAssetsCursor = variant {
@@ -97,6 +98,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
+type CertifyAssetsStrategy = variant { Reset; Accumulate };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/libs/satellite/satellite.did
+++ b/src/libs/satellite/satellite.did
@@ -88,6 +88,15 @@ type AutomationController = record {
   expires_at : nat64;
 };
 type AutomationScope = variant { Write; Submit };
+type CertifyAssetsArgs = record {
+  cursor : CertifyAssetsCursor;
+  chunk_size : opt nat32;
+};
+type CertifyAssetsCursor = variant {
+  Heap : record { offset : nat64 };
+  Stable : record { key : opt AssetKey };
+};
+type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;
@@ -439,6 +448,7 @@ service : (InitSatelliteArgs) -> {
   authenticate_automation : (AuthenticateAutomationArgs) -> (
       AuthenticateAutomationResultResponse,
     );
+  certify_assets_chunk : (CertifyAssetsArgs) -> (CertifyAssetsResult);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/libs/satellite/src/api/storage.rs
+++ b/src/libs/satellite/src/api/storage.rs
@@ -1,8 +1,10 @@
+use crate::assets::storage::certified_assets::chunk::certify_assets_chunk as init_certify_assets_chunk;
 use crate::assets::storage::store::{commit_batch_store, create_batch_store, create_chunk_store};
 use crate::hooks::storage::{
     invoke_on_delete_asset, invoke_on_delete_filtered_assets, invoke_on_delete_many_assets,
     invoke_upload_asset,
 };
+use crate::types::interface::{CertifyAssetsArgs, CertifyAssetsResult};
 use crate::{
     caller, count_assets_store, count_collection_assets_store, delete_asset_store,
     delete_assets_store, delete_filtered_assets_store, get_asset_store, list_assets_store,
@@ -117,4 +119,8 @@ pub fn set_asset_token(collection: CollectionKey, full_path: FullPath, token: As
 
     // No hook currently available for this function for simplicity reasons,
     // but not against adding one if it proves useful.
+}
+
+pub fn certify_assets_chunk(args: CertifyAssetsArgs) -> CertifyAssetsResult {
+    init_certify_assets_chunk(args)
 }

--- a/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
@@ -1,0 +1,107 @@
+use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
+use junobuild_storage::certified_assets::extend_and_init_certified_assets;
+use junobuild_storage::types::config::StorageConfig;
+use crate::assets::storage::strategy_impls::StorageState;
+use crate::assets::storage::types::state::StableKey;
+use crate::certification::strategy_impls::StorageCertificate;
+use crate::memory::state::STATE;
+use crate::types::state::State;
+
+pub struct InitCertifiedAssetsArgs {
+    pub cursor: InitCertifiedAssetsCursor,
+}
+
+pub enum InitCertifiedAssetsCursor {
+    Heap { offset: usize },
+    Stable { key: Option<StableKey> },
+}
+
+pub struct InitCertifiedAssetsResult {
+    pub next_cursor: Option<InitCertifiedAssetsCursor>,
+}
+
+pub fn certify_assets_chunk(args: InitCertifiedAssetsArgs) -> InitCertifiedAssetsResult {
+    STATE.with(|state| {
+        certify_assets_chunk_impl(&state.borrow(), args)
+    })
+}
+
+fn certify_assets_chunk_impl(
+    state: &State,
+    args: InitCertifiedAssetsArgs,
+) -> InitCertifiedAssetsResult {
+    let mut asset_hashes = CertifiedAssetHashes::default();
+
+    let config = &state.heap.storage.config;
+
+    let next_cursor = match args.cursor {
+        InitCertifiedAssetsCursor::Heap { offset } => {
+            process_heap_chunk(state, &mut asset_hashes, config, offset)
+        }
+        InitCertifiedAssetsCursor::Stable { key } => {
+            process_stable_chunk(state, &mut asset_hashes, config, key)
+        }
+    };
+
+    extend_and_init_certified_assets(
+        &mut asset_hashes,
+        config,
+        &StorageState,
+        &StorageCertificate,
+    );
+
+    InitCertifiedAssetsResult { next_cursor }
+}
+
+const CHUNK_SIZE: usize = 1000;
+
+fn process_heap_chunk(
+    state: &State,
+    asset_hashes: &mut CertifiedAssetHashes,
+    config: &StorageConfig,
+    offset: usize,
+) -> Option<InitCertifiedAssetsCursor> {
+    let mut count = 0;
+
+    for asset in state.heap.storage.assets.values().skip(offset).take(CHUNK_SIZE) {
+        asset_hashes.insert(asset, config);
+        count += 1;
+    }
+
+    if count == CHUNK_SIZE {
+        Some(InitCertifiedAssetsCursor::Heap { offset: offset + CHUNK_SIZE })
+    } else {
+        None
+    }
+}
+
+fn process_stable_chunk(
+    state: &State,
+    asset_hashes: &mut CertifiedAssetHashes,
+    config: &StorageConfig,
+    from_key: Option<StableKey>,
+) -> Option<InitCertifiedAssetsCursor> {
+    let iter = match &from_key {
+        None => state.stable.assets.iter(),
+        Some(key) => state.stable.assets.iter_from_prev_key(key),
+    };
+
+    let mut last_key: Option<StableKey> = None;
+
+    let mut count = 0;
+
+    for entry in iter.take(CHUNK_SIZE) {
+        asset_hashes.insert(&entry.value(), config);
+        count += 1;
+
+        if count == CHUNK_SIZE {
+            last_key = Some(entry.key().clone());
+        }
+    }
+
+    if count == CHUNK_SIZE {
+        Some(InitCertifiedAssetsCursor::Stable { key: last_key })
+    } else {
+        None
+    }
+}

--- a/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
@@ -9,6 +9,7 @@ use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
 use junobuild_storage::certified_assets::extend_and_init_certified_assets;
 use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::store::AssetKey;
+use std::ops::Bound;
 
 const DEFAULT_CHUNK_SIZE: usize = 1000;
 
@@ -91,7 +92,7 @@ fn process_stable_chunk(
 
     let iter = match &stable_key {
         None => state.stable.assets.iter(),
-        Some(key) => state.stable.assets.iter_from_prev_key(key),
+        Some(key) => state.stable.assets.range((Bound::Excluded(key.clone()), Bound::Unbounded)),
     };
 
     let mut last_key: Option<AssetKey> = None;

--- a/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
@@ -16,21 +16,18 @@ pub fn certify_assets_chunk(args: CertifyAssetsArgs) -> CertifyAssetsResult {
 }
 
 fn certify_assets_chunk_impl(state: &State, args: CertifyAssetsArgs) -> CertifyAssetsResult {
-    let mut asset_hashes = CertifiedAssetHashes::default();
-
     let config = &state.heap.storage.config;
 
-    let chunk_size = args.chunk_size
+    let chunk_size = args
+        .chunk_size
         .map(|s| usize::try_from(s).unwrap_or(DEFAULT_CHUNK_SIZE))
         .unwrap_or(DEFAULT_CHUNK_SIZE);
 
-    let next_cursor = match args.cursor {
+    let (mut asset_hashes, next_cursor) = match args.cursor {
         CertifyAssetsCursor::Heap { offset } => {
-            process_heap_chunk(state, &mut asset_hashes, config, offset, chunk_size)
+            process_heap_chunk(state, config, offset, chunk_size)
         }
-        CertifyAssetsCursor::Stable { key } => {
-            process_stable_chunk(state, &mut asset_hashes, config, key, chunk_size)
-        }
+        CertifyAssetsCursor::Stable { key } => process_stable_chunk(state, config, key, chunk_size),
     };
 
     extend_and_init_certified_assets(
@@ -43,13 +40,15 @@ fn certify_assets_chunk_impl(state: &State, args: CertifyAssetsArgs) -> CertifyA
     CertifyAssetsResult { next_cursor }
 }
 
+type ProcessChunkResult = (CertifiedAssetHashes, Option<CertifyAssetsCursor>);
+
 fn process_heap_chunk(
     state: &State,
-    asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     offset: usize,
     chunk_size: usize,
-) -> Option<CertifyAssetsCursor> {
+) -> ProcessChunkResult {
+    let mut asset_hashes = CertifiedAssetHashes::default();
     let mut count = 0;
 
     for asset in state
@@ -64,30 +63,32 @@ fn process_heap_chunk(
         count += 1;
     }
 
-    if count == chunk_size {
+    let next_cursor = if count == chunk_size {
         Some(CertifyAssetsCursor::Heap {
             offset: offset + chunk_size,
         })
     } else {
         None
-    }
+    };
+
+    (asset_hashes, next_cursor)
 }
 
 fn process_stable_chunk(
     state: &State,
-    asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     from_key: Option<StableKey>,
     chunk_size: usize,
-) -> Option<CertifyAssetsCursor> {
+) -> ProcessChunkResult {
+    let mut asset_hashes = CertifiedAssetHashes::default();
+    let mut count = 0;
+
     let iter = match &from_key {
         None => state.stable.assets.iter(),
         Some(key) => state.stable.assets.iter_from_prev_key(key),
     };
 
     let mut last_key: Option<StableKey> = None;
-
-    let mut count = 0;
 
     for entry in iter.take(chunk_size) {
         asset_hashes.insert(&entry.value(), config);
@@ -98,9 +99,11 @@ fn process_stable_chunk(
         }
     }
 
-    if count == chunk_size {
+    let next_cursor = if count == chunk_size {
         Some(CertifyAssetsCursor::Stable { key: last_key })
     } else {
         None
-    }
+    };
+
+    (asset_hashes, next_cursor)
 }

--- a/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
@@ -1,44 +1,28 @@
-use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
-use junobuild_storage::certified_assets::extend_and_init_certified_assets;
-use junobuild_storage::types::config::StorageConfig;
+use crate::assets::storage::certified_assets::types::CertifyAssetsCursor;
 use crate::assets::storage::strategy_impls::StorageState;
 use crate::assets::storage::types::state::StableKey;
 use crate::certification::strategy_impls::StorageCertificate;
 use crate::memory::state::STATE;
+use crate::types::interface::{CertifyAssetsArgs, CertifyAssetsResult};
 use crate::types::state::State;
+use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
+use junobuild_storage::certified_assets::extend_and_init_certified_assets;
+use junobuild_storage::types::config::StorageConfig;
 
-pub struct InitCertifiedAssetsArgs {
-    pub cursor: InitCertifiedAssetsCursor,
+pub fn certify_assets_chunk(args: CertifyAssetsArgs) -> CertifyAssetsResult {
+    STATE.with(|state| certify_assets_chunk_impl(&state.borrow(), args))
 }
 
-pub enum InitCertifiedAssetsCursor {
-    Heap { offset: usize },
-    Stable { key: Option<StableKey> },
-}
-
-pub struct InitCertifiedAssetsResult {
-    pub next_cursor: Option<InitCertifiedAssetsCursor>,
-}
-
-pub fn certify_assets_chunk(args: InitCertifiedAssetsArgs) -> InitCertifiedAssetsResult {
-    STATE.with(|state| {
-        certify_assets_chunk_impl(&state.borrow(), args)
-    })
-}
-
-fn certify_assets_chunk_impl(
-    state: &State,
-    args: InitCertifiedAssetsArgs,
-) -> InitCertifiedAssetsResult {
+fn certify_assets_chunk_impl(state: &State, args: CertifyAssetsArgs) -> CertifyAssetsResult {
     let mut asset_hashes = CertifiedAssetHashes::default();
 
     let config = &state.heap.storage.config;
 
     let next_cursor = match args.cursor {
-        InitCertifiedAssetsCursor::Heap { offset } => {
+        CertifyAssetsCursor::Heap { offset } => {
             process_heap_chunk(state, &mut asset_hashes, config, offset)
         }
-        InitCertifiedAssetsCursor::Stable { key } => {
+        CertifyAssetsCursor::Stable { key } => {
             process_stable_chunk(state, &mut asset_hashes, config, key)
         }
     };
@@ -50,7 +34,7 @@ fn certify_assets_chunk_impl(
         &StorageCertificate,
     );
 
-    InitCertifiedAssetsResult { next_cursor }
+    CertifyAssetsResult { next_cursor }
 }
 
 const CHUNK_SIZE: usize = 1000;
@@ -60,16 +44,25 @@ fn process_heap_chunk(
     asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     offset: usize,
-) -> Option<InitCertifiedAssetsCursor> {
+) -> Option<CertifyAssetsCursor> {
     let mut count = 0;
 
-    for asset in state.heap.storage.assets.values().skip(offset).take(CHUNK_SIZE) {
+    for asset in state
+        .heap
+        .storage
+        .assets
+        .values()
+        .skip(offset)
+        .take(CHUNK_SIZE)
+    {
         asset_hashes.insert(asset, config);
         count += 1;
     }
 
     if count == CHUNK_SIZE {
-        Some(InitCertifiedAssetsCursor::Heap { offset: offset + CHUNK_SIZE })
+        Some(CertifyAssetsCursor::Heap {
+            offset: offset + CHUNK_SIZE,
+        })
     } else {
         None
     }
@@ -80,7 +73,7 @@ fn process_stable_chunk(
     asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     from_key: Option<StableKey>,
-) -> Option<InitCertifiedAssetsCursor> {
+) -> Option<CertifyAssetsCursor> {
     let iter = match &from_key {
         None => state.stable.assets.iter(),
         Some(key) => state.stable.assets.iter_from_prev_key(key),
@@ -100,7 +93,7 @@ fn process_stable_chunk(
     }
 
     if count == CHUNK_SIZE {
-        Some(InitCertifiedAssetsCursor::Stable { key: last_key })
+        Some(CertifyAssetsCursor::Stable { key: last_key })
     } else {
         None
     }

--- a/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
@@ -9,6 +9,8 @@ use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
 use junobuild_storage::certified_assets::extend_and_init_certified_assets;
 use junobuild_storage::types::config::StorageConfig;
 
+const DEFAULT_CHUNK_SIZE: usize = 1000;
+
 pub fn certify_assets_chunk(args: CertifyAssetsArgs) -> CertifyAssetsResult {
     STATE.with(|state| certify_assets_chunk_impl(&state.borrow(), args))
 }
@@ -18,12 +20,16 @@ fn certify_assets_chunk_impl(state: &State, args: CertifyAssetsArgs) -> CertifyA
 
     let config = &state.heap.storage.config;
 
+    let chunk_size = args.chunk_size
+        .map(|s| usize::try_from(s).unwrap_or(DEFAULT_CHUNK_SIZE))
+        .unwrap_or(DEFAULT_CHUNK_SIZE);
+
     let next_cursor = match args.cursor {
         CertifyAssetsCursor::Heap { offset } => {
-            process_heap_chunk(state, &mut asset_hashes, config, offset)
+            process_heap_chunk(state, &mut asset_hashes, config, offset, chunk_size)
         }
         CertifyAssetsCursor::Stable { key } => {
-            process_stable_chunk(state, &mut asset_hashes, config, key)
+            process_stable_chunk(state, &mut asset_hashes, config, key, chunk_size)
         }
     };
 
@@ -37,13 +43,12 @@ fn certify_assets_chunk_impl(state: &State, args: CertifyAssetsArgs) -> CertifyA
     CertifyAssetsResult { next_cursor }
 }
 
-const CHUNK_SIZE: usize = 1000;
-
 fn process_heap_chunk(
     state: &State,
     asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     offset: usize,
+    chunk_size: usize,
 ) -> Option<CertifyAssetsCursor> {
     let mut count = 0;
 
@@ -53,15 +58,15 @@ fn process_heap_chunk(
         .assets
         .values()
         .skip(offset)
-        .take(CHUNK_SIZE)
+        .take(chunk_size)
     {
         asset_hashes.insert(asset, config);
         count += 1;
     }
 
-    if count == CHUNK_SIZE {
+    if count == chunk_size {
         Some(CertifyAssetsCursor::Heap {
-            offset: offset + CHUNK_SIZE,
+            offset: offset + chunk_size,
         })
     } else {
         None
@@ -73,6 +78,7 @@ fn process_stable_chunk(
     asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     from_key: Option<StableKey>,
+    chunk_size: usize,
 ) -> Option<CertifyAssetsCursor> {
     let iter = match &from_key {
         None => state.stable.assets.iter(),
@@ -83,16 +89,16 @@ fn process_stable_chunk(
 
     let mut count = 0;
 
-    for entry in iter.take(CHUNK_SIZE) {
+    for entry in iter.take(chunk_size) {
         asset_hashes.insert(&entry.value(), config);
         count += 1;
 
-        if count == CHUNK_SIZE {
+        if count == chunk_size {
             last_key = Some(entry.key().clone());
         }
     }
 
-    if count == CHUNK_SIZE {
+    if count == chunk_size {
         Some(CertifyAssetsCursor::Stable { key: last_key })
     } else {
         None

--- a/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
@@ -8,6 +8,7 @@ use crate::types::state::State;
 use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
 use junobuild_storage::certified_assets::extend_and_init_certified_assets;
 use junobuild_storage::types::config::StorageConfig;
+use junobuild_storage::types::store::AssetKey;
 
 const DEFAULT_CHUNK_SIZE: usize = 1000;
 
@@ -77,25 +78,32 @@ fn process_heap_chunk(
 fn process_stable_chunk(
     state: &State,
     config: &StorageConfig,
-    from_key: Option<StableKey>,
+    from_key: Option<AssetKey>,
     chunk_size: usize,
 ) -> ProcessChunkResult {
     let mut asset_hashes = CertifiedAssetHashes::default();
     let mut count = 0;
 
-    let iter = match &from_key {
+    let stable_key = from_key.map(|key| StableKey {
+        collection: key.collection,
+        full_path: key.full_path,
+    });
+
+    let iter = match &stable_key {
         None => state.stable.assets.iter(),
         Some(key) => state.stable.assets.iter_from_prev_key(key),
     };
 
-    let mut last_key: Option<StableKey> = None;
+    let mut last_key: Option<AssetKey> = None;
 
     for entry in iter.take(chunk_size) {
-        asset_hashes.insert(&entry.value(), config);
+        let asset = entry.value();
+
+        asset_hashes.insert(&asset, config);
         count += 1;
 
         if count == chunk_size {
-            last_key = Some(entry.key().clone());
+            last_key = Some(asset.key);
         }
     }
 

--- a/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/chunk.rs
@@ -1,15 +1,14 @@
-use crate::assets::storage::certified_assets::types::CertifyAssetsCursor;
 use crate::assets::storage::strategy_impls::StorageState;
 use crate::assets::storage::types::state::StableKey;
 use crate::certification::strategy_impls::StorageCertificate;
 use crate::memory::state::STATE;
-use crate::types::interface::{CertifyAssetsArgs, CertifyAssetsResult};
 use crate::types::state::State;
 use junobuild_storage::certification::types::certified::CertifiedAssetHashes;
-use junobuild_storage::certified_assets::extend_and_init_certified_assets;
 use junobuild_storage::types::config::StorageConfig;
 use junobuild_storage::types::store::AssetKey;
 use std::ops::Bound;
+use junobuild_storage::types::interface::CertifyAssetsCursor;
+use crate::types::interface::{CertifyAssetsArgs, CertifyAssetsResult};
 
 const DEFAULT_CHUNK_SIZE: usize = 1000;
 
@@ -25,32 +24,41 @@ fn certify_assets_chunk_impl(state: &State, args: CertifyAssetsArgs) -> CertifyA
         .map(|s| usize::try_from(s).unwrap_or(DEFAULT_CHUNK_SIZE))
         .unwrap_or(DEFAULT_CHUNK_SIZE);
 
-    let (mut asset_hashes, next_cursor) = match args.cursor {
+    let next_cursor = match args.cursor {
         CertifyAssetsCursor::Heap { offset } => {
-            process_heap_chunk(state, config, offset, chunk_size)
+            junobuild_storage::certified_assets::certify_assets_chunk(
+                args.strategy,
+                config,
+                &StorageState,
+                &StorageCertificate,
+                |asset_hashes| {
+                    process_heap_chunk(state, asset_hashes, config, offset, chunk_size)
+                },
+            )
         }
-        CertifyAssetsCursor::Stable { key } => process_stable_chunk(state, config, key, chunk_size),
+        CertifyAssetsCursor::Stable { key } => {
+            junobuild_storage::certified_assets::certify_assets_chunk(
+                args.strategy,
+                config,
+                &StorageState,
+                &StorageCertificate,
+                |asset_hashes| {
+                    process_stable_chunk(state, asset_hashes, config, key, chunk_size)
+                },
+            )
+        }
     };
-
-    extend_and_init_certified_assets(
-        &mut asset_hashes,
-        config,
-        &StorageState,
-        &StorageCertificate,
-    );
 
     CertifyAssetsResult { next_cursor }
 }
 
-type ProcessChunkResult = (CertifiedAssetHashes, Option<CertifyAssetsCursor>);
-
 fn process_heap_chunk(
     state: &State,
+    asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     offset: usize,
     chunk_size: usize,
-) -> ProcessChunkResult {
-    let mut asset_hashes = CertifiedAssetHashes::default();
+) -> Option<CertifyAssetsCursor> {
     let mut count = 0;
 
     for asset in state
@@ -65,24 +73,22 @@ fn process_heap_chunk(
         count += 1;
     }
 
-    let next_cursor = if count == chunk_size {
+    if count == chunk_size {
         Some(CertifyAssetsCursor::Heap {
             offset: offset + chunk_size,
         })
     } else {
         None
-    };
-
-    (asset_hashes, next_cursor)
+    }
 }
 
 fn process_stable_chunk(
     state: &State,
+    asset_hashes: &mut CertifiedAssetHashes,
     config: &StorageConfig,
     from_key: Option<AssetKey>,
     chunk_size: usize,
-) -> ProcessChunkResult {
-    let mut asset_hashes = CertifiedAssetHashes::default();
+) -> Option<CertifyAssetsCursor> {
     let mut count = 0;
 
     let stable_key = from_key.map(|key| StableKey {
@@ -99,7 +105,6 @@ fn process_stable_chunk(
 
     for entry in iter.take(chunk_size) {
         let asset = entry.value();
-
         asset_hashes.insert(&asset, config);
         count += 1;
 
@@ -108,11 +113,9 @@ fn process_stable_chunk(
         }
     }
 
-    let next_cursor = if count == chunk_size {
+    if count == chunk_size {
         Some(CertifyAssetsCursor::Stable { key: last_key })
     } else {
         None
-    };
-
-    (asset_hashes, next_cursor)
+    }
 }

--- a/src/libs/satellite/src/assets/storage/certified_assets/mod.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/mod.rs
@@ -1,4 +1,3 @@
 pub mod all;
 pub mod chunk;
-pub mod types;
 pub mod upgrade;

--- a/src/libs/satellite/src/assets/storage/certified_assets/mod.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/mod.rs
@@ -1,2 +1,3 @@
 pub mod runtime;
 pub mod upgrade;
+mod chunk;

--- a/src/libs/satellite/src/assets/storage/certified_assets/mod.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/mod.rs
@@ -1,3 +1,4 @@
 pub mod all;
+pub mod chunk;
+pub mod types;
 pub mod upgrade;
-mod chunk;

--- a/src/libs/satellite/src/assets/storage/certified_assets/types.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/types.rs
@@ -1,9 +1,0 @@
-use candid::{CandidType, Deserialize};
-use junobuild_storage::types::store::AssetKey;
-use serde::Serialize;
-
-#[derive(CandidType, Serialize, Deserialize)]
-pub enum CertifyAssetsCursor {
-    Heap { offset: usize },
-    Stable { key: Option<AssetKey> },
-}

--- a/src/libs/satellite/src/assets/storage/certified_assets/types.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/types.rs
@@ -1,9 +1,9 @@
-use crate::assets::storage::types::state::StableKey;
 use candid::{CandidType, Deserialize};
+use junobuild_storage::types::store::AssetKey;
 use serde::Serialize;
 
 #[derive(CandidType, Serialize, Deserialize)]
 pub enum CertifyAssetsCursor {
     Heap { offset: usize },
-    Stable { key: Option<StableKey> },
+    Stable { key: Option<AssetKey> },
 }

--- a/src/libs/satellite/src/assets/storage/certified_assets/types.rs
+++ b/src/libs/satellite/src/assets/storage/certified_assets/types.rs
@@ -1,0 +1,9 @@
+use crate::assets::storage::types::state::StableKey;
+use candid::{CandidType, Deserialize};
+use serde::Serialize;
+
+#[derive(CandidType, Serialize, Deserialize)]
+pub enum CertifyAssetsCursor {
+    Heap { offset: usize },
+    Stable { key: Option<StableKey> },
+}

--- a/src/libs/satellite/src/lib.rs
+++ b/src/libs/satellite/src/lib.rs
@@ -21,8 +21,9 @@ mod user;
 use crate::db::types::config::DbConfig;
 use crate::db::types::interface::SetDbConfig;
 use crate::types::interface::{
-    AuthenticateAutomationResultResponse, AuthenticateResultResponse, AuthenticationArgs, Config,
-    DeleteProposalAssets, GetDelegationArgs, GetDelegationResultResponse,
+    AuthenticateAutomationResultResponse, AuthenticateResultResponse, AuthenticationArgs,
+    CertifyAssetsArgs, CertifyAssetsResult, Config, DeleteProposalAssets, GetDelegationArgs,
+    GetDelegationResultResponse,
 };
 use crate::types::state::CollectionType;
 use automation::types::AuthenticateAutomationArgs;
@@ -532,6 +533,12 @@ pub fn get_many_assets(
     api::storage::get_many_assets(assets)
 }
 
+#[doc(hidden)]
+#[update(guard = "caller_is_admin")]
+pub fn certify_assets_chunk(args: CertifyAssetsArgs) -> CertifyAssetsResult {
+    api::storage::certify_assets_chunk(args)
+}
+
 // ---------------------------------------------------------
 // Mgmt
 // ---------------------------------------------------------
@@ -569,21 +576,22 @@ pub fn memory_size() -> MemorySize {
 macro_rules! include_satellite {
     () => {
         use junobuild_satellite::{
-            authenticate, authenticate_automation, commit_asset_upload, commit_proposal,
-            commit_proposal_asset_upload, commit_proposal_many_assets_upload, count_assets,
-            count_collection_assets, count_collection_docs, count_docs, count_proposals, del_asset,
-            del_assets, del_controller_self, del_controllers, del_custom_domain, del_doc, del_docs,
-            del_filtered_assets, del_filtered_docs, del_many_assets, del_many_docs, del_rule,
-            delete_proposal_assets, deposit_cycles, get_asset, get_auth_config,
-            get_automation_config, get_config, get_db_config, get_delegation, get_doc,
-            get_many_assets, get_many_docs, get_proposal, get_storage_config, http_request,
-            http_request_streaming_callback, init, init_asset_upload, init_proposal,
-            init_proposal_asset_upload, init_proposal_many_assets_upload, list_assets,
-            list_controllers, list_custom_domains, list_docs, list_proposals, list_rules,
-            post_upgrade, pre_upgrade, reject_proposal, set_asset_token, set_auth_config,
-            set_automation_config, set_controllers, set_custom_domain, set_db_config, set_doc,
-            set_many_docs, set_rule, set_storage_config, submit_proposal,
-            switch_storage_system_memory, upload_asset_chunk, upload_proposal_asset_chunk,
+            authenticate, authenticate_automation, certify_assets_chunk, commit_asset_upload,
+            commit_proposal, commit_proposal_asset_upload, commit_proposal_many_assets_upload,
+            count_assets, count_collection_assets, count_collection_docs, count_docs,
+            count_proposals, del_asset, del_assets, del_controller_self, del_controllers,
+            del_custom_domain, del_doc, del_docs, del_filtered_assets, del_filtered_docs,
+            del_many_assets, del_many_docs, del_rule, delete_proposal_assets, deposit_cycles,
+            get_asset, get_auth_config, get_automation_config, get_config, get_db_config,
+            get_delegation, get_doc, get_many_assets, get_many_docs, get_proposal,
+            get_storage_config, http_request, http_request_streaming_callback, init,
+            init_asset_upload, init_proposal, init_proposal_asset_upload,
+            init_proposal_many_assets_upload, list_assets, list_controllers, list_custom_domains,
+            list_docs, list_proposals, list_rules, post_upgrade, pre_upgrade, reject_proposal,
+            set_asset_token, set_auth_config, set_automation_config, set_controllers,
+            set_custom_domain, set_db_config, set_doc, set_many_docs, set_rule, set_storage_config,
+            submit_proposal, switch_storage_system_memory, upload_asset_chunk,
+            upload_proposal_asset_chunk,
         };
 
         ic_cdk::export_candid!();

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -56,7 +56,6 @@ pub mod state {
 }
 
 pub mod interface {
-    use crate::assets::storage::certified_assets::types::CertifyAssetsCursor;
     use crate::automation::types::AuthenticationAutomationError;
     use crate::db::types::config::DbConfig;
     use crate::Doc;
@@ -71,6 +70,7 @@ pub mod interface {
     use junobuild_cdn::proposals::ProposalId;
     use junobuild_storage::types::config::StorageConfig;
     use serde::{Deserialize, Serialize};
+    use junobuild_storage::types::interface::{CertifyAssetsCursor, CertifyAssetsStrategy};
 
     #[derive(CandidType, Deserialize)]
     pub struct Config {
@@ -134,6 +134,7 @@ pub mod interface {
     pub struct CertifyAssetsArgs {
         pub cursor: CertifyAssetsCursor,
         pub chunk_size: Option<u32>,
+        pub strategy: CertifyAssetsStrategy,
     }
 
     #[derive(CandidType, Serialize, Deserialize)]

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -56,6 +56,7 @@ pub mod state {
 }
 
 pub mod interface {
+    use crate::assets::storage::certified_assets::types::CertifyAssetsCursor;
     use crate::automation::types::AuthenticationAutomationError;
     use crate::db::types::config::DbConfig;
     use crate::Doc;
@@ -127,6 +128,16 @@ pub mod interface {
     pub enum AuthenticateAutomationResultResponse {
         Ok(PreparedAutomation),
         Err(AuthenticationAutomationError),
+    }
+
+    #[derive(CandidType, Serialize, Deserialize)]
+    pub struct CertifyAssetsArgs {
+        pub cursor: CertifyAssetsCursor,
+    }
+
+    #[derive(CandidType, Serialize, Deserialize)]
+    pub struct CertifyAssetsResult {
+        pub next_cursor: Option<CertifyAssetsCursor>,
     }
 }
 

--- a/src/libs/satellite/src/types.rs
+++ b/src/libs/satellite/src/types.rs
@@ -133,6 +133,7 @@ pub mod interface {
     #[derive(CandidType, Serialize, Deserialize)]
     pub struct CertifyAssetsArgs {
         pub cursor: CertifyAssetsCursor,
+        pub chunk_size: Option<u32>,
     }
 
     #[derive(CandidType, Serialize, Deserialize)]

--- a/src/libs/storage/src/certified_assets.rs
+++ b/src/libs/storage/src/certified_assets.rs
@@ -38,14 +38,18 @@ where
     let next_cursor = STATE.with(|state| {
         let asset_hashes = &mut state.borrow_mut().runtime.storage.asset_hashes;
 
-        if let CertifyAssetsStrategy::Reset = strategy {
+        if let CertifyAssetsStrategy::Clear = strategy {
             *asset_hashes = CertifiedAssetHashes::default();
         }
 
         let next_cursor = insert(asset_hashes);
 
         // 2. Extend with rewrite etc.
-        extend_certified_assets(asset_hashes, config, storage_state);
+        if next_cursor.is_none() {
+            if let CertifyAssetsStrategy::AppendWithRouting = strategy {
+                extend_certified_assets(asset_hashes, config, storage_state);
+            }
+        }
 
         next_cursor
     });

--- a/src/libs/storage/src/certified_assets.rs
+++ b/src/libs/storage/src/certified_assets.rs
@@ -1,10 +1,12 @@
 use crate::certification::types::certified::CertifiedAssetHashes;
+use crate::memory::STATE;
 use crate::rewrites::rewrite_source_to_path;
 use crate::routing::get_routing;
 use crate::runtime::init_certified_assets;
 use crate::strategies::{StorageCertificateStrategy, StorageStateStrategy};
 use crate::types::config::StorageConfig;
 use crate::types::http_request::{Routing, RoutingDefault};
+use crate::types::interface::{CertifyAssetsCursor, CertifyAssetsStrategy};
 
 pub fn extend_and_init_certified_assets(
     asset_hashes: &mut CertifiedAssetHashes,
@@ -12,6 +14,52 @@ pub fn extend_and_init_certified_assets(
     storage_state: &impl StorageStateStrategy,
     certificate: &impl StorageCertificateStrategy,
 ) {
+    // 1. Extend with rewrite etc.
+    extend_certified_assets(asset_hashes, config, storage_state);
+
+    // 2. Save the asset tree in the runtime heap
+    init_certified_assets(asset_hashes);
+
+    // 3. Update the root hash and the canister certified data
+    certificate.update_certified_data();
+}
+
+pub fn certify_assets_chunk<F>(
+    strategy: CertifyAssetsStrategy,
+    config: &StorageConfig,
+    storage_state: &impl StorageStateStrategy,
+    certificate: &impl StorageCertificateStrategy,
+    insert: F,
+) -> Option<CertifyAssetsCursor>
+where
+    F: FnOnce(&mut CertifiedAssetHashes) -> Option<CertifyAssetsCursor>,
+{
+    // 1. Borrow or re-create the asset tree
+    let next_cursor = STATE.with(|state| {
+        let asset_hashes = &mut state.borrow_mut().runtime.storage.asset_hashes;
+
+        if let CertifyAssetsStrategy::Reset = strategy {
+            *asset_hashes = CertifiedAssetHashes::default();
+        }
+
+        let next_cursor = insert(asset_hashes);
+
+        // 2. Extend with rewrite etc.
+        extend_certified_assets(asset_hashes, config, storage_state);
+
+        next_cursor
+    });
+
+    // 3. Update the root hash and the canister certified data
+    certificate.update_certified_data();
+
+    next_cursor
+}
+
+fn extend_certified_assets(
+    asset_hashes: &mut CertifiedAssetHashes,
+    config: &StorageConfig,
+    storage_state: &impl StorageStateStrategy,) {
     for (source, destination) in config.rewrites.clone() {
         if let Ok(Routing::Default(RoutingDefault { url: _, asset })) =
             get_routing(destination, &Vec::new(), false, storage_state)
@@ -32,6 +80,4 @@ pub fn extend_and_init_certified_assets(
             &config.unwrap_iframe(),
         );
     }
-
-    init_certified_assets(asset_hashes, certificate);
 }

--- a/src/libs/storage/src/runtime.rs
+++ b/src/libs/storage/src/runtime.rs
@@ -19,15 +19,10 @@ use std::collections::HashMap;
 
 pub fn init_certified_assets(
     asset_hashes: &CertifiedAssetHashes,
-    certificate: &impl StorageCertificateStrategy,
 ) {
-    // 1. Init all asset in tree
     STATE.with(|state| {
         init_certified_assets_impl(asset_hashes, &mut state.borrow_mut().runtime.storage)
     });
-
-    // 2. Update the root hash and the canister certified data
-    certificate.update_certified_data();
 }
 
 pub fn update_certified_asset(

--- a/src/libs/storage/src/types.rs
+++ b/src/libs/storage/src/types.rs
@@ -233,8 +233,9 @@ pub mod interface {
 
     #[derive(CandidType, Serialize, Deserialize)]
     pub enum CertifyAssetsStrategy {
-        Reset,
-        Accumulate,
+        Clear,
+        Append,
+        AppendWithRouting
     }
 }
 

--- a/src/libs/storage/src/types.rs
+++ b/src/libs/storage/src/types.rs
@@ -224,6 +224,18 @@ pub mod interface {
         pub max_memory_size: Option<StorageConfigMaxMemorySize>,
         pub version: Option<Version>,
     }
+
+    #[derive(CandidType, Serialize, Deserialize)]
+    pub enum CertifyAssetsCursor {
+        Heap { offset: usize },
+        Stable { key: Option<AssetKey> },
+    }
+
+    #[derive(CandidType, Serialize, Deserialize)]
+    pub enum CertifyAssetsStrategy {
+        Reset,
+        Accumulate,
+    }
 }
 
 pub mod config {

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -90,6 +90,15 @@ type AutomationController = record {
   expires_at : nat64;
 };
 type AutomationScope = variant { Write; Submit };
+type CertifyAssetsArgs = record {
+  cursor : CertifyAssetsCursor;
+  chunk_size : opt nat32;
+};
+type CertifyAssetsCursor = variant {
+  Heap : record { offset : nat64 };
+  Stable : record { key : opt AssetKey };
+};
+type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;
@@ -441,6 +450,7 @@ service : (InitSatelliteArgs) -> {
   authenticate_automation : (AuthenticateAutomationArgs) -> (
       AuthenticateAutomationResultResponse,
     );
+  certify_assets_chunk : (CertifyAssetsArgs) -> (CertifyAssetsResult);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -92,6 +92,7 @@ type AutomationController = record {
 type AutomationScope = variant { Write; Submit };
 type CertifyAssetsArgs = record {
   cursor : CertifyAssetsCursor;
+  strategy : CertifyAssetsStrategy;
   chunk_size : opt nat32;
 };
 type CertifyAssetsCursor = variant {
@@ -99,6 +100,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
+type CertifyAssetsStrategy = variant { Reset; Accumulate };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/satellite/satellite.did
+++ b/src/satellite/satellite.did
@@ -100,7 +100,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
-type CertifyAssetsStrategy = variant { Reset; Accumulate };
+type CertifyAssetsStrategy = variant { Append; Clear; AppendWithRouting };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -90,6 +90,15 @@ type AutomationController = record {
   expires_at : nat64;
 };
 type AutomationScope = variant { Write; Submit };
+type CertifyAssetsArgs = record {
+  cursor : CertifyAssetsCursor;
+  chunk_size : opt nat32;
+};
+type CertifyAssetsCursor = variant {
+  Heap : record { offset : nat64 };
+  Stable : record { key : opt AssetKey };
+};
+type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;
@@ -441,6 +450,7 @@ service : (InitSatelliteArgs) -> {
   authenticate_automation : (AuthenticateAutomationArgs) -> (
       AuthenticateAutomationResultResponse,
     );
+  certify_assets_chunk : (CertifyAssetsArgs) -> (CertifyAssetsResult);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -92,6 +92,7 @@ type AutomationController = record {
 type AutomationScope = variant { Write; Submit };
 type CertifyAssetsArgs = record {
   cursor : CertifyAssetsCursor;
+  strategy : CertifyAssetsStrategy;
   chunk_size : opt nat32;
 };
 type CertifyAssetsCursor = variant {
@@ -99,6 +100,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
+type CertifyAssetsStrategy = variant { Reset; Accumulate };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/sputnik/sputnik.did
+++ b/src/sputnik/sputnik.did
@@ -100,7 +100,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
-type CertifyAssetsStrategy = variant { Reset; Accumulate };
+type CertifyAssetsStrategy = variant { Append; Clear; AppendWithRouting };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -115,7 +115,10 @@ export type CertifyAssetsCursor =
 export interface CertifyAssetsResult {
 	next_cursor: [] | [CertifyAssetsCursor];
 }
-export type CertifyAssetsStrategy = { Reset: null } | { Accumulate: null };
+export type CertifyAssetsStrategy =
+	| { Append: null }
+	| { Clear: null }
+	| { AppendWithRouting: null };
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -104,6 +104,16 @@ export interface AutomationController {
 	expires_at: bigint;
 }
 export type AutomationScope = { Write: null } | { Submit: null };
+export interface CertifyAssetsArgs {
+	cursor: CertifyAssetsCursor;
+	chunk_size: [] | [number];
+}
+export type CertifyAssetsCursor =
+	| { Heap: { offset: bigint } }
+	| { Stable: { key: [] | [AssetKey] } };
+export interface CertifyAssetsResult {
+	next_cursor: [] | [CertifyAssetsCursor];
+}
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;
@@ -516,6 +526,7 @@ export interface _SERVICE {
 		[AuthenticateAutomationArgs],
 		AuthenticateAutomationResultResponse
 	>;
+	certify_assets_chunk: ActorMethod<[CertifyAssetsArgs], CertifyAssetsResult>;
 	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;

--- a/src/tests/declarations/test_satellite/test_satellite.did.d.ts
+++ b/src/tests/declarations/test_satellite/test_satellite.did.d.ts
@@ -106,6 +106,7 @@ export interface AutomationController {
 export type AutomationScope = { Write: null } | { Submit: null };
 export interface CertifyAssetsArgs {
 	cursor: CertifyAssetsCursor;
+	strategy: CertifyAssetsStrategy;
 	chunk_size: [] | [number];
 }
 export type CertifyAssetsCursor =
@@ -114,6 +115,7 @@ export type CertifyAssetsCursor =
 export interface CertifyAssetsResult {
 	next_cursor: [] | [CertifyAssetsCursor];
 }
+export type CertifyAssetsStrategy = { Reset: null } | { Accumulate: null };
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -123,8 +123,13 @@ export const idlFactory = ({ IDL }) => {
 		Heap: IDL.Record({ offset: IDL.Nat64 }),
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
+	const CertifyAssetsStrategy = IDL.Variant({
+		Reset: IDL.Null,
+		Accumulate: IDL.Null
+	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,
+		strategy: CertifyAssetsStrategy,
 		chunk_size: IDL.Opt(IDL.Nat32)
 	});
 	const CertifyAssetsResult = IDL.Record({

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -124,8 +124,9 @@ export const idlFactory = ({ IDL }) => {
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
 	const CertifyAssetsStrategy = IDL.Variant({
-		Reset: IDL.Null,
-		Accumulate: IDL.Null
+		Append: IDL.Null,
+		Clear: IDL.Null,
+		AppendWithRouting: IDL.Null
 	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,

--- a/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.certified.did.js
@@ -111,6 +111,25 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Tuple(IDL.Principal, AutomationController),
 		Err: AuthenticationAutomationError
 	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const CertifyAssetsCursor = IDL.Variant({
+		Heap: IDL.Record({ offset: IDL.Nat64 }),
+		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
+	});
+	const CertifyAssetsArgs = IDL.Record({
+		cursor: CertifyAssetsCursor,
+		chunk_size: IDL.Opt(IDL.Nat32)
+	});
+	const CertifyAssetsResult = IDL.Record({
+		next_cursor: IDL.Opt(CertifyAssetsCursor)
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -177,14 +196,6 @@ export const idlFactory = ({ IDL }) => {
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
-	});
-	const AssetKey = IDL.Record({
-		token: IDL.Opt(IDL.Text),
-		collection: IDL.Text,
-		owner: IDL.Principal,
-		name: IDL.Text,
-		description: IDL.Opt(IDL.Text),
-		full_path: IDL.Text
 	});
 	const AssetEncodingNoContent = IDL.Record({
 		modified: IDL.Nat64,
@@ -523,6 +534,7 @@ export const idlFactory = ({ IDL }) => {
 			[AuthenticateAutomationResultResponse],
 			[]
 		),
+		certify_assets_chunk: IDL.Func([CertifyAssetsArgs], [CertifyAssetsResult], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -123,8 +123,13 @@ export const idlFactory = ({ IDL }) => {
 		Heap: IDL.Record({ offset: IDL.Nat64 }),
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
+	const CertifyAssetsStrategy = IDL.Variant({
+		Reset: IDL.Null,
+		Accumulate: IDL.Null
+	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,
+		strategy: CertifyAssetsStrategy,
 		chunk_size: IDL.Opt(IDL.Nat32)
 	});
 	const CertifyAssetsResult = IDL.Record({

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -124,8 +124,9 @@ export const idlFactory = ({ IDL }) => {
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
 	const CertifyAssetsStrategy = IDL.Variant({
-		Reset: IDL.Null,
-		Accumulate: IDL.Null
+		Append: IDL.Null,
+		Clear: IDL.Null,
+		AppendWithRouting: IDL.Null
 	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,

--- a/src/tests/declarations/test_satellite/test_satellite.factory.did.js
+++ b/src/tests/declarations/test_satellite/test_satellite.factory.did.js
@@ -111,6 +111,25 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Tuple(IDL.Principal, AutomationController),
 		Err: AuthenticationAutomationError
 	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const CertifyAssetsCursor = IDL.Variant({
+		Heap: IDL.Record({ offset: IDL.Nat64 }),
+		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
+	});
+	const CertifyAssetsArgs = IDL.Record({
+		cursor: CertifyAssetsCursor,
+		chunk_size: IDL.Opt(IDL.Nat32)
+	});
+	const CertifyAssetsResult = IDL.Record({
+		next_cursor: IDL.Opt(CertifyAssetsCursor)
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -177,14 +196,6 @@ export const idlFactory = ({ IDL }) => {
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
-	});
-	const AssetKey = IDL.Record({
-		token: IDL.Opt(IDL.Text),
-		collection: IDL.Text,
-		owner: IDL.Principal,
-		name: IDL.Text,
-		description: IDL.Opt(IDL.Text),
-		full_path: IDL.Text
 	});
 	const AssetEncodingNoContent = IDL.Record({
 		modified: IDL.Nat64,
@@ -523,6 +534,7 @@ export const idlFactory = ({ IDL }) => {
 			[AuthenticateAutomationResultResponse],
 			[]
 		),
+		certify_assets_chunk: IDL.Func([CertifyAssetsArgs], [CertifyAssetsResult], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/tests/declarations/test_sputnik/test_sputnik.did.d.ts
+++ b/src/tests/declarations/test_sputnik/test_sputnik.did.d.ts
@@ -196,6 +196,16 @@ export interface AutomationController {
 	expires_at: bigint;
 }
 export type AutomationScope = { Write: null } | { Submit: null };
+export interface CertifyAssetsArgs {
+	cursor: CertifyAssetsCursor;
+	chunk_size: [] | [number];
+}
+export type CertifyAssetsCursor =
+	| { Heap: { offset: bigint } }
+	| { Stable: { key: [] | [AssetKey] } };
+export interface CertifyAssetsResult {
+	next_cursor: [] | [CertifyAssetsCursor];
+}
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;
@@ -607,6 +617,7 @@ export interface _SERVICE {
 		[AuthenticateAutomationArgs],
 		AuthenticateAutomationResultResponse
 	>;
+	certify_assets_chunk: ActorMethod<[CertifyAssetsArgs], CertifyAssetsResult>;
 	commit_asset_upload: ActorMethod<[CommitBatch], undefined>;
 	commit_proposal: ActorMethod<[CommitProposal], null>;
 	commit_proposal_asset_upload: ActorMethod<[CommitBatch], undefined>;

--- a/src/tests/declarations/test_sputnik/test_sputnik.did.d.ts
+++ b/src/tests/declarations/test_sputnik/test_sputnik.did.d.ts
@@ -198,6 +198,7 @@ export interface AutomationController {
 export type AutomationScope = { Write: null } | { Submit: null };
 export interface CertifyAssetsArgs {
 	cursor: CertifyAssetsCursor;
+	strategy: CertifyAssetsStrategy;
 	chunk_size: [] | [number];
 }
 export type CertifyAssetsCursor =
@@ -206,6 +207,7 @@ export type CertifyAssetsCursor =
 export interface CertifyAssetsResult {
 	next_cursor: [] | [CertifyAssetsCursor];
 }
+export type CertifyAssetsStrategy = { Reset: null } | { Accumulate: null };
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;

--- a/src/tests/declarations/test_sputnik/test_sputnik.did.d.ts
+++ b/src/tests/declarations/test_sputnik/test_sputnik.did.d.ts
@@ -207,7 +207,10 @@ export type CertifyAssetsCursor =
 export interface CertifyAssetsResult {
 	next_cursor: [] | [CertifyAssetsCursor];
 }
-export type CertifyAssetsStrategy = { Reset: null } | { Accumulate: null };
+export type CertifyAssetsStrategy =
+	| { Append: null }
+	| { Clear: null }
+	| { AppendWithRouting: null };
 export type CollectionType = { Db: null } | { Storage: null };
 export interface CommitBatch {
 	batch_id: bigint;

--- a/src/tests/declarations/test_sputnik/test_sputnik.factory.did.js
+++ b/src/tests/declarations/test_sputnik/test_sputnik.factory.did.js
@@ -123,8 +123,13 @@ export const idlFactory = ({ IDL }) => {
 		Heap: IDL.Record({ offset: IDL.Nat64 }),
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
+	const CertifyAssetsStrategy = IDL.Variant({
+		Reset: IDL.Null,
+		Accumulate: IDL.Null
+	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,
+		strategy: CertifyAssetsStrategy,
 		chunk_size: IDL.Opt(IDL.Nat32)
 	});
 	const CertifyAssetsResult = IDL.Record({

--- a/src/tests/declarations/test_sputnik/test_sputnik.factory.did.js
+++ b/src/tests/declarations/test_sputnik/test_sputnik.factory.did.js
@@ -111,6 +111,25 @@ export const idlFactory = ({ IDL }) => {
 		Ok: IDL.Tuple(IDL.Principal, AutomationController),
 		Err: AuthenticationAutomationError
 	});
+	const AssetKey = IDL.Record({
+		token: IDL.Opt(IDL.Text),
+		collection: IDL.Text,
+		owner: IDL.Principal,
+		name: IDL.Text,
+		description: IDL.Opt(IDL.Text),
+		full_path: IDL.Text
+	});
+	const CertifyAssetsCursor = IDL.Variant({
+		Heap: IDL.Record({ offset: IDL.Nat64 }),
+		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
+	});
+	const CertifyAssetsArgs = IDL.Record({
+		cursor: CertifyAssetsCursor,
+		chunk_size: IDL.Opt(IDL.Nat32)
+	});
+	const CertifyAssetsResult = IDL.Record({
+		next_cursor: IDL.Opt(CertifyAssetsCursor)
+	});
 	const CommitBatch = IDL.Record({
 		batch_id: IDL.Nat,
 		headers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
@@ -177,14 +196,6 @@ export const idlFactory = ({ IDL }) => {
 	const DepositCyclesArgs = IDL.Record({
 		cycles: IDL.Nat,
 		destination_id: IDL.Principal
-	});
-	const AssetKey = IDL.Record({
-		token: IDL.Opt(IDL.Text),
-		collection: IDL.Text,
-		owner: IDL.Principal,
-		name: IDL.Text,
-		description: IDL.Opt(IDL.Text),
-		full_path: IDL.Text
 	});
 	const AssetEncodingNoContent = IDL.Record({
 		modified: IDL.Nat64,
@@ -600,6 +611,7 @@ export const idlFactory = ({ IDL }) => {
 			[AuthenticateAutomationResultResponse],
 			[]
 		),
+		certify_assets_chunk: IDL.Func([CertifyAssetsArgs], [CertifyAssetsResult], []),
 		commit_asset_upload: IDL.Func([CommitBatch], [], []),
 		commit_proposal: IDL.Func([CommitProposal], [IDL.Null], []),
 		commit_proposal_asset_upload: IDL.Func([CommitBatch], [], []),

--- a/src/tests/declarations/test_sputnik/test_sputnik.factory.did.js
+++ b/src/tests/declarations/test_sputnik/test_sputnik.factory.did.js
@@ -124,8 +124,9 @@ export const idlFactory = ({ IDL }) => {
 		Stable: IDL.Record({ key: IDL.Opt(AssetKey) })
 	});
 	const CertifyAssetsStrategy = IDL.Variant({
-		Reset: IDL.Null,
-		Accumulate: IDL.Null
+		Append: IDL.Null,
+		Clear: IDL.Null,
+		AppendWithRouting: IDL.Null
 	});
 	const CertifyAssetsArgs = IDL.Record({
 		cursor: CertifyAssetsCursor,

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -90,6 +90,15 @@ type AutomationController = record {
   expires_at : nat64;
 };
 type AutomationScope = variant { Write; Submit };
+type CertifyAssetsArgs = record {
+  cursor : CertifyAssetsCursor;
+  chunk_size : opt nat32;
+};
+type CertifyAssetsCursor = variant {
+  Heap : record { offset : nat64 };
+  Stable : record { key : opt AssetKey };
+};
+type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;
@@ -441,6 +450,7 @@ service : (InitSatelliteArgs) -> {
   authenticate_automation : (AuthenticateAutomationArgs) -> (
       AuthenticateAutomationResultResponse,
     );
+  certify_assets_chunk : (CertifyAssetsArgs) -> (CertifyAssetsResult);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -92,6 +92,7 @@ type AutomationController = record {
 type AutomationScope = variant { Write; Submit };
 type CertifyAssetsArgs = record {
   cursor : CertifyAssetsCursor;
+  strategy : CertifyAssetsStrategy;
   chunk_size : opt nat32;
 };
 type CertifyAssetsCursor = variant {
@@ -99,6 +100,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
+type CertifyAssetsStrategy = variant { Reset; Accumulate };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/tests/fixtures/test_satellite/test_satellite.did
+++ b/src/tests/fixtures/test_satellite/test_satellite.did
@@ -100,7 +100,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
-type CertifyAssetsStrategy = variant { Reset; Accumulate };
+type CertifyAssetsStrategy = variant { Append; Clear; AppendWithRouting };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/tests/fixtures/test_sputnik/test_sputnik.did
+++ b/src/tests/fixtures/test_sputnik/test_sputnik.did
@@ -90,6 +90,15 @@ type AutomationController = record {
   expires_at : nat64;
 };
 type AutomationScope = variant { Write; Submit };
+type CertifyAssetsArgs = record {
+  cursor : CertifyAssetsCursor;
+  chunk_size : opt nat32;
+};
+type CertifyAssetsCursor = variant {
+  Heap : record { offset : nat64 };
+  Stable : record { key : opt AssetKey };
+};
+type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;
@@ -441,6 +450,7 @@ service : (InitSatelliteArgs) -> {
   authenticate_automation : (AuthenticateAutomationArgs) -> (
       AuthenticateAutomationResultResponse,
     );
+  certify_assets_chunk : (CertifyAssetsArgs) -> (CertifyAssetsResult);
   commit_asset_upload : (CommitBatch) -> ();
   commit_proposal : (CommitProposal) -> (null);
   commit_proposal_asset_upload : (CommitBatch) -> ();

--- a/src/tests/fixtures/test_sputnik/test_sputnik.did
+++ b/src/tests/fixtures/test_sputnik/test_sputnik.did
@@ -92,6 +92,7 @@ type AutomationController = record {
 type AutomationScope = variant { Write; Submit };
 type CertifyAssetsArgs = record {
   cursor : CertifyAssetsCursor;
+  strategy : CertifyAssetsStrategy;
   chunk_size : opt nat32;
 };
 type CertifyAssetsCursor = variant {
@@ -99,6 +100,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
+type CertifyAssetsStrategy = variant { Reset; Accumulate };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/tests/fixtures/test_sputnik/test_sputnik.did
+++ b/src/tests/fixtures/test_sputnik/test_sputnik.did
@@ -100,7 +100,7 @@ type CertifyAssetsCursor = variant {
   Stable : record { key : opt AssetKey };
 };
 type CertifyAssetsResult = record { next_cursor : opt CertifyAssetsCursor };
-type CertifyAssetsStrategy = variant { Reset; Accumulate };
+type CertifyAssetsStrategy = variant { Append; Clear; AppendWithRouting };
 type CollectionType = variant { Db; Storage };
 type CommitBatch = record {
   batch_id : nat;

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
@@ -47,10 +47,12 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 
 	const certifyChunks = async ({
 		cursor,
-		strategy
+		strategy,
+		appendStrategy = { AppendWithRouting: null }
 	}: {
 		cursor: SatelliteDid.CertifyAssetsCursor;
 		strategy: SatelliteDid.CertifyAssetsStrategy;
+		appendStrategy?: SatelliteDid.CertifyAssetsStrategy;
 	}) => {
 		const { certify_assets_chunk } = actor;
 
@@ -63,7 +65,7 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 		const next = fromNullable(result.next_cursor);
 
 		if (nonNullish(next)) {
-			await certifyChunks({ cursor: next, strategy: { AppendWithRouting: null } });
+			await certifyChunks({ cursor: next, strategy: appendStrategy });
 		}
 	};
 
@@ -177,23 +179,11 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 					strategy: { Clear: null }
 				});
 
-				const certifyWithoutRouting = async (cursor: SatelliteDid.CertifyAssetsCursor) => {
-					const result = await certify_assets_chunk({
-						cursor,
-						chunk_size: toNullable(2),
-						strategy: { Append: null }
-					});
-
-					const next = fromNullable(result.next_cursor);
-
-					if (nonNullish(next)) {
-						await certifyWithoutRouting(next);
-					}
-				};
-
-				await certifyWithoutRouting(
-					'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } }
-				);
+				await certifyChunks({
+					cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
+					strategy: { Clear: null },
+					appendStrategy: { Append: null }
+				});
 
 				const request: SatelliteDid.HttpRequest = {
 					body: Uint8Array.from([]),

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
@@ -1,0 +1,101 @@
+import type { SatelliteActor, SatelliteDid } from '$declarations';
+import type { Actor, PocketIc } from '@dfinity/pic';
+import { fromNullable, nonNullish, toNullable } from '@dfinity/utils';
+import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
+import type { Principal } from '@icp-sdk/core/principal';
+import { MEMORIES } from '../../../../constants/satellite-tests.constants';
+import { assertCertification } from '../../../../utils/certification-tests.utils';
+import { uploadAsset } from '../../../../utils/satellite-storage-tests.utils';
+import { setupSatelliteStock } from '../../../../utils/satellite-tests.utils';
+
+describe('Satellite > Storage > certify_assets_chunk', () => {
+	let pic: PocketIc;
+	let canisterId: Principal;
+	let actor: Actor<SatelliteActor>;
+	let currentDate: Date;
+	let controller: Ed25519KeyIdentity;
+
+	beforeAll(async () => {
+		const {
+			actor: a,
+			canisterId: c,
+			currentDate: cD,
+			pic: p,
+			controller: cO
+		} = await setupSatelliteStock();
+
+		pic = p;
+		canisterId = c;
+		actor = a;
+		currentDate = cD;
+		controller = cO;
+
+		actor.setIdentity(controller);
+	});
+
+	afterAll(async () => {
+		await pic?.tearDown();
+	});
+
+	const assets = ['hello1.html', 'hello2.html', 'hello3.html'];
+
+	const upload = async () => {
+		for (const name of assets) {
+			await uploadAsset({ full_path: `/${name}`, name, collection: '#dapp', actor });
+		}
+	};
+
+	const certifyChunks = async (cursor: SatelliteDid.CertifyAssetsCursor) => {
+		const { certify_assets_chunk } = actor;
+
+		const result = await certify_assets_chunk({
+			cursor,
+			chunk_size: toNullable(2)
+		});
+
+		const next = fromNullable(result.next_cursor);
+
+		if (nonNullish(next)) {
+			await certifyChunks(next);
+		}
+	};
+
+	const assertAssets = async () => {
+		const { http_request } = actor;
+
+		for (const name of assets) {
+			const full_path = `/${name}`;
+
+			const request: SatelliteDid.HttpRequest = {
+				body: Uint8Array.from([]),
+				certificate_version: toNullable(2),
+				headers: [],
+				method: 'GET',
+				url: full_path
+			};
+
+			const response = await http_request(request);
+
+			await assertCertification({ canisterId, pic, request, response, currentDate });
+		}
+	};
+
+	describe.each(MEMORIES)('$title', ({ memory }) => {
+		beforeAll(async () => {
+			const { del_assets, switch_storage_system_memory } = actor;
+
+			await del_assets('#dapp');
+
+			if ('Stable' in memory) {
+				await switch_storage_system_memory();
+			}
+
+			await upload();
+		});
+
+		it('should certify all assets chunk by chunk', async () => {
+			await certifyChunks('Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } });
+			await assertAssets();
+		});
+	});
+});

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
@@ -45,18 +45,25 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 		}
 	};
 
-	const certifyChunks = async (cursor: SatelliteDid.CertifyAssetsCursor) => {
+	const certifyChunks = async ({
+		cursor,
+		strategy
+	}: {
+		cursor: SatelliteDid.CertifyAssetsCursor;
+		strategy: SatelliteDid.CertifyAssetsStrategy;
+	}) => {
 		const { certify_assets_chunk } = actor;
 
 		const result = await certify_assets_chunk({
 			cursor,
-			chunk_size: toNullable(2)
+			chunk_size: toNullable(2),
+			strategy
 		});
 
 		const next = fromNullable(result.next_cursor);
 
 		if (nonNullish(next)) {
-			await certifyChunks(next);
+			await certifyChunks({ cursor: next, strategy: { Accumulate: null } });
 		}
 	};
 
@@ -94,7 +101,10 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 		});
 
 		it('should certify all assets chunk by chunk', async () => {
-			await certifyChunks('Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } });
+			await certifyChunks({
+				cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
+				strategy: { Reset: null }
+			});
 			await assertAssets();
 		});
 	});

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
@@ -63,7 +63,7 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 		const next = fromNullable(result.next_cursor);
 
 		if (nonNullish(next)) {
-			await certifyChunks({ cursor: next, strategy: { Accumulate: null } });
+			await certifyChunks({ cursor: next, strategy: { AppendWithRouting: null } });
 		}
 	};
 
@@ -103,9 +103,40 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 		it('should certify all assets chunk by chunk', async () => {
 			await certifyChunks({
 				cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
-				strategy: { Reset: null }
+				strategy: { Clear: null }
 			});
 			await assertAssets();
+		});
+
+		it('should apply routing on last chunk', async () => {
+			const { set_storage_config, http_request } = actor;
+
+			await set_storage_config({
+				headers: [],
+				iframe: toNullable(),
+				redirects: [],
+				rewrites: [['/unknown.html', '/hello1.html']],
+				raw_access: toNullable(),
+				max_memory_size: toNullable(),
+				version: toNullable(1n)
+			});
+
+			await certifyChunks({
+				cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
+				strategy: { Clear: null }
+			});
+
+			const request: SatelliteDid.HttpRequest = {
+				body: Uint8Array.from([]),
+				certificate_version: toNullable(2),
+				headers: [],
+				method: 'GET',
+				url: '/unknown.html'
+			};
+
+			const response = await http_request(request);
+
+			await assertCertification({ canisterId, pic, request, response, currentDate });
 		});
 	});
 });

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
@@ -100,29 +100,12 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 			await upload();
 		});
 
-		it('should certify all assets chunk by chunk', async () => {
-			await certifyChunks({
+		it('should not certify assets beyond current chunk', async () => {
+			const { certify_assets_chunk, http_request } = actor;
+
+			await certify_assets_chunk({
 				cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
-				strategy: { Clear: null }
-			});
-			await assertAssets();
-		});
-
-		it('should apply routing on last chunk', async () => {
-			const { set_storage_config, http_request } = actor;
-
-			await set_storage_config({
-				headers: [],
-				iframe: toNullable(),
-				redirects: [],
-				rewrites: [['/unknown.html', '/hello1.html']],
-				raw_access: toNullable(),
-				max_memory_size: toNullable(),
-				version: toNullable(1n)
-			});
-
-			await certifyChunks({
-				cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
+				chunk_size: toNullable(2),
 				strategy: { Clear: null }
 			});
 
@@ -131,12 +114,101 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 				certificate_version: toNullable(2),
 				headers: [],
 				method: 'GET',
-				url: '/unknown.html'
+				url: '/hello3.html'
 			};
 
 			const response = await http_request(request);
 
-			await assertCertification({ canisterId, pic, request, response, currentDate });
+			await expect(
+				assertCertification({ canisterId, pic, request, response, currentDate })
+			).rejects.toThrow();
+		});
+
+		it('should certify all assets chunk by chunk', async () => {
+			await certifyChunks({
+				cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
+				strategy: { Clear: null }
+			});
+			await assertAssets();
+		});
+
+		describe('With routing', () => {
+			beforeAll(async () => {
+				const { set_storage_config } = actor;
+
+				await set_storage_config({
+					headers: [],
+					iframe: toNullable(),
+					redirects: [],
+					rewrites: [['/unknown.html', '/hello1.html']],
+					raw_access: toNullable(),
+					max_memory_size: toNullable(),
+					version: toNullable(1n)
+				});
+			});
+
+			it('should apply routing on last chunk', async () => {
+				const { http_request } = actor;
+
+				await certifyChunks({
+					cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
+					strategy: { Clear: null }
+				});
+
+				const request: SatelliteDid.HttpRequest = {
+					body: Uint8Array.from([]),
+					certificate_version: toNullable(2),
+					headers: [],
+					method: 'GET',
+					url: '/unknown.html'
+				};
+
+				const response = await http_request(request);
+
+				await assertCertification({ canisterId, pic, request, response, currentDate });
+			});
+
+			it('should not apply routing without AppendWithRouting strategy', async () => {
+				const { certify_assets_chunk, http_request } = actor;
+
+				await certify_assets_chunk({
+					cursor: 'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } },
+					chunk_size: toNullable(2),
+					strategy: { Clear: null }
+				});
+
+				const certifyWithoutRouting = async (cursor: SatelliteDid.CertifyAssetsCursor) => {
+					const result = await certify_assets_chunk({
+						cursor,
+						chunk_size: toNullable(2),
+						strategy: { Append: null }
+					});
+
+					const next = fromNullable(result.next_cursor);
+
+					if (nonNullish(next)) {
+						await certifyWithoutRouting(next);
+					}
+				};
+
+				await certifyWithoutRouting(
+					'Heap' in memory ? { Heap: { offset: 0n } } : { Stable: { key: [] } }
+				);
+
+				const request: SatelliteDid.HttpRequest = {
+					body: Uint8Array.from([]),
+					certificate_version: toNullable(2),
+					headers: [],
+					method: 'GET',
+					url: '/unknown.html'
+				};
+
+				const response = await http_request(request);
+
+				await expect(
+					assertCertification({ canisterId, pic, request, response, currentDate })
+				).rejects.toThrow();
+			});
 		});
 	});
 });

--- a/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
+++ b/src/tests/specs/satellite/stock/storage/satellite.storage.certify.spec.ts
@@ -3,6 +3,7 @@ import type { Actor, PocketIc } from '@dfinity/pic';
 import { fromNullable, nonNullish, toNullable } from '@dfinity/utils';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import type { Principal } from '@icp-sdk/core/principal';
+import { JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER } from '@junobuild/errors';
 import { MEMORIES } from '../../../../constants/satellite-tests.constants';
 import { assertCertification } from '../../../../utils/certification-tests.utils';
 import { uploadAsset } from '../../../../utils/satellite-storage-tests.utils';
@@ -199,6 +200,25 @@ describe('Satellite > Storage > certify_assets_chunk', () => {
 					assertCertification({ canisterId, pic, request, response, currentDate })
 				).rejects.toThrow();
 			});
+		});
+	});
+
+	describe('Some identity', () => {
+		beforeAll(() => {
+			const user = Ed25519KeyIdentity.generate();
+			actor.setIdentity(user);
+		});
+
+		it('should throw if not admin', async () => {
+			const { certify_assets_chunk } = actor;
+
+			await expect(
+				certify_assets_chunk({
+					cursor: { Heap: { offset: 0n } },
+					chunk_size: toNullable(2),
+					strategy: { Clear: null }
+				})
+			).rejects.toThrow(JUNO_AUTH_ERROR_NOT_ADMIN_CONTROLLER);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Certifying the assets of the js.icp.build (https://github.com/dfinity/icp-js-sdk-docs/) documentation fails because there are more than 20k assets in the Satellite and the loop hit the execution limit. That's why, I introduce a new endpoint that can be use in the CLI or with a script to rebuild/repair the certification tree.

# Notes

I rather like to automate the work in a scripts. It gives more control and I'm afraid of implementing an infinite loop in the canister.
