### PR TITLE
fix(sputnik): incorrect stub path fallback when no custom functions

### DIFF
--- a/src/sputnik/build.rs
+++ b/src/sputnik/build.rs
@@ -21,6 +21,6 @@ fn main() {
         println!("cargo:rerun-if-changed={source}");
         fs::copy(&source, "src/generated.rs").expect("Failed to copy generated.rs");
     } else {
-        fs::copy("src/functions.rs", "src/generated.rs").expect("Failed to copy generated.rs");
+        fs::copy("resources/functions.rs", "src/generated.rs").expect("Failed to copy generated.rs");
     }
 }


### PR DESCRIPTION
# Motivation

While developing the serverless functions https outcall in TS (https://github.com/junobuild/examples/pull/23) and landed on an error on `juno functions build`

```
Generating /juno/target/sputnik/juno.package.json...
   Compiling sputnik v0.4.0 (/juno/target/juno-main/src/sputnik)
error: failed to run custom build command for `sputnik v0.4.0 (/juno/target/juno-main/src/sputnik)`

Caused by:
  process didn't exit successfully: `/juno/target/juno-main/target/release/build/sputnik-6b33bed64265759b/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=DEV_SCRIPT_PATH
  cargo:rerun-if-env-changed=DEV_FUNCTIONS_PATH
  cargo:rustc-env=DEV_SCRIPT_PATH=/juno/target/deploy/sputnik.index.mjs

  --- stderr

  thread 'main' (881) panicked at src/sputnik/build.rs:24:58:
  Failed to copy generated.rs: Os { code: 2, kind: NotFound, message: "No such file or directory" }
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The root cause is a typo in the `build.rs` of sputnik to redo the stub if there aren't any custom query or update
