### PR TITLE
fix(sputnik): support Vec<T> and Option<Vec<T>> in JsonData nested conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,9 +2319,9 @@
 			}
 		},
 		"node_modules/@junobuild/functions-tools": {
-			"version": "0.6.8",
-			"resolved": "https://registry.npmjs.org/@junobuild/functions-tools/-/functions-tools-0.6.8.tgz",
-			"integrity": "sha512-zMGHLa0dWiKSeH7eFcL5gjowQKcf1QgvXxD1sA8v50g/h3E9KMri574kFJHEVd8yCAmRND7FoaZJp8nvyteIFg==",
+			"version": "0.6.9",
+			"resolved": "https://registry.npmjs.org/@junobuild/functions-tools/-/functions-tools-0.6.9.tgz",
+			"integrity": "sha512-SVDVOvvEmXJmP6dNnySNuej8Z2Sgc+P0NrFLOV4pPtWYDX0gyQp0Q9xjztTvJ2QowptbBC8N7QxLez0oM9FI5A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -6483,9 +6483,9 @@
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9590,9 +9590,9 @@
 			}
 		},
 		"node_modules/string-width": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-			"integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+			"integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/src/libs/macros/src/functions/derive.rs
+++ b/src/libs/macros/src/functions/derive.rs
@@ -65,8 +65,12 @@ fn derive_struct(
         .map(|f| {
             let fname = &f.ident;
             if has_nested_attr(f) {
-                if unwrap_option(&f.ty).is_some() {
+                if unwrap_option(&f.ty).and_then(|inner| unwrap_vec(inner)).is_some() {
+                    quote! { #fname: input.#fname.map(|v| v.into_iter().map(|i| i.into()).collect()), }
+                } else if unwrap_option(&f.ty).is_some() {
                     quote! { #fname: input.#fname.map(|v| v.into()), }
+                } else if unwrap_vec(&f.ty).is_some() {
+                    quote! { #fname: input.#fname.into_iter().map(|v| v.into()).collect(), }
                 } else {
                     quote! { #fname: input.#fname.into(), }
                 }
@@ -81,8 +85,12 @@ fn derive_struct(
         .map(|f| {
             let fname = &f.ident;
             if has_nested_attr(f) {
-                if unwrap_option(&f.ty).is_some() {
+                if unwrap_option(&f.ty).and_then(|inner| unwrap_vec(inner)).is_some() {
+                    quote! { #fname: json_data.#fname.map(|v| v.into_iter().map(|i| i.into()).collect()), }
+                } else if unwrap_option(&f.ty).is_some() {
                     quote! { #fname: json_data.#fname.map(|v| v.into()), }
+                } else if unwrap_vec(&f.ty).is_some() {
+                    quote! { #fname: json_data.#fname.into_iter().map(|v| v.into()).collect(), }
                 } else {
                     quote! { #fname: json_data.#fname.into(), }
                 }
@@ -240,7 +248,11 @@ fn derive_enum(
                         .map(|f| {
                             let fname = &f.ident;
                             if has_nested_attr(f) {
-                                quote! { #fname: #fname.into(), }
+                                if unwrap_vec(&f.ty).is_some() {
+                                    quote! { #fname: #fname.into_iter().map(|v| v.into()).collect(), }
+                                } else {
+                                    quote! { #fname: #fname.into(), }
+                                }
                             } else {
                                 quote! { #fname: #fname, }
                             }
@@ -279,7 +291,11 @@ fn derive_enum(
                         .map(|f| {
                             let fname = &f.ident;
                             if has_nested_attr(f) {
-                                quote! { #fname: #fname.into(), }
+                                if unwrap_vec(&f.ty).is_some() {
+                                    quote! { #fname: #fname.into_iter().map(|v| v.into()).collect(), }
+                                } else {
+                                    quote! { #fname: #fname.into(), }
+                                }
                             } else {
                                 quote! { #fname: #fname, }
                             }
@@ -353,7 +369,7 @@ fn has_nested_attr(field: &syn::Field) -> bool {
 fn nested_json_data_ident(ty: &Type) -> Type {
     if let Type::Path(mut tp) = ty.clone() {
         let seg = tp.path.segments.last_mut().unwrap();
-        if seg.ident == "Option" {
+        if seg.ident == "Option" || seg.ident == "Vec" {
             if let syn::PathArguments::AngleBracketed(ref mut args) = seg.arguments {
                 if let Some(syn::GenericArgument::Type(inner)) = args.args.first_mut() {
                     *inner = nested_json_data_ident(inner);
@@ -386,6 +402,20 @@ fn unwrap_option(ty: &Type) -> Option<&Type> {
     if let Type::Path(tp) = ty {
         let seg = tp.path.segments.last()?;
         if seg.ident == "Option" {
+            if let syn::PathArguments::AngleBracketed(ref args) = seg.arguments {
+                if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                    return Some(inner);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn unwrap_vec(ty: &Type) -> Option<&Type> {
+    if let Type::Path(tp) = ty {
+        let seg = tp.path.segments.last()?;
+        if seg.ident == "Vec" {
             if let syn::PathArguments::AngleBracketed(ref args) = seg.arguments {
                 if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
                     return Some(inner);

--- a/src/tests/fixtures/test_sputnik/resources/custom-functions-vec.ts
+++ b/src/tests/fixtures/test_sputnik/resources/custom-functions-vec.ts
@@ -1,0 +1,16 @@
+import { defineQuery } from '@junobuild/functions';
+import { j } from '@junobuild/schema';
+
+// Assertion which would make the npm run build:test-sputnik fail
+
+const ItemSchema = j.strictObject({ inviteCode: j.string() });
+
+export const getItem = defineQuery({
+	result: j.strictObject({ item: ItemSchema.optional() }),
+	handler: () => ({ item: { inviteCode: 'ABC123' } })
+});
+
+export const listItems = defineQuery({
+	result: j.strictObject({ items: j.array(ItemSchema) }),
+	handler: () => ({ items: [{ inviteCode: 'ABC123' }] })
+});

--- a/src/tests/fixtures/test_sputnik/resources/index.ts
+++ b/src/tests/fixtures/test_sputnik/resources/index.ts
@@ -8,6 +8,7 @@ export * from './custom-functions';
 export * from './custom-functions-enum';
 export * from './custom-functions-guard';
 export * from './custom-functions-option';
+export * from './custom-functions-vec';
 export * from './on-delete-asset';
 export * from './on-delete-doc';
 export * from './on-delete-filtered-assets';


### PR DESCRIPTION
# Motivation

Includes https://github.com/junobuild/juno-js/pull/895 and extend macros to support nested JsonData in Vec.
