### PR TITLE
feat(console): emergency patch to create users with zero credits

### DIFF
--- a/src/console/src/accounts/impls.rs
+++ b/src/console/src/accounts/impls.rs
@@ -1,4 +1,4 @@
-use crate::constants::E8S_PER_ICP;
+use crate::constants::{NO_CREDITS};
 use crate::types::state::{Account, OpenIdData, Provider};
 use ic_cdk::api::time;
 use junobuild_auth::openid::credentials::delegation::types::interface::OpenIdDelegationCredential;
@@ -74,7 +74,7 @@ impl Account {
             mission_control_id: None,
             provider: provider.clone(),
             owner: *user,
-            credits: E8S_PER_ICP,
+            credits: NO_CREDITS,
             created_at: now,
             updated_at: now,
         }

--- a/src/console/src/constants.rs
+++ b/src/console/src/constants.rs
@@ -18,6 +18,11 @@ pub const MISSION_CONTROL_CREATION_FEE_CYCLES: CyclesTokens =
 // A credit which can be used to start one satellite or one orbiter.
 pub const E8S_PER_ICP: Tokens = Tokens::from_e8s(100_000_000);
 
+// On Apr. 4, 2026, someone exploited the free tier to spin up free canisters.
+// They created roughly 60-70 identities to spin up the same number of canisters.
+// The rate limiter worked as expected — they had to wait a few minutes before creating more users.
+// Unfortunately, until further notice, credits must be requested on demand to prevent this
+// kind of abuse and protect the integrity of the Console.
 pub const NO_CREDITS: Tokens = Tokens::from_e8s(0);
 
 pub const RELEASES_METADATA_JSON: &str = "/releases/metadata.json";

--- a/src/console/src/constants.rs
+++ b/src/console/src/constants.rs
@@ -18,6 +18,8 @@ pub const MISSION_CONTROL_CREATION_FEE_CYCLES: CyclesTokens =
 // A credit which can be used to start one satellite or one orbiter.
 pub const E8S_PER_ICP: Tokens = Tokens::from_e8s(100_000_000);
 
+pub const NO_CREDITS: Tokens = Tokens::from_e8s(0);
+
 pub const RELEASES_METADATA_JSON: &str = "/releases/metadata.json";
 
 // Default freezing threshold to create Satellites and Mission Controls


### PR DESCRIPTION
# Motivation

Copy of the message I shared on Discord, OC and X:

```
everyone I get the feeling that the day has finally come that someone is taking advantage of the authentication in the Console to spin up free canisters, as I randomly noticed that close to 100 TCycles were burned in the last hours. After checking the sign-ups I noticed a spike in Internet Identity sign-ins (up to 71 today, versus 2 with Google and 1 with GitHub). If the sign-ins were spread out, I'd assume there was an event or some buzz, but it rather looks like an attack.

As an active precautionary measure, I have disabled free Satellites for new users, at least temporarily. I'll likely display a message for new users like "Hey, want a free Satellite? Reach out on Discord or something."

Hope that makes sense. That said, if I misunderstood and there is a hackathon somewhere, please let me know!!
```

This patch has been deployed and it "resoled" the issue. I should proceed with improving the UX as mentionned.

