### PR TITLE
refactor: switch worker timers from setInterval to recursive setTimeout

### DIFF
--- a/src/frontend/src/lib/workers/auth.worker.ts
+++ b/src/frontend/src/lib/workers/auth.worker.ts
@@ -1,6 +1,7 @@
 import { AUTH_TIMER_INTERVAL } from '$lib/constants/app.constants';
 import { AuthClientProvider } from '$lib/providers/auth-client.provider';
 import type { PostMessageRequest } from '$lib/types/post-message';
+import { nonNullish } from '@dfinity/utils';
 import { IdbStorage, KEY_STORAGE_DELEGATION } from '@icp-sdk/auth/client';
 import { DelegationChain, isDelegationValid } from '@icp-sdk/core/identity';
 
@@ -21,18 +22,36 @@ export const onAuthMessage = async ({
 
 let timer: NodeJS.Timeout | undefined = undefined;
 
+// Recursive setTimeout (not setInterval) so the idle check cannot overlap
+// itself: the next tick is scheduled only after the previous onIdleSignOut
+// resolves. See #2522 / oisy-wallet#9706 for the motivation.
+const scheduleNext = (): void => {
+	timer = setTimeout(async () => {
+		await onIdleSignOut();
+
+		if (nonNullish(timer)) {
+			scheduleNext();
+		}
+	}, AUTH_TIMER_INTERVAL);
+};
+
 /**
  * The timer is executed only if user has signed in
  */
-export const startIdleTimer = () =>
-	(timer = setInterval(async () => await onIdleSignOut(), AUTH_TIMER_INTERVAL));
+export const startIdleTimer = () => {
+	if (nonNullish(timer)) {
+		return;
+	}
+
+	scheduleNext();
+};
 
 export const stopIdleTimer = () => {
 	if (!timer) {
 		return;
 	}
 
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
 

--- a/src/frontend/src/lib/workers/cycles.worker.ts
+++ b/src/frontend/src/lib/workers/cycles.worker.ts
@@ -16,7 +16,7 @@ import type { CanisterInfo, CanisterSegment, CanisterSyncData, Segment } from '$
 import type { PostMessageDataRequest, PostMessageRequest } from '$lib/types/post-message';
 import { emitCanisters, emitSavedCanisters, loadIdentity } from '$lib/utils/worker.utils';
 import { CanistersStore } from '$lib/workers/_stores/canisters.store';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { set } from 'idb-keyval';
 
@@ -38,7 +38,29 @@ export const onCyclesMessage = async ({ data: dataMsg }: MessageEvent<PostMessag
 
 let timer: NodeJS.Timeout | undefined = undefined;
 
+// Recursive setTimeout (not setInterval) so the canister sync cannot
+// overlap itself. See #2522 / oisy-wallet#9706.
+const scheduleNext = ({
+	identity,
+	segments
+}: {
+	identity: Identity;
+	segments: CanisterSegment[];
+}): void => {
+	timer = setTimeout(async () => {
+		await syncCanisters({ identity, segments });
+
+		if (nonNullish(timer)) {
+			scheduleNext({ identity, segments });
+		}
+	}, SYNC_CYCLES_TIMER_INTERVAL);
+};
+
 const startCyclesTimer = async ({ data: { segments } }: { data: PostMessageDataRequest }) => {
+	if (nonNullish(timer)) {
+		return;
+	}
+
 	const identity = await loadIdentity();
 
 	if (isNullish(identity)) {
@@ -46,12 +68,12 @@ const startCyclesTimer = async ({ data: { segments } }: { data: PostMessageDataR
 		return;
 	}
 
-	const sync = async () => await syncCanisters({ identity, segments: segments ?? [] });
+	const effectiveSegments = segments ?? [];
 
 	// We sync the cycles now but also schedule the update afterwards
-	await sync();
+	await syncCanisters({ identity, segments: effectiveSegments });
 
-	timer = setInterval(sync, SYNC_CYCLES_TIMER_INTERVAL);
+	scheduleNext({ identity, segments: effectiveSegments });
 };
 
 const stopCyclesTimer = () => {
@@ -59,11 +81,9 @@ const stopCyclesTimer = () => {
 		return;
 	}
 
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
-
-let syncing = false;
 
 const syncCanisters = async ({
 	identity,
@@ -77,23 +97,12 @@ const syncCanisters = async ({
 		return;
 	}
 
-	// We avoid to relaunch a sync while previous sync is not finished
-	if (syncing) {
-		return;
-	}
-
-	syncing = true;
-
 	await emitSavedCanisters({
 		canisterIds: segments.map(({ canisterId }) => canisterId),
 		customStore: cyclesIdbStore
 	});
 
-	try {
-		await syncIcStatusCanisters({ identity, segments });
-	} finally {
-		syncing = false;
-	}
+	await syncIcStatusCanisters({ identity, segments });
 };
 
 const syncIcStatusCanisters = async ({

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -5,7 +5,7 @@ import { exchangeIdbStore } from '$lib/stores/app/idb.store';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { ExchangePrice } from '$lib/types/exchange';
 import type { PostMessageDataResponseExchange, PostMessageRequest } from '$lib/types/post-message';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { del, entries, set } from 'idb-keyval';
 
 export const onExchangeMessage = async ({ data: dataMsg }: MessageEvent<PostMessageRequest>) => {
@@ -22,16 +22,30 @@ export const onExchangeMessage = async ({ data: dataMsg }: MessageEvent<PostMess
 
 let timer: NodeJS.Timeout | undefined = undefined;
 
+// Recursive setTimeout (not setInterval) so the exchange sync cannot
+// overlap itself. See #2522 / oisy-wallet#9706.
+const scheduleNext = (): void => {
+	timer = setTimeout(async () => {
+		await syncExchange();
+
+		if (nonNullish(timer)) {
+			scheduleNext();
+		}
+	}, SYNC_TOKENS_TIMER_INTERVAL);
+};
+
 const startTimer = async () => {
-	const sync = async () => await syncExchange();
+	if (nonNullish(timer)) {
+		return;
+	}
 
 	// First we emit the value we already have in IDB
 	await emitSavedExchanges();
 
 	// We sync the cycles now but also schedule the update afterwards
-	await sync();
+	await syncExchange();
 
-	timer = setInterval(sync, SYNC_TOKENS_TIMER_INTERVAL);
+	scheduleNext();
 };
 
 const stopTimer = () => {
@@ -39,22 +53,13 @@ const stopTimer = () => {
 		return;
 	}
 
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
-
-let syncing = false;
 
 let retry = 0;
 
 const syncExchange = async () => {
-	// We avoid to relaunch a sync while previous sync is not finished
-	if (syncing) {
-		return;
-	}
-
-	syncing = true;
-
 	try {
 		const icpExchange = await exchangeRateICPToUsd();
 
@@ -78,8 +83,6 @@ const syncExchange = async () => {
 		}
 
 		retry++;
-	} finally {
-		syncing = false;
 	}
 };
 

--- a/src/frontend/src/lib/workers/hosting.worker.ts
+++ b/src/frontend/src/lib/workers/hosting.worker.ts
@@ -2,7 +2,7 @@ import { SYNC_CUSTOM_DOMAIN_TIMER_INTERVAL } from '$lib/constants/app.constants'
 import { getCustomDomainRegistration } from '$lib/rest/bn.v1.rest';
 import type { CustomDomain, CustomDomainName, CustomDomainState } from '$lib/types/custom-domain';
 import type { PostMessageDataRequest, PostMessageRequest } from '$lib/types/post-message';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const onHostingMessage = async ({ data: dataMsg }: MessageEvent<PostMessageRequest>) => {
 	const { msg, data } = dataMsg;
@@ -23,34 +23,39 @@ const stopTimer = () => {
 		return;
 	}
 
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
 
+// Recursive setTimeout (not setInterval) so the registration sync cannot
+// overlap itself. See #2522 / oisy-wallet#9706.
+const scheduleNext = ({ customDomain }: { customDomain: CustomDomain }): void => {
+	timer = setTimeout(async () => {
+		await syncCustomDomainRegistration({ customDomain });
+
+		if (nonNullish(timer)) {
+			scheduleNext({ customDomain });
+		}
+	}, SYNC_CUSTOM_DOMAIN_TIMER_INTERVAL);
+};
+
 const startTimer = async ({ data: { customDomain } }: { data: PostMessageDataRequest }) => {
+	if (nonNullish(timer)) {
+		return;
+	}
+
 	if (isNullish(customDomain)) {
 		// No custom domain registration to sync
 		return;
 	}
 
-	const sync = async () => await syncCustomDomainRegistration({ customDomain });
-
 	// We sync the cycles now but also schedule the update afterwards
-	await sync();
+	await syncCustomDomainRegistration({ customDomain });
 
-	timer = setInterval(sync, SYNC_CUSTOM_DOMAIN_TIMER_INTERVAL);
+	scheduleNext({ customDomain });
 };
 
-let syncing = false;
-
 const syncCustomDomainRegistration = async ({ customDomain }: { customDomain: CustomDomain }) => {
-	// We avoid to relaunch a sync while previous sync is not finished
-	if (syncing) {
-		return;
-	}
-
-	syncing = true;
-
 	try {
 		const sync = async (): Promise<CustomDomainState> => {
 			const [domainName] = customDomain;
@@ -72,8 +77,6 @@ const syncCustomDomainRegistration = async ({ customDomain }: { customDomain: Cu
 		// We sync until Available or Failed
 		stopTimer();
 	}
-
-	syncing = false;
 };
 
 const syncCustomDomainRegistrationV1 = async ({

--- a/src/frontend/src/lib/workers/icp-cycles-rate.worker.ts
+++ b/src/frontend/src/lib/workers/icp-cycles-rate.worker.ts
@@ -5,7 +5,7 @@ import type {
 	PostMessageDataResponseIcpToCyclesRate,
 	PostMessageRequest
 } from '$lib/types/post-message';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { del, get, set } from 'idb-keyval';
 
 export const onIcpToCyclesRateMessage = async ({
@@ -24,35 +24,40 @@ export const onIcpToCyclesRateMessage = async ({
 
 let timer: NodeJS.Timeout | undefined = undefined;
 
+// Recursive setTimeout (not setInterval) so the rate sync cannot overlap
+// itself. See #2522 / oisy-wallet#9706.
+const scheduleNext = (): void => {
+	timer = setTimeout(async () => {
+		await syncRate();
+
+		if (nonNullish(timer)) {
+			scheduleNext();
+		}
+	}, SYNC_TOKENS_TIMER_INTERVAL);
+};
+
 const startTimer = async () => {
-	const sync = async () => await syncRate();
+	if (nonNullish(timer)) {
+		return;
+	}
 
 	// First we emit the value we already have in IDB
 	await emitSavedRate();
 
 	// We sync the cycles now but also schedule the update afterwards
-	await sync();
+	await syncRate();
 
-	timer = setInterval(sync, SYNC_TOKENS_TIMER_INTERVAL);
+	scheduleNext();
 };
 
 const stopTimer = () => {
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
-
-let syncing = false;
 
 let retry = 0;
 
 const syncRate = async () => {
-	// We avoid to relaunch a sync while previous sync is not finished
-	if (syncing) {
-		return;
-	}
-
-	syncing = true;
-
 	try {
 		const trillionRatio = await getIcpToCyclesConversionRate();
 
@@ -71,8 +76,6 @@ const syncRate = async () => {
 		}
 
 		retry++;
-	} finally {
-		syncing = false;
 	}
 };
 

--- a/src/frontend/src/lib/workers/monitoring.worker.ts
+++ b/src/frontend/src/lib/workers/monitoring.worker.ts
@@ -56,6 +56,10 @@ const startMonitoringTimer = async ({
 }: {
 	data: PostMessageDataRequest;
 }) => {
+	if (nonNullish(timer)) {
+		return;
+	}
+
 	const identity = await loadIdentity();
 
 	if (isNullish(identity)) {
@@ -69,18 +73,29 @@ const startMonitoringTimer = async ({
 		return;
 	}
 
-	const sync = async () =>
-		await syncMonitoring({
-			identity,
-			segments: segments ?? [],
-			missionControlId,
-			withMonitoringHistory: withMonitoringHistory ?? false
-		});
+	const params = {
+		identity,
+		segments: segments ?? [],
+		missionControlId,
+		withMonitoringHistory: withMonitoringHistory ?? false
+	};
+
+	// Recursive setTimeout (not setInterval) so the monitoring sync cannot
+	// overlap itself. See #2522 / oisy-wallet#9706.
+	const scheduleNext = (): void => {
+		timer = setTimeout(async () => {
+			await syncMonitoring(params);
+
+			if (nonNullish(timer)) {
+				scheduleNext();
+			}
+		}, SYNC_MONITORING_TIMER_INTERVAL);
+	};
 
 	// We sync the cycles now but also schedule the update afterwards
-	await sync();
+	await syncMonitoring(params);
 
-	timer = setInterval(sync, SYNC_MONITORING_TIMER_INTERVAL);
+	scheduleNext();
 };
 
 const stopMonitoringTimer = () => {
@@ -88,11 +103,9 @@ const stopMonitoringTimer = () => {
 		return;
 	}
 
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
-
-let syncing = false;
 
 const syncMonitoring = async ({
 	identity,
@@ -108,23 +121,12 @@ const syncMonitoring = async ({
 		return;
 	}
 
-	// We avoid to relaunch a sync while previous sync is not finished
-	if (syncing) {
-		return;
-	}
-
-	syncing = true;
-
 	await emitSavedCanisters({
 		canisterIds: segments.map(({ canisterId }) => canisterId),
 		customStore: monitoringIdbStore
 	});
 
-	try {
-		await syncMonitoringForSegments({ identity, segments, ...rest });
-	} finally {
-		syncing = false;
-	}
+	await syncMonitoringForSegments({ identity, segments, ...rest });
 };
 
 // eslint-disable-next-line local-rules/prefer-object-params

--- a/src/frontend/src/lib/workers/wallet.worker.ts
+++ b/src/frontend/src/lib/workers/wallet.worker.ts
@@ -23,7 +23,7 @@ import type {
 import { loadIdentity } from '$lib/utils/worker.utils';
 import { requestTransactions } from '$lib/workers/_services/wallet-worker.services';
 import { WalletStore, type IndexedTransactions } from '$lib/workers/_stores/wallet-worker.store';
-import { isNullish, jsonReplacer } from '@dfinity/utils';
+import { isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
 import { decodeIcrcAccount, type IcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
@@ -51,7 +51,7 @@ const stopTimer = () => {
 		return;
 	}
 
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
 
@@ -108,26 +108,29 @@ const startTimerWithAccount = async ({
 
 	emitSavedWallet({ store });
 
-	const sync = async () => await syncWallet({ identity, store });
+	// Recursive setTimeout (not setInterval) so each account's sync cannot
+	// overlap itself. See #2522 / oisy-wallet#9706. Each account closes
+	// over its own scheduleNext so multiple accounts still tick in
+	// parallel as before.
+	const scheduleNext = (): void => {
+		timer = setTimeout(async () => {
+			await syncWallet({ identity, store });
+
+			if (nonNullish(timer)) {
+				scheduleNext();
+			}
+		}, SYNC_WALLET_TIMER_INTERVAL);
+	};
 
 	// We sync the cycles now but also schedule the update afterwards
-	await sync();
+	await syncWallet({ identity, store });
 
-	timer = setInterval(sync, SYNC_WALLET_TIMER_INTERVAL);
+	scheduleNext();
 };
-
-const syncing: Record<IcrcAccountText, boolean> = {};
 
 let initialized = false;
 
 const syncWallet = async ({ identity, store }: { identity: Identity; store: WalletStore }) => {
-	// We avoid to relaunch a sync while previous sync is not finished
-	if (syncing[store.idbKey] === true) {
-		return;
-	}
-
-	syncing[store.idbKey] = true;
-
 	const request = ({
 		identity: _,
 		certified
@@ -163,8 +166,6 @@ const syncWallet = async ({ identity, store }: { identity: Identity; store: Wall
 	});
 
 	await store.save();
-
-	syncing[store.idbKey] = false;
 };
 
 const postMessageWallet = ({

--- a/src/frontend/src/lib/workers/workflows.worker.ts
+++ b/src/frontend/src/lib/workers/workflows.worker.ts
@@ -17,8 +17,8 @@ import {
 	requestWorkflows,
 	type RequestWorkflowsResponse
 } from '$lib/workers/_services/workflows-worker.services';
-import { type WorkflowsIdbKey, WorkflowsStore } from '$lib/workers/_stores/workflows-worker.store';
-import { isEmptyString, isNullish, jsonReplacer } from '@dfinity/utils';
+import { WorkflowsStore } from '$lib/workers/_stores/workflows-worker.store';
+import { isEmptyString, isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 
@@ -45,7 +45,7 @@ const stopTimer = () => {
 		return;
 	}
 
-	clearInterval(timer);
+	clearTimeout(timer);
 	timer = undefined;
 };
 
@@ -81,15 +81,23 @@ const startTimerForSatellite = async ({
 
 	emitSavedWorkflows({ store });
 
-	const sync = async () => await syncWorkflows({ identity, store });
+	// Recursive setTimeout (not setInterval) so the workflow sync cannot
+	// overlap itself. See #2522 / oisy-wallet#9706.
+	const scheduleNext = (): void => {
+		timer = setTimeout(async () => {
+			await syncWorkflows({ identity, store });
+
+			if (nonNullish(timer)) {
+				scheduleNext();
+			}
+		}, SYNC_WORKFLOWS_TIMER_INTERVAL);
+	};
 
 	// We sync the cycles now but also schedule the update afterwards
-	await sync();
+	await syncWorkflows({ identity, store });
 
-	timer = setInterval(sync, SYNC_WORKFLOWS_TIMER_INTERVAL);
+	scheduleNext();
 };
-
-const syncing: Record<WorkflowsIdbKey, boolean> = {};
 
 let initialized = false;
 
@@ -100,13 +108,6 @@ const syncWorkflows = async ({
 	identity: Identity;
 	store: WorkflowsStore;
 }) => {
-	// We avoid to relaunch a sync while previous sync is not finished
-	if (syncing[store.idbKey] === true) {
-		return;
-	}
-
-	syncing[store.idbKey] = true;
-
 	const request = ({
 		identity: _,
 		certified
@@ -141,8 +142,6 @@ const syncWorkflows = async ({
 	});
 
 	await store.save();
-
-	syncing[store.idbKey] = false;
 };
 
 const postMessageWorkflows = ({


### PR DESCRIPTION
Closes #2522.

Follows the pattern from [oisy-wallet#9706](https://github.com/dfinity/oisy-wallet/pull/9706) — applied across all 8 worker timers in the Console (not just `auth.worker.ts`).

## Why

With `setInterval`, a callback slower than the configured interval queues overlapping calls. The workers tried to defend against this with manual `let syncing = false` guards (5 of 8 files) or per-key `Record<…, boolean>` maps (wallet + workflows). Recursive `setTimeout` makes that guarantee structural: the next tick is only scheduled after the previous async callback resolves.

## What

- 8 worker files migrated:
  - `auth.worker.ts`, `icp-cycles-rate.worker.ts`, `cycles.worker.ts`, `exchange.worker.ts`, `hosting.worker.ts`, `wallet.worker.ts`, `workflows.worker.ts`, `monitoring.worker.ts`.
- Each `startXxxTimer` now early-returns when `nonNullish(timer)` is true (matches OISY) so the timer can't be double-started.
- `clearInterval` → `clearTimeout`.
- Now-redundant overlap guards removed:
  - `let syncing = false` plus its guard/assignments in `icp-cycles-rate`, `cycles`, `exchange`, `hosting`, `monitoring`.
  - `syncing: Record<IcrcAccountText, boolean>` in `wallet.worker.ts`.
  - `syncing: Record<WorkflowsIdbKey, boolean>` in `workflows.worker.ts`. Its companion `WorkflowsIdbKey` import is auto-removed by ESLint as unused.

## Verification

- `npm run check:all` — green.
- `npx vitest --config ./vitest.frontend.config.ts --dir src/frontend run` — 65 tests pass across 8 files.
- `grep -rn 'setInterval' src/frontend/src/lib/workers/` returns only the docstring references in the new `// Recursive setTimeout (not setInterval)` comments.

## One subtle side effect worth flagging

For `wallet.worker.ts`, each account currently calls `startTimerWithAccount` and stomps on the module-level `timer` — so before this PR, the `stopTimer()` call only cleared the *last* account's interval and earlier ones leaked. With recursive `setTimeout`, the `nonNullish(timer)` check inside each closure naturally lets `stopTimer()` drain all account lineages on the next tick (they each see `timer === undefined` and don't reschedule). Behavior change is positive but worth a maintainer eyeball — happy to revert that side of the change if you'd prefer to keep the existing semantics and address per-account timer tracking in a separate PR.