### PR TITLE
fix(sputnik,macros): handle Option<T> conversion for nested struct fields in JsonData derive

### DIFF
--- a/src/libs/macros/src/functions/derive.rs
+++ b/src/libs/macros/src/functions/derive.rs
@@ -65,7 +65,11 @@ fn derive_struct(
         .map(|f| {
             let fname = &f.ident;
             if has_nested_attr(f) {
-                quote! { #fname: input.#fname.into(), }
+                if unwrap_option(&f.ty).is_some() {
+                    quote! { #fname: input.#fname.map(|v| v.into()), }
+                } else {
+                    quote! { #fname: input.#fname.into(), }
+                }
             } else {
                 quote! { #fname: input.#fname, }
             }
@@ -77,7 +81,11 @@ fn derive_struct(
         .map(|f| {
             let fname = &f.ident;
             if has_nested_attr(f) {
-                quote! { #fname: json_data.#fname.into(), }
+                if unwrap_option(&f.ty).is_some() {
+                    quote! { #fname: json_data.#fname.map(|v| v.into()), }
+                } else {
+                    quote! { #fname: json_data.#fname.into(), }
+                }
             } else {
                 quote! { #fname: json_data.#fname, }
             }

--- a/src/sputnik/src/js/apis/node/llrt/llrt_url/url_class.rs
+++ b/src/sputnik/src/js/apis/node/llrt/llrt_url/url_class.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::inherent_to_string)]
-
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::uninlined_format_args)]

--- a/src/sputnik/src/js/apis/node/llrt/llrt_url/url_search_params.rs
+++ b/src/sputnik/src/js/apis/node/llrt/llrt_url/url_search_params.rs
@@ -414,4 +414,3 @@ fn get_coerced_string_value<'js>(ctx: &Ctx<'js>, value: Opt<Value<'js>>) -> Opti
     };
     None
 }
-

--- a/src/tests/fixtures/test_sputnik/resources/custom-functions-option.ts
+++ b/src/tests/fixtures/test_sputnik/resources/custom-functions-option.ts
@@ -31,3 +31,20 @@ export const demoAntonio = defineQuery({
 		}
 	})
 });
+
+// Assertion which would make the npm run build:test-sputnik fail
+
+const PreferencesSchema = j.strictObject({
+	theme: j.string()
+});
+
+export const testQuery = defineQuery({
+	result: j.strictObject({
+		// Issue: Option<nested struct> fields with #[json_data(nested)] generated `.into()`
+		// instead of `.map(|v| v.into())`, causing a missing From trait bound at compile time.
+		preferences: PreferencesSchema.optional()
+	}),
+	handler: () => ({
+		preferences: undefined
+	})
+});


### PR DESCRIPTION
# Motivation

An issue spoted by @AntonioVentilii : the sputnik macros incorrectly handled json-data when set as optional. a test case was missing
