### PR TITLE
refactor(frontend): replace Option with Nullish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			"dependencies": {
 				"@dfinity/oisy-wallet-signer": "^4.1.2",
 				"@dfinity/utils": "^4.2.0",
+				"@dfinity/zod-schemas": "^3.2.0",
 				"@icp-sdk/auth": "^5.0.0",
 				"@icp-sdk/canisters": "^3.4.0",
 				"@icp-sdk/core": "5.0.0",
@@ -914,9 +915,9 @@
 			}
 		},
 		"node_modules/@dfinity/zod-schemas": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-3.1.0.tgz",
-			"integrity": "sha512-VW4nk3LD4FVRwwVIfcQNUmrdULbQ3bKFbefBhy6njnpQ3/6BuQNT/sN3c+xrZva/8XwW2xTMMXkPD0tOp5wGdA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-3.2.0.tgz",
+			"integrity": "sha512-xEmsHFETM3XFZj2QUVxzAYcwMn7uCX1VoAKqNygN8EZj4RdoWkdPdQjwTo5DACvmVRW+r+MlhfODsZWbBqqOGg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"@icp-sdk/core": "*",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
 	"dependencies": {
 		"@dfinity/oisy-wallet-signer": "^4.1.2",
 		"@dfinity/utils": "^4.2.0",
+		"@dfinity/zod-schemas": "^3.2.0",
 		"@icp-sdk/auth": "^5.0.0",
 		"@icp-sdk/canisters": "^3.4.0",
 		"@icp-sdk/core": "5.0.0",

--- a/src/frontend/src/lib/api/_agent/_agent.api.ts
+++ b/src/frontend/src/lib/api/_agent/_agent.api.ts
@@ -1,14 +1,14 @@
 import { LOCAL_REPLICA_HOST } from '$lib/constants/app.constants';
 import { isDev } from '$lib/env/app.env';
-import type { Option } from '$lib/types/utils';
 import { isNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { HttpAgent, type Identity } from '@icp-sdk/core/agent';
 
 export interface GetAgentParams {
 	identity: Identity;
 }
 
-let agents: Option<Record<string, HttpAgent>> = undefined;
+let agents: Nullish<Record<string, HttpAgent>> = undefined;
 
 // Attempt to prevent the random IC issue triggered by agent-js at the end of the Satellite creation process in the UI.
 // Note: The process of creation works as expected; the module is successfully created. It's really the calls from the UI that fails randomly, "fortunately".

--- a/src/frontend/src/lib/api/actors/actor.api.ts
+++ b/src/frontend/src/lib/api/actors/actor.api.ts
@@ -1,7 +1,7 @@
 import { getAgent, type GetAgentParams } from '$lib/api/_agent/_agent.api';
-import type { OptionIdentity } from '$lib/types/itentity';
-import type { Option } from '$lib/types/utils';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { Actor, type ActorConfig, type ActorMethod, type ActorSubclass } from '@icp-sdk/core/agent';
 import type { IDL } from '@icp-sdk/core/candid';
 import { Principal } from '@icp-sdk/core/principal';
@@ -14,11 +14,11 @@ type CreateActorParams = {
 
 export interface GetActorParams {
 	certified?: boolean;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 export class ActorApi<T = Record<string, ActorMethod>> {
-	#actors: Option<Record<string, ActorSubclass<T>>> = undefined;
+	#actors: Nullish<Record<string, ActorSubclass<T>>> = undefined;
 
 	async getActor({
 		identity,

--- a/src/frontend/src/lib/api/actors/actor.deprecated.api.ts
+++ b/src/frontend/src/lib/api/actors/actor.deprecated.api.ts
@@ -17,7 +17,7 @@ import {
 	idlFactorySatellite009
 } from '$declarations';
 import { ActorApi } from '$lib/api/actors/actor.api';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type { Principal } from '@icp-sdk/core/principal';
 
@@ -38,7 +38,7 @@ export const getMissionControlActor004 = ({
 	missionControlId
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlActor004> =>
 	missionControl004Actor.getActor({
 		canisterId: missionControlId,
@@ -54,7 +54,7 @@ export const getMissionControlActor0013 = ({
 	missionControlId
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlActor0013> =>
 	missionControl0013Actor.getActor({
 		canisterId: missionControlId,
@@ -70,7 +70,7 @@ export const getSatelliteActor008 = ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteActor008> =>
 	satellite008Actor.getActor({
 		canisterId: satelliteId,
@@ -86,7 +86,7 @@ export const getSatelliteActor009 = ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteActor009> =>
 	satellite009Actor.getActor({
 		canisterId: satelliteId,
@@ -102,7 +102,7 @@ export const getSatelliteActor0021 = ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteActor0021> =>
 	satellite0021Actor.getActor({
 		canisterId: satelliteId,
@@ -118,7 +118,7 @@ export const getSatelliteActor0022 = ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteActor0022> =>
 	satellite0022Actor.getActor({
 		canisterId: satelliteId,
@@ -134,7 +134,7 @@ export const getOrbiterActor007 = ({
 	identity
 }: {
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<OrbiterActor007> =>
 	orbiter007Actor.getActor({
 		canisterId: orbiterId,
@@ -150,7 +150,7 @@ export const getOrbiterActor008 = ({
 	identity
 }: {
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<OrbiterActor008> =>
 	orbiter008Actor.getActor({
 		canisterId: orbiterId,

--- a/src/frontend/src/lib/api/actors/actor.juno.api.ts
+++ b/src/frontend/src/lib/api/actors/actor.juno.api.ts
@@ -13,7 +13,7 @@ import {
 } from '$declarations';
 import { ActorApi, type GetActorParams } from '$lib/api/actors/actor.api';
 import { CONSOLE_CANISTER_ID, OBSERVATORY_CANISTER_ID } from '$lib/constants/app.constants';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type { Principal } from '@icp-sdk/core/principal';
 
@@ -33,7 +33,7 @@ export const getConsoleActor = async ({
 		identity
 	});
 
-export const getObservatoryActor = async (identity: OptionIdentity): Promise<ObservatoryActor> =>
+export const getObservatoryActor = async (identity: NullishIdentity): Promise<ObservatoryActor> =>
 	await observatoryActor.getActor({
 		canisterId: OBSERVATORY_CANISTER_ID,
 		idlFactory: idlFactoryObservatory,
@@ -45,7 +45,7 @@ export const getSatelliteActor = async ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteActor> =>
 	await satelliteActor.getActor({
 		canisterId: satelliteId,
@@ -58,7 +58,7 @@ export const getOrbiterActor = async ({
 	identity
 }: {
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<OrbiterActor> =>
 	await orbiterActor.getActor({
 		canisterId: orbiterId,
@@ -71,7 +71,7 @@ export const getMissionControlActor = async ({
 	missionControlId
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlActor> =>
 	await missionControlActor.getActor({
 		canisterId: missionControlId,

--- a/src/frontend/src/lib/api/call/query.api.ts
+++ b/src/frontend/src/lib/api/call/query.api.ts
@@ -1,4 +1,4 @@
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { isNullish } from '@dfinity/utils';
 
 export type QueryAndUpdateOnResponse<R> = (options: { certified: boolean; response: R }) => void;
@@ -6,7 +6,7 @@ export type QueryAndUpdateOnResponse<R> = (options: { certified: boolean; respon
 export interface QueryAndUpdateOnErrorOptions<E = unknown> {
 	error: E;
 	// The identity used for the request
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 export type QueryAndUpdateOnError<E = unknown> = (
@@ -25,7 +25,7 @@ export type QueryAndUpdatePromiseResolution = 'all_settled' | 'race';
 
 export interface QueryAndUpdateRequestParams {
 	certified: boolean;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 /**
@@ -46,7 +46,7 @@ export const queryAndUpdate = async <R, E = unknown>({
 	onError?: QueryAndUpdateOnError<E>;
 	onCertifiedError?: QueryAndUpdateOnCertifiedError<E>;
 	strategy?: QueryAndUpdateStrategy;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	resolution?: QueryAndUpdatePromiseResolution;
 }): Promise<void> => {
 	let certifiedDone = false;

--- a/src/frontend/src/lib/api/cmc.api.ts
+++ b/src/frontend/src/lib/api/cmc.api.ts
@@ -1,6 +1,6 @@
 import { getAgent } from '$lib/api/_agent/_agent.api';
 import { CMC_CANISTER_ID } from '$lib/constants/app.constants';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish } from '@dfinity/utils';
 import { type CmcDid, CmcCanister } from '@icp-sdk/canisters/cmc';
 import type { BlockHeight } from '@icp-sdk/canisters/ledger/icp';
@@ -31,7 +31,7 @@ export const notifyTopUp = async ({
 	identity,
 	request
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	request: CmcDid.NotifyTopUpArg;
 }): Promise<BlockHeight> => {
 	const { notifyTopUp } = await cmcCanister({ identity });
@@ -42,14 +42,14 @@ export const notifyMintCycles = async ({
 	identity,
 	request
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	request: CmcDid.NotifyMintCyclesArg;
 }): Promise<CmcDid.NotifyMintCyclesSuccess> => {
 	const { notifyMintCycles } = await cmcCanister({ identity });
 	return await notifyMintCycles(request);
 };
 
-const cmcCanister = async ({ identity }: { identity: OptionIdentity }): Promise<CmcCanister> => {
+const cmcCanister = async ({ identity }: { identity: NullishIdentity }): Promise<CmcCanister> => {
 	assertNonNullish(identity, 'No internet identity to initialize the Cmc actor.');
 
 	const agent = await getAgent({ identity });

--- a/src/frontend/src/lib/api/console.api.ts
+++ b/src/frontend/src/lib/api/console.api.ts
@@ -6,7 +6,7 @@ import type {
 	CreateWithConfig,
 	CreateWithConfigAndName
 } from '$lib/types/factory';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Metadata } from '$lib/types/metadata';
 import type { OrbiterId } from '$lib/types/orbiter';
 import type { SatelliteId } from '$lib/types/satellite';
@@ -30,7 +30,7 @@ export const getAccount = async (
 	return fromNullable(await get_account());
 };
 
-export const getCredits = async (identity: OptionIdentity): Promise<bigint> => {
+export const getCredits = async (identity: NullishIdentity): Promise<bigint> => {
 	const { get_credits } = await getConsoleActor({ identity });
 	const { e8s } = await get_credits();
 	return e8s;
@@ -39,19 +39,19 @@ export const getCredits = async (identity: OptionIdentity): Promise<bigint> => {
 export const getSatelliteFee = async ({
 	identity
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<ConsoleDid.FactoryFee> => await getFee({ identity, segmentKind: { Satellite: null } });
 
 export const getOrbiterFee = async ({
 	identity
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<ConsoleDid.FactoryFee> => await getFee({ identity, segmentKind: { Orbiter: null } });
 
 export const getMissionControlFee = async ({
 	identity
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<ConsoleDid.FactoryFee> =>
 	await getFee({ identity, segmentKind: { MissionControl: null } });
 
@@ -59,7 +59,7 @@ const getFee = async ({
 	identity,
 	segmentKind
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	segmentKind: ConsoleDid.SegmentKind;
 }): Promise<ConsoleDid.FactoryFee> => {
 	const { get_fee } = await getConsoleActor({ identity });
@@ -75,7 +75,7 @@ export const setSegmentMetadata = async ({
 	segmentId: Principal;
 	segmentKind: ConsoleDid.StorableSegmentKind;
 	metadata: Metadata;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<ConsoleDid.Segment> => {
 	const { set_segment_metadata } = await getConsoleActor({ identity });
 	return set_segment_metadata({
@@ -90,7 +90,7 @@ export const unsetSegment = async ({
 	identity
 }: {
 	args: ConsoleDid.UnsetSegmentsArgs;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { unset_segment } = await getConsoleActor({ identity });
 	await unset_segment(args);
@@ -101,7 +101,7 @@ export const setSegment = async ({
 	identity
 }: {
 	args: ConsoleDid.SetSegmentsArgs;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<ConsoleDid.Segment> => {
 	const { set_segment } = await getConsoleActor({ identity });
 	return set_segment(args);
@@ -112,7 +112,7 @@ export const setManySegments = async ({
 	identity
 }: {
 	args: ConsoleDid.SetSegmentsArgs[];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<ConsoleDid.Segment[]> => {
 	const { set_many_segments } = await getConsoleActor({ identity });
 	return set_many_segments(args);
@@ -122,7 +122,7 @@ export const createMissionControlWithConfig = async ({
 	identity,
 	config: { subnetId }
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	config: CreateWithConfig;
 }): Promise<SatelliteId> => {
 	assertNonNullish(identity);
@@ -140,7 +140,7 @@ export const createSatelliteWithConfig = async ({
 	identity,
 	config: { name, subnetId, kind }
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	config: CreateSatelliteConfig;
 }): Promise<SatelliteId> => {
 	assertNonNullish(identity);
@@ -173,7 +173,7 @@ export const createOrbiterWithConfig = async ({
 	identity,
 	config: { name, subnetId }
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	config: CreateWithConfigAndName;
 }): Promise<OrbiterId> => {
 	assertNonNullish(identity);

--- a/src/frontend/src/lib/api/cycles-ledger.api.ts
+++ b/src/frontend/src/lib/api/cycles-ledger.api.ts
@@ -1,5 +1,5 @@
 import { getAgent } from '$lib/api/_agent/_agent.api';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
 import {
 	type WithdrawParams,
@@ -14,7 +14,7 @@ export const withdrawCycles = async ({
 	identity
 }: {
 	canisterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & Pick<WithdrawParams, 'amount'>): Promise<WithdrawResult> => {
 	const { withdraw } = await getCyclesLedgerActor({ identity });
 
@@ -28,7 +28,7 @@ export const withdrawCycles = async ({
 const getCyclesLedgerActor = async ({
 	identity
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<CyclesLedgerCanister> => {
 	assertNonNullish(identity, 'No internet identity to initialize the Cycles Ledger actor.');
 

--- a/src/frontend/src/lib/api/icp-index.api.ts
+++ b/src/frontend/src/lib/api/icp-index.api.ts
@@ -1,5 +1,5 @@
 import { getAgent } from '$lib/api/_agent/_agent.api';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { toAccountIdentifier } from '$lib/utils/icp-icrc-account.utils';
 import { assertNonNullish } from '@dfinity/utils';
 import { IcpIndexCanister, type IcpIndexDid } from '@icp-sdk/canisters/ledger/icp';
@@ -13,7 +13,7 @@ export const getIcpTransactions = async ({
 	certified
 }: {
 	account: IcrcAccount;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	start?: bigint;
 	maxResults?: bigint;
 	certified: boolean;

--- a/src/frontend/src/lib/api/icp-ledger.api.ts
+++ b/src/frontend/src/lib/api/icp-ledger.api.ts
@@ -1,5 +1,5 @@
 import { getAgent } from '$lib/api/_agent/_agent.api';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish } from '@dfinity/utils';
 import {
 	IcpLedgerCanister,
@@ -12,7 +12,7 @@ export const icpTransfer = async ({
 	identity,
 	request
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	request: TransferRequest;
 }): Promise<BlockHeight> => {
 	const { transfer } = await ipcLedgerCanister({ identity });
@@ -23,7 +23,7 @@ export const icrcTransfer = async ({
 	identity,
 	request
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	request: Icrc1TransferRequest;
 }): Promise<BlockHeight> => {
 	const { icrc1Transfer } = await ipcLedgerCanister({ identity });
@@ -33,7 +33,7 @@ export const icrcTransfer = async ({
 const ipcLedgerCanister = async ({
 	identity
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<IcpLedgerCanister> => {
 	assertNonNullish(identity, 'No internet identity to initialize the Ledger actor.');
 

--- a/src/frontend/src/lib/api/icrc-index.api.ts
+++ b/src/frontend/src/lib/api/icrc-index.api.ts
@@ -1,6 +1,6 @@
 import { getAgent } from '$lib/api/_agent/_agent.api';
 import type { LedgerIds } from '$lib/schemas/wallet.schema';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish } from '@dfinity/utils';
 import {
 	type IcrcAccount,
@@ -17,7 +17,7 @@ export const getIcrcTransactions = async ({
 	certified
 }: {
 	account: IcrcAccount;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	start?: bigint;
 	maxResults?: bigint;
 	certified: boolean;

--- a/src/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/src/frontend/src/lib/api/icrc-ledger.api.ts
@@ -1,6 +1,6 @@
 import { getAgent } from '$lib/api/_agent/_agent.api';
 import type { LedgerId, LedgerIds } from '$lib/schemas/wallet.schema';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
 import {
 	IcrcLedgerCanister,
@@ -20,7 +20,7 @@ export const approveIcrcTransfer = async ({
 	validity = ONE_MINUTE,
 	...rest
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	ledgerId: LedgerId;
 	validity?: bigint;
 } & Pick<ApproveParams, 'amount' | 'spender' | 'memo'>): Promise<IcrcLedgerDid.BlockIndex> => {
@@ -40,7 +40,7 @@ export const icrcTransfer = async ({
 	request,
 	...rest
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	ledgerId: LedgerId;
 	request: TransferParams;
 }): Promise<IcrcLedgerDid.BlockIndex> => {
@@ -52,7 +52,7 @@ const icrcLedgerCanister = async ({
 	identity,
 	ledgerId
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	ledgerId: Principal;
 }): Promise<IcrcLedgerCanister> => {
 	assertNonNullish(identity, 'No internet identity to initialize the ICRC Ledger actor.');
@@ -71,7 +71,7 @@ export const getUncertifiedBalance = async ({
 	ledgerId
 }: {
 	account: IcrcAccount;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & Pick<LedgerIds, 'ledgerId'>): Promise<bigint> => {
 	assertNonNullish(identity, 'No internet identity to initialize the ICRC Index actor.');
 

--- a/src/frontend/src/lib/api/mission-control.api.ts
+++ b/src/frontend/src/lib/api/mission-control.api.ts
@@ -1,7 +1,7 @@
 import type { MissionControlDid } from '$declarations';
 import { getMissionControlActor } from '$lib/api/actors/actor.juno.api';
 import type { AccessKeyIdParam, AddAccessKeyParams } from '$lib/types/access-keys';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Metadata } from '$lib/types/metadata';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type { GetMonitoringParams, MonitoringHistory } from '$lib/types/monitoring';
@@ -18,7 +18,7 @@ export const setSatellitesController = async ({
 }: {
 	missionControlId: MissionControlId;
 	satelliteIds: Principal[];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AddAccessKeyParams) => {
 	try {
 		const { set_satellites_controllers } = await getMissionControlActor({
@@ -49,7 +49,7 @@ export const deleteSatellitesController = async ({
 }: {
 	missionControlId: MissionControlId;
 	satelliteIds: Principal[];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AccessKeyIdParam) => {
 	const { del_satellites_controllers } = await getMissionControlActor({
 		missionControlId,
@@ -65,7 +65,7 @@ export const setMissionControlController = async ({
 	...rest
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AddAccessKeyParams) => {
 	try {
 		const { set_mission_control_controllers } = await getMissionControlActor({
@@ -86,7 +86,7 @@ export const deleteMissionControlController = async ({
 	accessKeyId
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AccessKeyIdParam) => {
 	const { del_mission_control_controllers } = await getMissionControlActor({
 		missionControlId,
@@ -100,7 +100,7 @@ export const listMissionControlControllers = async ({
 	identity
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, MissionControlDid.AccessKey][]> => {
 	const { list_mission_control_controllers } = await getMissionControlActor({
 		missionControlId,
@@ -118,7 +118,7 @@ export const topUp = async ({
 	missionControlId: MissionControlId;
 	canisterId: Principal;
 	e8s: bigint;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { top_up } = await getMissionControlActor({ missionControlId, identity });
 	await top_up(canisterId, { e8s });
@@ -133,7 +133,7 @@ export const setSatelliteMetadata = async ({
 	missionControlId: MissionControlId;
 	satelliteId: Principal;
 	metadata: Metadata;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlDid.Satellite> => {
 	const { set_satellite_metadata } = await getMissionControlActor({ missionControlId, identity });
 	return set_satellite_metadata(satelliteId, metadata);
@@ -148,7 +148,7 @@ export const setOrbitersController = async ({
 }: {
 	missionControlId: MissionControlId;
 	orbiterIds: Principal[];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AddAccessKeyParams) => {
 	try {
 		const { set_orbiters_controllers } = await getMissionControlActor({
@@ -179,7 +179,7 @@ export const deleteOrbitersController = async ({
 }: {
 	missionControlId: MissionControlId;
 	orbiterIds: Principal[];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AccessKeyIdParam) => {
 	const { del_orbiters_controllers } = await getMissionControlActor({ missionControlId, identity });
 	await del_orbiters_controllers(orbiterIds, [Principal.from(accessKeyId)]);
@@ -194,7 +194,7 @@ export const deleteSatellite = async ({
 	missionControlId: MissionControlId;
 	satelliteId: Principal;
 	cyclesToDeposit: bigint;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { del_satellite } = await getMissionControlActor({ missionControlId, identity });
 	await del_satellite(satelliteId, cyclesToDeposit);
@@ -209,7 +209,7 @@ export const deleteOrbiter = async ({
 	missionControlId: MissionControlId;
 	orbiterId: Principal;
 	cyclesToDeposit: bigint;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { del_orbiter } = await getMissionControlActor({ missionControlId, identity });
 	await del_orbiter(orbiterId, cyclesToDeposit);
@@ -224,7 +224,7 @@ export const depositCycles = async ({
 	missionControlId: MissionControlId;
 	cycles: bigint;
 	destinationId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { deposit_cycles } = await getMissionControlActor({ missionControlId, identity });
 	return deposit_cycles({
@@ -242,7 +242,7 @@ export const setOrbiter = async ({
 	missionControlId: MissionControlId;
 	orbiterId: Principal;
 	orbiterName?: string;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlDid.Orbiter> => {
 	const { set_orbiter } = await getMissionControlActor({ missionControlId, identity });
 	return set_orbiter(orbiterId, toNullable(orbiterName));
@@ -255,7 +255,7 @@ export const unsetOrbiter = async ({
 }: {
 	missionControlId: MissionControlId;
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { unset_orbiter } = await getMissionControlActor({ missionControlId, identity });
 	return unset_orbiter(orbiterId);
@@ -270,7 +270,7 @@ export const setSatellite = async ({
 	missionControlId: MissionControlId;
 	satelliteId: Principal;
 	satelliteName?: string;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlDid.Satellite> => {
 	const { set_satellite } = await getMissionControlActor({ missionControlId, identity });
 	return set_satellite(satelliteId, toNullable(satelliteName));
@@ -283,7 +283,7 @@ export const unsetSatellite = async ({
 }: {
 	missionControlId: MissionControlId;
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { unset_satellite } = await getMissionControlActor({ missionControlId, identity });
 	return unset_satellite(satelliteId);
@@ -296,7 +296,7 @@ export const icpTransfer = async ({
 }: {
 	missionControlId: MissionControlId;
 	args: MissionControlDid.TransferArgs;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlDid.Result> => {
 	const { icp_transfer } = await getMissionControlActor({ missionControlId, identity });
 	return icp_transfer(args);
@@ -311,7 +311,7 @@ export const icrcTransfer = async ({
 	ledgerId: Principal;
 	missionControlId: MissionControlId;
 	args: MissionControlDid.TransferArg;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlDid.Result_1> => {
 	const { icrc_transfer } = await getMissionControlActor({ missionControlId, identity });
 	return icrc_transfer(ledgerId, args);
@@ -322,7 +322,7 @@ export const getUserData = async ({
 	identity
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<MissionControlDid.User> => {
 	const { get_user_data } = await getMissionControlActor({ missionControlId, identity });
 	return get_user_data();
@@ -334,7 +334,7 @@ export const getSettings = async ({
 	identity
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[] | [MissionControlDid.MissionControlSettings]> => {
 	const { get_settings } = await getMissionControlActor({ missionControlId, identity });
 	return get_settings();
@@ -346,7 +346,7 @@ export const updateAndStartMonitoring = async ({
 	config
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	config: MissionControlDid.MonitoringStartConfig;
 }): Promise<void> => {
 	const { update_and_start_monitoring } = await getMissionControlActor({
@@ -363,7 +363,7 @@ export const updateAndStopMonitoring = async ({
 	config
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	config: MissionControlDid.MonitoringStopConfig;
 }): Promise<void> => {
 	const { update_and_stop_monitoring } = await getMissionControlActor({
@@ -380,7 +380,7 @@ export const getMonitoringHistory = async ({
 	params: { from, to, segmentId }
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	params: GetMonitoringParams;
 }): Promise<MonitoringHistory> => {
 	const { get_monitoring_history } = await getMissionControlActor({
@@ -401,7 +401,7 @@ export const setConfig = async ({
 	config
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	config: MissionControlDid.Config | undefined;
 }): Promise<void> => {
 	const { set_config } = await getMissionControlActor({
@@ -419,7 +419,7 @@ export const setMetadata = async ({
 }: {
 	missionControlId: MissionControlId;
 	metadata: Metadata;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { set_metadata } = await getMissionControlActor({ missionControlId, identity });
 	await set_metadata(metadata);

--- a/src/frontend/src/lib/api/mission-control.deprecated.api.ts
+++ b/src/frontend/src/lib/api/mission-control.deprecated.api.ts
@@ -4,7 +4,7 @@ import {
 	getMissionControlActor004
 } from '$lib/api/actors/actor.deprecated.api';
 import type { AddAccessKeyParams } from '$lib/types/access-keys';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
 import { nonNullish, toNullable } from '@dfinity/utils';
 import { Principal } from '@icp-sdk/core/principal';
@@ -35,7 +35,7 @@ export const setMissionControlController004 = async ({
 	...rest
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AddAccessKeyParams) => {
 	try {
 		const actor = await getMissionControlActor004({ missionControlId, identity });
@@ -59,7 +59,7 @@ export const listSatelliteStatuses = async ({
 	satelliteId
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	satelliteId: Principal;
 }): Promise<[] | [[bigint, MissionControlDid0013.Result_2][]]> => {
 	const { list_satellite_statuses } = await getMissionControlActor0013({
@@ -78,7 +78,7 @@ export const listOrbiterStatuses = async ({
 	orbiterId
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	orbiterId: Principal;
 }): Promise<[] | [[bigint, MissionControlDid0013.Result_2][]]> => {
 	const { list_orbiter_statuses } = await getMissionControlActor0013({
@@ -96,7 +96,7 @@ export const listMissionControlStatuses = async ({
 	identity
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[] | [[bigint, MissionControlDid0013.Result_2][]]> => {
 	const { list_mission_control_statuses } = await getMissionControlActor0013({
 		missionControlId,
@@ -113,7 +113,7 @@ export const missionControlVersion = async ({
 	identity
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<string> => {
 	const { version } = await getMissionControlActor0013({ missionControlId, identity });
 	return version();
@@ -130,7 +130,7 @@ export const addSatellitesController003 = async ({
 }: {
 	missionControlId: MissionControlId;
 	satelliteIds: Principal[];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AddAccessKeyParams) => {
 	try {
 		// We use getMissionControlActor004 actor because the method add_satellites_controllers
@@ -159,7 +159,7 @@ export const addMissionControlController003 = async ({
 	identity
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AddAccessKeyParams) => {
 	try {
 		// We use getMissionControlActor004 actor because the method add_mission_control_controllers

--- a/src/frontend/src/lib/api/orbiter.api.ts
+++ b/src/frontend/src/lib/api/orbiter.api.ts
@@ -1,6 +1,6 @@
 import type { OrbiterDid } from '$declarations';
 import { getOrbiterActor } from '$lib/api/actors/actor.juno.api';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { PageViewsParams, PageViewsPeriod } from '$lib/types/orbiter';
 import { toBigIntNanoSeconds } from '$lib/utils/date.utils';
 import { nonNullish, toNullable } from '@dfinity/utils';
@@ -142,7 +142,7 @@ export const listOrbiterControllers = async ({
 	identity
 }: {
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, OrbiterDid.AccessKey][]> => {
 	const actor = await getOrbiterActor({ orbiterId, identity });
 	return actor.list_controllers();
@@ -153,7 +153,7 @@ export const listOrbiterSatelliteConfigs = async ({
 	identity
 }: {
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, OrbiterDid.OrbiterSatelliteConfig][]> => {
 	const { list_satellite_configs } = await getOrbiterActor({ orbiterId, identity });
 	return list_satellite_configs();
@@ -166,7 +166,7 @@ export const setOrbiterSatelliteConfigs = async ({
 }: {
 	orbiterId: Principal;
 	config: [Principal, OrbiterDid.SetSatelliteConfig][];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, OrbiterDid.OrbiterSatelliteConfig][]> => {
 	const actor = await getOrbiterActor({ orbiterId, identity });
 	return actor.set_satellite_configs(config);
@@ -181,7 +181,7 @@ export const depositCycles = async ({
 	orbiterId: Principal;
 	cycles: bigint;
 	destinationId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { deposit_cycles } = await getOrbiterActor({ orbiterId, identity });
 	return deposit_cycles({
@@ -196,7 +196,7 @@ export const setControllers = async ({
 }: {
 	args: OrbiterDid.SetControllersArgs;
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, OrbiterDid.AccessKey][]> => {
 	const { set_controllers } = await getOrbiterActor(rest);
 	return set_controllers(args);
@@ -208,7 +208,7 @@ export const deleteControllers = async ({
 }: {
 	args: OrbiterDid.DeleteControllersArgs;
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, OrbiterDid.AccessKey][]> => {
 	const { del_controllers } = await getOrbiterActor(rest);
 	return del_controllers(args);

--- a/src/frontend/src/lib/api/orbiter.deprecated.api.ts
+++ b/src/frontend/src/lib/api/orbiter.deprecated.api.ts
@@ -1,6 +1,6 @@
 import type { OrbiterDid007, OrbiterDid008 } from '$declarations';
 import { getOrbiterActor007, getOrbiterActor008 } from '$lib/api/actors/actor.deprecated.api';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { PageViewsParams } from '$lib/types/orbiter';
 import { toBigIntNanoSeconds } from '$lib/utils/date.utils';
 import { nonNullish, toNullable } from '@dfinity/utils';
@@ -14,7 +14,7 @@ export const listOrbiterSatelliteConfigs007 = async ({
 	identity
 }: {
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, OrbiterDid007.OrbiterSatelliteConfig][]> => {
 	const { list_satellite_configs } = await getOrbiterActor007({ orbiterId, identity });
 	return list_satellite_configs();
@@ -30,7 +30,7 @@ export const setOrbiterSatelliteConfigs007 = async ({
 }: {
 	orbiterId: Principal;
 	config: [Principal, OrbiterDid007.SetSatelliteConfig][];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, OrbiterDid007.OrbiterSatelliteConfig][]> => {
 	const actor = await getOrbiterActor007({ orbiterId, identity });
 	return actor.set_satellite_configs(config);
@@ -44,7 +44,7 @@ export const orbiterVersion = async ({
 	identity
 }: {
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<string> => {
 	const { version } = await getOrbiterActor007({ orbiterId, identity });
 	return version();

--- a/src/frontend/src/lib/api/satellites.api.ts
+++ b/src/frontend/src/lib/api/satellites.api.ts
@@ -1,7 +1,7 @@
 import type { MissionControlDid, SatelliteDid } from '$declarations';
 import { getSatelliteActor } from '$lib/api/actors/actor.juno.api';
 import type { CustomDomains } from '$lib/types/custom-domain';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { ListParams } from '$lib/types/list';
 import { toListParams } from '$lib/utils/satellite.utils';
 import { isNullish, toNullable } from '@dfinity/utils';
@@ -16,7 +16,7 @@ export const listDocs = async ({
 	satelliteId: Principal;
 	collection: string;
 	params: ListParams;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.ListResults_1> => {
 	const { list_docs } = await getSatelliteActor({ satelliteId, identity });
 	return list_docs(collection, toListParams(params));
@@ -31,7 +31,7 @@ export const getDoc = async ({
 	satelliteId: Principal;
 	collection: string;
 	key: string;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[] | [SatelliteDid.Doc]> => {
 	const { get_doc } = await getSatelliteActor({ satelliteId, identity });
 	return get_doc(collection, key);
@@ -48,7 +48,7 @@ export const setDoc = async ({
 	collection: string;
 	key: string;
 	doc: SatelliteDid.SetDoc;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.Doc> => {
 	const { set_doc } = await getSatelliteActor({ satelliteId, identity });
 	return set_doc(collection, key, doc);
@@ -63,7 +63,7 @@ export const listAssets = async ({
 	satelliteId: Principal;
 	collection: string;
 	params: ListParams;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.ListResults> => {
 	const actor = await getSatelliteActor({ satelliteId, identity });
 	return actor.list_assets(collection, toListParams(params));
@@ -78,7 +78,7 @@ export const listRules = async ({
 	satelliteId: Principal;
 	type: SatelliteDid.CollectionType;
 	filter: SatelliteDid.ListRulesParams;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.ListRulesResults> => {
 	const { list_rules } = await getSatelliteActor({ satelliteId, identity });
 	return list_rules(type, filter);
@@ -92,7 +92,7 @@ export const getRule = async ({
 }: {
 	satelliteId: Principal;
 	type: SatelliteDid.CollectionType;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	collection: string;
 }): Promise<[] | [SatelliteDid.Rule]> => {
 	const { get_rule } = await getSatelliteActor({ satelliteId, identity });
@@ -109,7 +109,7 @@ export const setRule = async ({
 	satelliteId: Principal;
 	collection: string;
 	type: SatelliteDid.CollectionType;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	rule: SatelliteDid.SetRule;
 }): Promise<SatelliteDid.Rule> => {
 	const { set_rule } = await getSatelliteActor({ satelliteId, identity });
@@ -127,7 +127,7 @@ export const deleteRule = async ({
 	collection: string;
 	type: SatelliteDid.CollectionType;
 	rule: SatelliteDid.Rule;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const delRule: SatelliteDid.DelRule = {
 		version: rule.version
@@ -142,7 +142,7 @@ export const listControllers = async ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, MissionControlDid.AccessKey][]> => {
 	const actor = await getSatelliteActor({ satelliteId, identity });
 	return actor.list_controllers();
@@ -156,7 +156,7 @@ export const setCustomDomain = async ({
 	satelliteId: Principal;
 	domainName: string;
 	boundaryNodesId: string | undefined;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { set_custom_domain } = await getSatelliteActor(rest);
 	await set_custom_domain(domainName, toNullable(boundaryNodesId));
@@ -168,7 +168,7 @@ export const deleteCustomDomain = async ({
 }: {
 	satelliteId: Principal;
 	domainName: string;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { del_custom_domain } = await getSatelliteActor(rest);
 	await del_custom_domain(domainName);
@@ -176,7 +176,7 @@ export const deleteCustomDomain = async ({
 
 export const listCustomDomains = async (params: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<CustomDomains> => {
 	const { list_custom_domains } = await getSatelliteActor(params);
 	return list_custom_domains();
@@ -188,7 +188,7 @@ export const setAuthConfig = async ({
 }: {
 	satelliteId: Principal;
 	config: SatelliteDid.SetAuthenticationConfig;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.AuthenticationConfig> => {
 	const { set_auth_config } = await getSatelliteActor(rest);
 	return set_auth_config(config);
@@ -200,7 +200,7 @@ export const setAutomationConfig = async ({
 }: {
 	satelliteId: Principal;
 	config: SatelliteDid.SetAutomationConfig;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.AutomationConfig> => {
 	const { set_automation_config } = await getSatelliteActor(rest);
 	return set_automation_config(config);
@@ -208,7 +208,7 @@ export const setAutomationConfig = async ({
 
 export const getConfig = async (params: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.Config> => {
 	const { get_config } = await getSatelliteActor(params);
 	return get_config();
@@ -225,7 +225,7 @@ export const deleteDoc = async ({
 	collection: string;
 	key: string;
 	doc: SatelliteDid.Doc | undefined;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { del_doc } = await getSatelliteActor({ satelliteId, identity });
 	return del_doc(collection, key, {
@@ -242,7 +242,7 @@ export const deleteAsset = async ({
 	satelliteId: Principal;
 	collection: string;
 	full_path: string;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const actor = await getSatelliteActor({ satelliteId, identity });
 	return actor.del_asset(collection, full_path);
@@ -255,7 +255,7 @@ export const deleteDocs = async ({
 }: {
 	satelliteId: Principal;
 	collection: string;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { del_docs } = await getSatelliteActor({ satelliteId, identity });
 	return del_docs(collection);
@@ -268,7 +268,7 @@ export const deleteAssets = async ({
 }: {
 	satelliteId: Principal;
 	collection: string;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { del_assets } = await getSatelliteActor({ satelliteId, identity });
 	return del_assets(collection);
@@ -283,7 +283,7 @@ export const depositCycles = async ({
 	satelliteId: Principal;
 	cycles: bigint;
 	destinationId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	const { deposit_cycles } = await getSatelliteActor({ satelliteId, identity });
 	return deposit_cycles({
@@ -299,7 +299,7 @@ export const countCollectionAssets = async ({
 }: {
 	satelliteId: Principal;
 	collection: string;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<bigint> => {
 	const { count_collection_assets } = await getSatelliteActor({ satelliteId, identity });
 	return count_collection_assets(collection);
@@ -310,7 +310,7 @@ export const switchStorageSystemMemory = async ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { switch_storage_system_memory } = await getSatelliteActor({ satelliteId, identity });
 	await switch_storage_system_memory();
@@ -322,7 +322,7 @@ export const setControllers = async ({
 }: {
 	args: SatelliteDid.SetControllersArgs;
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, SatelliteDid.AccessKey][]> => {
 	const { set_controllers } = await getSatelliteActor(rest);
 	return set_controllers(args);
@@ -334,7 +334,7 @@ export const deleteControllers = async ({
 }: {
 	args: SatelliteDid.DeleteControllersArgs;
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[Principal, SatelliteDid.AccessKey][]> => {
 	const { del_controllers } = await getSatelliteActor(rest);
 	return del_controllers(args);

--- a/src/frontend/src/lib/api/satellites.deprecated.api.ts
+++ b/src/frontend/src/lib/api/satellites.deprecated.api.ts
@@ -6,7 +6,7 @@ import {
 	getSatelliteActor009
 } from '$lib/api/actors/actor.deprecated.api';
 import { PAGINATION } from '$lib/constants/app.constants';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { ListParams } from '$lib/types/list';
 import { toListParams } from '$lib/utils/satellite.utils';
 import { isNullish, toNullable } from '@dfinity/utils';
@@ -50,7 +50,7 @@ export const listDocs008 = async ({
 	satelliteId: Principal;
 	collection: string;
 	params: ListParams;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.ListResults_1> => {
 	const actor = await getSatelliteActor008({ satelliteId, identity });
 	const {
@@ -79,7 +79,7 @@ export const listAssets008 = async ({
 	satelliteId: Principal;
 	collection: string;
 	params: ListParams;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.ListResults> => {
 	const actor = await getSatelliteActor008({ satelliteId, identity });
 	const {
@@ -108,7 +108,7 @@ export const listAssets009 = async ({
 	satelliteId: Principal;
 	collection: string;
 	params: ListParams;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.ListResults> => {
 	const actor = await getSatelliteActor009({ satelliteId, identity });
 	const { items, ...rest } = await actor.list_assets(toNullable(collection), toListParams(params));
@@ -128,7 +128,7 @@ export const listRulesDeprecated = async ({
 }: {
 	satelliteId: Principal;
 	type: SatelliteDid.CollectionType;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[string, SatelliteDid.Rule][]> => {
 	const actor = await getSatelliteActor008({ satelliteId, identity });
 	const rules = await actor.list_rules(type);
@@ -150,7 +150,7 @@ export const satelliteVersion = async ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<string> => {
 	// For simplicity reason we just use an old actor (21 instead of 22) as the API did not change until it was fully deprecated.
 	const { version } = await getSatelliteActor0021({ satelliteId, identity });
@@ -165,7 +165,7 @@ export const satelliteBuildVersion = async ({
 	identity
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<string> => {
 	// For simplicity reason we just use an old actor (21 instead of 22) as the API did not change until it was fully deprecated.
 	const { build_version } = await getSatelliteActor0021({ satelliteId, identity });
@@ -182,7 +182,7 @@ export const listRules0022 = async ({
 }: {
 	satelliteId: Principal;
 	type: SatelliteDid.CollectionType;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<[string, SatelliteDid.Rule][]> => {
 	const actor = await getSatelliteActor0022({ satelliteId, identity });
 	return actor.list_rules(type);

--- a/src/frontend/src/lib/components/app/notifications/NotificationsCanisterLoader.svelte
+++ b/src/frontend/src/lib/components/app/notifications/NotificationsCanisterLoader.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { Principal } from '@icp-sdk/core/principal';
 	import Canister from '$lib/components/modules/canister/Canister.svelte';
 	import type { CanisterData, CanisterWarning } from '$lib/types/canister';
-	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		warnings: CanisterWarning | undefined;
 		data: CanisterData | undefined;
-		canisterId: Option<Principal>;
+		canisterId: Nullish<Principal>;
 	}
 
 	let {

--- a/src/frontend/src/lib/components/cli/CliAdd.svelte
+++ b/src/frontend/src/lib/components/cli/CliAdd.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, notEmptyString } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { Principal } from '@icp-sdk/core/principal';
 	import { fade } from 'svelte/transition';
 	import type { MissionControlDid } from '$declarations';
@@ -14,13 +15,12 @@
 	import { toasts } from '$lib/stores/app/toasts.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import type { Satellite } from '$lib/types/satellite';
-	import type { Option } from '$lib/types/utils';
 
 	interface Props {
-		missionControlId: Option<MissionControlId>;
+		missionControlId: Nullish<MissionControlId>;
 		principal: string;
 		redirect_uri: string;
-		profile: Option<string>;
+		profile: Nullish<string>;
 	}
 
 	let { missionControlId, principal, redirect_uri, profile }: Props = $props();

--- a/src/frontend/src/lib/components/mission-control/create/MissionControlCreateWizard.svelte
+++ b/src/frontend/src/lib/components/mission-control/create/MissionControlCreateWizard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { PrincipalText } from '@junobuild/schema';
 	import FactoryAdvancedOptions from '$lib/components/modules/factory/create/FactoryAdvancedOptions.svelte';
 	import FactoryCredits from '$lib/components/modules/factory/create/FactoryCredits.svelte';
@@ -12,7 +13,6 @@
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { FactoryCreateProgress } from '$lib/types/progress-factory-create';
-	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		detail: JunoModalDetail;
@@ -22,7 +22,7 @@
 
 	let { detail, onclose, oncontinue }: Props = $props();
 
-	let withFee = $state<Option<bigint>>(undefined);
+	let withFee = $state<Nullish<bigint>>(undefined);
 	let insufficientFunds = $state(true);
 
 	let step: 'init' | 'in_progress' | 'ready' | 'error' = $state('init');

--- a/src/frontend/src/lib/components/modals/factory/create/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/factory/create/OrbiterCreateModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { PrincipalText } from '@junobuild/schema';
 	import type { MissionControlDid } from '$declarations';
 	import FactoryAdvancedOptions from '$lib/components/modules/factory/create/FactoryAdvancedOptions.svelte';
@@ -18,7 +19,6 @@
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { FactoryCreateProgress } from '$lib/types/progress-factory-create';
-	import type { Option } from '$lib/types/utils';
 	import { navigateToAnalytics } from '$lib/utils/nav.utils';
 	import { testId } from '$lib/utils/test.utils';
 
@@ -29,7 +29,7 @@
 
 	let { detail, onclose }: Props = $props();
 
-	let withFee = $state<Option<bigint>>(undefined);
+	let withFee = $state<Nullish<bigint>>(undefined);
 	let insufficientFunds = $state(true);
 
 	let step: 'init' | 'in_progress' | 'ready' | 'error' = $state('init');

--- a/src/frontend/src/lib/components/modals/factory/create/SatelliteCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/factory/create/SatelliteCreateModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { PrincipalText } from '@junobuild/schema';
 	import type { MissionControlDid } from '$declarations';
 	import FactoryAdvancedOptions from '$lib/components/modules/factory/create/FactoryAdvancedOptions.svelte';
@@ -19,7 +20,6 @@
 	import type { JunoModalDetail } from '$lib/types/modal';
 	import type { FactoryCreateProgress } from '$lib/types/progress-factory-create';
 	import type { SatelliteId } from '$lib/types/satellite';
-	import type { Option } from '$lib/types/utils';
 	import { navigateToSatellite } from '$lib/utils/nav.utils';
 	import { testId } from '$lib/utils/test.utils';
 
@@ -30,7 +30,7 @@
 
 	let { detail, onclose }: Props = $props();
 
-	let withFee = $state<Option<bigint>>(undefined);
+	let withFee = $state<Nullish<bigint>>(undefined);
 	let insufficientFunds = $state(true);
 
 	let step: 'init' | 'in_progress' | 'ready' | 'error' = $state('init');

--- a/src/frontend/src/lib/components/modules/canister/display/CanisterSubnet.svelte
+++ b/src/frontend/src/lib/components/modules/canister/display/CanisterSubnet.svelte
@@ -10,8 +10,6 @@
 	import { loadSubnetId } from '$lib/services/ic-mgmt/subnets.services';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { subnetStore } from '$lib/stores/ic-mgmt/subnet.store';
-	import type { Subnet } from '$lib/types/subnet';
-	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		canisterId: Principal;
@@ -25,7 +23,7 @@
 		});
 	});
 
-	let subnet: Option<Subnet> = $derived($subnetStore?.[canisterId.toText()]);
+	let subnet = $derived($subnetStore?.[canisterId.toText()]);
 
 	let subnetId: PrincipalText | undefined = $derived(subnet?.subnetId);
 </script>

--- a/src/frontend/src/lib/components/modules/factory/create/FactoryCredits.svelte
+++ b/src/frontend/src/lib/components/modules/factory/create/FactoryCredits.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
 	import { fromNullable, isNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { Snippet } from 'svelte';
 	import FactoryCreditsWithFee from '$lib/components/modules/factory/create/FactoryCreditsWithFee.svelte';
 	import FactoryWalletInfo from '$lib/components/modules/factory/create/FactoryWalletInfo.svelte';
 	import type { SelectedWallet } from '$lib/schemas/wallet.schema';
 	import type { JunoModalCreateSegmentDetail, JunoModalDetail } from '$lib/types/modal';
-	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		detail: JunoModalDetail;
 		priceLabel: string;
 		selectedWallet: SelectedWallet | undefined;
-		withFee: Option<bigint>;
+		withFee: Nullish<bigint>;
 		insufficientFunds?: boolean;
 		children: Snippet;
 		onclose: () => void;

--- a/src/frontend/src/lib/components/modules/factory/create/FactoryCreditsWithFee.svelte
+++ b/src/frontend/src/lib/components/modules/factory/create/FactoryCreditsWithFee.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { Snippet } from 'svelte';
 	import FactoryWalletInfo from '$lib/components/modules/factory/create/FactoryWalletInfo.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
@@ -13,7 +14,6 @@
 	} from '$lib/derived/wallet/balance.derived';
 	import { icpToUsd } from '$lib/derived/wallet/exchange.derived';
 	import type { SelectedToken, SelectedWallet } from '$lib/schemas/wallet.schema';
-	import type { Option } from '$lib/types/utils';
 	import { formatCyclesToHTML } from '$lib/utils/cycles.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 	import { formatICPToHTML } from '$lib/utils/icp.utils';
@@ -23,7 +23,7 @@
 		fee: bigint;
 		priceLabel: string;
 		selectedWallet: SelectedWallet | undefined;
-		withFee: Option<bigint>;
+		withFee: Nullish<bigint>;
 		insufficientFunds?: boolean;
 		children: Snippet;
 		onclose: () => void;

--- a/src/frontend/src/lib/components/modules/out-of-sync/OutOfSyncSegments.svelte
+++ b/src/frontend/src/lib/components/modules/out-of-sync/OutOfSyncSegments.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
 	import { isEmptyString, nonNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { Snippet } from 'svelte';
 	import Segment from '$lib/components/modules/segments/Segment.svelte';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import type { Orbiter } from '$lib/types/orbiter';
 	import type { Satellite } from '$lib/types/satellite';
-	import type { Option } from '$lib/types/utils';
 	import { orbiterName } from '$lib/utils/orbiter.utils';
 	import { satelliteName } from '$lib/utils/satellite.utils';
 
 	interface Props {
 		label: Snippet;
 		satellites: Satellite[];
-		orbiter: Option<Orbiter>;
+		orbiter: Nullish<Orbiter>;
 	}
 
 	let { label, satellites, orbiter }: Props = $props();

--- a/src/frontend/src/lib/components/modules/segments/SegmentsTable.svelte
+++ b/src/frontend/src/lib/components/modules/segments/SegmentsTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isEmptyString, isNullish, nonNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { Principal } from '@icp-sdk/core/principal';
 	import { onMount, type Snippet, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -19,13 +20,12 @@
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { toasts } from '$lib/stores/app/toasts.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
-	import type { Option } from '$lib/types/utils';
 	import { orbiterName } from '$lib/utils/orbiter.utils';
 	import { satelliteName } from '$lib/utils/satellite.utils';
 	import { waitReady } from '$lib/utils/timeout.utils';
 
 	interface Props {
-		missionControlId: Option<MissionControlId>;
+		missionControlId: Nullish<MissionControlId>;
 		children?: Snippet;
 		selectedMissionControl?: boolean;
 		selectedSatellites: [Principal, MissionControlDid.Satellite][];

--- a/src/frontend/src/lib/components/modules/snapshot/Snapshots.svelte
+++ b/src/frontend/src/lib/components/modules/snapshot/Snapshots.svelte
@@ -13,8 +13,6 @@
 	import { toasts } from '$lib/stores/app/toasts.store';
 	import { snapshotStore } from '$lib/stores/ic-mgmt/snapshot.store';
 	import type { CanisterSegmentWithLabel, Segment } from '$lib/types/canister';
-	import type { Snapshots } from '$lib/types/progress-snapshot';
-	import type { Option } from '$lib/types/utils';
 	import { formatToDate } from '$lib/utils/date.utils';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
@@ -28,7 +26,7 @@
 
 	let { canisterId, segment, segmentLabel }: Props = $props();
 
-	let snapshots: Option<Snapshots> = $derived($snapshotStore?.[canisterId.toText()]);
+	let snapshots = $derived($snapshotStore?.[canisterId.toText()]);
 
 	let segmentWithLabel: CanisterSegmentWithLabel = $derived({
 		canisterId: canisterId.toText(),

--- a/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyReview.svelte
+++ b/src/frontend/src/lib/components/monitoring/MonitoringCreateStrategyReview.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { Principal } from '@icp-sdk/core/principal';
 	import type { MissionControlDid } from '$declarations';
 	import MonitoringSelectedModules from '$lib/components/monitoring/MonitoringSelectedModules.svelte';
 	import MonitoringStepReview from '$lib/components/monitoring/MonitoringStepReview.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import type { Option } from '$lib/types/utils';
 	import { formatTCycles } from '$lib/utils/cycles.utils';
 
 	interface Props {
@@ -21,7 +21,7 @@
 			monitored: boolean;
 			strategy: MissionControlDid.CyclesMonitoringStrategy | undefined;
 		};
-		userEmail: Option<string>;
+		userEmail: Nullish<string>;
 		reuseStrategy: MissionControlDid.CyclesMonitoringStrategy | undefined;
 		onback: () => void;
 		onsubmit: ($event: MouseEvent | TouchEvent) => Promise<void>;

--- a/src/frontend/src/lib/components/monitoring/create/MonitoringCreateWizard.svelte
+++ b/src/frontend/src/lib/components/monitoring/create/MonitoringCreateWizard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { nonNullish, notEmptyString, fromNullishNullable, NullishError } from '@dfinity/utils';
+	import { nonNullish, notEmptyString, fromNullishNullable } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { Principal } from '@icp-sdk/core/principal';
 	import type { MissionControlDid } from '$declarations';
 	import MonitoringCreateSelectStrategy from '$lib/components/monitoring/MonitoringCreateSelectStrategy.svelte';
@@ -21,7 +22,6 @@
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import type { MonitoringStrategyProgress } from '$lib/types/progress-strategy';
 	import { metadataEmail } from '$lib/utils/metadata.utils';
-	import type { Nullish } from '@dfinity/zod-schemas';
 
 	interface Props {
 		missionControlId: MissionControlId;

--- a/src/frontend/src/lib/components/monitoring/create/MonitoringCreateWizard.svelte
+++ b/src/frontend/src/lib/components/monitoring/create/MonitoringCreateWizard.svelte
@@ -20,7 +20,6 @@
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import type { MonitoringStrategyProgress } from '$lib/types/progress-strategy';
-	import type { Option } from '$lib/types/utils';
 	import { metadataEmail } from '$lib/utils/metadata.utils';
 
 	interface Props {
@@ -94,7 +93,7 @@
 	let metadata = $derived(user.metadata);
 	let missionControlEmail = $derived(metadataEmail(metadata));
 	let hasMissionControlEmail = $derived(nonNullish(missionControlEmail));
-	let userEmail: Option<string> = $state(undefined);
+	let userEmail = $state(undefined);
 
 	// Strategy choice
 

--- a/src/frontend/src/lib/components/monitoring/create/MonitoringCreateWizard.svelte
+++ b/src/frontend/src/lib/components/monitoring/create/MonitoringCreateWizard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish, notEmptyString, fromNullishNullable } from '@dfinity/utils';
+	import { nonNullish, notEmptyString, fromNullishNullable, NullishError } from '@dfinity/utils';
 	import type { Principal } from '@icp-sdk/core/principal';
 	import type { MissionControlDid } from '$declarations';
 	import MonitoringCreateSelectStrategy from '$lib/components/monitoring/MonitoringCreateSelectStrategy.svelte';
@@ -21,6 +21,7 @@
 	import type { MissionControlId } from '$lib/types/mission-control';
 	import type { MonitoringStrategyProgress } from '$lib/types/progress-strategy';
 	import { metadataEmail } from '$lib/utils/metadata.utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 
 	interface Props {
 		missionControlId: MissionControlId;
@@ -93,7 +94,7 @@
 	let metadata = $derived(user.metadata);
 	let missionControlEmail = $derived(metadataEmail(metadata));
 	let hasMissionControlEmail = $derived(nonNullish(missionControlEmail));
-	let userEmail = $state(undefined);
+	let userEmail = $state<Nullish<string>>(undefined);
 
 	// Strategy choice
 

--- a/src/frontend/src/lib/components/satellites/auth/UserPasskeyAuthenticator.svelte
+++ b/src/frontend/src/lib/components/satellites/auth/UserPasskeyAuthenticator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import { bytesToAAGUID } from '@junobuild/ic-client/webauthn';
 	import Value from '$lib/components/ui/Value.svelte';
 	import aaguids from '$lib/env/aaguids.json';
@@ -8,7 +9,6 @@
 	import { theme } from '$lib/stores/app/theme.store';
 	import { Theme } from '$lib/types/theme';
 	import type { User } from '$lib/types/user';
-	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		user: User;
@@ -16,7 +16,7 @@
 
 	let { user }: Props = $props();
 
-	const mapAaguid = (user: User): Option<Aaguid> => {
+	const mapAaguid = (user: User): Nullish<Aaguid> => {
 		const {
 			data: { providerData }
 		} = user;
@@ -44,7 +44,7 @@
 		return aaguidText;
 	};
 
-	const mapAaguidText = (aaguid: Option<Aaguid>): Option<AaguidName> => {
+	const mapAaguidText = (aaguid: Nullish<Aaguid>): Nullish<AaguidName> => {
 		if (isNullish(aaguid)) {
 			return null;
 		}

--- a/src/frontend/src/lib/components/satellites/hosting/AddCustomDomain.svelte
+++ b/src/frontend/src/lib/components/satellites/hosting/AddCustomDomain.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { SatelliteDid } from '$declarations';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import type { Satellite } from '$lib/types/satellite';
-	import type { Option } from '$lib/types/utils';
 	import { emit } from '$lib/utils/events.utils';
 
 	interface Props {
 		satellite: Satellite;
-		config?: Option<SatelliteDid.AuthenticationConfig>;
+		config?: Nullish<SatelliteDid.AuthenticationConfig>;
 	}
 
 	let { satellite, config = undefined }: Props = $props();

--- a/src/frontend/src/lib/components/satellites/hosting/AddCustomDomainAuth.svelte
+++ b/src/frontend/src/lib/components/satellites/hosting/AddCustomDomainAuth.svelte
@@ -1,9 +1,9 @@
 <script lang="ts" module>
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import type { SatelliteDid } from '$declarations';
-	import type { Option } from '$lib/types/utils';
 
 	export interface AddCustomDomainAuthProps {
-		config: Option<SatelliteDid.AuthenticationConfig>;
+		config: Nullish<SatelliteDid.AuthenticationConfig>;
 		useDomainForDerivationOrigin: boolean;
 	}
 </script>

--- a/src/frontend/src/lib/components/satellites/hosting/CustomDomain.svelte
+++ b/src/frontend/src/lib/components/satellites/hosting/CustomDomain.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish, fromNullishNullable } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 	import { run } from 'svelte/legacy';
 	import type { SatelliteDid } from '$declarations';
@@ -13,7 +14,6 @@
 	import type { CustomDomain, CustomDomainState } from '$lib/types/custom-domain';
 	import type { PostMessageDataResponseHosting } from '$lib/types/post-message';
 	import type { Satellite } from '$lib/types/satellite';
-	import type { Option } from '$lib/types/utils';
 	import { emit } from '$lib/utils/events.utils';
 	import { keyOf } from '$lib/utils/utils';
 
@@ -23,7 +23,7 @@
 		type?: 'default' | 'custom';
 		customDomain?: CustomDomain | undefined;
 		satellite?: Satellite | undefined;
-		config?: Option<SatelliteDid.AuthenticationConfig>;
+		config?: Nullish<SatelliteDid.AuthenticationConfig>;
 	}
 
 	let {
@@ -40,13 +40,13 @@
 		({ host } = new URL(url));
 	});
 
-	let authDomain: string | undefined = $derived(
+	let authDomain = $derived(
 		fromNullishNullable(fromNullishNullable(config?.internet_identity)?.derivation_origin)
 	);
 
-	let mainDomain: boolean = $derived(host === authDomain && nonNullish(authDomain));
+	let mainDomain = $derived(host === authDomain && nonNullish(authDomain));
 
-	let registrationState: Option<CustomDomainState> = $state(undefined);
+	let registrationState = $state<Nullish<CustomDomainState>>(undefined);
 
 	let worker = $state<HostingWorker | undefined>();
 

--- a/src/frontend/src/lib/components/satellites/hosting/CustomDomainActions.svelte
+++ b/src/frontend/src/lib/components/satellites/hosting/CustomDomainActions.svelte
@@ -17,16 +17,16 @@
 	import type { CustomDomain } from '$lib/types/custom-domain';
 	import type { JunoModalCustomDomainDetail } from '$lib/types/modal';
 	import type { Satellite } from '$lib/types/satellite';
-	import type { Option } from '$lib/types/utils';
 	import { buildDeleteAuthenticationConfig } from '$lib/utils/auth.config.utils';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 
 	interface Props {
 		satellite: Satellite;
 		customDomain: CustomDomain | undefined;
-		displayState: Option<string>;
-		config: Option<SatelliteDid.AuthenticationConfig>;
+		displayState: Nullish<string>;
+		config: Nullish<SatelliteDid.AuthenticationConfig>;
 	}
 
 	let { satellite, customDomain, displayState, config }: Props = $props();

--- a/src/frontend/src/lib/components/satellites/hosting/CustomDomainActions.svelte
+++ b/src/frontend/src/lib/components/satellites/hosting/CustomDomainActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish, fromNullishNullable } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import { run, stopPropagation } from 'svelte/legacy';
 	import type { SatelliteDid } from '$declarations';
 	import { setAuthConfig } from '$lib/api/satellites.api';
@@ -20,7 +21,6 @@
 	import { buildDeleteAuthenticationConfig } from '$lib/utils/auth.config.utils';
 	import { emit } from '$lib/utils/events.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
-	import type { Nullish } from '@dfinity/zod-schemas';
 
 	interface Props {
 		satellite: Satellite;

--- a/src/frontend/src/lib/components/satellites/hosting/CustomDomainInfo.svelte
+++ b/src/frontend/src/lib/components/satellites/hosting/CustomDomainInfo.svelte
@@ -10,6 +10,7 @@
 
 <script lang="ts">
 	import { nonNullish, fromNullishNullable } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import { createEventDispatcher } from 'svelte';
 	import { run, stopPropagation } from 'svelte/legacy';
 	import { fade } from 'svelte/transition';
@@ -18,7 +19,6 @@
 	import Popover from '$lib/components/ui/Popover.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/app/i18n.store';
-	import type { Option } from '$lib/types/utils';
 	import { keyOf } from '$lib/utils/utils';
 
 	interface Props {
@@ -30,7 +30,7 @@
 	let { customDomain, mainDomain } = $derived(info);
 
 	// svelte-ignore state_referenced_locally
-	let registrationState = $state<Option<CustomDomainState>>(info.registrationState);
+	let registrationState = $state<Nullish<CustomDomainState>>(info.registrationState);
 
 	let visible = $state(true);
 

--- a/src/frontend/src/lib/components/satellites/hosting/CustomDomainInfo.svelte
+++ b/src/frontend/src/lib/components/satellites/hosting/CustomDomainInfo.svelte
@@ -3,7 +3,7 @@
 
 	export interface SelectedCustomDomain {
 		customDomain: CustomDomain | undefined;
-		registrationState: Option<CustomDomainState>;
+		registrationState: Nullish<CustomDomainState>;
 		mainDomain: boolean;
 	}
 </script>

--- a/src/frontend/src/lib/components/satellites/loaders/SatelliteConfigLoader.svelte
+++ b/src/frontend/src/lib/components/satellites/loaders/SatelliteConfigLoader.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import { type Snippet, untrack } from 'svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { satellite } from '$lib/derived/satellite.derived';
 	import { loadSatelliteConfig } from '$lib/services/satellite/satellite-config.services';
 	import type { Satellite } from '$lib/types/satellite';
-	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		children: Snippet;
@@ -15,7 +15,7 @@
 
 	let loading = $state(false);
 
-	const load = async (satellite: Option<Satellite>) => {
+	const load = async (satellite: Nullish<Satellite>) => {
 		// Satellite is either not loaded or not found
 		if (isNullish(satellite)) {
 			return;

--- a/src/frontend/src/lib/components/satellites/overview/deployments/SatelliteLastDeploymentsLoader.svelte
+++ b/src/frontend/src/lib/components/satellites/overview/deployments/SatelliteLastDeploymentsLoader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import { type Snippet, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import Html from '$lib/components/ui/Html.svelte';
@@ -8,7 +9,6 @@
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { workflowsCertifiedStore } from '$lib/stores/workflows/workflows.store';
 	import type { Satellite } from '$lib/types/satellite';
-	import type { Option } from '$lib/types/utils';
 	import type { CertifiedWorkflows } from '$lib/types/workflow';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 	import { deploymentsLink } from '$lib/utils/nav.utils';
@@ -22,7 +22,7 @@
 
 	let satelliteId = $derived(satellite.satellite_id);
 
-	let workflows = $state<Option<CertifiedWorkflows>>(undefined);
+	let workflows = $state<Nullish<CertifiedWorkflows>>(undefined);
 
 	const load = () => {
 		if ($satelliteAutomationConfig === undefined) {

--- a/src/frontend/src/lib/derived/console/account.mission-control.derived.ts
+++ b/src/frontend/src/lib/derived/console/account.mission-control.derived.ts
@@ -1,7 +1,7 @@
 import { accountCertifiedStore } from '$lib/stores/account.store';
 import type { MissionControlCertifiedId, MissionControlId } from '$lib/types/mission-control';
-import type { Option } from '$lib/types/utils';
 import { fromNullable, isNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { derived } from 'svelte/store';
 
 export const missionControlCertifiedId = derived(
@@ -23,7 +23,7 @@ export const missionControlCertifiedId = derived(
 
 export const missionControlId = derived(
 	[accountCertifiedStore],
-	([$accountCertifiedStore]): Option<MissionControlId> => {
+	([$accountCertifiedStore]): Nullish<MissionControlId> => {
 		if (isNullish($accountCertifiedStore)) {
 			return undefined;
 		}

--- a/src/frontend/src/lib/derived/satellite.derived.ts
+++ b/src/frontend/src/lib/derived/satellite.derived.ts
@@ -1,12 +1,12 @@
 import { pageSatelliteId } from '$lib/derived/app/page.derived.svelte.js';
 import { satellites } from '$lib/derived/satellites.derived';
 import type { Satellite, SatelliteUi } from '$lib/types/satellite';
-import type { Option } from '$lib/types/utils';
 import { satelliteMetadata } from '$lib/utils/satellite.utils';
 import { isNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { derived, type Readable } from 'svelte/store';
 
-export const satellite: Readable<Option<Satellite>> = derived(
+export const satellite: Readable<Nullish<Satellite>> = derived(
 	[satellites, pageSatelliteId],
 	([$satellites, $pageSatelliteId]) => {
 		if (isNullish($pageSatelliteId)) {
@@ -27,7 +27,7 @@ export const satellite: Readable<Option<Satellite>> = derived(
 	}
 );
 
-export const satelliteUi: Readable<Option<SatelliteUi>> = derived(
+export const satelliteUi: Readable<Nullish<SatelliteUi>> = derived(
 	[satellite],
 	([$satelliteStore]) => {
 		if (isNullish($satelliteStore)) {

--- a/src/frontend/src/lib/derived/version.derived.ts
+++ b/src/frontend/src/lib/derived/version.derived.ts
@@ -1,13 +1,13 @@
 import { satellites } from '$lib/derived/satellites.derived';
 import { versionStore } from '$lib/stores/version.store';
 import type { SatelliteIdText } from '$lib/types/satellite';
-import type { Option } from '$lib/types/utils';
 import type { SatelliteVersionMetadataUi, VersionMetadataUi } from '$lib/types/version';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { compare } from 'semver';
 import { derived, type Readable } from 'svelte/store';
 
-export const missionControlVersion: Readable<Option<VersionMetadataUi>> = derived(
+export const missionControlVersion: Readable<Nullish<VersionMetadataUi>> = derived(
 	[versionStore],
 	([$versionStore]) => {
 		if (isNullish($versionStore.missionControl)) {
@@ -24,7 +24,7 @@ export const missionControlVersion: Readable<Option<VersionMetadataUi>> = derive
 	}
 );
 
-export const orbiterVersion: Readable<Option<VersionMetadataUi>> = derived(
+export const orbiterVersion: Readable<Nullish<VersionMetadataUi>> = derived(
 	[versionStore],
 	([$versionStore]) => {
 		if (isNullish($versionStore.orbiter)) {
@@ -43,7 +43,7 @@ export const orbiterVersion: Readable<Option<VersionMetadataUi>> = derived(
 
 export const satellitesVersion = derived([versionStore], ([$versionStore]) =>
 	Object.entries($versionStore.satellites).reduce<
-		Record<SatelliteIdText, Option<SatelliteVersionMetadataUi>>
+		Record<SatelliteIdText, Nullish<SatelliteVersionMetadataUi>>
 	>(
 		(acc, [key, value]) => ({
 			...acc,

--- a/src/frontend/src/lib/derived/wallet/wallet.derived.ts
+++ b/src/frontend/src/lib/derived/wallet/wallet.derived.ts
@@ -4,11 +4,11 @@ import {
 } from '$lib/derived/console/account.mission-control.derived';
 import { devId } from '$lib/derived/dev.derived';
 import type { WalletId } from '$lib/schemas/wallet.schema';
-import type { Option } from '$lib/types/utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { derived, type Readable } from 'svelte/store';
 
-export const walletIds: Readable<Option<WalletId[]>> = derived(
+export const walletIds: Readable<Nullish<WalletId[]>> = derived(
 	[missionControlId, missionControlIdNotLoaded, devId],
 	([$missionControlId, $missionControlIdNotLoaded, $devId]) => {
 		if (isNullish($devId)) {

--- a/src/frontend/src/lib/services/_loader.services.ts
+++ b/src/frontend/src/lib/services/_loader.services.ts
@@ -1,7 +1,7 @@
 import type { DataStore } from '$lib/stores/_data.store';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { get } from 'svelte/store';
@@ -13,7 +13,7 @@ export const loadDataStore = async <T>({
 	errorLabel,
 	reload = false
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	store: DataStore<T>;
 	load: (identity: Identity) => Promise<T>;
 	errorLabel: keyof I18nErrors;

--- a/src/frontend/src/lib/services/access-keys/access-keys.services.ts
+++ b/src/frontend/src/lib/services/access-keys/access-keys.services.ts
@@ -7,10 +7,10 @@ import type {
 	AddAccessKeyParams,
 	AddAccessKeyResult
 } from '$lib/types/access-keys';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
-import type { Option } from '$lib/types/utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { get } from 'svelte/store';
 
 export const addAccessKey = async ({
@@ -18,8 +18,8 @@ export const addAccessKey = async ({
 	addAccessKeyWithDevFn,
 	...rest
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<MissionControlId>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<MissionControlId>;
 	accessKey: AddAccessKeyParams;
 	addAccessKeyWithMissionControlFn: AccessKeyWithMissionControlFn;
 	addAccessKeyWithDevFn: AccessKeyWithDevFn;
@@ -36,8 +36,8 @@ export const removeAccessKey = async ({
 	removeAccessKeyWithDevFn,
 	...rest
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<MissionControlId>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<MissionControlId>;
 	accessKey: AccessKeyIdParam;
 	removeAccessKeyWithMissionControlFn: AccessKeyWithMissionControlFn;
 	removeAccessKeyWithDevFn: AccessKeyWithDevFn;
@@ -56,8 +56,8 @@ const executeAccessKey = async <AccessKeyParams>({
 	accessKeyWithDevFn,
 	errorLabel
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<MissionControlId>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<MissionControlId>;
 	accessKey: AccessKeyParams;
 	accessKeyWithMissionControlFn: AccessKeyWithMissionControlFn;
 	accessKeyWithDevFn: AccessKeyWithDevFn;

--- a/src/frontend/src/lib/services/access-keys/mission-control.key.services.ts
+++ b/src/frontend/src/lib/services/access-keys/mission-control.key.services.ts
@@ -9,7 +9,7 @@ import type {
 	AddAccessKeyParams,
 	AddAccessKeyResult
 } from '$lib/types/access-keys';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
 import { isNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -25,7 +25,7 @@ export const addMissionControlAccessKey = async ({
 	...rest
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AddAccessKeyParams): Promise<AddAccessKeyResult> => {
 	const applyAccessKeyFn: ApplyAccessKeyFn = async ({ identity }) => {
 		await setMissionControlController({
@@ -49,7 +49,7 @@ export const removeMissionControlAccessKey = async ({
 	...rest
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & AccessKeyIdParam): Promise<AddAccessKeyResult> => {
 	const applyAccessKeyFn: ApplyAccessKeyFn = async ({ identity }) => {
 		await deleteMissionControlController({
@@ -69,7 +69,7 @@ const executeAccessKey = async ({
 	identity,
 	applyAccessKeyFn
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	applyAccessKeyFn: ApplyAccessKeyFn;
 }): Promise<AddAccessKeyResult> => {
 	// TODO: indentity check service

--- a/src/frontend/src/lib/services/attach-detach/attach.services.ts
+++ b/src/frontend/src/lib/services/attach-detach/attach.services.ts
@@ -3,20 +3,20 @@ import { setOrbiter, setSatellite } from '$lib/api/mission-control.api';
 import { loadSegments } from '$lib/services/segments.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
-import type { Option } from '$lib/types/utils';
 import { i18nCapitalize, i18nFormat } from '$lib/utils/i18n.utils';
 import { container } from '$lib/utils/juno.utils';
 import { isNullish, nonNullish, toNullable } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Principal } from '@icp-sdk/core/principal';
 import { orbiterVersion, satelliteVersion } from '@junobuild/admin';
 import { get } from 'svelte/store';
 
 interface AttachParams {
-	identity: OptionIdentity;
-	missionControlId: Option<MissionControlId>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<MissionControlId>;
 	segment: 'satellite' | 'orbiter';
 	segmentId: Principal;
 }
@@ -24,7 +24,7 @@ interface AttachParams {
 interface AttachWithMissionControlParams {
 	missionControlId: MissionControlId;
 	canisterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 export const attachSegment = async ({

--- a/src/frontend/src/lib/services/attach-detach/detach.services.ts
+++ b/src/frontend/src/lib/services/attach-detach/detach.services.ts
@@ -2,16 +2,16 @@ import { unsetSegment } from '$lib/api/console.api';
 import { unsetOrbiter, unsetSatellite } from '$lib/api/mission-control.api';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
-import type { Option } from '$lib/types/utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
 
 interface DetachParams {
-	identity: OptionIdentity;
-	missionControlId: Option<MissionControlId>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<MissionControlId>;
 	monitoringEnabled: boolean;
 	segment: 'satellite' | 'orbiter';
 	segmentId: Principal;
@@ -78,7 +78,7 @@ const detachWithConsole = async ({
 interface DetachWithMissionControlParams {
 	missionControlId: MissionControlId;
 	canisterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 const detachWithMissionControl = async ({

--- a/src/frontend/src/lib/services/attach-detach/out-of-sync.services.ts
+++ b/src/frontend/src/lib/services/attach-detach/out-of-sync.services.ts
@@ -11,13 +11,13 @@ import {
 import { loadSegments } from '$lib/services/segments.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type { Orbiter } from '$lib/types/orbiter';
 import { type OutOfSyncProgress, OutOfSyncProgressStep } from '$lib/types/progress-out-of-sync';
 import type { Satellite } from '$lib/types/satellite';
-import type { Option } from '$lib/types/utils';
 import { isNullish, toNullable } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
@@ -28,8 +28,8 @@ export const reconcileSegments = async ({
 	onProgress,
 	onSyncTextProgress
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<MissionControlId>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<MissionControlId>;
 	onProgress: (progress: OutOfSyncProgress | undefined) => void;
 	onSyncTextProgress: (text: string) => void;
 }): Promise<{ result: 'ok' } | { result: 'error'; err?: unknown }> => {

--- a/src/frontend/src/lib/services/cli.services.ts
+++ b/src/frontend/src/lib/services/cli.services.ts
@@ -8,11 +8,11 @@ import {
 } from '$lib/services/mission-control/mission-control.services';
 import type { AddAccessKeyParams } from '$lib/types/access-keys';
 import type { MissionControlId } from '$lib/types/mission-control';
-import type { Option } from '$lib/types/utils';
 import { bigintStringify } from '$lib/utils/number.utils';
 import { orbiterName } from '$lib/utils/orbiter.utils';
 import { satelliteName } from '$lib/utils/satellite.utils';
 import { nonNullish, notEmptyString } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { PrincipalText } from '@junobuild/schema';
@@ -20,9 +20,9 @@ import type { PrincipalText } from '@junobuild/schema';
 interface SetCliControllersParams {
 	// If set, then controllers are set with the Mission Control
 	// else, they are set directly
-	missionControlId: Option<MissionControlId>;
+	missionControlId: Nullish<MissionControlId>;
 	controllerId: PrincipalText;
-	profile: Option<string>;
+	profile: Nullish<string>;
 	identity: Identity;
 	selectedMissionControl: boolean;
 	selectedSatellites: [Principal, MissionControlDid.Satellite][];
@@ -51,7 +51,7 @@ export const setCliControllers = async ({
 	}
 };
 
-const toMetadata = (profile: Option<string>): Pick<AddAccessKeyParams, 'metadata'> =>
+const toMetadata = (profile: Nullish<string>): Pick<AddAccessKeyParams, 'metadata'> =>
 	notEmptyString(profile) ? { metadata: { profile } } : {};
 
 const setCliControllersWithoutMissionControl = async ({

--- a/src/frontend/src/lib/services/cmc.services.ts
+++ b/src/frontend/src/lib/services/cmc.services.ts
@@ -1,7 +1,7 @@
 import { icpTransfer as icpTransferWithDev } from '$lib/api/icp-ledger.api';
 import { CMC_CANISTER_ID } from '$lib/constants/app.constants';
 import { ICP_TOP_UP_FEE, ICP_TRANSACTION_FEE } from '$lib/constants/token.constants';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { nowInBigIntNanoSeconds } from '$lib/utils/date.utils';
 import { waitForMilliseconds } from '$lib/utils/timeout.utils';
 import { principalToSubAccount, type TokenAmountV2 } from '@dfinity/utils';
@@ -15,7 +15,7 @@ import { Principal } from '@icp-sdk/core/principal';
 
 interface SendIcpToCmcParams {
 	subAccount: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	tokenAmount: TokenAmountV2;
 	memo: bigint;
 }

--- a/src/frontend/src/lib/services/console/account.services.ts
+++ b/src/frontend/src/lib/services/console/account.services.ts
@@ -8,7 +8,7 @@ import { accountErrorSignOut } from '$lib/services/console/auth/auth.services';
 import { accountCertifiedStore } from '$lib/stores/account.store';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { get } from 'svelte/store';
@@ -16,7 +16,7 @@ import { get } from 'svelte/store';
 export const initAccount = async ({
 	identity
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
 	// If not signed in, we are not going to init and load a mission control.
 	if (isNullish(identity)) {

--- a/src/frontend/src/lib/services/console/credits.services.ts
+++ b/src/frontend/src/lib/services/console/credits.services.ts
@@ -1,14 +1,14 @@
 import { getCredits } from '$lib/api/console.api';
 import { loadDataStore } from '$lib/services/_loader.services';
 import { creditsUncertifiedStore } from '$lib/stores/console/credits.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Identity } from '@icp-sdk/core/agent';
 
 export const loadCredits = async ({
 	identity,
 	reload = false
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	reload?: boolean;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
 	const load = (identity: Identity): Promise<bigint> => getCredits(identity);

--- a/src/frontend/src/lib/services/factory/factory.create.services.ts
+++ b/src/frontend/src/lib/services/factory/factory.create.services.ts
@@ -42,7 +42,7 @@ import type {
 	CreateWithConfig,
 	CreateWithConfigAndName
 } from '$lib/types/factory';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type { JunoModal, JunoModalCreateSegmentDetail } from '$lib/types/modal';
 import type { OrbiterId } from '$lib/types/orbiter';
@@ -51,10 +51,10 @@ import {
 	FactoryCreateProgressStep
 } from '$lib/types/progress-factory-create';
 import type { SatelliteId } from '$lib/types/satellite';
-import type { Option } from '$lib/types/utils';
 import { emit } from '$lib/utils/events.utils';
 import { waitAndRestartWallet } from '$lib/utils/wallet.utils';
 import { assertNonNullish, isEmptyString, isNullish, nonNullish, toNullable } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 import type { PrincipalText } from '@junobuild/schema';
@@ -64,14 +64,14 @@ type GetFeeBalance =
 	| Omit<JunoModalCreateSegmentDetail, 'monitoringConfig' | 'monitoringEnabled'>
 	| { error: null | string };
 
-type GetFeeBalanceFn = (params: { identity: OptionIdentity }) => Promise<GetFeeBalance>;
+type GetFeeBalanceFn = (params: { identity: NullishIdentity }) => Promise<GetFeeBalance>;
 
 export const initSatelliteWizard = ({
 	missionControlId,
 	identity
 }: {
-	missionControlId: Option<Principal>;
-	identity: OptionIdentity;
+	missionControlId: Nullish<Principal>;
+	identity: NullishIdentity;
 }): Promise<void> =>
 	initCreateWizard({
 		missionControlId,
@@ -84,8 +84,8 @@ export const initOrbiterWizard = ({
 	missionControlId,
 	identity
 }: {
-	missionControlId: Option<Principal>;
-	identity: OptionIdentity;
+	missionControlId: Nullish<Principal>;
+	identity: NullishIdentity;
 }): Promise<void> =>
 	initCreateWizard({
 		missionControlId,
@@ -97,7 +97,7 @@ export const initOrbiterWizard = ({
 export const initMissionControlWizard = ({
 	identity
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> =>
 	initCreateWizard({
 		missionControlId: null,
@@ -112,8 +112,8 @@ const initCreateWizard = async ({
 	feeFn,
 	modalType
 }: {
-	missionControlId: Option<MissionControlId>;
-	identity: OptionIdentity;
+	missionControlId: Nullish<MissionControlId>;
+	identity: NullishIdentity;
 	feeFn: GetFeeBalanceFn;
 	modalType: 'create_satellite' | 'create_orbiter' | 'create_mission_control';
 }) => {
@@ -220,8 +220,8 @@ const getCreateFeeBalance = async ({
 	identity,
 	getFee
 }: {
-	identity: OptionIdentity;
-	getFee: (params: { identity: OptionIdentity }) => Promise<ConsoleDid.FactoryFee>;
+	identity: NullishIdentity;
+	getFee: (params: { identity: NullishIdentity }) => Promise<ConsoleDid.FactoryFee>;
 }): Promise<GetFeeBalance> => {
 	const labels = get(i18n);
 
@@ -267,12 +267,12 @@ const getCreateFeeBalance = async ({
 };
 
 interface CreateWizardParams {
-	selectedWallet: Option<SelectedWallet>;
-	missionControlId: Option<Principal>;
-	identity: OptionIdentity;
+	selectedWallet: Nullish<SelectedWallet>;
+	missionControlId: Nullish<Principal>;
+	identity: NullishIdentity;
 	subnetId: PrincipalText | undefined;
 	monitoringStrategy: MissionControlDid.CyclesMonitoringStrategy | undefined;
-	withFee: Option<bigint>;
+	withFee: Nullish<bigint>;
 	onProgress: (progress: FactoryCreateProgress | undefined) => void;
 }
 

--- a/src/frontend/src/lib/services/factory/factory.delete.services.ts
+++ b/src/frontend/src/lib/services/factory/factory.delete.services.ts
@@ -6,13 +6,13 @@ import { detachSegment } from '$lib/services/attach-detach/detach.services';
 import { loadSegments } from '$lib/services/segments.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import {
 	type FactoryDeleteProgress,
 	FactoryDeleteProgressStep
 } from '$lib/types/progress-factory-delete';
-import type { Option } from '$lib/types/utils';
 import { isNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
@@ -20,8 +20,8 @@ import { get } from 'svelte/store';
 interface DeleteWizardParams {
 	segmentId: Principal;
 	segment: 'satellite' | 'orbiter';
-	missionControlId: Option<Principal>;
-	identity: OptionIdentity;
+	missionControlId: Nullish<Principal>;
+	identity: NullishIdentity;
 	cyclesToDeposit: bigint;
 	canisterIdForDeposit: Principal;
 	monitoringEnabled: boolean;

--- a/src/frontend/src/lib/services/ic-mgmt/settings.services.ts
+++ b/src/frontend/src/lib/services/ic-mgmt/settings.services.ts
@@ -3,7 +3,7 @@ import { canisterUpdateSettings } from '$lib/api/ic.api';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
 import type { CanisterInfo, CanisterSettings } from '$lib/types/canister';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { lacksCyclesForFreezingThreshold } from '$lib/utils/canister.utils';
 import { isNullish, toNullable } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
@@ -17,7 +17,7 @@ export const updateSettings = async ({
 	canisterInfo
 }: {
 	canisterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	currentSettings: CanisterSettings;
 	canisterInfo: CanisterInfo;
 	newSettings: Omit<CanisterSettings, 'controllers'>;

--- a/src/frontend/src/lib/services/ic-mgmt/snapshots.services.ts
+++ b/src/frontend/src/lib/services/ic-mgmt/snapshots.services.ts
@@ -15,7 +15,7 @@ import { i18n } from '$lib/stores/app/i18n.store';
 import { snapshotsIdbStore } from '$lib/stores/app/idb.store';
 import { toasts } from '$lib/stores/app/toasts.store';
 import { snapshotStore } from '$lib/stores/ic-mgmt/snapshot.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { type SnapshotProgress, SnapshotProgressStep } from '$lib/types/progress-snapshot';
 import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -40,7 +40,7 @@ type SnapshotOnProgress = (progress: SnapshotProgress | undefined) => void;
 
 interface SnapshotParams {
 	canisterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	onProgress: SnapshotOnProgress;
 }
 
@@ -251,7 +251,7 @@ export const loadSnapshots = async ({
 	reload = false
 }: {
 	canisterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	reload?: boolean;
 }): Promise<{ success: boolean }> => {
 	const canisterIdText = canisterId.toText();

--- a/src/frontend/src/lib/services/metadata.services.ts
+++ b/src/frontend/src/lib/services/metadata.services.ts
@@ -17,21 +17,21 @@ import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
 import { segmentsUncertifiedStore } from '$lib/stores/console/segments.store';
 import { satellitesUncertifiedStore } from '$lib/stores/mission-control/satellites.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Metadata } from '$lib/types/metadata';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type { SatelliteId, SatelliteUiMetadata } from '$lib/types/satellite';
-import type { Option } from '$lib/types/utils';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import { get } from 'svelte/store';
 import * as z from 'zod';
 
 interface SetSatelliteMetadataParams {
-	missionControlId: Option<MissionControlId>;
+	missionControlId: Nullish<MissionControlId>;
 	satellite: MissionControlDid.Satellite;
 	metadata: SatelliteUiMetadata;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 export const setSatelliteMetadata = async ({

--- a/src/frontend/src/lib/services/mission-control/mission-control.orbiters.services.ts
+++ b/src/frontend/src/lib/services/mission-control/mission-control.orbiters.services.ts
@@ -4,9 +4,9 @@ import { loadDataStore } from '$lib/services/_loader.services';
 import { authStore } from '$lib/stores/auth.store';
 import { orbitersUncertifiedStore } from '$lib/stores/mission-control/orbiter.store';
 import type { CreateWithConfigAndName } from '$lib/types/factory';
-import type { OptionIdentity } from '$lib/types/itentity';
-import type { Option } from '$lib/types/utils';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish, toNullable } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
@@ -16,8 +16,8 @@ export const createOrbiter = async ({
 	missionControlId,
 	config: { name }
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<Principal>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<Principal>;
 	config: Pick<CreateWithConfigAndName, 'name'>;
 }): Promise<MissionControlDid.Orbiter> => {
 	assertNonNullish(missionControlId);
@@ -35,8 +35,8 @@ export const createOrbiterWithConfig = async ({
 	missionControlId,
 	config: { name, subnetId }
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<Principal>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<Principal>;
 	config: CreateWithConfigAndName;
 }): Promise<MissionControlDid.Orbiter> => {
 	assertNonNullish(missionControlId);
@@ -56,7 +56,7 @@ export const loadOrbiters = async ({
 	missionControlId,
 	reload = false
 }: {
-	missionControlId: Option<Principal>;
+	missionControlId: Nullish<Principal>;
 	reload?: boolean;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
 	if (missionControlId === undefined) {

--- a/src/frontend/src/lib/services/mission-control/mission-control.satellites.services.ts
+++ b/src/frontend/src/lib/services/mission-control/mission-control.satellites.services.ts
@@ -4,9 +4,9 @@ import { loadDataStore } from '$lib/services/_loader.services';
 import { authStore } from '$lib/stores/auth.store';
 import { satellitesUncertifiedStore } from '$lib/stores/mission-control/satellites.store';
 import type { CreateSatelliteConfig } from '$lib/types/factory';
-import type { OptionIdentity } from '$lib/types/itentity';
-import type { Option } from '$lib/types/utils';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish, toNullable } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
@@ -19,8 +19,8 @@ export const createSatellite = async ({
 	missionControlId,
 	config: { name }
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<Principal>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<Principal>;
 	config: Required<Pick<CreateSatelliteConfig, 'name'>>;
 }): Promise<MissionControlDid.Satellite> => {
 	assertNonNullish(missionControlId);
@@ -38,8 +38,8 @@ export const createSatelliteWithConfig = async ({
 	missionControlId,
 	config: { name, subnetId, kind }
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<Principal>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<Principal>;
 	config: CreateSatelliteConfig;
 }): Promise<MissionControlDid.Satellite> => {
 	assertNonNullish(missionControlId);
@@ -68,7 +68,7 @@ export const loadSatellites = async ({
 	missionControlId,
 	reload = false
 }: {
-	missionControlId: Option<Principal>;
+	missionControlId: Nullish<Principal>;
 	reload?: boolean;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
 	if (missionControlId === undefined) {

--- a/src/frontend/src/lib/services/mission-control/mission-control.services.ts
+++ b/src/frontend/src/lib/services/mission-control/mission-control.services.ts
@@ -27,13 +27,13 @@ import {
 } from '$lib/stores/mission-control/mission-control.store';
 import { versionStore } from '$lib/stores/version.store';
 import type { AddAccessKeyParams } from '$lib/types/access-keys';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Metadata } from '$lib/types/metadata';
 import type { MissionControlId } from '$lib/types/mission-control';
-import type { Option } from '$lib/types/utils';
 import { isNotValidEmail } from '$lib/utils/email.utils';
 import { container } from '$lib/utils/juno.utils';
 import { fromNullable, isEmptyString, isNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Principal } from '@icp-sdk/core/principal';
 import { missionControlVersion } from '@junobuild/admin';
@@ -127,7 +127,7 @@ export const loadSettings = async ({
 	skipVersionGuard = false
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	reload?: boolean;
 	skipVersionGuard?: boolean;
 }): Promise<{ success: boolean }> => {
@@ -170,7 +170,7 @@ export const loadUserData = async ({
 	skipVersionGuard = false
 }: {
 	missionControlId: MissionControlId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	reload?: boolean;
 	skipVersionGuard?: boolean;
 }): Promise<{ success: boolean }> => {
@@ -207,8 +207,8 @@ export const setMetadataEmail = async ({
 	email,
 	metadata
 }: {
-	missionControlId: Option<Principal>;
-	identity: OptionIdentity;
+	missionControlId: Nullish<Principal>;
+	identity: NullishIdentity;
 	email: string;
 	metadata: Metadata;
 }): Promise<{ success: boolean }> => {

--- a/src/frontend/src/lib/services/mission-control/monitoring.services.ts
+++ b/src/frontend/src/lib/services/mission-control/monitoring.services.ts
@@ -22,7 +22,7 @@ import { loadSatellites } from '$lib/services/mission-control/mission-control.sa
 import { loadSettings, loadUserData } from '$lib/services/mission-control/mission-control.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Metadata } from '$lib/types/metadata';
 import type { MissionControlId } from '$lib/types/mission-control';
 import type { JunoModal, JunoModalCreateMonitoringStrategyDetail } from '$lib/types/modal';
@@ -30,7 +30,6 @@ import {
 	type MonitoringStrategyProgress,
 	MonitoringStrategyProgressStep
 } from '$lib/types/progress-strategy';
-import type { Option } from '$lib/types/utils';
 import { isNotValidEmail } from '$lib/utils/email.utils';
 import { emit } from '$lib/utils/events.utils';
 import {
@@ -42,13 +41,14 @@ import {
 	notEmptyString,
 	toNullable
 } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
 
 type MonitoringStrategyOnProgress = (progress: MonitoringStrategyProgress | undefined) => void;
 
 interface MonitoringCyclesStrategyParams {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	missionControlId: MissionControlId;
 	satellites: Principal[];
 	orbiters: Principal[];
@@ -59,7 +59,7 @@ export interface ApplyMonitoringCyclesStrategyOptions {
 	monitoringConfig: MissionControlDid.MonitoringConfig | undefined;
 	saveAsDefaultStrategy: boolean;
 	metadata: Metadata;
-	userEmail: Option<string>;
+	userEmail: Nullish<string>;
 }
 
 interface ApplyMonitoringCyclesStrategyParams extends MonitoringCyclesStrategyParams {
@@ -538,8 +538,8 @@ export const setMonitoringNotification = async ({
 	monitoringConfig,
 	enabled
 }: {
-	identity: OptionIdentity;
-	missionControlId: Option<Principal>;
+	identity: NullishIdentity;
+	missionControlId: Nullish<Principal>;
 	monitoringConfig: MissionControlDid.MonitoringConfig | undefined;
 	enabled: boolean;
 }): Promise<{ success: boolean }> => {

--- a/src/frontend/src/lib/services/orbiter/orbiters.services.ts
+++ b/src/frontend/src/lib/services/orbiter/orbiters.services.ts
@@ -14,7 +14,7 @@ import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
 import { authStore } from '$lib/stores/auth.store';
 import { orbitersConfigsStore } from '$lib/stores/orbiter/orbiter-configs.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { OrbiterSatelliteConfigEntry } from '$lib/types/orbiter';
 import type { SatelliteIdText } from '$lib/types/satellite';
 import { nonNullish, toNullable } from '@dfinity/utils';
@@ -76,7 +76,7 @@ const listOrbiterSatelliteConfigs = async ({
 	...rest
 }: {
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	orbiterVersion: string;
 }): Promise<[Principal, OrbiterDid.OrbiterSatelliteConfig][]> => {
 	if (compare(orbiterVersion, ORBITER_v0_0_8) >= 0) {
@@ -105,7 +105,7 @@ export const setOrbiterSatelliteConfigs = async ({
 }: {
 	orbiterId: Principal;
 	config: Record<SatelliteIdText, OrbiterSatelliteConfigEntry>;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	orbiterVersion: string;
 	features: OrbiterDid.OrbiterSatelliteFeatures | undefined;
 }): Promise<[Principal, OrbiterDid.OrbiterSatelliteConfig][]> => {

--- a/src/frontend/src/lib/services/satellite/_list-docs.services.ts
+++ b/src/frontend/src/lib/services/satellite/_list-docs.services.ts
@@ -1,13 +1,13 @@
 import type { SatelliteDid } from '$declarations';
 import type { listDocs as listDocsApi } from '$lib/api/satellites.api';
 import type { listDocs008 } from '$lib/api/satellites.deprecated.api';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { ListParams } from '$lib/types/list';
 import type { Principal } from '@icp-sdk/core/principal';
 
 export type ListDocsParams = ListParams & {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 };
 
 export interface ListDocsResult<T> {

--- a/src/frontend/src/lib/services/satellite/authentication/auth.config.services.ts
+++ b/src/frontend/src/lib/services/satellite/authentication/auth.config.services.ts
@@ -14,9 +14,8 @@ import { DbCollectionType } from '$lib/constants/rules.constants';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
 import type { OpenIdAuthProvider } from '$lib/types/auth';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Satellite } from '$lib/types/satellite';
-import type { Option } from '$lib/types/utils';
 import {
 	assertExternalAlternativeOrigins,
 	buildDeleteAuthenticationConfig,
@@ -36,6 +35,7 @@ import {
 	notEmptyString,
 	toNullable
 } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { Principal } from '@icp-sdk/core/principal';
 import type { PrincipalText } from '@junobuild/schema';
 import { get } from 'svelte/store';
@@ -43,7 +43,7 @@ import { get } from 'svelte/store';
 interface UpdateAuthConfigParams {
 	satellite: Satellite;
 	config: SatelliteDid.AuthenticationConfig | undefined;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 export interface UpdateAuthConfigResult {
@@ -64,7 +64,7 @@ interface UpdateAuthConfigRulesParams extends UpdateAuthConfigParams {
 
 interface UpdateAuthConfigIIParams extends UpdateAuthConfigParams {
 	externalAlternativeOrigins: string;
-	derivationOrigin: Option<URL>;
+	derivationOrigin: Nullish<URL>;
 }
 
 interface UpdateAuthConfigOpenIdParams extends UpdateAuthConfigParams {

--- a/src/frontend/src/lib/services/satellite/automation/_automation.config.services.ts
+++ b/src/frontend/src/lib/services/satellite/automation/_automation.config.services.ts
@@ -3,7 +3,7 @@ import { setAutomationConfig } from '$lib/api/satellites.api';
 import { loadSatelliteConfig } from '$lib/services/satellite/satellite-config.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Satellite } from '$lib/types/satellite';
 import { isNullish, toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
@@ -27,7 +27,7 @@ export const updateConfig = async ({
 	satellite: Satellite;
 	automationConfig: SatelliteDid.AutomationConfig;
 	providerConfig: SatelliteDid.OpenIdAutomationProviderConfig;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<UpdateAutomationConfigResult> => {
 	const updateAutomationConfig: SatelliteDid.SetAutomationConfig = {
 		...automationConfig,
@@ -69,7 +69,7 @@ export const setConfig = async ({
 }: {
 	satellite: Satellite;
 	config: SatelliteDid.SetAutomationConfig;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<UpdateResult> => {
 	const labels = get(i18n);
 

--- a/src/frontend/src/lib/services/satellite/automation/automation.config.create.services.ts
+++ b/src/frontend/src/lib/services/satellite/automation/automation.config.create.services.ts
@@ -1,7 +1,7 @@
 import type { SatelliteDid } from '$declarations';
 import { setConfig } from '$lib/services/satellite/automation/_automation.config.services';
 import { loadSatelliteConfig } from '$lib/services/satellite/satellite-config.services';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Satellite } from '$lib/types/satellite';
 import type { WorkflowReferences } from '$lib/types/workflow';
 import { toNullable } from '@dfinity/utils';
@@ -12,7 +12,7 @@ export const createAutomationConfig = async ({
 	...rest
 }: {
 	satellite: Satellite;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	repoKey: SatelliteDid.RepositoryKey;
 	repoReferences: WorkflowReferences | undefined;
 }): Promise<{
@@ -41,7 +41,7 @@ const setAutomationConfig = async ({
 	repoReferences
 }: {
 	satellite: Satellite;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	repoKey: SatelliteDid.RepositoryKey;
 	repoReferences: WorkflowReferences | undefined;
 }): Promise<{

--- a/src/frontend/src/lib/services/satellite/automation/automation.config.delete.services.ts
+++ b/src/frontend/src/lib/services/satellite/automation/automation.config.delete.services.ts
@@ -4,7 +4,7 @@ import {
 	type UpdateAutomationConfigResult,
 	updateConfig
 } from '$lib/services/satellite/automation/_automation.config.services';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Satellite } from '$lib/types/satellite';
 import { toDocRepositoryKey } from '$lib/utils/workflow.utils';
 
@@ -19,7 +19,7 @@ export const deleteAutomationRepoConfig = async ({
 	automationConfig: SatelliteDid.AutomationConfig;
 	providerConfig: SatelliteDid.OpenIdAutomationProviderConfig;
 	satellite: Satellite;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<UpdateAutomationConfigResult> => {
 	const keyToRemove = toDocRepositoryKey(repoKey);
 

--- a/src/frontend/src/lib/services/satellite/automation/automation.config.edit.services.ts
+++ b/src/frontend/src/lib/services/satellite/automation/automation.config.edit.services.ts
@@ -5,7 +5,7 @@ import {
 	updateConfig
 } from '$lib/services/satellite/automation/_automation.config.services';
 import type { AddAccessKeyScope } from '$lib/types/access-keys';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Satellite } from '$lib/types/satellite';
 import type { WorkflowReferences } from '$lib/types/workflow';
 import { toNullable } from '@dfinity/utils';
@@ -23,7 +23,7 @@ export const updateAutomationKeysConfig = async ({
 	automationConfig: SatelliteDid.AutomationConfig;
 	providerConfig: SatelliteDid.OpenIdAutomationProviderConfig;
 	satellite: Satellite;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<UpdateAutomationConfigResult> => {
 	const updateProviderConfig: SatelliteDid.OpenIdAutomationProviderConfig = {
 		...providerConfig,
@@ -60,7 +60,7 @@ export const updateAutomationConnectRepositoryConfig = async ({
 	automationConfig: SatelliteDid.AutomationConfig;
 	providerConfig: SatelliteDid.OpenIdAutomationProviderConfig;
 	satellite: Satellite;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<UpdateAutomationConfigResult> => {
 	const updateProviderConfig: SatelliteDid.OpenIdAutomationProviderConfig = {
 		...providerConfig,

--- a/src/frontend/src/lib/services/satellite/collection/collection.services.ts
+++ b/src/frontend/src/lib/services/satellite/collection/collection.services.ts
@@ -13,7 +13,7 @@ import { SATELLITE_v0_0_21, SATELLITE_v0_1_4 } from '$lib/constants/version.cons
 import { isSatelliteFeatureSupported } from '$lib/services/_feature.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { memoryFromText, permissionFromText } from '$lib/utils/rules.utils';
 import { fromNullable, isNullish, nonNullish, toNullable } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
@@ -34,7 +34,7 @@ export const setRule = async ({
 	satelliteId: Principal;
 	collection: string;
 	type: SatelliteDid.CollectionType;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	read: PermissionText;
 	write: PermissionText;
 	memory: MemoryText;
@@ -76,7 +76,7 @@ export const setRule = async ({
 
 export const getRuleUser = (params: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<{ result: 'success' | 'error' | 'skip'; rule?: SatelliteDid.Rule | undefined }> =>
 	getRuleForCollection({
 		...params,
@@ -87,7 +87,7 @@ export const getRuleUser = (params: {
 
 export const getRuleDapp = (params: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<{ result: 'success' | 'error' | 'skip'; rule?: SatelliteDid.Rule | undefined }> =>
 	getRuleForCollection({
 		...params,
@@ -104,7 +104,7 @@ const getRuleForCollection = async ({
 	type
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	requiredMinVersion: string;
 	collection: string;
 	type: SatelliteDid.CollectionType;

--- a/src/frontend/src/lib/services/satellite/collection/rules.loader.services.ts
+++ b/src/frontend/src/lib/services/satellite/collection/rules.loader.services.ts
@@ -3,7 +3,7 @@ import { listRules } from '$lib/api/satellites.api';
 import { listRules0022, listRulesDeprecated } from '$lib/api/satellites.deprecated.api';
 import { filterSystemRules } from '$lib/constants/rules.constants';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { RulesData } from '$lib/types/rules.context';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { Writable } from 'svelte/store';
@@ -17,7 +17,7 @@ export const reloadContextRules = async ({
 	satelliteId: Principal;
 	store: Writable<RulesData>;
 	type: SatelliteDid.CollectionType;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	try {
 		const { items: rules } = await listRules({

--- a/src/frontend/src/lib/services/satellite/hosting/custom-domain.services.ts
+++ b/src/frontend/src/lib/services/satellite/hosting/custom-domain.services.ts
@@ -10,7 +10,7 @@ import { toasts } from '$lib/stores/app/toasts.store';
 import { authStore } from '$lib/stores/auth.store';
 import { customDomainsStore } from '$lib/stores/satellite/custom-domains.store';
 import type { CustomDomainName } from '$lib/types/custom-domain';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { assertNonNullish, fromNullable, nonNullish } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
@@ -26,7 +26,7 @@ export const deleteCustomDomain = async ({
 	customDomain: SatelliteDid.CustomDomain;
 	domainName: CustomDomainName;
 	deleteCustomDomain: boolean;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }) => {
 	assertNonNullish(identity, get(i18n).core.not_logged_in);
 

--- a/src/frontend/src/lib/services/satellite/hosting/hosting.services.ts
+++ b/src/frontend/src/lib/services/satellite/hosting/hosting.services.ts
@@ -4,12 +4,12 @@ import { registerDomain, validateDomain } from '$lib/rest/bn.v1.rest';
 import { execute } from '$lib/services/_progress.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { type HostingProgress, HostingProgressStep } from '$lib/types/progress-hosting';
-import type { Option } from '$lib/types/utils';
 import { buildSetAuthenticationConfig } from '$lib/utils/auth.config.utils';
 import { waitForMilliseconds } from '$lib/utils/timeout.utils';
 import { assertNonNullish, fromNullishNullable, notEmptyString } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
 
@@ -23,9 +23,9 @@ export const configHosting = async ({
 }: {
 	domainName: string;
 	useDomainForDerivationOrigin: boolean;
-	config: Option<SatelliteDid.AuthenticationConfig>;
+	config: Nullish<SatelliteDid.AuthenticationConfig>;
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	onProgress: (progress: HostingProgress | undefined) => void;
 }): Promise<{ success: 'ok' | 'error'; err?: unknown }> => {
 	try {

--- a/src/frontend/src/lib/services/satellite/hosting/hosting.storage.services.ts
+++ b/src/frontend/src/lib/services/satellite/hosting/hosting.storage.services.ts
@@ -5,7 +5,7 @@ import { instantSatelliteVersion } from '$lib/services/_feature.services';
 import { busy } from '$lib/stores/app/busy.store';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Satellite } from '$lib/types/satellite';
 import { nonNullish } from '@dfinity/utils';
 import { compare } from 'semver';
@@ -16,7 +16,7 @@ export const countHostingAssets = async ({
 	identity
 }: {
 	satellite: Satellite;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<
 	| {
 			result: 'success';
@@ -59,7 +59,7 @@ export const switchHostingMemory = async ({
 	identity
 }: {
 	satellite: Satellite;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<
 	| {
 			result: 'success';

--- a/src/frontend/src/lib/services/satellite/logs.services.ts
+++ b/src/frontend/src/lib/services/satellite/logs.services.ts
@@ -5,7 +5,7 @@ import { SATELLITE_v0_0_16 } from '$lib/constants/version.constants';
 import { isSatelliteFeatureSupported } from '$lib/services/_feature.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Log, LogDataDid, LogLevel } from '$lib/types/log';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -20,7 +20,7 @@ export const listLogs = async ({
 	levels = ['Info', 'Debug', 'Warning', 'Error', 'Unknown']
 }: {
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	desc?: boolean;
 	levels?: LogLevel[];
 }): Promise<{ results?: [string, Log][]; error?: unknown }> => {

--- a/src/frontend/src/lib/services/satellite/proposals/proposals.cdn.services.ts
+++ b/src/frontend/src/lib/services/satellite/proposals/proposals.cdn.services.ts
@@ -3,7 +3,7 @@ import { listAssets } from '$lib/api/satellites.api';
 import { COLLECTION_CDN_RELEASES } from '$lib/constants/storage.constants';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { ListOrder, ListParams } from '$lib/types/list';
 import type { ProposalRecord } from '$lib/types/proposals';
 import type { SatelliteIdText } from '$lib/types/satellite';
@@ -26,7 +26,7 @@ export const findWasmAssetForProposal = async ({
 }: {
 	proposal: ProposalRecord;
 	satelliteId: SatelliteIdText;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<SatelliteDid.AssetNoContent | undefined> => {
 	try {
 		assertNonNullish(identity);

--- a/src/frontend/src/lib/services/satellite/proposals/proposals.list.satellite.services.ts
+++ b/src/frontend/src/lib/services/satellite/proposals/proposals.list.satellite.services.ts
@@ -1,7 +1,7 @@
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
 import { proposalsStore } from '$lib/stores/satellite/proposals.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { LoadProposalsBaseParams, LoadProposalsResult } from '$lib/types/proposals';
 import { container } from '$lib/utils/juno.utils';
 import { assertNonNullish, nonNullish } from '@dfinity/utils';
@@ -38,7 +38,7 @@ const loadSatelliteProposals = async ({
 }: {
 	satelliteId: Principal;
 	skipReload: boolean;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<{ result: 'loaded' } | { result: 'skipped' } | { result: 'error'; err: unknown }> => {
 	// We load the satellite proposals when needed
 	const store = get(proposalsStore);

--- a/src/frontend/src/lib/services/satellite/proposals/proposals.list.services.ts
+++ b/src/frontend/src/lib/services/satellite/proposals/proposals.list.services.ts
@@ -4,7 +4,7 @@ import { reloadSatelliteProposals } from '$lib/services/satellite/proposals/prop
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
 import { proposalsStore } from '$lib/stores/satellite/proposals.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Satellite } from '$lib/types/satellite';
 import { get } from 'svelte/store';
 
@@ -13,7 +13,7 @@ export const loadProposals = async ({
 	satellites
 }: {
 	satellites: Satellite[];
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<{ result: 'loaded' | 'error' }> => {
 	// Split those Satellites that do not support proposals.
 	const [newSatellites, oldSatellites] = satellites.reduce<[Satellite[], Satellite[]]>(

--- a/src/frontend/src/lib/services/satellite/proposals/proposals.services.ts
+++ b/src/frontend/src/lib/services/satellite/proposals/proposals.services.ts
@@ -3,7 +3,7 @@ import { reloadSatelliteProposals } from '$lib/services/satellite/proposals/prop
 import { wizardBusy } from '$lib/stores/app/busy.store';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { ProposalRecord } from '$lib/types/proposals';
 import type { SatelliteIdText } from '$lib/types/satellite';
 import { container } from '$lib/utils/juno.utils';
@@ -23,7 +23,7 @@ import { get } from 'svelte/store';
 interface ExecuteProposalParams {
 	nextSteps: (steps: 'init' | 'in_progress' | 'ready' | 'error') => void;
 	clearProposalAssets: boolean;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	proposal: ProposalRecord;
 	satelliteId: SatelliteIdText;
 }

--- a/src/frontend/src/lib/services/satellite/satellite-config.services.ts
+++ b/src/frontend/src/lib/services/satellite/satellite-config.services.ts
@@ -8,7 +8,7 @@ import { i18n } from '$lib/stores/app/i18n.store';
 import { satellitesConfigIdbStore } from '$lib/stores/app/idb.store';
 import { toasts } from '$lib/stores/app/toasts.store';
 import { uncertifiedSatellitesConfigsStore } from '$lib/stores/satellite/satellites-configs.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { SatelliteId } from '$lib/types/satellite';
 import { nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
@@ -33,7 +33,7 @@ export const loadSatelliteConfig = async ({
 	reload = false
 }: {
 	satelliteId: SatelliteId;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	reload?: boolean;
 }): Promise<{ result: 'skip' | 'success' | 'error' }> => {
 	// We load only once per session or when required.

--- a/src/frontend/src/lib/services/satellite/user/user.services.ts
+++ b/src/frontend/src/lib/services/satellite/user/user.services.ts
@@ -11,7 +11,7 @@ import { isSatelliteFeatureSupported } from '$lib/services/_feature.services';
 import { busy } from '$lib/stores/app/busy.store';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { PaginationContext } from '$lib/types/pagination.context';
 import type { User } from '$lib/types/user';
 import type { UserUsage, UserUsageCollection } from '$lib/types/user-usage';
@@ -27,7 +27,7 @@ import { get } from 'svelte/store';
 interface OpenUserDetailParams {
 	user: User;
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 export const openUserDetail = async ({ user, satelliteId, identity }: OpenUserDetailParams) => {
@@ -162,7 +162,7 @@ const loadUserUsages = async ({
 
 export type BanUser = {
 	user: User;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	satelliteId: Principal;
 } & Pick<PaginationContext<User>, 'setItem'>;
 

--- a/src/frontend/src/lib/services/segments.services.ts
+++ b/src/frontend/src/lib/services/segments.services.ts
@@ -1,7 +1,7 @@
 import { loadConsoleSegments } from '$lib/services/console/segments.services';
 import { loadOrbiters } from '$lib/services/mission-control/mission-control.orbiters.services';
 import { loadSatellites } from '$lib/services/mission-control/mission-control.satellites.services';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Principal } from '@icp-sdk/core/principal';
 
 export const loadSegments = async ({
@@ -10,7 +10,7 @@ export const loadSegments = async ({
 	reloadSatellites = true,
 	reloadOrbiters = true
 }: {
-	missionControlId: Option<Principal>;
+	missionControlId: Nullish<Principal>;
 	reload?: boolean;
 	reloadSatellites?: boolean;
 	reloadOrbiters?: boolean;

--- a/src/frontend/src/lib/services/top-up/_top-up.cmc.services.ts
+++ b/src/frontend/src/lib/services/top-up/_top-up.cmc.services.ts
@@ -2,7 +2,7 @@ import { notifyTopUp } from '$lib/api/cmc.api';
 import { MEMO_CMC_TOP_UP } from '$lib/constants/wallet.constants';
 import { pollNotifyCmc, sendIcpToCmc } from '$lib/services/cmc.services';
 import { i18n } from '$lib/stores/app/i18n.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { i18nFormat } from '$lib/utils/i18n.utils';
 import type { TokenAmountV2 } from '@dfinity/utils';
 import { ProcessingError } from '@icp-sdk/canisters/cmc';
@@ -12,7 +12,7 @@ import { get } from 'svelte/store';
 
 interface TopUpWithCmcParams {
 	canisterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	tokenAmount: TokenAmountV2;
 }
 

--- a/src/frontend/src/lib/services/top-up/top-up.services.ts
+++ b/src/frontend/src/lib/services/top-up/top-up.services.ts
@@ -5,7 +5,7 @@ import { execute } from '$lib/services/_progress.services';
 import { topUpWithCmc } from '$lib/services/top-up/_top-up.cmc.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { type TopUpProgress, TopUpProgressStep } from '$lib/types/progress-topup';
 import { emit } from '$lib/utils/events.utils';
 import { assertAndConvertAmountToToken, isTokenCycles, isTokenIcp } from '$lib/utils/token.utils';
@@ -23,7 +23,7 @@ export const topUp = async ({
 	canisterId,
 	onProgress
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	selectedWallet: SelectedWallet | undefined;
 	selectedToken: SelectedToken;
 	balance: bigint;

--- a/src/frontend/src/lib/services/upgrade/upgrade.cdn.services.ts
+++ b/src/frontend/src/lib/services/upgrade/upgrade.cdn.services.ts
@@ -3,7 +3,7 @@ import { instantSatelliteVersion } from '$lib/services/_feature.services';
 import { downloadWasmFromDevCdn } from '$lib/services/upgrade/upgrade.download.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Wasm } from '$lib/types/upgrade';
 import { i18nFormat } from '$lib/utils/i18n.utils';
 import { mapJunoPackageMetadata } from '$lib/utils/version.utils';
@@ -21,7 +21,7 @@ export const prepareWasmUpgrade = async ({
 }: {
 	asset: SatelliteDid.AssetNoContent;
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<{ result: 'success'; wasm: Wasm } | { result: 'error'; err?: unknown }> => {
 	try {
 		const result = await downloadWasmFromDevCdn({ asset, satelliteId, identity });

--- a/src/frontend/src/lib/services/upgrade/upgrade.download.services.ts
+++ b/src/frontend/src/lib/services/upgrade/upgrade.download.services.ts
@@ -1,7 +1,7 @@
 import type { SatelliteDid } from '$declarations';
 import { downloadWasm } from '$lib/rest/cdn.dev';
 import { downloadRelease } from '$lib/rest/cdn.rest';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Wasm } from '$lib/types/upgrade';
 import { sha256 } from '$lib/utils/crypto.utils';
 import { container } from '$lib/utils/juno.utils';
@@ -32,7 +32,7 @@ export const downloadWasmFromDevCdn = async ({
 }: {
 	asset: SatelliteDid.AssetNoContent;
 	satelliteId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<Omit<Wasm, 'version'>> => {
 	const downloadUrl = downloadUrlLib({
 		assetKey: { fullPath: full_path, token: fromNullable(token) },

--- a/src/frontend/src/lib/services/upgrade/upgrade.services.ts
+++ b/src/frontend/src/lib/services/upgrade/upgrade.services.ts
@@ -2,7 +2,7 @@ import { loadSnapshots } from '$lib/services/ic-mgmt/snapshots.services';
 import { wizardBusy } from '$lib/stores/app/busy.store';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Wasm } from '$lib/types/upgrade';
 import { isNullish } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
@@ -21,7 +21,7 @@ export interface UpgradeParams {
 	) => void;
 	takeSnapshot: boolean;
 	canisterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 export const upgrade = async ({

--- a/src/frontend/src/lib/services/wallet/_convert.cmc.services.ts
+++ b/src/frontend/src/lib/services/wallet/_convert.cmc.services.ts
@@ -1,14 +1,14 @@
 import { notifyMintCycles } from '$lib/api/cmc.api';
 import { pollNotifyCmc } from '$lib/services/cmc.services';
 import { i18n } from '$lib/stores/app/i18n.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { i18nFormat } from '$lib/utils/i18n.utils';
 import { toNullable } from '@dfinity/utils';
 import { ProcessingError } from '@icp-sdk/canisters/cmc';
 import { get } from 'svelte/store';
 
 interface ConvertIcpWithCmcParams {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	blockHeight: bigint;
 }
 

--- a/src/frontend/src/lib/services/wallet/convert.icp-to-cycles.services.ts
+++ b/src/frontend/src/lib/services/wallet/convert.icp-to-cycles.services.ts
@@ -6,7 +6,7 @@ import { sendIcpToCmc } from '$lib/services/cmc.services';
 import { convertIcpWithCmc } from '$lib/services/wallet/_convert.cmc.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { type ConvertIcpProgress, ConvertIcpProgressStep } from '$lib/types/progress-convert-icp';
 import { assertAndConvertAmountToToken } from '$lib/utils/token.utils';
 import { waitAndRestartWallet } from '$lib/utils/wallet.utils';
@@ -20,7 +20,7 @@ export const convertIcpToCycles = async ({
 	amount,
 	onProgress
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	selectedWallet: SelectedWallet;
 	balance: bigint;
 	amount: string | undefined;

--- a/src/frontend/src/lib/services/wallet/wallet.approve.services.ts
+++ b/src/frontend/src/lib/services/wallet/wallet.approve.services.ts
@@ -2,7 +2,7 @@ import { approveIcrcTransfer } from '$lib/api/icrc-ledger.api';
 import { CONSOLE_CANISTER_ID, CYCLES_LEDGER_CANISTER_ID } from '$lib/constants/app.constants';
 import { CYCLES_TRANSACTION_FEE } from '$lib/constants/token.constants';
 import { MEMO_CANISTER_APPROVE } from '$lib/constants/wallet.constants';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { IcpLedgerDid } from '@icp-sdk/canisters/ledger/icp';
 import { Principal } from '@icp-sdk/core/principal';
 
@@ -10,7 +10,7 @@ export const approveCreateCanisterWithCycles = async ({
 	identity,
 	amount: effectiveAmount
 }: {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	amount: bigint;
 }): Promise<void> => {
 	const spender: IcpLedgerDid.Account = {

--- a/src/frontend/src/lib/services/wallet/wallet.send.services.ts
+++ b/src/frontend/src/lib/services/wallet/wallet.send.services.ts
@@ -14,7 +14,7 @@ import type { SelectedToken, SelectedWallet } from '$lib/schemas/wallet.schema';
 import { execute } from '$lib/services/_progress.services';
 import { i18n } from '$lib/stores/app/i18n.store';
 import { toasts } from '$lib/stores/app/toasts.store';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { MissionControlId } from '$lib/types/mission-control';
 import { type SendTokensProgress, SendTokensProgressStep } from '$lib/types/progress-send-tokens';
 import { nowInBigIntNanoSeconds } from '$lib/utils/date.utils';
@@ -35,7 +35,7 @@ import { get } from 'svelte/store';
 interface SendTokensParams {
 	destination: string;
 	token: TokenAmountV2 | undefined;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	selectedWallet: SelectedWallet;
 	selectedToken: SelectedToken;
 	onProgress: (progress: SendTokensProgress | undefined) => void;
@@ -176,7 +176,7 @@ const sendIcrcWithMissionControl = async ({
 }: {
 	destination: string;
 	token: TokenAmountV2;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	missionControlId: MissionControlId;
 }): Promise<void> => {
 	const { owner, subaccount } = decodeIcrcAccount(destination);
@@ -207,7 +207,7 @@ const sendIcpWithMissionControl = async ({
 }: {
 	destination: string;
 	token: TokenAmountV2;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	missionControlId: MissionControlId;
 }): Promise<void> => {
 	const args: MissionControlDid.TransferArgs = {
@@ -232,7 +232,7 @@ const sendIcpWithIcrcAndDev = async ({
 }: {
 	destination: string;
 	token: TokenAmountV2;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { owner, subaccount } = decodeIcrcAccount(destination);
 
@@ -259,7 +259,7 @@ const sendIcpWithDev = async ({
 }: {
 	destination: string;
 	token: TokenAmountV2;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const request: TransferRequest = {
 		to: AccountIdentifier.fromHex(destination),
@@ -281,7 +281,7 @@ const sendCyclesWithDev = async ({
 }: {
 	destination: string;
 	token: TokenAmountV2;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }): Promise<void> => {
 	const { owner, subaccount } = decodeIcrcAccount(destination);
 

--- a/src/frontend/src/lib/stores/_canister-data.store.ts
+++ b/src/frontend/src/lib/stores/_canister-data.store.ts
@@ -1,8 +1,8 @@
 import type { CanisterIdText } from '$lib/types/canister';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { type Readable, writable } from 'svelte/store';
 
-type CanisterData<T> = Option<Record<CanisterIdText, { data: T } | null>>;
+type CanisterData<T> = Nullish<Record<CanisterIdText, { data: T } | null>>;
 
 export interface CanisterDataStore<T> extends Readable<CanisterData<T>> {
 	set: (data: { canisterId: CanisterIdText; data: T }) => void;

--- a/src/frontend/src/lib/stores/_canister.store.ts
+++ b/src/frontend/src/lib/stores/_canister.store.ts
@@ -1,9 +1,9 @@
 import type { CanisterIdText } from '$lib/types/canister';
-import type { Option } from '$lib/types/utils';
 import { nonNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { writable, type Readable } from 'svelte/store';
 
-export type CanisterStoreData<T> = Option<Record<CanisterIdText, T | null>>;
+export type CanisterStoreData<T> = Nullish<Record<CanisterIdText, T | null>>;
 
 export interface CanisterStore<T> extends Readable<CanisterStoreData<T>> {
 	set: (params: { canisterId: CanisterIdText; data: T }) => void;

--- a/src/frontend/src/lib/stores/_certified-canister.store.ts
+++ b/src/frontend/src/lib/stores/_certified-canister.store.ts
@@ -1,11 +1,13 @@
 import type { CanisterStore } from '$lib/stores/_canister.store';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { CertifiedData } from '$lib/types/store';
-import type { Option } from '$lib/types/utils';
 import { nonNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { writable, type Readable } from 'svelte/store';
 
-export type CertifiedCanisterStoreData<T> = Option<Record<CanisterIdText, CertifiedData<T> | null>>;
+export type CertifiedCanisterStoreData<T> = Nullish<
+	Record<CanisterIdText, CertifiedData<T> | null>
+>;
 
 export interface CertifiedCanisterStore<T> extends Readable<CertifiedCanisterStoreData<T>> {
 	set: (params: { canisterId: CanisterIdText; data: CertifiedData<T> }) => void;

--- a/src/frontend/src/lib/stores/_certified.store.ts
+++ b/src/frontend/src/lib/stores/_certified.store.ts
@@ -1,8 +1,8 @@
 import type { CertifiedData } from '$lib/types/store';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { writable, type Readable } from 'svelte/store';
 
-type CertifiedStoreData<T> = Option<CertifiedData<T>>;
+type CertifiedStoreData<T> = Nullish<CertifiedData<T>>;
 
 export interface CertifiedStore<T> extends Readable<CertifiedStoreData<T>> {
 	set: (data: CertifiedData<T>) => void;

--- a/src/frontend/src/lib/stores/_data.store.ts
+++ b/src/frontend/src/lib/stores/_data.store.ts
@@ -1,7 +1,7 @@
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { writable, type Readable } from 'svelte/store';
 
-type Data<T> = Option<{ data: T }>;
+type Data<T> = Nullish<{ data: T }>;
 
 export interface DataStore<T> extends Readable<Data<T>> {
 	set: (data: T) => void;

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -2,17 +2,17 @@ import { AuthBroadcastChannel } from '$lib/providers/auth-broadcast.provider';
 import { AuthClientProvider } from '$lib/providers/auth-client.provider';
 import type { SignInWithAuthClient, SignInWithNewAuthClient } from '$lib/types/auth';
 import { SignInInitError } from '$lib/types/errors';
-import type { OptionIdentity } from '$lib/types/itentity';
-import type { Option } from '$lib/types/utils';
+import type { NullishIdentity } from '$lib/types/itentity';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { AuthClient } from '@icp-sdk/auth/client';
 import { type Readable, writable } from 'svelte/store';
 
 export interface AuthStoreData {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
-let authClient: Option<AuthClient>;
+let authClient: Nullish<AuthClient>;
 
 export interface AuthStore extends Readable<AuthStoreData> {
 	sync: () => Promise<void>;

--- a/src/frontend/src/lib/stores/ic-mgmt/subnet.store.ts
+++ b/src/frontend/src/lib/stores/ic-mgmt/subnet.store.ts
@@ -1,6 +1,6 @@
 import { initCanisterStore } from '$lib/stores/_canister.store';
 import type { Subnet } from '$lib/types/subnet';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 
-export type SubnetData = Option<Subnet>;
+export type SubnetData = Nullish<Subnet>;
 export const subnetStore = initCanisterStore<SubnetData>();

--- a/src/frontend/src/lib/stores/satellite/rules.context.store.ts
+++ b/src/frontend/src/lib/stores/satellite/rules.context.store.ts
@@ -1,6 +1,6 @@
 import type { SatelliteDid } from '$declarations';
 import { reloadContextRules } from '$lib/services/satellite/collection/rules.loader.services';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { RulesContext, RulesData } from '$lib/types/rules.context';
 import type { Principal } from '@icp-sdk/core/principal';
 import { derived, get, writable } from 'svelte/store';
@@ -18,7 +18,7 @@ export const initRulesContext = ({
 		rule: undefined
 	});
 
-	const reloadRules = async ({ identity }: { identity: OptionIdentity }) =>
+	const reloadRules = async ({ identity }: { identity: NullishIdentity }) =>
 		await reloadContextRules({
 			satelliteId: get(store).satelliteId,
 			type,
@@ -31,7 +31,7 @@ export const initRulesContext = ({
 		identity
 	}: {
 		satelliteId: Principal;
-		identity: OptionIdentity;
+		identity: NullishIdentity;
 	}) => {
 		store.set({
 			satelliteId,

--- a/src/frontend/src/lib/stores/wallet/_wallet.store.ts
+++ b/src/frontend/src/lib/stores/wallet/_wallet.store.ts
@@ -1,4 +1,4 @@
 import type { IcrcAccountText, LedgerIdText } from '$lib/schemas/wallet.schema';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 
-export type CertifiedWalletStoreData<T> = Option<Record<IcrcAccountText, Record<LedgerIdText, T>>>;
+export type CertifiedWalletStoreData<T> = Nullish<Record<IcrcAccountText, Record<LedgerIdText, T>>>;

--- a/src/frontend/src/lib/stores/workflows/workflows.store.ts
+++ b/src/frontend/src/lib/stores/workflows/workflows.store.ts
@@ -1,9 +1,9 @@
 import type { SatelliteIdText } from '$lib/types/satellite';
-import type { Option } from '$lib/types/utils';
 import type { CertifiedWorkflows, WorkflowProvider } from '$lib/types/workflow';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { type Readable, writable } from 'svelte/store';
 
-type CertifiedWorkflowsStoreData = Option<
+type CertifiedWorkflowsStoreData = Nullish<
 	Record<SatelliteIdText, Record<WorkflowProvider, CertifiedWorkflows>>
 >;
 

--- a/src/frontend/src/lib/types/auth.context.ts
+++ b/src/frontend/src/lib/types/auth.context.ts
@@ -1,5 +1,5 @@
 import type { SatelliteDid } from '$declarations';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Readable } from 'svelte/store';
 
 export interface AuthConfigData {
@@ -12,7 +12,7 @@ export interface AuthConfigContext {
 		rule?: SatelliteDid.Rule | undefined;
 	}) => void;
 
-	config: Readable<Option<SatelliteDid.AuthenticationConfig>>;
+	config: Readable<Nullish<SatelliteDid.AuthenticationConfig>>;
 	rule: Readable<SatelliteDid.Rule | undefined>;
 	supportSettings: Readable<boolean>;
 	supportConfig: Readable<boolean>;

--- a/src/frontend/src/lib/types/auth.ts
+++ b/src/frontend/src/lib/types/auth.ts
@@ -1,8 +1,8 @@
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { AuthClient } from '@icp-sdk/auth/client';
 
 export interface SignedInIdentity {
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 }
 
 export type SignInWithAuthClient = (params: {

--- a/src/frontend/src/lib/types/data.context.ts
+++ b/src/frontend/src/lib/types/data.context.ts
@@ -1,4 +1,4 @@
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Writable } from 'svelte/store';
 
 export interface DataStore<T> {
@@ -6,7 +6,7 @@ export interface DataStore<T> {
 	data: T | undefined;
 }
 
-export type DataStoreData<T> = Option<DataStore<T>>;
+export type DataStoreData<T> = Nullish<DataStore<T>>;
 
 export interface DataContext<T> {
 	store: Writable<DataStoreData<T>>;

--- a/src/frontend/src/lib/types/itentity.ts
+++ b/src/frontend/src/lib/types/itentity.ts
@@ -1,4 +1,4 @@
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Identity } from '@icp-sdk/core/agent';
 
-export type OptionIdentity = Option<Identity>;
+export type NullishIdentity = Nullish<Identity>;

--- a/src/frontend/src/lib/types/modal.ts
+++ b/src/frontend/src/lib/types/modal.ts
@@ -9,7 +9,7 @@ import type { ProposalRecord } from '$lib/types/proposals';
 import type { Satellite, SatelliteIdText } from '$lib/types/satellite';
 import type { User as UserListed } from '$lib/types/user';
 import type { UserUsageCollection } from '$lib/types/user-usage';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { BuildType } from '@junobuild/admin';
 
@@ -34,7 +34,7 @@ export type JunoModalUpgradeSatelliteDetail = JunoModalUpgradeDetail &
 export interface JunoModalCreateSegmentDetail {
 	fee: ConsoleDid.FactoryFee;
 	monitoringEnabled: boolean;
-	monitoringConfig: Option<MissionControlDid.MonitoringConfig>;
+	monitoringConfig: Nullish<MissionControlDid.MonitoringConfig>;
 }
 
 export interface JunoModalCustomDomainDetail {

--- a/src/frontend/src/lib/types/orbiter.ts
+++ b/src/frontend/src/lib/types/orbiter.ts
@@ -1,5 +1,5 @@
 import type { MissionControlDid, OrbiterDid } from '$declarations';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { PrincipalText } from '@junobuild/schema';
 
@@ -20,7 +20,7 @@ export type AnalyticsPeriodicity = 4 | 8 | 12 | 24 | 168 | 720;
 export type PageViewsParams = {
 	satelliteId?: Principal;
 	orbiterId: Principal;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 } & Omit<PageViewsFilters, 'from'> &
 	Required<Pick<PageViewsFilters, 'from'>>;
 

--- a/src/frontend/src/lib/types/proposals.ts
+++ b/src/frontend/src/lib/types/proposals.ts
@@ -1,11 +1,11 @@
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Proposal, ProposalKey } from '@junobuild/cdn';
 
 export type ProposalRecord = [ProposalKey, Proposal];
 
 export interface LoadProposalsBaseParams {
 	skipReload: boolean;
-	identity: OptionIdentity;
+	identity: NullishIdentity;
 	toastError?: boolean;
 }
 

--- a/src/frontend/src/lib/types/rules.context.ts
+++ b/src/frontend/src/lib/types/rules.context.ts
@@ -1,5 +1,5 @@
 import type { CollectionRule } from '$lib/types/collection';
-import type { OptionIdentity } from '$lib/types/itentity';
+import type { NullishIdentity } from '$lib/types/itentity';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { Readable, Writable } from 'svelte/store';
 
@@ -12,8 +12,8 @@ export interface RulesData {
 export interface RulesContext {
 	store: Writable<RulesData>;
 
-	reload: (params: { identity: OptionIdentity }) => Promise<void>;
-	init: (params: { satelliteId: Principal; identity: OptionIdentity }) => Promise<void>;
+	reload: (params: { identity: NullishIdentity }) => Promise<void>;
+	init: (params: { satelliteId: Principal; identity: NullishIdentity }) => Promise<void>;
 
 	hasAnyRules: Readable<boolean>;
 	emptyRules: Readable<boolean>;

--- a/src/frontend/src/lib/types/utils.ts
+++ b/src/frontend/src/lib/types/utils.ts
@@ -1,3 +1,0 @@
-// We disable the eslint rule here because this is the utility type that we use to define such rule.
-
-export type Option<T> = T | null | undefined;

--- a/src/frontend/src/lib/types/version.ts
+++ b/src/frontend/src/lib/types/version.ts
@@ -5,7 +5,7 @@ import type {
 	VersionMetadataSchema
 } from '$lib/schemas/version.schema';
 import type { SatelliteIdText } from '$lib/types/satellite';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type * as z from 'zod';
 
 export type VersionMetadata = z.infer<typeof VersionMetadataSchema>;
@@ -18,7 +18,7 @@ export type VersionMetadataUi = VersionMetadata & { warning: boolean };
 export type SatelliteVersionMetadataUi = SatelliteVersionMetadata & { warning: boolean };
 
 export interface VersionRegistry {
-	satellites: Record<SatelliteIdText, Option<SatelliteVersionMetadata>>;
-	missionControl: Option<VersionMetadata>;
-	orbiter: Option<VersionMetadata>;
+	satellites: Record<SatelliteIdText, Nullish<SatelliteVersionMetadata>>;
+	missionControl: Nullish<VersionMetadata>;
+	orbiter: Nullish<VersionMetadata>;
 }

--- a/src/frontend/src/lib/utils/auth.config.utils.ts
+++ b/src/frontend/src/lib/utils/auth.config.utils.ts
@@ -1,13 +1,13 @@
 import type { SatelliteDid } from '$declarations';
-import type { Option } from '$lib/types/utils';
 import { fromNullable, isNullish, nonNullish, toNullable } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 
 export const buildSetAuthenticationConfig = ({
 	config,
 	domainName,
 	externalOrigins
 }: {
-	config: Option<SatelliteDid.AuthenticationConfig>;
+	config: Nullish<SatelliteDid.AuthenticationConfig>;
 	domainName: string;
 	externalOrigins?: string[];
 }): Omit<SatelliteDid.SetAuthenticationConfig, 'version'> => {

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -1,38 +1,38 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
-import type { Option } from '$lib/types/utils';
 import { nonNullish } from '@dfinity/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { Principal } from '@icp-sdk/core/principal';
 import type { LoadEvent } from '@sveltejs/kit';
 
-export const overviewLink = (satelliteId: Option<Principal>): string =>
+export const overviewLink = (satelliteId: Nullish<Principal>): string =>
 	`/satellite/?s=${satelliteId?.toText() ?? ''}`;
 
-export const deploymentsLink = (satelliteId: Option<Principal>): string =>
+export const deploymentsLink = (satelliteId: Nullish<Principal>): string =>
 	`/deployments/?s=${satelliteId?.toText() ?? ''}`;
 
-export const monitoringLink = (satelliteId?: Option<Principal>): string =>
+export const monitoringLink = (satelliteId?: Nullish<Principal>): string =>
 	`/monitoring/${nonNullish(satelliteId) ? `?s=${satelliteId?.toText() ?? ''}` : ''}`;
 
-export const analyticsLink = (satelliteId?: Option<Principal>): string =>
+export const analyticsLink = (satelliteId?: Nullish<Principal>): string =>
 	`/analytics/${nonNullish(satelliteId) ? `?s=${satelliteId?.toText() ?? ''}` : ''}`;
 
-export const upgradeDockLink = (satelliteId?: Option<Principal>): string =>
+export const upgradeDockLink = (satelliteId?: Nullish<Principal>): string =>
 	`/upgrade-dock/${nonNullish(satelliteId) ? `?s=${satelliteId?.toText() ?? ''}` : ''}`;
 
-export const upgradeChangesLink = (satelliteId: Option<Principal>): string =>
+export const upgradeChangesLink = (satelliteId: Nullish<Principal>): string =>
 	`/upgrade-dock/?tab=changes${nonNullish(satelliteId) ? `&s=${satelliteId?.toText() ?? ''}` : ''}`;
 
-export const navigateToSatellite = async (satelliteId: Option<Principal>) =>
+export const navigateToSatellite = async (satelliteId: Nullish<Principal>) =>
 	await goto(overviewLink(satelliteId));
 
-export const navigateToAnalytics = async (satelliteId: Option<Principal>) =>
+export const navigateToAnalytics = async (satelliteId: Nullish<Principal>) =>
 	await goto(analyticsLink(satelliteId), { replaceState: true });
 
-export const navigateToMonitoring = async (satelliteId: Option<Principal>) =>
+export const navigateToMonitoring = async (satelliteId: Nullish<Principal>) =>
 	await goto(monitoringLink(satelliteId), { replaceState: true });
 
-export const navigateToChangesDock = async (satelliteId: Option<Principal>) =>
+export const navigateToChangesDock = async (satelliteId: Nullish<Principal>) =>
 	await goto(upgradeChangesLink(satelliteId), { replaceState: true });
 
 export const back = async ({ pop }: { pop: boolean }) => {
@@ -45,10 +45,10 @@ export const back = async ({ pop }: { pop: boolean }) => {
 };
 
 export interface RouteSatellite {
-	satellite: Option<string>;
+	satellite: Nullish<string>;
 }
 export interface RouteTab {
-	tab: Option<string>;
+	tab: Nullish<string>;
 }
 
 export const loadRouteSatellite = ($event: LoadEvent): RouteSatellite => {

--- a/src/frontend/src/routes/(standalone)/cli/+page.svelte
+++ b/src/frontend/src/routes/(standalone)/cli/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
+	import type { Nullish } from '@dfinity/zod-schemas';
 	import { fade } from 'svelte/transition';
 	import SignInActions from '$lib/components/auth/sign-in/SignInActions.svelte';
 	import CliAdd from '$lib/components/cli/CliAdd.svelte';
@@ -13,13 +14,12 @@
 	import { onIntersection } from '$lib/directives/intersection.directives';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { onLayoutTitleIntersection } from '$lib/stores/app/layout-intersecting.store';
-	import type { Option } from '$lib/types/utils';
 
 	interface Props {
 		data: {
-			redirect_uri: Option<string>;
-			principal: Option<string>;
-			profile: Option<string>;
+			redirect_uri: Nullish<string>;
+			principal: Nullish<string>;
+			profile: Nullish<string>;
 		};
 	}
 

--- a/src/frontend/src/routes/(standalone)/cli/+page.ts
+++ b/src/frontend/src/routes/(standalone)/cli/+page.ts
@@ -1,11 +1,11 @@
 import { browser } from '$app/environment';
-import type { Option } from '$lib/types/utils';
+import type { Nullish } from '@dfinity/zod-schemas';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = (
 	$event: LoadEvent
-): { redirect_uri: Option<string>; principal: Option<string>; profile: Option<string> } => {
+): { redirect_uri: Nullish<string>; principal: Nullish<string>; profile: Nullish<string> } => {
 	if (!browser) {
 		return {
 			redirect_uri: undefined,


### PR DESCRIPTION
# Motivation

Using `Option` as `T | undefined | null` does not actually align with Zod `nullish` or `isNullish` and `nonNullish` so makes sense to align the term.
