### PR TITLE
feat(frontend): handle aaguid without logo

### DIFF
--- a/scripts/passkey.aaguids.mjs
+++ b/scripts/passkey.aaguids.mjs
@@ -52,13 +52,13 @@ await Promise.all(entries.map(([key, value]) => saveIcons({ aaguid: key, value }
 const destJson = join(ENV_DEST_FOLDER, 'aaguids.json');
 const cleanJson = entries.reduce((acc, [key, value]) => {
 	const { name, icon_dark, icon_light } = value;
-	const withoutLogo = isNullish(icon_dark) || isNullish(icon_light);
+	const noLogo = isNullish(icon_dark) || isNullish(icon_light);
 
 	return {
 		...acc,
 		[key]: {
 			name,
-			...(withoutLogo && { noLogo: true })
+			...(noLogo && { noLogo: true })
 		}
 	};
 }, {});

--- a/scripts/passkey.aaguids.mjs
+++ b/scripts/passkey.aaguids.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { notEmptyString } from '@dfinity/utils';
+import { isNullish, notEmptyString } from '@dfinity/utils';
 import { downloadFromURL } from '@junobuild/cli-tools';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -51,11 +51,15 @@ await Promise.all(entries.map(([key, value]) => saveIcons({ aaguid: key, value }
 
 const destJson = join(ENV_DEST_FOLDER, 'aaguids.json');
 const cleanJson = entries.reduce((acc, [key, value]) => {
-	const { name } = value;
+	const { name, icon_dark, icon_light } = value;
+	const withoutLogo = isNullish(icon_dark) || isNullish(icon_light);
 
 	return {
 		...acc,
-		[key]: name
+		[key]: {
+			name,
+			...(withoutLogo && { noLogo: true })
+		}
 	};
 }, {});
 await writeFile(destJson, JSON.stringify(cleanJson, null, 2), 'utf-8');

--- a/src/frontend/src/lib/components/satellites/auth/UserPasskeyAuthenticator.svelte
+++ b/src/frontend/src/lib/components/satellites/auth/UserPasskeyAuthenticator.svelte
@@ -4,7 +4,7 @@
 	import { bytesToAAGUID } from '@junobuild/ic-client/webauthn';
 	import Value from '$lib/components/ui/Value.svelte';
 	import aaguids from '$lib/env/aaguids.json';
-	import { type Aaguid, type AaguidName, PasskeyAaguidsSchema } from '$lib/schemas/passkey-aaguids';
+	import { type AaguidKey, type Aaguid, PasskeyAaguidsSchema } from '$lib/schemas/passkey-aaguids';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import { theme } from '$lib/stores/app/theme.store';
 	import { Theme } from '$lib/types/theme';
@@ -16,7 +16,7 @@
 
 	let { user }: Props = $props();
 
-	const mapAaguid = (user: User): Nullish<Aaguid> => {
+	const mapAaguidKey = (user: User): Nullish<AaguidKey> => {
 		const {
 			data: { providerData }
 		} = user;
@@ -44,7 +44,7 @@
 		return aaguidText;
 	};
 
-	const mapAaguidText = (aaguid: Nullish<Aaguid>): Nullish<AaguidName> => {
+	const mapAaguid = (aaguid: Nullish<AaguidKey>): Nullish<Aaguid> => {
 		if (isNullish(aaguid)) {
 			return null;
 		}
@@ -60,17 +60,18 @@
 		return data[aaguid];
 	};
 
-	let aaguid = $derived(mapAaguid(user));
-	let authenticator = $derived(mapAaguidText(aaguid));
+	let aaguidKey = $derived(mapAaguidKey(user));
+	let aaguid = $derived(mapAaguid(aaguidKey));
+	let authenticator = $derived(aaguid?.name);
 
 	let iconSrc = $derived(
-		notEmptyString(aaguid)
-			? `/aaguids/${aaguid}-${$theme === Theme.DARK ? 'dark' : 'light'}.svg`
+		notEmptyString(aaguidKey) && aaguid?.noLogo !== true
+			? `/aaguids/${aaguidKey}-${$theme === Theme.DARK ? 'dark' : 'light'}.svg`
 			: undefined
 	);
 </script>
 
-{#if notEmptyString(aaguid)}
+{#if notEmptyString(aaguidKey)}
 	<div>
 		<Value>
 			{#snippet label()}

--- a/src/frontend/src/lib/schemas/passkey-aaguids.ts
+++ b/src/frontend/src/lib/schemas/passkey-aaguids.ts
@@ -1,16 +1,19 @@
 import * as z from 'zod';
 
-const AaguidSchema = z
+const AaguidKeySchema = z
 	.string()
 	.regex(
 		/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
 		'Invalid AAGUID format'
 	);
 
+export type AaguidKey = z.infer<typeof AaguidKeySchema>;
+
+const AaguidSchema = z.strictObject({
+	name: z.string(),
+	noLogo: z.boolean().optional()
+});
+
 export type Aaguid = z.infer<typeof AaguidSchema>;
 
-const AaguidNameSchema = z.string();
-
-export type AaguidName = z.infer<typeof AaguidNameSchema>;
-
-export const PasskeyAaguidsSchema = z.record(AaguidSchema, AaguidNameSchema);
+export const PasskeyAaguidsSchema = z.record(AaguidKeySchema, AaguidSchema);


### PR DESCRIPTION
# Motivation

Passwall was added to the aaguid list in #2721 (source https://github.com/passkeydeveloper/passkey-authenticator-aaguids/pull/87) without a logo. To avoid displaying a missing image, we should extend our schema and component to handle entries that have no logo.
