### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -17,7 +17,7 @@ runs:
   using: 'composite'
   steps:
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
       with:
         base: main
         commit-message: ${{ inputs.title }}

--- a/.github/actions/docker-build-base/action.yml
+++ b/.github/actions/docker-build-base/action.yml
@@ -8,7 +8,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Update system packages
       run: sudo apt-get update
@@ -18,10 +18,10 @@ runs:
     # more information, see
     # https://github.com/docker/build-push-action/issues/539
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Build base Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         file: Dockerfile

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -19,10 +19,10 @@ runs:
   using: "composite"
   steps:
     - name: Set up docker buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Build ${{ inputs.name }}
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         file: Dockerfile
         cache-from: type=gha,scope=cached-stage
@@ -34,7 +34,7 @@ runs:
       shell: bash
 
     - name: Upload ${{ inputs.name }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         # name is the name used to display and retrieve the artifact
         name: ${{ inputs.wasm }}

--- a/.github/actions/download-wasms/action.yml
+++ b/.github/actions/download-wasms/action.yml
@@ -12,49 +12,49 @@ runs:
   using: "composite"
   steps:
     - name: Download satellite.wasm.gz
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: satellite.wasm.gz
         path: ${{ inputs.path }}
 
     - name: Download orbiter.wasm.gz
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: orbiter.wasm.gz
         path: ${{ inputs.path }}
 
     - name: Download sputnik.wasm.gz
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: sputnik.wasm.gz
         path: ${{ inputs.path }}
 
     - name: Download console.wasm.gz
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: console.wasm.gz
         path: ${{ inputs.path }}
 
     - name: Download observatory.wasm.gz
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: observatory.wasm.gz
         path: ${{ inputs.path }}
 
     - name: Download mission_control.wasm.gz
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: mission_control.wasm.gz
         path: ${{ inputs.path }}
 
     - name: Download test_satellite.wasm.gz
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: test_satellite.wasm.gz
         path: ${{ inputs.path }}
 
     - name: Download test_sputnik.wasm.gz
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: test_sputnik.wasm.gz
         path: ${{ inputs.path }}

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,7 +5,7 @@ description: Checkout and install dependencies
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version-file: '.node-version'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Add wasm targets
         run: |
@@ -31,7 +31,7 @@ jobs:
           rustup target add wasm32-wasip1
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/did.yml
+++ b/.github/workflows/did.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Restore Cargo cache
         id: cargo-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/bin/
@@ -22,7 +22,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Add Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
@@ -34,7 +34,7 @@ jobs:
           echo "DIDC_RELEASE=$(echo $release)" >> $GITHUB_ENV
       - name: Restore didc cache
         id: didc-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /usr/local/bin/didc
           key: ${{ runner.os }}-didc-${{ env.DIDC_RELEASE }}
@@ -44,7 +44,7 @@ jobs:
           curl -SL https://github.com/dfinity/candid/releases/download/$DIDC_RELEASE/didc-linux64 > /usr/local/bin/didc
           chmod +x /usr/local/bin/didc
       - name: Save didc
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: steps.didc-cache.outputs.cache-hit != 'true'
         with: 
           path: /usr/local/bin/didc
@@ -55,7 +55,7 @@ jobs:
       - name: Generating candids
         run: ENV=github npm run generate
       - name: Save Cargo
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: steps.cargo-cache.outputs.cache-hit != 'true'
         with:
           path: |

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint

--- a/.github/workflows/frontend-reproducibility.yaml
+++ b/.github/workflows/frontend-reproducibility.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Frontend tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Base Docker Image
         uses: ./.github/actions/docker-build-base
@@ -44,13 +44,13 @@ jobs:
             target: scratch_orbiter
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build ${{ matrix.name }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: Dockerfile
@@ -64,7 +64,7 @@ jobs:
       - run: sha256sum ./${{ matrix.name }} > ${{ matrix.name }}.sha256
 
       - name: 'Upload ${{ matrix.name }}'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           # name is the name used to display and retrieve the artifact
           name: ${{ matrix.name }}
@@ -73,7 +73,7 @@ jobs:
           path: ./${{ matrix.name }}
 
       - name: 'Upload ${{ matrix.name }}.sha256'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.name }}.sha256
           path: ./${{ matrix.name }}.sha256
@@ -81,7 +81,7 @@ jobs:
   metadata:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build metadata
         run: bash .github/scripts/metadata
@@ -89,7 +89,7 @@ jobs:
           CANISTERS: console,observatory,mission_control,satellite,orbiter
 
       - name: Upload metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           # name is the name used to display and retrieve the artifact
           name: metadata.json
@@ -118,7 +118,7 @@ jobs:
             target: orbiter
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: 'Copy ${{ matrix.name }}'
         run: bash .github/scripts/candid
@@ -126,7 +126,7 @@ jobs:
           CANISTER: ${{ matrix.target }}
 
       - name: 'Upload ${{ matrix.name }}'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.name }}
           path: ./${{ matrix.name }}
@@ -141,7 +141,7 @@ jobs:
             custom_did_file: satellite_extension.did
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: 'Copy ${{ matrix.name }}'
         run: bash .github/scripts/candid
@@ -150,7 +150,7 @@ jobs:
           CUSTOM_DID_FILE: ${{ matrix.custom_did_file }}
 
       - name: 'Upload ${{ matrix.name }}'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.name }}
           path: ./${{ matrix.name }}
@@ -159,106 +159,106 @@ jobs:
     runs-on: ubuntu-latest
     needs: ['docker-build', 'metadata', 'candid', 'candid_extension']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download console.wasm.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: console.wasm.gz
           path: .
 
       - name: Download observatory.wasm.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: observatory.wasm.gz
           path: .
 
       - name: Download mission_control.wasm.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mission_control.wasm.gz
           path: .
 
       - name: Download satellite.wasm.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: satellite.wasm.gz
           path: .
 
       - name: Download orbiter.wasm.gz
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: orbiter.wasm.gz
           path: .
 
       - name: Download console.did
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: console.did
           path: .
 
       - name: Download observatory.did
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: observatory.did
           path: .
 
       - name: Download mission_control.did
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mission_control.did
           path: .
 
       - name: Download satellite.did
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: satellite.did
           path: .
 
       - name: Download satellite_extension.did
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: satellite_extension.did
           path: .
 
       - name: Download orbiter.did
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: orbiter.did
           path: .
 
       - name: Download console.wasm.gz.sha256
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: console.wasm.gz.sha256
           path: .
 
       - name: Download observatory.wasm.gz.sha256
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: observatory.wasm.gz.sha256
           path: .
 
       - name: Download mission_control.wasm.gz.sha256
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mission_control.wasm.gz.sha256
           path: .
 
       - name: Download satellite.wasm.gz.sha256
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: satellite.wasm.gz.sha256
           path: .
 
       - name: Download orbiter.wasm.gz.sha256
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: orbiter.wasm.gz.sha256
           path: .
 
       - name: Download metadata.json
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: metadata.json
           path: .
@@ -272,7 +272,7 @@ jobs:
           CANISTERS: console,observatory,mission_control,satellite,orbiter
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |

--- a/.github/workflows/tests-screenshots.yml
+++ b/.github/workflows/tests-screenshots.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Base Docker Image
         uses: ./.github/actions/docker-build-base
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build and upload ${{ matrix.name }}
         uses: ./.github/actions/docker-build
@@ -74,7 +74,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -94,7 +94,7 @@ jobs:
         run: npm run e2e:ci:snapshots
 
       - name: Commit Playwright updated screenshots
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
           add: ./src/e2e

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Base Docker Image
         uses: ./.github/actions/docker-build-base
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build and upload ${{ matrix.name }}
         uses: ./.github/actions/docker-build
@@ -89,7 +89,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -125,7 +125,7 @@ jobs:
       - name: E2E tests
         run: npm run e2e:ci
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/update-env.yml
+++ b/.github/workflows/update-env.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Update
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Update

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -16,7 +16,7 @@ jobs:
   rust-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
         # First, check rust GitHub releases for a new version. We assume that the
         # latest version's tag name is the version.

--- a/.github/workflows/update-sputnik-polyfills.yml
+++ b/.github/workflows/update-sputnik-polyfills.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Update


### PR DESCRIPTION
Closes #1361.

Replaces every mutable tag reference (`@v4`, `@v3`, `@stable`, `@v1`, etc.) with the full commit SHA across all workflows and composite actions. The original version is preserved as a trailing `# vN` comment so humans (and Dependabot) can still see at a glance which release is in use.

## Why

A tag on GitHub can be re-pointed to a different commit after the fact. If an upstream maintainer (or someone who compromised a maintainer account) re-points `actions/checkout@v4` to a malicious commit, every CI run starts executing the new code with our repo secrets. Pinning to a SHA freezes the exact code being run. The ref can still be moved later — but only via an explicit, reviewable PR.

This is the pattern referenced by the [Paul Millr post linked in the issue](https://x.com/paulmillr/status/1900948425325031448).

## Scope

- 11 workflows + 6 composite actions touched.
- 74 references rewritten in total.
- No behaviour changes — same versions, just frozen.

## Refs pinned

| Action | Tag → SHA |
|---|---|
| `actions/checkout` | `v4` → `34e1148…` |
| `actions/setup-node` | `v4` → `49933ea…` |
| `actions/cache` (+ `restore`, `save`) | `v4` → `0057852…` |
| `actions/upload-artifact` | `v4` → `ea165f8…` |
| `actions/download-artifact` | `v4` → `d3f86a1…` |
| `dtolnay/rust-toolchain` | `stable` → `29eef33…` |
| `softprops/action-gh-release` | `v1` → `de2c0eb…` |
| `docker/setup-buildx-action` | `v3` → `8d2750c…` |
| `docker/build-push-action` | `v5` → `ca052bb…` |
| `EndBug/add-and-commit` | `v9` → `a94899b…` |
| `peter-evans/create-pull-request` | `v6` → `c5a7806…` |

## One thing worth flagging

The example in the issue body shows pinning the *checkout ref* (`with: ref: \${{ env.CHECKOUT_REF }}`) rather than pinning the *action itself*. I went with the standard interpretation — pinning the action's commit SHA — because that's what the linked Paul Millr post is about and it's the more impactful supply-chain mitigation. Happy to redo as ref-pinning instead, or both, if you wanted the other thing.

## Verification

- `npm run check:all` — green (unchanged from main).
- Every YAML file in `.github/` parses cleanly.
- A grep for unpinned external refs (`uses: <owner>/<repo>@<non-hex>`) returns empty.
- Once this PR is opened, the next CI run on it exercises every pinned action.