### PR TITLE
feat(frontend): inline wallet picker for create wizards

### DIFF
--- a/src/frontend/src/lib/components/icons/IconSwap.svelte
+++ b/src/frontend/src/lib/components/icons/IconSwap.svelte
@@ -1,0 +1,19 @@
+<!-- source: https://fonts.google.com/icons?selected=Material+Icons+Round:swap_horiz:&icon.size=24&icon.color=%23000000&icon.query=swap&icon.style=Rounded -->
+<script lang="ts">
+	interface Props {
+		size?: string;
+	}
+
+	let { size = '24px' }: Props = $props();
+</script>
+
+<svg
+	fill="currentColor"
+	height={size}
+	viewBox="0 0 24 24"
+	width={size}
+	xmlns="http://www.w3.org/2000/svg"
+	><path d="M0 0h24v24H0V0z" fill="none" /><path
+		d="M6.14 11.86l-2.78 2.79c-.19.2-.19.51 0 .71l2.78 2.79c.31.32.85.09.85-.35V16H13c.55 0 1-.45 1-1s-.45-1-1-1H6.99v-1.79c0-.45-.54-.67-.85-.35zm14.51-3.21l-2.78-2.79c-.31-.32-.85-.09-.85.35V8H11c-.55 0-1 .45-1 1s.45 1 1 1h6.01v1.79c0 .45.54.67.85.35l2.78-2.79c.2-.19.2-.51.01-.7z"
+	/></svg
+>

--- a/src/frontend/src/lib/components/mission-control/create/MissionControlCreateWizard.svelte
+++ b/src/frontend/src/lib/components/mission-control/create/MissionControlCreateWizard.svelte
@@ -94,12 +94,12 @@
 		{detail}
 		{onclose}
 		priceLabel={$i18n.mission_control.create_price}
-		{selectedWallet}
+		bind:selectedWallet
 		bind:withFee
 		bind:insufficientFunds
 	>
 		<form onsubmit={onSubmit}>
-			<FactoryAdvancedOptions {detail} withMonitoring={false} bind:selectedWallet bind:subnetId />
+			<FactoryAdvancedOptions {detail} withMonitoring={false} bind:subnetId />
 
 			<button disabled={$authSignedOut || insufficientFunds} type="submit">
 				{$i18n.core.create}

--- a/src/frontend/src/lib/components/modals/factory/create/OrbiterCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/factory/create/OrbiterCreateModal.svelte
@@ -107,17 +107,12 @@
 			{detail}
 			{onclose}
 			priceLabel={$i18n.analytics.create_orbiter_price}
-			{selectedWallet}
+			bind:selectedWallet
 			bind:withFee
 			bind:insufficientFunds
 		>
 			<form onsubmit={onSubmit}>
-				<FactoryAdvancedOptions
-					{detail}
-					bind:selectedWallet
-					bind:subnetId
-					bind:monitoringStrategy
-				/>
+				<FactoryAdvancedOptions {detail} bind:subnetId bind:monitoringStrategy />
 
 				<button
 					{...testId(testIds.createAnalytics.create)}

--- a/src/frontend/src/lib/components/modals/factory/create/SatelliteCreateModal.svelte
+++ b/src/frontend/src/lib/components/modals/factory/create/SatelliteCreateModal.svelte
@@ -110,7 +110,7 @@
 			{detail}
 			{onclose}
 			priceLabel={$i18n.satellites.create_satellite_price}
-			{selectedWallet}
+			bind:selectedWallet
 			bind:withFee
 			bind:insufficientFunds
 		>
@@ -169,12 +169,7 @@
 					</Value>
 				</div>
 
-				<FactoryAdvancedOptions
-					{detail}
-					bind:selectedWallet
-					bind:subnetId
-					bind:monitoringStrategy
-				/>
+				<FactoryAdvancedOptions {detail} bind:subnetId bind:monitoringStrategy />
 
 				<button
 					{...testId(testIds.createSatellite.create)}

--- a/src/frontend/src/lib/components/modules/factory/create/FactoryAdvancedOptions.svelte
+++ b/src/frontend/src/lib/components/modules/factory/create/FactoryAdvancedOptions.svelte
@@ -4,13 +4,10 @@
 	import CanisterSubnets from '$lib/components/modules/canister/display/CanisterSubnets.svelte';
 	import CanisterMonitoringDefaultStrategy from '$lib/components/modules/canister/monitoring/CanisterMonitoringDefaultStrategy.svelte';
 	import Collapsible from '$lib/components/ui/Collapsible.svelte';
-	import WalletPicker from '$lib/components/wallet/WalletPicker.svelte';
-	import type { SelectedWallet } from '$lib/schemas/wallet.schema';
 	import { i18n } from '$lib/stores/app/i18n.store';
 	import type { JunoModalDetail } from '$lib/types/modal';
 
 	interface Props {
-		selectedWallet: SelectedWallet | undefined;
 		subnetId: PrincipalText | undefined;
 		monitoringStrategy?: MissionControlDid.CyclesMonitoringStrategy | undefined;
 		detail: JunoModalDetail;
@@ -18,7 +15,6 @@
 	}
 
 	let {
-		selectedWallet = $bindable(),
 		subnetId = $bindable(),
 		monitoringStrategy = $bindable(),
 		detail,
@@ -30,8 +26,6 @@
 	{#snippet header()}
 		{$i18n.core.advanced_options}
 	{/snippet}
-
-	<WalletPicker filterMissionControlZeroBalance bind:selectedWallet />
 
 	<CanisterSubnets bind:subnetId />
 

--- a/src/frontend/src/lib/components/modules/factory/create/FactoryCredits.svelte
+++ b/src/frontend/src/lib/components/modules/factory/create/FactoryCredits.svelte
@@ -20,7 +20,7 @@
 	let {
 		detail,
 		priceLabel,
-		selectedWallet,
+		selectedWallet = $bindable(undefined),
 		insufficientFunds = $bindable(true),
 		withFee = $bindable(undefined),
 		children,
@@ -43,7 +43,7 @@
 		{fee}
 		{onclose}
 		{priceLabel}
-		{selectedWallet}
+		bind:selectedWallet
 		bind:insufficientFunds
 		bind:withFee
 	>

--- a/src/frontend/src/lib/components/modules/factory/create/FactoryCreditsWithFee.svelte
+++ b/src/frontend/src/lib/components/modules/factory/create/FactoryCreditsWithFee.svelte
@@ -3,6 +3,7 @@
 	import type { Snippet } from 'svelte';
 	import FactoryWalletInfo from '$lib/components/modules/factory/create/FactoryWalletInfo.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
+	import InlineWalletPicker from '$lib/components/wallet/InlineWalletPicker.svelte';
 	import { E8S_PER_ICP } from '$lib/constants/app.constants';
 	import { CYCLES, ICP } from '$lib/constants/token.constants';
 	import { creditsOrZero } from '$lib/derived/console/credits.derived';
@@ -14,6 +15,7 @@
 	} from '$lib/derived/wallet/balance.derived';
 	import { icpToUsd } from '$lib/derived/wallet/exchange.derived';
 	import type { SelectedToken, SelectedWallet } from '$lib/schemas/wallet.schema';
+	import { i18n } from '$lib/stores/app/i18n.store';
 	import { formatCyclesToHTML } from '$lib/utils/cycles.utils';
 	import { i18nFormat } from '$lib/utils/i18n.utils';
 	import { formatICPToHTML } from '$lib/utils/icp.utils';
@@ -32,7 +34,7 @@
 	let {
 		fee,
 		priceLabel,
-		selectedWallet,
+		selectedWallet = $bindable(undefined),
 		insufficientFunds = $bindable(true),
 		withFee = $bindable(undefined),
 		children,
@@ -76,9 +78,15 @@
 					value: isTokenIcp(selectedToken)
 						? formatICPToHTML({ e8s: fee, bold: true, icpToUsd: $icpToUsd })
 						: formatCyclesToHTML({ e12s: fee, bold: true })
-				},
+				}
+			])}
+		/>
+		{$i18n.wallet.your_wallet}
+		<InlineWalletPicker bind:selectedWallet />
+		<Html
+			text={i18nFormat($i18n.wallet.current_balance, [
 				{
-					placeholder: '{1}',
+					placeholder: '{0}',
 					value: isTokenIcp(selectedToken)
 						? formatICPToHTML({ e8s: balanceOrZero, bold: false, icpToUsd: $icpToUsd })
 						: formatCyclesToHTML({ e12s: balanceOrZero, bold: false })

--- a/src/frontend/src/lib/components/wallet/InlineWalletPicker.svelte
+++ b/src/frontend/src/lib/components/wallet/InlineWalletPicker.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { decodeIcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
+	import { untrack } from 'svelte';
+	import IconSwap from '$lib/components/icons/IconSwap.svelte';
+	import { missionControlId } from '$lib/derived/console/account.mission-control.derived';
+	import { devId } from '$lib/derived/dev.derived';
+	import { missionControlHasIcp } from '$lib/derived/wallet/balance.derived';
+	import type { SelectedWallet, WalletId, WalletIdText } from '$lib/schemas/wallet.schema';
+	import { i18n } from '$lib/stores/app/i18n.store';
+
+	interface Props {
+		selectedWallet: SelectedWallet | undefined;
+	}
+
+	let { selectedWallet = $bindable(undefined) }: Props = $props();
+
+	let walletIdText = $state<WalletIdText | undefined>($devId?.toText());
+
+	$effect(() => {
+		walletIdText;
+
+		untrack(() => {
+			selectedWallet = nonNullish(walletIdText)
+				? walletIdText === $devId?.toText()
+					? { type: 'dev', walletId: decodeIcrcAccount(walletIdText) as WalletId }
+					: walletIdText === $missionControlId?.toText()
+						? { type: 'mission_control', walletId: decodeIcrcAccount(walletIdText) as WalletId }
+						: undefined
+				: undefined;
+		});
+	});
+
+	let pickerEnabled = $derived(nonNullish($missionControlId) && $missionControlHasIcp);
+
+	const toggleWallet = () => {
+		walletIdText =
+			nonNullish($missionControlId) && walletIdText === $missionControlId.toText()
+				? $devId?.toText()
+				: $missionControlId?.toText();
+	};
+</script>
+
+{#snippet devWallet()}
+	{$i18n.wallet.dev}
+{/snippet}
+
+{#snippet walletWithToggle()}
+	{nonNullish($missionControlId) && walletIdText === $missionControlId.toText()
+		? $i18n.mission_control.title
+		: $i18n.wallet.dev}
+	<button class="square" aria-label={$i18n.wallet.toggle_wallet} onclick={toggleWallet}
+		><IconSwap size="16" />
+	</button>
+{/snippet}
+
+{#if pickerEnabled}
+	{@render walletWithToggle()}
+{:else}
+	{@render devWallet()}
+{/if}
+
+<style lang="scss">
+	button {
+		vertical-align: bottom;
+	}
+</style>

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -336,7 +336,7 @@
 		"tags_placeholder": "Comma-separated or one per line. Leave empty for no tags.",
 		"enter_name": "Enter a name for your Satellite",
 		"edit_details": "Edit details",
-		"create_satellite_price": "Starting a new Satellite requires {0}. Your current balance is {1}.",
+		"create_satellite_price": "Starting a new Satellite requires {0}.",
 		"loading_satellites": "Loading your Satellites",
 		"overview": "Overview",
 		"id": "Satellite ID",
@@ -354,7 +354,7 @@
 		"edit_email": "Edit your email address",
 		"empty": "The Mission Control is your central hub for managing modules. It is required to activate monitoring. Additional advanced features will be added in the future.",
 		"description": "Get Mission Control to unlock advanced features such as monitoring.",
-		"create_price": "Starting Mission Control requires {0}. Your current balance is {1}.",
+		"create_price": "Starting Mission Control requires {0}.",
 		"initializing": "Initializing Mission Control...",
 		"ready": "Your Mission Control is ready!",
 		"attaching": "Sharing existing modules with Mission Control...",
@@ -417,7 +417,10 @@
 		"convert_preparing": "Preparing conversion...",
 		"convert_transferring": "Transferring ICP...",
 		"convert_minting": "Converting ICP to Cycles...",
-		"convert_done": "Your Cycles have been converted to ICP."
+		"convert_done": "Your Cycles have been converted to ICP.",
+		"your_wallet": "Your",
+		"current_balance": "wallet current balance is {0}.",
+		"toggle_wallet": "Toggle wallet"
 	},
 	"authentication": {
 		"title": "Authentication",
@@ -465,7 +468,7 @@
 		"error_msg": "An error occurred while processing the analytics for the selected filters. Please refine to try again.",
 		"description": "Get analytics to measure and analyse how users engage with your apps.",
 		"initializing": "Initializing analytics...",
-		"create_orbiter_price": "Starting with the analytics requires {0}. Your current balance is {1}.",
+		"create_orbiter_price": "Starting with the analytics requires {0}.",
 		"create": "Create analytics",
 		"ready": "Your analytics are ready!",
 		"satellites": "Satellite(s)",

--- a/src/frontend/src/lib/i18n/zh-cn.json
+++ b/src/frontend/src/lib/i18n/zh-cn.json
@@ -337,7 +337,7 @@
 		"tags_placeholder": "逗号分隔或每行一个，留空则不添加标签。",
 		"enter_name": "输入卫星名称",
 		"edit_details": "编辑详情",
-		"create_satellite_price": "启动新的 Satellite 需要 {0}。您当前的余额为 {1}。",
+		"create_satellite_price": "启动新的 Satellite 需要 {0}。",
 		"loading_satellites": "正在加载所有卫星",
 		"overview": "概览",
 		"id": "卫星ID",
@@ -355,7 +355,7 @@
 		"edit_email": "编辑您的电子邮件地址",
 		"empty": "Mission Control 是管理模块的中心枢纽。激活监控功能需要 Mission Control。未来将添加更多高级功能。",
 		"description": "获取 Mission Control 以解锁监控等高级功能。",
-		"create_price": "启动 Mission Control 需要 {0}。您当前的余额为 {1}。",
+		"create_price": "启动 Mission Control 需要 {0}。",
 		"initializing": "正在初始化 Mission Control...",
 		"ready": "您的 Mission Control 已就绪！",
 		"attaching": "正在与任务控制中心共享现有模块...",
@@ -418,7 +418,10 @@
 		"convert_preparing": "准备兑换中...",
 		"convert_transferring": "转账 ICP 中...",
 		"convert_minting": "将 ICP 兑换为 Cycles 中...",
-		"convert_done": "您的 Cycles 已成功兑换。"
+		"convert_done": "您的 Cycles 已成功兑换。",
+		"your_wallet": "您的钱包",
+		"current_balance": "当前余额为 {0}。",
+		"toggle_wallet": "切换钱包"
 	},
 	"authentication": {
 		"title": "身份认证",
@@ -466,7 +469,7 @@
 		"error_msg": "处理所选过滤器的统计时发生错误。请调整过滤条件后重试。",
 		"description": "获取统计数据以衡量和分析用户如何与您的应用互动。",
 		"initializing": "正在初始化统计...",
-		"create_orbiter_price": "启动分析功能需要 {0}。您当前的余额为 {1}。",
+		"create_orbiter_price": "启动分析功能需要 {0}。",
 		"create": "创建统计",
 		"ready": "您的统计已就绪！",
 		"satellites": "卫星",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -428,6 +428,9 @@ interface I18nWallet {
 	convert_transferring: string;
 	convert_minting: string;
 	convert_done: string;
+	your_wallet: string;
+	current_balance: string;
+	toggle_wallet: string;
 }
 
 interface I18nAuthentication {


### PR DESCRIPTION
# Motivation

Having the mission control wallet mumbo jumbo in advance options is sub-optimal and also an issue for #2754 in which I would like to introduce multiple steps in the wizard. Therefore inlining it with a toggle

<img width="1533" height="1034" alt="Capture d’écran 2026-04-10 à 10 35 35" src="https://github.com/user-attachments/assets/1a873e66-d835-4e72-b737-983fc864bdcf" />

<img width="1533" height="1034" alt="Capture d’écran 2026-04-10 à 10 35 50" src="https://github.com/user-attachments/assets/9a477b54-349d-481a-b359-e43d53c55d0f" />
