### PR TITLE
feat(macros,functions): support for optional()

### DIFF
--- a/src/libs/macros/src/functions/derive.rs
+++ b/src/libs/macros/src/functions/derive.rs
@@ -33,8 +33,12 @@ fn derive_struct(
                 .iter()
                 .filter(|a| a.path().is_ident("serde"))
                 .collect();
+            let skip = unwrap_option(ftype)
+                .map(|_| quote! { #[serde(skip_serializing_if = "Option::is_none")] });
+
             if let Some(with_path) = map_with_path(ftype) {
                 quote! {
+                    #skip
                     #[serde(with = #with_path)]
                     #(#serde_attrs)*
                     pub #fname: #ftype,
@@ -42,11 +46,13 @@ fn derive_struct(
             } else if has_nested_attr(f) {
                 let nested_type = nested_json_data_ident(ftype);
                 quote! {
+                    #skip
                     #(#serde_attrs)*
                     pub #fname: #nested_type,
                 }
             } else {
                 quote! {
+                    #skip
                     #(#serde_attrs)*
                     pub #fname: #ftype,
                 }


### PR DESCRIPTION
# Motivation

While implementing support for http_request #2634 in the functions I discovered that using `z.optional()` was not supported unlike `z.nullable()`. I think it's more TS/JS dev user friendly to support the former, therefore we add an option to the serde serializer for rquickjs.
