### PR TITLE
fix(skylab): sveltekit overwriting types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"types": ["node", "wicg-file-system-access"]
 	},
 	"exclude": ["src/tests/**/*", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
# Motivation

Not sure why it started today but when installing the Console for Skylab in the docker image (https://github.com/junobuild/juno-docker/actions/runs/23975180702/job/69930999406) it starts failing because SvelteKit overwrite the `tsconfig` types.
